### PR TITLE
-- fix for CRM-13129

### DIFF
--- a/hrstaffdir/hrstaffdir.php
+++ b/hrstaffdir/hrstaffdir.php
@@ -25,8 +25,11 @@ function hrstaffdir_civicrm_searchColumns($objectName, &$headers, &$values, &$se
   if ($objectName == 'profile') {
     $profileId = hrstaffdir_getUFGroupID();
     $session = CRM_Core_Session::singleton();
-    CRM_Utils_Request::retrieve('gid', 'Positive', $session);
-    if ($profileId == $session->get('gid')) {
+    $gid = CRM_Utils_Request::retrieve('gid', 'Positive', CRM_Core_DAO::$_nullObject);
+    if (isset($gid) && $profileId == $gid) {
+      $session->set('staffDirectoryGid', $gid);
+    }
+    if ($profileId == $session->get('staffDirectoryGid')) {
       foreach ($values as &$value) {
         $found = preg_match('/;id=([^&]*)/', $value[0], $matches);
         if ($found) {


### PR DESCRIPTION
It was broken because once the search form is submitted, gid parameter will no longer exist in the url. So, the if condition failed and causes\d the link to not appear. I have made the fix by storing the variable value in the session, after it is retrieved from the url, so that its value will persist even after the form submission.
