### PR TITLE
-- Modification to pass test for change in join/leave dates fields

### DIFF
--- a/hrjob/tests/phpunit/api/v3/HRJobTest.php
+++ b/hrjob/tests/phpunit/api/v3/HRJobTest.php
@@ -302,69 +302,12 @@ class api_v3_HRJobTest extends CiviUnitTestCase {
     }
   }
 
-  /**
-   * A list of test-cases for the "initial join date" and "final termination date" fields.
-   */
-  function jobSummaryDateTestCases() {
-    $cases = array();
-
-    $cases[] = array(
-      array(),
-      array('start' => '', 'end' => '')
-    );
-    $cases[] = array(
-      array(
-        array('period_start_date' => '', 'period_end_date' => ''),
-      ),
-      array('start' => '', 'end' => '')
-    );
-    $cases[] = array(
-      array(
-        array('period_start_date' => '2012-01-02', 'period_end_date' => ''),
-      ),
-      array('start' => '2012-01-02 00:00:00', 'end' => '')
-    );
-    $cases[] = array(
-      array(
-        array('period_start_date' => '', 'period_end_date' => ''),
-        array('period_start_date' => '2012-01-02', 'period_end_date' => ''),
-        array('period_start_date' => '2011-05-01', 'period_end_date' => ''),
-        array('period_start_date' => '2013-04-01', 'period_end_date' => ''),
-      ),
-      array('start' => '2011-05-01 00:00:00', 'end' => '')
-    );
-    $cases[] = array(
-      array(
-        array('period_start_date' => '', 'period_end_date' => '2012-01-02'),
-      ),
-      array('start' => '', 'end' => '2012-01-02 00:00:00')
-    );
-    $cases[] = array(
-      array(
-        array('period_start_date' => '', 'period_end_date' => '2011-09-02'),
-        array('period_start_date' => '', 'period_end_date' => '2013-01-02'),
-        array('period_start_date' => '', 'period_end_date' => '2012-08-02'),
-        array('period_start_date' => '', 'period_end_date' => ''),
-      ),
-      array('start' => '', 'end' => '2013-01-02 00:00:00')
-    );
-    $cases[] = array(
-      array(
-        array('period_start_date' => '', 'period_end_date' => '2011-09-02'),
-        array('period_start_date' => '', 'period_end_date' => '2013-01-02'),
-        array('period_start_date' => '2009-08-05', 'period_end_date' => '2012-08-02'),
-        array('period_start_date' => '2010-09-01', 'period_end_date' => ''),
-      ),
-      array('start' => '2009-08-05 00:00:00', 'end' => '2013-01-02 00:00:00')
-    );
-    return $cases;
-  }
+  //TODO check for length of employment field value
 
   /**
-   * @dataProvider jobSummaryDateTestCases
    * @param array $jobFixtures list of API calls to make for creating the jobs
    * @param array $expectedDates list of job-summary values that are expected
-   */
+   
   function testJobSummaryDates($jobFixtures, $expectedDates) {
     // Make some noise to ensure we filter correctly
     $this->callAPISuccess('HRJob', 'create', array(
@@ -404,7 +347,7 @@ class api_v3_HRJobTest extends CiviUnitTestCase {
     $this->assertEquals($expectedDates['start'], $result['values'][$result['id']][$fields['Initial_Join_Date']['field']], 'Compare Initial_Join_Date');
     $this->assertEquals($expectedDates['end'], $result['values'][$result['id']][$fields['Final_Termination_Date']['field']], 'Compare Final_Termination_Date');
   }
-
+  */
   // TODO test summary transitions
 
   function testDuplicateWithChange() {


### PR DESCRIPTION
As join/leave fields for Job Summary profile can be set manually (HR-263), test for this is removed. Though it can modified to check length of employment field once HR-264 is complete.
