### PR TITLE
CRM-13243 - Don't use convertCheckboxes with SELECT[name=is_enrolled]

### DIFF
--- a/hrjob/js/common/mbind.js
+++ b/hrjob/js/common/mbind.js
@@ -3,6 +3,10 @@ CRM.HRApp.module('Common', function(Common, HRApp, Backbone, Marionette, $, _) {
   /**
    * Converter for checkbox/boolean fields
    *
+   * Note that this works well with *only* checkboxes. If the template does
+   * or could include a mix of widgets for the same field, then you would need
+   * to define separate bindings (with separate converters) for each widget.
+   *
    * @param direction
    * @param value
    * @return {*}
@@ -39,20 +43,9 @@ CRM.HRApp.module('Common', function(Common, HRApp, Backbone, Marionette, $, _) {
   Common.mbind = function(view) {
     var modelBinder = new Backbone.ModelBinder();
 
-    // ModelBinder - Some bindings to use in all our views
-    var booleanFieldRE = /^is_/;
-    var onBindingCreate = function(bindings) {
-      _.each(bindings, function(value, key){
-        if (booleanFieldRE.test(key)) {
-          value.converter = Common.convertCheckbox;
-        }
-      });
-    };
-
     // View - onRender listener
     var onRender = function() {
       var bindings = Backbone.ModelBinder.createDefaultBindings(this.el, view.bindingAttribute || 'name');
-      onBindingCreate(bindings); // Apply some changes to bindings across all our views
       view.triggerMethod.call(view, 'binding:create', bindings);
       modelBinder.bind(this.model, this.el, bindings);
     };

--- a/hrjob/js/jobtabapp/general/edit_views.js
+++ b/hrjob/js/jobtabapp/general/edit_views.js
@@ -17,6 +17,16 @@ CRM.HRApp.module('JobTabApp.General', function(General, HRApp, Backbone, Marione
       HRApp.Common.Views.StandardForm.prototype.onRender.apply(this, arguments);
       this.toggleIsPrimary();
     },
+    onBindingCreate: function(bindings) {
+      bindings.is_primary = {
+        selector: 'input[name=is_primary]',
+        converter: HRApp.Common.convertCheckbox
+      };
+      bindings.is_tied_to_funding = {
+        selector: 'input[name=is_tied_to_funding]',
+        converter: HRApp.Common.convertCheckbox
+      };
+    },
     /**
      * Define form validation rules
      *


### PR DESCRIPTION
The SELECT works with the default converter but not the checkbox-converter.
We'll require opt-in for checkboxConverter rather than automatically using
it on all booleans.
