### PR TITLE
-- HR-177 Emergency Contact Type - Please remove all values other than Emergency Contact Is

### DIFF
--- a/hremerg/hremerg.php
+++ b/hremerg/hremerg.php
@@ -93,3 +93,19 @@ function hremerg_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
 function hremerg_civicrm_managed(&$entities) {
   return _hremerg_civix_civicrm_managed($entities);
 }
+
+function hremerg_civicrm_pageRun($page) {
+  if ($page instanceof CRM_Contact_Page_View_Relationship) {
+    $relationshipTypes = CRM_Core_PseudoConstant::relationshipType();
+    foreach ($relationshipTypes as $id => $value) {
+      if ($value['label_a_b'] == 'Emergency Contact is') {
+        CRM_Core_Resources::singleton()->addSetting(array(
+          'hremerg' => array(
+            'relationshipTypeId' => $id,
+           ),
+        ));
+      }
+    }
+    CRM_Core_Resources::singleton()->addScriptFile('org.civicrm.hrui', 'js/hrui.js');
+  }
+}

--- a/hrui/js/hrui.js
+++ b/hrui/js/hrui.js
@@ -5,8 +5,40 @@ cj(document).ready(function($) {
   cj('.crm-contact-job_title').parent('div.crm-summary-row').hide();
  
   //rename "Summary" tab to "Personal Details"
-  $('#tab_summary a').text('Personal Details');  
+  $('#tab_summary a').text('Personal Details');
+
+  // to make Emergency Contact is as default selected
+  if (CRM.hremerg) {
+    cj("select#relationship_type_id option[value='" + CRM.hremerg.relationshipTypeId + "_a_b']").attr('selected',true);
+  }
+  var relationshipTypeValue = cj( "#relationship_type_id option:selected" ).val();
+  var contactAutocomplete   = cj('#contact_1');
+  // always reset field so that correct data url is linked
+  contactAutocomplete.unautocomplete( );
+  // to enable create new contact dropdown and select contact autocomplete which is disabled on form load
+  if ( relationshipTypeValue ) {
+    cj('#profiles_1').attr('disabled', false);
+    contactAutocomplete.attr('disabled', false);
+    contactAutocomplete.addClass('ac_input');
+    buildCreateNewSelect( 'profiles_1', relationshipTypeValue );
+    var dataUrl =   CRM.url('civicrm/ajax/rest', 'className=CRM_Contact_Page_AJAX&fnName=getContactList&json=1&context=relationship&rel=') + relationshipTypeValue;
+    contactAutocomplete.autocomplete( dataUrl, { width : 200, selectFirst : false, matchContains: true,} );
+    contactAutocomplete.result(function( event, data ) {
+      cj("input[name='contact_select_id[1]']").val(data[1]);
+      cj('#relationship-refresh-save').show( );
+      buildRelationFields(relationshipTypeValue);
+    });
+  } 
+  else {
+    cj('#profiles_1').attr('disabled', true);
+    contactAutocomplete.removeClass('ac_input');
+    contactAutocomplete.attr('disabled', true);
+    contactAutocomplete.unautocomplete( );
+  }
+  // hide Relationship dropdown
+  cj('.crm-relationship-form-block .crm-relationship-form-block-relationship_type_id').hide();
 });
+
 // for inline edit
 cj(document).ajaxSuccess(function() {
   cj('#current_employer').parent('div.crm-content').parent('div.crm-summary-row').hide();


### PR DESCRIPTION
Did modifications for #1. Hide the "Relationship Type" field (with jQuery) and auto-select "Emergency Contact is".

The auto-complete for "Select contact" was handled on OnChange event of 'Ralationship dropdown' , removing 'Ralationship dropdown' was restricting Contact listing. So I added a code to enable auto-complete and called url to fetch contact listing when form is ready.
