### PR TITLE
PCHR-614: Hidden leave entitlement for contracts other than current

### DIFF
--- a/hrabsence/js/models.js
+++ b/hrabsence/js/models.js
@@ -277,6 +277,22 @@ CRM.HRAbsenceApp.module('Models', function(Models, HRAbsenceApp, Backbone, Mario
       this.each(function(model) {
         var apiparamsget = model.get('api.HRJobLeave.get');
         _.each(apiparamsget.values, function(contractIds, contractVals) {
+          var isCurrentPeriod = true;
+          var periodStartDate = model.get('period_start_date');
+          var periodEndDate = model.get('period_end_date');
+
+          if (periodStartDate !== undefined && Date.parse(periodStartDate) > Date.now()) {
+            isCurrentPeriod = false;
+          }
+
+          if(periodEndDate !== undefined && Date.parse(periodEndDate) < Date.now()) {
+            isCurrentPeriod = false;
+          }
+
+          if(!isCurrentPeriod) {
+            return;
+          }
+
           var statsKey = model.get('id');
           if (!stats[statsKey]) {
             stats[statsKey] = {


### PR DESCRIPTION
The problem solved by this PR was that absence entitlement was shown for contracts that are not current. 
Before:
![before](https://cloud.githubusercontent.com/assets/15697510/12092133/3137ba68-b2f3-11e5-9b15-be5d7727da88.png)
After:
![after](https://cloud.githubusercontent.com/assets/15697510/12092132/3136ad80-b2f3-11e5-8fb4-6c31c6064084.png)

