### PR TITLE
UY-29: Correct input date formats

### DIFF
--- a/hrabsence/CRM/HRAbsence/Form/AbsenceRequest.php
+++ b/hrabsence/CRM/HRAbsence/Form/AbsenceRequest.php
@@ -411,8 +411,16 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
         ));
         $start_date = date_create($result['values'][0]['activity_date_time']);
         $end_date = date_create($result['values'][$result['count'] - 1]['activity_date_time']);
-        $this->assign('fromDate', date_format($start_date, 'm/d/Y'));
-        $this->assign('toDate', date_format($end_date, 'm/d/Y'));
+        $phpEquivalentDateFormats = array(
+            'dd' => 'd',
+            'mm' => 'm',
+            'yy' => 'Y',
+            'MM' => 'F',
+            'DD' => 'l',
+        );
+        $dateFormat = strtr(CRM_Core_Config::singleton()->dateInputFormat, $phpEquivalentDateFormats);
+        $this->assign('fromDate', date_format($start_date, $dateFormat));
+        $this->assign('toDate', date_format($end_date, $dateFormat));
 
         global $user;
         $today = time();


### PR DESCRIPTION
**Issue:**
Dates were not formatted right in date input fields on absence edit page in CiviCRM because the format was statically defined in php code and it was not respecting the format chosen by admin in CiviCRM localization settings.
![uy-29-before](https://cloud.githubusercontent.com/assets/7393885/12236200/64007b82-b89e-11e5-8035-c2a7a5062aa9.png)


**Solution:**
Removed static date format and added a logic to change format in php specific date formats.
![uy-29-after](https://cloud.githubusercontent.com/assets/7393885/12236275/d186ffe6-b89e-11e5-9ccb-d8750e59ffa5.png)

