### PR TITLE
Crm 13184 - Disable unnecessary reports

### DIFF
--- a/hrui/hrui.php
+++ b/hrui/hrui.php
@@ -79,8 +79,24 @@ function hrui_civicrm_install() {
   }
   if ($resetNavigation === true) {
     CRM_Core_BAO_Navigation::resetNavigation();
-  } 
+  }  
   
+  // Delete unnecessary reports 
+  $reports = array("Constituent Summary","Constituent Detail","Current Employers");
+  if (!empty($reports)) {    
+    foreach ($reports as $reportTitle) {
+         $instanceID = CRM_Core_DAO::getFieldValue(
+          'CRM_Report_DAO_Instance',
+          $reportTitle,
+          'id',
+          'title'
+         );
+         if ($instanceID) {
+          CRM_Report_BAO_ReportInstance::del($instanceID);
+         }
+     }
+   }
+   
   // get a list of all tab options
   $options = CRM_Core_OptionGroup::values('contact_view_options', TRUE, FALSE);
   $tabsToUnset = array($options['Activities'], $options['Tags']);


### PR DESCRIPTION
Deleted the unnecessary reports as option for disabling the reports doesn't seems to be working, After making is_active=0  I can still see the reports.    
