### PR TITLE
-- CRM-12946 added "is_visa_required" checkbox in Immigration Tab

### DIFF
--- a/hrvisa/hrvisa.php
+++ b/hrvisa/hrvisa.php
@@ -3,6 +3,33 @@
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'hrvisa.civix.php';
 
 /**
+ * Implementation of hook_civicrm_buildProfile
+ */
+function hrvisa_civicrm_buildProfile($name) {
+  if ($name == 'hrvisa_tab') {
+    $contactID = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    $cfId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', 'Is_Visa_Required', 'id', 'name');
+    $params = array(
+      'entityID' => $contactID, 
+      "custom_{$cfId}" => 1
+    );
+    $value = CRM_Core_BAO_CustomValueTable::getValues($params);
+    $regionParams = array(
+      'markup' => "<p id='custom_{$cfId}_is_visa_required'>
+        Is Visa Required &nbsp;<input type='checkbox' id='is_visa_required' value='1' name='is_visa_required'></p>",
+      'weight' => -1
+    );
+
+    //check if the value is set. If it is, then add attribute checked='checked'
+    if ($value["custom_{$cfId}"]) {
+      $regionParams['markup'] = "<p id='custom_{$cfId}_is_visa_required'>Is Visa Required &nbsp;
+        <input type='checkbox' id='is_visa_required' value='1' name='is_visa_required' checked='checked'></p>";
+    }
+    CRM_Core_Region::instance('profile-form-hrvisa_tab')->add($regionParams);
+  }
+}
+
+/**
  * Implementation of hook_civicrm_config
  */
 function hrvisa_civicrm_config(&$config) {
@@ -86,6 +113,8 @@ function hrvisa_civicrm_tabs(&$tabs, $contactID) {
       ));
     }
   }
+  CRM_Core_Resources::singleton()->addScriptFile('org.civicrm.hrvisa', 'js/hrvisa.js');
+  CRM_Core_Resources::singleton()->addSetting(array('contactID' => $contactID));
 }
 
 function hrvisa_getCustomGroupId() {

--- a/hrvisa/js/hrvisa.js
+++ b/hrvisa/js/hrvisa.js
@@ -1,0 +1,25 @@
+cj(function($) {
+  $(document).on("click", "#is_visa_required", function() {
+    var fieldName = $(this).parent().attr('id').replace('_is_visa_required', '');
+
+    //params to be passed in the api
+    var params = $.parseJSON('{"sequential": "1"}');
+    params["entity_id"] = CRM.contactID;
+    params[fieldName] = $(this).is(":Checked") ? 1 : 0;
+    CRM.api('CustomValue', 'create', params,{
+      success: function(data) {
+        if (data.is_error == '0') {
+          params[fieldName] ? CRM.alert("Visa is Required", '', 'success') : CRM.alert("Visa is Not Required", '', 'success');
+        }
+      }
+    });
+  });
+
+  //hide "is visa required" checkbox that appears within the profile dialog
+  $(document).on("click", ".crm-profile-name-hrvisa_tab .action-item", function() {
+    $(document).ajaxSuccess(function() {
+      var parentID = $('#is_visa_required').parent().attr('id');
+      $('#profile-dialog #' + parentID).hide();
+    });
+  });
+});

--- a/hrvisa/xml/auto_install.xml
+++ b/hrvisa/xml/auto_install.xml
@@ -18,6 +18,20 @@
       <created_date>0000-00-00 00:00:00</created_date>
       <is_reserved>1</is_reserved>
     </CustomGroup>
+    <CustomGroup>
+      <name>Immigration_Summary</name>
+      <title>Immigration (Summary)</title>
+      <extends>Individual</extends>
+      <collapse_display>0</collapse_display>
+      <help_pre></help_pre>
+      <help_post></help_post>
+      <weight>10</weight>
+      <is_active>1</is_active>
+      <table_name>civicrm_value_immigration_summary_13</table_name>
+      <collapse_adv_display>0</collapse_adv_display>
+      <created_date>0000-00-00 00:00:00</created_date>
+      <is_reserved>1</is_reserved>
+    </CustomGroup>
   </CustomGroups>
   <CustomFields>
     <CustomField>
@@ -125,7 +139,46 @@
       <column_name>comments_56</column_name>
       <custom_group_name>Immigration</custom_group_name>
     </CustomField>
+    <CustomField>
+      <name>Is_Visa_Required</name>
+      <label>Is Visa Required</label>
+      <data_type>String</data_type>
+      <html_type>CheckBox</html_type>
+      <is_required>0</is_required>
+      <is_searchable>0</is_searchable>
+      <is_search_range>0</is_search_range>
+      <weight>1</weight>
+      <is_active>1</is_active>
+      <is_view>0</is_view>
+      <text_length>255</text_length>
+      <note_columns>60</note_columns>
+      <note_rows>4</note_rows>
+      <column_name>is_visa_required_74</column_name>
+      <option_group_name>is_visa_required_20130702051150</option_group_name>
+      <custom_group_name>Immigration_Summary</custom_group_name>
+    </CustomField>
   </CustomFields>
+  <OptionGroups>
+    <OptionGroup>
+      <name>is_visa_required_20130702051150</name>
+      <title>Is Visa Required</title>
+      <is_reserved>1</is_reserved>
+      <is_active>1</is_active>
+    </OptionGroup>
+  </OptionGroups>
+  <OptionValues>
+    <OptionValue>
+      <label></label>
+      <value>1</value>
+      <name>is_visa_required</name>
+      <is_default>0</is_default>
+      <weight>1</weight>
+      <is_optgroup>0</is_optgroup>
+      <is_reserved>0</is_reserved>
+      <is_active>1</is_active>
+      <option_group_name>is_visa_required_20130702051150</option_group_name>
+    </OptionValue>
+  </OptionValues>
   <ProfileGroups>
     <ProfileGroup>
       <is_active>1</is_active>


### PR DESCRIPTION
In this issue, I did the following to add the checkbox and handle it through ajax api:
1. Used CRM_Core_Region::instance() within hook_civicrm_buildProfile hook to add the checkbox within Immigration tab.
2. Created a custom group Immigration summary which has the checkbox field "is_visa_required" so that a custom table will be created which can be used in step 3 to store the value of the checkbox created in step 1.
3. Now, to provide the checkbox created in step 1 with CRM.api support i.e. to store the value(1 or 0) of checkbox, I used the custom field table created in step 2. So, now when we click on the checkbox, its value will be passed as a value for  the column of is_visa_required customfield in the db and will be stored through ajax api within the custom table.
