### PR TITLE
Pchr 784 contracts import

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
@@ -132,6 +132,12 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
           CRM_Utils_Array::value('title', $extIdentifier) . ' (match to contact)';
       }
 
+      $contactId = CRM_Utils_Array::value('contact_id', $fields);
+      if($contactId) {
+        $fields['contact_id'] = $contactId;
+        $fields['contact_id']['title'] = CRM_Utils_Array::value('title', $contactId) . ' (match to contact)';
+      }
+
       $fields = array_merge($fields, $tmpContactField);
 
       self::$_importableFields = $fields;

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Form/MapFieldBaseClass.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Form/MapFieldBaseClass.php
@@ -69,7 +69,15 @@ class CRM_Hrjobcontract_Import_Form_MapFieldBaseClass extends CRM_Import_Form_Ma
   public function preProcess() {
     $this->_mapperFields = $this->get('fields');
     $this->_entity = $this->get('_entity');
-    $this->_highlightedFields = array();
+    $this->_highlightedFields = array(
+      'contact_id',
+      'position',
+      'contract_type',
+      'period_start_date',
+      'email',
+      'external_identifier',
+      'title'
+    );
     $v = $this->_mapperFields;
     asort($this->_mapperFields);
     $this->_columnCount = $this->get('columnCount');
@@ -297,10 +305,10 @@ class CRM_Hrjobcontract_Import_Form_MapFieldBaseClass extends CRM_Import_Form_Ma
         $importKeys[] = $mapperPart[0];
       }
       $requiredFields = array(
-        //'contact_id' => ts('Contact ID'),
-        //'title' => ts('Job Title'),
-        //'position' => ts('Job Position'),
-        //'contract_type' => ts('Job Contract Type'),
+        'title' => ts('Job Title'),
+        'position' => ts('Job Position'),
+        'contract_type' => ts('Job Contract Type'),
+        'period_start_date' => ts('Contract Start Date')
       );
 
       $missingNames = array();
@@ -316,6 +324,14 @@ class CRM_Hrjobcontract_Import_Form_MapFieldBaseClass extends CRM_Import_Form_Ma
       }
       if ($errorRequired) {
         $errors['_qf_default'] = ts('Missing required fields:') . ' ' . implode(ts(' and '), $missingNames);
+      }
+
+      if(
+        !in_array('contact_id', $importKeys)
+        && !in_array('email', $importKeys)
+        && !in_array('external_identifier', $importKeys)
+      ) {
+        $errors['_qf_default'] = ts('Contact ID, Email or External Identifier is required.');
       }
     }
 

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Parser/Api.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Parser/Api.php
@@ -362,6 +362,15 @@ class CRM_Hrjobcontract_Import_Parser_Api extends CRM_Hrjobcontract_Import_Parse
         $mappedParams[$value] = $params[$key];
       }
     }
+
+    // disable validation of pseudoconstant values
+    // if they don't exist, they'll be ignored later
+    foreach($fields as &$field) {
+      if(isset($field['pseudoconstant'])) {
+        unset($field['pseudoconstant']);
+      }
+    }
+
     _civicrm_api3_validate_fields($entity, $action, $mappedParams, $fields);
     foreach ($fieldKeys as $key => $value) {
       if (!empty($mappedParams[$value])) {


### PR DESCRIPTION
Fixing issues with import of job contracts and roles:
1. Non-existants values for pseudocontant fields cause errors (now they're simply ignored, just like in Civi's importers)
2. Date/time format setting is ignored
3. Mandatory fields aren't correctly marked as mandatory