### PR TITLE
-- CRM-12914 made email addresses clickable in search results

### DIFF
--- a/hrstaffdir/hrstaffdir.php
+++ b/hrstaffdir/hrstaffdir.php
@@ -3,6 +3,15 @@
 require_once 'hrstaffdir.civix.php';
 
 /**
+ * Implementation of hook_civicrm_pageRun
+ */
+function hrstaffdir_civicrm_pageRun($page) {
+  if ($page instanceof CRM_Profile_Page_Listings) {
+    CRM_Core_Resources::singleton()->addScriptFile('org.civicrm.hrstaffdir', 'js/hrstaffdir.js');
+  }
+}
+
+/**
  * Implementation of hook_civicrm_config
  */
 function hrstaffdir_civicrm_config(&$config) {
@@ -20,7 +29,7 @@ function hrstaffdir_civicrm_searchColumns($objectName, &$headers, &$values, &$se
       foreach ($values as &$value) {
         $found = preg_match('/;id=([^&]*)/', $value[0], $matches);
         if ($found) {
-          $value['sort_name'] = "<a href='" . CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid={$matches[1]}") . "'>{$value['sort_name']}</a>";
+          $value[1] = "<a href='" . CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid={$matches[1]}") . "'>{$value[1]}</a>";
         }
       }
     }

--- a/hrstaffdir/js/hrstaffdir.js
+++ b/hrstaffdir/js/hrstaffdir.js
@@ -1,0 +1,12 @@
+//js to make email addresses clickable in search results
+cj(function($) {
+  if ($('tr:has(td.crm-email)').length > 0) {
+    $(".crm-search-results td.crm-email").each(function() {
+      if ($(this).text()) {
+        var email = $(this).text();
+        var clickableEmail = '<a href="mailto:' + email + '">' + email + '</a>';
+        $(this).html(clickableEmail);
+      }
+    });
+  }
+});


### PR DESCRIPTION
Used pageRun hook to include the js file. Used the class "crm-email" to identify the table cell and convert it into a link with mailto in its href.

This issue also includes the PR https://github.com/civicrm/civicrm-core/pull/1154
