### PR TITLE
PCHR-764: Cacelled leave shows 0 now

### DIFF
--- a/hrabsence/js/models.js
+++ b/hrabsence/js/models.js
@@ -37,6 +37,11 @@ CRM.HRAbsenceApp.module('Models', function(Models, HRAbsenceApp, Backbone, Mario
         else {
           var val = parseInt(this.get('absence_range').duration);
         }
+        // return 0 if the status = cancelled
+        if(this.get('status_id') == 3) {
+          return 0;
+        }
+
         return CRM.HRAbsenceApp.formatDuration(val * CRM.HRAbsenceApp.absenceTypeCollection.findDirection(this.get('activity_type_id')));
       } else {
         return '';


### PR DESCRIPTION
**Issue:**
When a leave is Rejected/Cancelled, the count is displayed as -1 on list tab under Absences tab of a contact in CiviCRM admin.
![absence-tab-before](https://cloud.githubusercontent.com/assets/7393885/12235909/e93d81de-b89c-11e5-9a48-3d40d91b8b33.png)

**Solution:**
Check if the status is "Cancelled" (numerical value for cancelled leave is 3) and return 0.
![absence-tab-after](https://cloud.githubusercontent.com/assets/7393885/12235908/e934c24c-b89c-11e5-9ff4-0b39881de878.png)