### PR TITLE
--HR-217 Directory link gives Access denied message

### DIFF
--- a/hrprofile/hrprofile.php
+++ b/hrprofile/hrprofile.php
@@ -22,6 +22,13 @@ function hrprofile_civicrm_xmlMenu(&$files) {
  * Implementation of hook_civicrm_install
  */
 function hrprofile_civicrm_install() {
+  $groups = CRM_Core_PseudoConstant::get('CRM_Core_BAO_UFField', 'uf_group_id', array('labelColumn' => 'name'));
+  $profileId = array_search('hrstaffdir_listing', $groups);
+  if ($profileId) {
+    $originalUrl = "civicrm/profile&reset=1&gid={$profileId}&force=1";
+    $updatedUrl = "civicrm/profile/table&reset=1&gid={$profileId}&force=1";
+    hrprofile_updateNavigation($originalUrl, $updatedUrl);
+  }
   return _hrprofile_civix_civicrm_install();
 }
 
@@ -29,6 +36,13 @@ function hrprofile_civicrm_install() {
  * Implementation of hook_civicrm_uninstall
  */
 function hrprofile_civicrm_uninstall() {
+  $groups = CRM_Core_PseudoConstant::get('CRM_Core_BAO_UFField', 'uf_group_id', array('labelColumn' => 'name'));
+  $profileId = array_search('hrstaffdir_listing', $groups);
+  if ($profileId) {
+    $originalUrl = "civicrm/profile/table&reset=1&gid={$profileId}&force=1";
+    $updatedUrl = "civicrm/profile&reset=1&gid={$profileId}&force=1";
+    hrprofile_updateNavigation($originalUrl, $updatedUrl);
+  }
   return _hrprofile_civix_civicrm_uninstall();
 }
 
@@ -36,6 +50,13 @@ function hrprofile_civicrm_uninstall() {
  * Implementation of hook_civicrm_enable
  */
 function hrprofile_civicrm_enable() {
+  $groups = CRM_Core_PseudoConstant::get('CRM_Core_BAO_UFField', 'uf_group_id', array('labelColumn' => 'name'));
+  $profileId = array_search('hrstaffdir_listing', $groups);
+  if ($profileId) {
+    $originalUrl = "civicrm/profile&reset=1&gid={$profileId}&force=1";
+    $updatedUrl = "civicrm/profile/table&reset=1&gid={$profileId}&force=1";
+    hrprofile_updateNavigation($originalUrl, $updatedUrl);
+  }
   return _hrprofile_civix_civicrm_enable();
 }
 
@@ -43,6 +64,13 @@ function hrprofile_civicrm_enable() {
  * Implementation of hook_civicrm_disable
  */
 function hrprofile_civicrm_disable() {
+  $groups = CRM_Core_PseudoConstant::get('CRM_Core_BAO_UFField', 'uf_group_id', array('labelColumn' => 'name'));
+  $profileId = array_search('hrstaffdir_listing', $groups);
+  if ($profileId) {
+    $originalUrl = "civicrm/profile/table&reset=1&gid={$profileId}&force=1";
+    $updatedUrl = "civicrm/profile&reset=1&gid={$profileId}&force=1";
+    hrprofile_updateNavigation($originalUrl, $updatedUrl);
+  }
   return _hrprofile_civix_civicrm_disable();
 }
 
@@ -67,4 +95,20 @@ function hrprofile_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
  */
 function hrprofile_civicrm_managed(&$entities) {
   return _hrprofile_civix_civicrm_managed($entities);
+}
+
+function hrprofile_updateNavigation($orginalUrl, $updatedUrl) {
+ 
+    $navigationParams = array(
+                              'label' => 'Directory',
+                              'url' => "$orginalUrl",
+                              'is_active' => 1,
+                              );
+    $navigationParamsNew = array(
+                                 'label' => 'Directory',
+                                 'url' => "$updatedUrl",
+                                 'is_active' => 1,
+                                 );
+    $navigation = CRM_Core_BAO_Navigation::processUpdate($navigationParams,$navigationParamsNew);
+    return true;
 }

--- a/hrstaffdir/CRM/Hrstaffdir/Upgrader.php
+++ b/hrstaffdir/CRM/Hrstaffdir/Upgrader.php
@@ -136,23 +136,4 @@ class CRM_Hrstaffdir_Upgrader extends CRM_Hrstaffdir_Upgrader_Base {
     }
     return TRUE;
   } // */
-
-  public function upgrade_4203() {
-    $groups = CRM_Core_PseudoConstant::get('CRM_Core_BAO_UFField', 'uf_group_id', array('labelColumn' => 'name'));
-    $profileId = array_search('hrstaffdir_listing', $groups);
-    if ($profileId) {
-      $navigationParams = array(
-                                'label' => 'Directory',
-                                'url' => "civicrm/profile&reset=1&gid={$profileId}&force=1",
-                                'is_active' => 1,
-                                );
-      $navigationParamsNew = array(
-                                   'label' => 'Directory',
-                                   'url' => "civicrm/profile/table&reset=1&gid={$profileId}&force=1",
-                                   'is_active' => 1,
-                                   );
-      $navigation = CRM_Core_BAO_Navigation::processUpdate($navigationParams,$navigationParamsNew);
-      return TRUE;
-    }
-  }
 }

--- a/hrstaffdir/hrstaffdir.php
+++ b/hrstaffdir/hrstaffdir.php
@@ -98,7 +98,7 @@ function hrstaffdir_civicrm_install() {
     // add to navigation
     $navigationParams = array(
       'label' => 'Directory',
-      'url' => "civicrm/profile/table&reset=1&gid={$profileId}&force=1",
+      'url' => "civicrm/profile&reset=1&gid={$profileId}&force=1",
       'is_active' => 1,
     );
     $navigation = CRM_Core_BAO_Navigation::add($navigationParams);
@@ -122,7 +122,7 @@ function hrstaffdir_civicrm_uninstall() {
   $profileId = hrstaffdir_getUFGroupID();
   $navigationParams = array(
     'label' => 'Directory',
-    'url' => "civicrm/profile/table&reset=1&gid={$profileId}&force=1",
+    'url' => "civicrm/profile&reset=1&gid={$profileId}&force=1",
   );
   $navigation = CRM_Core_BAO_Navigation::retrieve($navigationParams,$defaultParams);
   CRM_Core_BAO_Navigation::processDelete($navigation->id);
@@ -137,7 +137,7 @@ function hrstaffdir_civicrm_enable() {
   $profileId = hrstaffdir_getUFGroupID();
   $params = array(
     'label' => 'Directory',
-    'url' => "civicrm/profile/table&reset=1&gid={$profileId}&force=1",
+    'url' => "civicrm/profile&reset=1&gid={$profileId}&force=1",
     'is_active' => 0,
   );
   $newParams = array(
@@ -155,7 +155,7 @@ function hrstaffdir_civicrm_disable() {
   $profileId = hrstaffdir_getUFGroupID();
   $params = array(
     'label' => 'Directory',
-    'url' => "civicrm/profile/table&reset=1&gid={$profileId}&force=1",
+    'url' => "civicrm/profile&reset=1&gid={$profileId}&force=1",
     'is_active' => 1,
   );
   $newParams = array(


### PR DESCRIPTION
 Directory link gives Access denied message after upgrade, As the "hrprofile" extension is not getting enabled when we upgrade the  HR extension and Menu link create for this is handled in this extension and path is changed  in "hrstaffdir" extension.

Modification is done for below cases,

1 hrstaffdirecory is Installed, hrprofile is not installed
Directory link will be : civicrm/profile

2 hrstaffdirecory is Installed, hrprofile is  installed
Directory link will be : civicrm/profile/table

3 hrstaffdirecory is Installed, hrprofile is  enable
Directory link will be : civicrm/profile/table

4 hrstaffdirecory is Installed, hrprofile is  disabled
Directory link will be : civicrm/profile

5 hrstaffdirecory is Installed, hrprofile is  uninstalled
Directory link will be : civicrm/profile
