### PR TITLE
PCHR-800 - Matching job contract and job role at import 

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/HrJobRoles.php
@@ -7,18 +7,21 @@ class CRM_Hrjobroles_BAO_HrJobRoles extends CRM_Hrjobroles_DAO_HrJobRoles {
    *
    * @param array $params key-value pairs
    * @return CRM_Hrjobroles_DAO_HrJobRoles|NULL
-   *
+   */
   public static function create($params) {
-    $className = 'CRM_Hrjobroles_DAO_HrJobRoles';
     $entityName = 'HrJobRoles';
     $hook = empty($params['id']) ? 'create' : 'edit';
 
     CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
-    $instance = new $className();
+    $instance = new static();
     $instance->copyValues($params);
     $instance->save();
     CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
 
     return $instance;
-  } */
+  }
+
+  public static function importableFields() {
+    return static::import();
+  }
 }

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/DAO/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/DAO/HrJobRoles.php
@@ -476,7 +476,7 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
         ) ,
         'hrjc_role_start_date' => array(
           'name' => 'start_date',
-          'type' => CRM_Utils_Type::T_TIMESTAMP,
+          'type' => CRM_Utils_Type::T_DATE | CRM_Utils_Type::T_TIME,
           'title' => ts('start_date') ,
           'import' => true,
           'where' => 'civicrm_hrjobroles.start_date',
@@ -487,7 +487,7 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
         ) ,
         'hrjc_role_end_date' => array(
           'name' => 'end_date',
-          'type' => CRM_Utils_Type::T_TIMESTAMP,
+          'type' => CRM_Utils_Type::T_DATE | CRM_Utils_Type::T_TIME,
           'title' => ts('end_date') ,
           'import' => true,
           'where' => 'civicrm_hrjobroles.end_date',

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
@@ -16,12 +16,6 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
     $this->installCostCentreTypes();
   }
 
-  public function upgrade_1002(){
-    $this->installCostCentreTypes();
-
-    return TRUE;
-  }
-
   /**
    * Example: Run an external SQL script when the module is uninstalled
    *
@@ -54,6 +48,19 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
     $this->ctx->log->info('Applying update for job role start and end dates');
     CRM_Core_DAO::executeQuery("ALTER TABLE  `civicrm_hrjobroles` ADD COLUMN  `start_date` timestamp DEFAULT 0 COMMENT 'Start Date of the job role'");
     CRM_Core_DAO::executeQuery("ALTER TABLE  `civicrm_hrjobroles` ADD COLUMN  `end_date` timestamp DEFAULT 0 COMMENT 'End Date of the job role'");
+    return TRUE;
+  }
+
+  public function upgrade_1002(){
+    $this->installCostCentreTypes();
+
+    return TRUE;
+  }
+
+  public function upgrade_1003() {
+    CRM_Core_DAO::executeQuery('ALTER TABLE `civicrm_hrjobroles` MODIFY COLUMN `start_date` DATETIME DEFAULT 0');
+    CRM_Core_DAO::executeQuery('ALTER TABLE `civicrm_hrjobroles` MODIFY COLUMN `end_date` DATETIME DEFAULT 0');
+
     return TRUE;
   }
 

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContractRevision.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContractRevision.php
@@ -8,7 +8,7 @@ class CRM_Hrjobcontract_BAO_HRJobContractRevision extends CRM_Hrjobcontract_DAO_
    * Create a new HRJobContractRevision based on array-data
    *
    * @param array $params key-value pairs
-   * @return CRM_HRJob_DAO_HRJobContractRevision|NULL
+   * @return CRM_HRJobContract_DAO_HRJobContractRevision|NULL
    *
    */
   public static function create($params) {

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Form/MapFieldBaseClass.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Form/MapFieldBaseClass.php
@@ -70,14 +70,16 @@ class CRM_Hrjobcontract_Import_Form_MapFieldBaseClass extends CRM_Import_Form_Ma
     $this->_mapperFields = $this->get('fields');
     $this->_entity = $this->get('_entity');
     $this->_highlightedFields = array(
-      'contact_id',
-      'position',
-      'contract_type',
-      'period_start_date',
-      'email',
-      'external_identifier',
-      'title'
+      'HRJobContract-contact_id',
+      'HRJobContract-email',
+      'HRJobContract-external_identifier',
+
+      'HRJobDetails-position',
+      'HRJobDetails-contract_type',
+      'HRJobDetails-period_start_date',
+      'HRJobDetails-title'
     );
+
     $v = $this->_mapperFields;
     asort($this->_mapperFields);
     $this->_columnCount = $this->get('columnCount');
@@ -92,8 +94,7 @@ class CRM_Hrjobcontract_Import_Form_MapFieldBaseClass extends CRM_Import_Form_Ma
       $this->assign('rowDisplayCount', 3);
       /* if we had a column header to skip, stash it for later */
       $this->_columnHeaders = $this->_dataValues[0];
-    }
-    else {
+    } else {
       $this->assign('rowDisplayCount', 2);
     }
     $this->doDuplicateOptionHandling();
@@ -304,11 +305,12 @@ class CRM_Hrjobcontract_Import_Form_MapFieldBaseClass extends CRM_Import_Form_Ma
       foreach ($fields['mapper'] as $mapperPart) {
         $importKeys[] = $mapperPart[0];
       }
+
       $requiredFields = array(
-        'title' => ts('Job Title'),
-        'position' => ts('Job Position'),
-        'contract_type' => ts('Job Contract Type'),
-        'period_start_date' => ts('Contract Start Date')
+        'HRJobDetails.title' => ts('Job Title'),
+        'HRJobDetails.position' => ts('Job Position'),
+        'HRJobDetails.contract_type' => ts('Job Contract Type'),
+        'HRJobDetails.period_start_date' => ts('Contract Start Date')
       );
 
       $missingNames = array();
@@ -327,9 +329,9 @@ class CRM_Hrjobcontract_Import_Form_MapFieldBaseClass extends CRM_Import_Form_Ma
       }
 
       if(
-        !in_array('contact_id', $importKeys)
-        && !in_array('email', $importKeys)
-        && !in_array('external_identifier', $importKeys)
+        !in_array('HRJobContract.contact_id', $importKeys)
+        && !in_array('HRJobContract.email', $importKeys)
+        && !in_array('HRJobContract.external_identifier', $importKeys)
       ) {
         $errors['_qf_default'] = ts('Contact ID, Email or External Identifier is required.');
       }

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Form/MapFieldBaseClass.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Form/MapFieldBaseClass.php
@@ -307,10 +307,10 @@ class CRM_Hrjobcontract_Import_Form_MapFieldBaseClass extends CRM_Import_Form_Ma
       }
 
       $requiredFields = array(
-        'HRJobDetails.title' => ts('Job Title'),
-        'HRJobDetails.position' => ts('Job Position'),
-        'HRJobDetails.contract_type' => ts('Job Contract Type'),
-        'HRJobDetails.period_start_date' => ts('Contract Start Date')
+        'HRJobDetails-title' => ts('Job Title'),
+        'HRJobDetails-position' => ts('Job Position'),
+        'HRJobDetails-contract_type' => ts('Job Contract Type'),
+        'HRJobDetails-period_start_date' => ts('Contract Start Date')
       );
 
       $missingNames = array();
@@ -329,9 +329,9 @@ class CRM_Hrjobcontract_Import_Form_MapFieldBaseClass extends CRM_Import_Form_Ma
       }
 
       if(
-        !in_array('HRJobContract.contact_id', $importKeys)
-        && !in_array('HRJobContract.email', $importKeys)
-        && !in_array('HRJobContract.external_identifier', $importKeys)
+        !in_array('HRJobContract-contact_id', $importKeys)
+        && !in_array('HRJobContract-email', $importKeys)
+        && !in_array('HRJobContract-external_identifier', $importKeys)
       ) {
         $errors['_qf_default'] = ts('Contact ID, Email or External Identifier is required.');
       }

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Parser.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Parser.php
@@ -286,37 +286,17 @@ abstract class CRM_Hrjobcontract_Import_Parser extends CRM_Import_Parser {
     }
   }
   
-  /**
-   * @param $name
-   * @param $title
-   * @param int $type
-   * @param string $headerPattern
-   * @param string $dataPattern
-   */
-  function addField2222($name, $title, $type = CRM_Utils_Type::T_INT, $headerPattern = '//', $dataPattern = '//') {
-    if (empty($name)) {
-      $this->_fields['doNotImport'] = new CRM_Hrjobcontract_Import_Field($name, $title, $type, $headerPattern, $dataPattern);
-    }
-    else {
-      $tempField = CRM_Contact_BAO_Contact::importableFields('All', NULL);
-      if (array_key_exists($name, $tempField)) {
-        $this->_fields[$name] = new CRM_Hrjobcontract_Import_Field($name, $title, $type, $headerPattern, $dataPattern,
-          CRM_Utils_Array::value('hasLocationType', $tempField[$name])
-        );
-        $this->_activeEntityFields[$this->_entity][$name] = $this->_fields[$name];
-      }
-    }
-  }
-  
   function addField($name, $title, $type = CRM_Utils_Type::T_INT, $headerPattern = '//', $dataPattern = '//') {
     if (empty($name) || $name == "do_not_import") {
       $this->_fields['doNotImport'] = new CRM_Hrjobcontract_Import_Field($name, $title, $type, $headerPattern, $dataPattern);
     }
     else {
       foreach($this->_entity as $entity) {
+        $entityFieldName = str_replace($entity.'-', '',$name);
+
         $entityName = "CRM_Hrjobcontract_BAO_{$entity}";
         $tempField = $entityName::importableFields($entity, NULL);
-        if (array_key_exists("$name", $tempField)) {
+        if (array_key_exists($entityFieldName, $tempField)) {
           $this->_fields[$name] = new CRM_Hrjobcontract_Import_Field($name, $title, $type, $headerPattern, $dataPattern);
           $this->_activeEntityFields[$entity][$name] = $this->_fields[$name];
         }

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Parser/Api.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Parser/Api.php
@@ -20,34 +20,47 @@ class CRM_Hrjobcontract_Import_Parser_Api extends CRM_Hrjobcontract_Import_Parse
   protected $_params = array();
   
   function setFields() {
-      $this->_fields = array();
-      $allFields = array();
-      $entityFields = array();
-      
-      foreach ($this->_entity as $entity) {
-        $entityName = "CRM_Hrjobcontract_BAO_{$entity}";
-          $entityFields[$entity] = $entityName::importableFields($entity, NULL);
-          foreach ($entityFields[$entity] as $key => $field) {
-            if (!empty($field['required'])) {
-              $this->_requiredFields[$entity] = $field;
-            }
-            // date is 4 & time is 8. Together they make 12 - in theory a binary operator makes sense here but as it's not a common pattern it doesn't seem worth the confusion
-            if (CRM_Utils_Array::value('type', $field) == 12
-               || CRM_Utils_Array::value('type', $field) == 4) {
-              if(!isset($this->_dateFields[$entity])) {
-                $this->_dateFields[$entity] = array();
-              }
+    $this->_fields = array();
+    $allFields = array();
+    $entityFields = array();
 
-              $this->_dateFields[$entity][] = $key;
-            }
-          }
-          $allFields = array_merge($entityFields[$entity], $allFields);
+    foreach ($this->_entity as $entity) {
+      $entityName = "CRM_Hrjobcontract_BAO_{$entity}";
+      $entityFields[$entity] = array();
+      $importableFields = call_user_func(array($entityName, 'importableFields'), $entity, NULL);
+      foreach ($importableFields as $key => $field) {
+        if($key === 'do_not_import') {
+          continue;
+        }
+
+        $entityFields[$entity][$entity . '-' . $key] = $field;
       }
+
+      foreach ($entityFields[$entity] as $key => $field) {
+        if (!empty($field['required'])) {
+          $this->_requiredFields[$entity] = $field;
+        }
+        // date is 4 & time is 8. Together they make 12 - in theory a binary operator makes sense here but as it's not a common pattern it doesn't seem worth the confusion
+        if (CRM_Utils_Array::value('type', $field) == 12
+          || CRM_Utils_Array::value('type', $field) == 4
+        ) {
+          if (!isset($this->_dateFields[$entity])) {
+            $this->_dateFields[$entity] = array();
+          }
+
+          $this->_dateFields[$entity][] = $key;
+        }
+      }
+
+      $allFields = array_merge($entityFields[$entity], $allFields);
+    }
+
     $this->_entityFields = $entityFields;
     $this->_allFields = $allFields;
 
     $this->_fields = array_merge(array('do_not_import' => array('title' => ts('- do not import -'))), $allFields);
   }
+
 
   /**
    * The summary function is a magic & mystical function
@@ -127,13 +140,14 @@ class CRM_Hrjobcontract_Import_Parser_Api extends CRM_Hrjobcontract_Import_Parse
         'role',
     );
     $ei = CRM_Hrjobcontract_ExportImportValuesConverter::singleton();
+
     $response = $this->summary($values);
 
     $this->_params['skipRecentView'] = TRUE;
     $this->_params['check_permissions'] = TRUE;
     
     $params = $this->getActiveFieldParams();
-    
+
     $formatValues = array();
     foreach ($params as $key => $field) {
       if ($field == NULL || $field === '') {
@@ -142,161 +156,17 @@ class CRM_Hrjobcontract_Import_Parser_Api extends CRM_Hrjobcontract_Import_Parse
 
       $formatValues[$key] = $field;
     }
-    
-    $importedJobContractId = null;
-    
-    if (!empty($params['jobcontract_id'])) {
-        $importedJobContractId = (int)$params['jobcontract_id'];
-    }
-    
-    if (!$importedJobContractId) {
-        $importedJobContractId = $this->_jobcontractIdIncremental++;
-    }
-    
-    if (empty($params['contact_id']) && !empty($params['email'])) {
-        $checkEmail = new CRM_Core_BAO_Email();
-        $checkEmail->email = $params['email'];
-        $checkEmail->find(TRUE);
-        if (!empty($checkEmail->contact_id))
-        {
-            $params['contact_id'] = $checkEmail->contact_id;
-        }
-    }
-    
-    if (!empty($formatValues['external_identifier'])) {
-      $checkCid = new CRM_Contact_DAO_Contact();
-      $checkCid->external_identifier = $formatValues['external_identifier'];
-      $checkCid->find(TRUE);
-      if (!empty($params['contact_id']) && $params['contact_id'] != $checkCid->id) {
-        array_unshift($values, 'Mismatch of External identifier :' . $formatValues['external_identifier'] . ' and Contact Id:' . $params['contact_id']);
-        return CRM_Import_Parser::ERROR;
-      }
-      if (!empty($checkCid->id)) {
-          $params['contact_id'] = $checkCid->id;
-      }
-    }
-    
-    if (empty($params['contact_id'])) {
-        $error = 'Missing "contact_id" / "email" / "external_identifier" value.';
-        array_unshift($values, $error);
-        return CRM_Import_Parser::ERROR;
-    }
-    
-    $revisionParams = $this->getEntityParams('HRJobContractRevision');
-    $revisionData = array();
-    foreach ($entityNames as $value) {
-        if (empty($revisionParams[$value . '_revision_id'])) {
-            $revisionParams[$value . '_revision_id'] = $this->_revisionIdIncremental;
-        }
-        $revisionData[$value] = $revisionParams[$value . '_revision_id'];
-    }
-    $this->_revisionIdIncremental++;
-    
-    if (empty($revisionData)) {
-        $error = 'Missing Revision data.';
-        array_unshift($values, $error);
-        return CRM_Import_Parser::ERROR;
-    }
-    
-    $revisionId = max($revisionData);
-    
-    if (empty($this->_jobContractIds[$importedJobContractId])) {
-        try {
-            $jobContractCreateResponse = civicrm_api3('HRJobContract', 'create', array('contact_id' => $params['contact_id']));
-        }
-        catch (CiviCRM_API3_Exception $e) {
-            $error = $e->getMessage();
-            array_unshift($values, $error);
-            return CRM_Import_Parser::ERROR;
-        }
-        $this->_jobContractIds[$importedJobContractId] = (int)$jobContractCreateResponse['id'];
-        $this->_previousRevision = array();
-        foreach ($entityNames as $value) {
-            $this->_previousRevision['imported'][$value] = null;
-            $this->_previousRevision['local'][$value] = null;
-        }
-        $this->_previousRevision['imported']['id'] = null;
-        $this->_previousRevision['local']['id'] = null;
-        $this->_revisionIds = array();
-        $this->_revisionEntityMap = array();
-    }
-    $localJobContractId = $this->_jobContractIds[$importedJobContractId];
-    
-    $newRevisionInstance = null;
-    if ($this->_previousRevision['imported']['id'] !== $revisionId) {
-        // create new Revision:
-        $newRevisionParams = $revisionParams;
-        unset($newRevisionParams['id']);
-        foreach ($entityNames as $value) {
-            unset($newRevisionParams[$value . '_revision_id']);
-        }
-        $newRevisionParams['jobcontract_id'] = $localJobContractId;
-        $newRevisionParams = $this->validateFields('HRJobContractRevision', $newRevisionParams);
-        $newRevisionInstance = CRM_Hrjobcontract_BAO_HRJobContractRevision::create($newRevisionParams);
-        
-        if (!empty($this->_previousRevision['imported']['id'])) {
-            foreach ($entityNames as $value) {
-                $field = $value . '_revision_id';
-                $newRevisionInstance->$field = $this->_previousRevision['local'][$value];
-            }
-            $newRevisionInstance->save();
-        }
-    }
-    
-    
-    
-    try {
-      foreach ($this->_entity as $entity) {
-        
-        if (in_array($entity, array('HRJobContract', 'HRJobContractRevision'))) {
-            continue;
-        }
-        
-        $entityClass = 'CRM_Hrjobcontract_BAO_' . $entity;
-        $tableName = _civicrm_get_table_name($entity);
-        
-        if (empty($revisionParams[$tableName . '_revision_id'])) {
-            continue;
-        }
-        
-        $params = $this->getEntityParams($entity);
-        $params['jobcontract_id'] = $localJobContractId;
-        
-        foreach ($params as $key => $value) {
-            $params[$key] = $ei->import($tableName, $key, $value);
-        }
 
-        $params = $this->formatDateParams($entity, $params);
-        $params = $this->validateFields($entity, $params);
-        $params['import'] = 1;
-        if ($revisionParams[$tableName . '_revision_id'] === $revisionId) {
-            if ($tableName === 'leave' || ($this->_previousRevision['imported'][$tableName] !== $revisionId)) {
-                if (!empty($newRevisionInstance)) {
-                    $params['jobcontract_revision_id'] = $newRevisionInstance->id;
-                } else {
-                    $params['jobcontract_revision_id'] = $this->_previousRevision['local'][$tableName];
-                }
-                if ($tableName === 'leave')
-                {
-                    foreach ($params['leave_amount'] as $leaveTypeId => $leaveAmount)
-                    {
-                        $params['leave_type'] = $leaveTypeId;
-                        $params['leave_amount'] = $leaveAmount;
-                        $entityInstance = $entityClass::create($params);
-                    }
-                }
-                else
-                {
-                    $entityInstance = $entityClass::create($params);
-                }
-                $this->_previousRevision['local'][$tableName] = $entityInstance->jobcontract_revision_id;
-            }
-        }
-        $this->_previousRevision['imported'][$tableName] = $revisionParams[$tableName . '_revision_id'];
-      }
-    } catch(CiviCRM_API3_Exception $e) {
-      $error = $e->getMessage();
-      array_unshift($values, $error);
+    try {
+      $importedJobContractId = $this->determineContractId($params);
+      $contactId = $this->determineContactId($params, $formatValues);
+      list($revisionParams, $revisionId) = $this->getRevisionData($entityNames);
+      $localJobContractId = $this->createJobContract($importedJobContractId, $contactId, $entityNames);
+      $newRevisionInstance = $this->createContractRevison($revisionId, $revisionParams, $entityNames, $localJobContractId);
+      $value = $this->importRelatedEntities($revisionParams, $localJobContractId, $ei, $revisionId, $newRevisionInstance);
+    } catch(\RuntimeException $e) {
+      array_unshift($values, $e->getMessage());
+
       return CRM_Import_Parser::ERROR;
     }
     
@@ -320,7 +190,7 @@ class CRM_Hrjobcontract_Import_Parser_Api extends CRM_Hrjobcontract_Import_Parse
   function formatDateParams($entity, $params) {
     $session = CRM_Core_Session::singleton();
     $dateType = $session->get('dateTypes');
-    $dateFields = $this->_dateFields[$entity];
+    $dateFields = isset($this->_dateFields[$entity]) ? $this->_dateFields[$entity] : array();
 
     foreach ($params as $key => $value) {
       if(!in_array($key, $dateFields)) {
@@ -369,6 +239,7 @@ class CRM_Hrjobcontract_Import_Parser_Api extends CRM_Hrjobcontract_Import_Parse
     
     $mappedParams = array();
     foreach ($fieldKeys as $key => $value) {
+      $key = str_replace($entity.'-', '', $key);
       if (!empty($params[$key])) {
         $mappedParams[$value] = $params[$key];
       }
@@ -408,10 +279,225 @@ class CRM_Hrjobcontract_Import_Parser_Api extends CRM_Hrjobcontract_Import_Parse
   function getEntityParams($entity) {
     $params = $this->getActiveFieldParams();
     for ($i = 0; $i < $this->_activeFieldCount; $i++) {
-      if (!isset($this->_activeEntityFields[$entity][$this->_activeFields[$i]->_name])) {
-        unset($params[$this->_activeFields[$i]->_name]);
+      if (!isset($this->_activeEntityFields[$entity][$entity.'-'.$this->_activeFields[$i]->_name])) {
+        unset($params[$entity.'-'.$this->_activeFields[$i]->_name]);
       }
     }
+
     return $params;
+  }
+
+  /**
+   * @param array $params
+   * @return integer
+   */
+  private function determineContractId($params) {
+    $importedJobContractId = NULL;
+
+    if (!empty($params['HRJobContract-jobcontract_id'])) {
+      $importedJobContractId = (int) $params['HRJobContract-jobcontract_id'];
+    }
+
+    if (!$importedJobContractId) {
+      $importedJobContractId = $this->_jobcontractIdIncremental++;
+    }
+    return $importedJobContractId;
+  }
+
+  private function determineContactId($params, $formatValues) {
+    if(!empty($params['HRJobContract-contact_id'])) {
+      return $params['HRJobContract-contact_id'];
+    }
+
+    if (!empty($params['HRJobContract-email'])) {
+      $checkEmail = new CRM_Core_BAO_Email();
+      $checkEmail->email = $params['HRJobContract-email'];
+      $checkEmail->find(TRUE);
+
+      if (!empty($checkEmail->contact_id))
+      {
+        return $checkEmail->contact_id;
+      }
+    }
+
+    if (!empty($formatValues['HRJobContract-external_identifier'])) {
+      $checkCid = new CRM_Contact_DAO_Contact();
+      $checkCid->external_identifier = $formatValues['HRJobContract-external_identifier'];
+      $checkCid->find(TRUE);
+
+      if (!empty($params['HRJobContract-contact_id']) && $params['HRJobContract-contact_id'] != $checkCid->id) {
+        throw new \RuntimeException('Mismatch of External identifier :' . $formatValues['external_identifier'] . ' and Contact Id:' . $params['contact_id']);
+      }
+
+      if (!empty($checkCid->id)) {
+        return $checkCid->id;
+      }
+    }
+
+    if (empty($params['HRJobContract-contact_id'])) {
+      $error = 'Missing "contact_id" / "email" / "external_identifier" value.';
+      throw new \RuntimeException($error);
+    }
+  }
+
+  private function getRevisionData($entityNames) {
+    $revisionParams = $this->getEntityParams('HRJobContractRevision');
+    $revisionData = array();
+    foreach ($entityNames as $value) {
+      if (empty($revisionParams[$value . '_revision_id'])) {
+        $revisionParams[$value . '_revision_id'] = $this->_revisionIdIncremental;
+      }
+      $revisionData[$value] = $revisionParams[$value . '_revision_id'];
+    }
+    $this->_revisionIdIncremental++;
+
+    if (empty($revisionData)) {
+      $error = 'Missing Revision data.';
+      throw new \RuntimeException($error);
+    }
+
+    return array($revisionParams, max($revisionData));
+  }
+
+  private function createJobContract($importedJobContractId, $contactId, $entityNames) {
+    if (empty($this->_jobContractIds[$importedJobContractId])) {
+      try {
+        $jobContractCreateResponse = civicrm_api3('HRJobContract', 'create', array('contact_id' => $contactId));
+      }
+      catch (CiviCRM_API3_Exception $e) {
+        throw new \RuntimeException($e->getMessage());
+      }
+      $this->_jobContractIds[$importedJobContractId] = (int)$jobContractCreateResponse['id'];
+      $this->_previousRevision = array();
+      foreach ($entityNames as $value) {
+        $this->_previousRevision['imported'][$value] = null;
+        $this->_previousRevision['local'][$value] = null;
+      }
+      $this->_previousRevision['imported']['id'] = null;
+      $this->_previousRevision['local']['id'] = null;
+      $this->_revisionIds = array();
+      $this->_revisionEntityMap = array();
+    }
+
+    return $this->_jobContractIds[$importedJobContractId];
+  }
+
+  /**
+   * @param $revisionId
+   * @param $revisionParams
+   * @param $entityNames
+   * @param $localJobContractId
+   * @return array
+   */
+  private function createContractRevison($revisionId, $revisionParams, $entityNames, $localJobContractId) {
+    $newRevisionInstance = NULL;
+    if ($this->_previousRevision['imported']['id'] !== $revisionId) {
+      // create new Revision:
+      $newRevisionParams = $revisionParams;
+      unset($newRevisionParams['id']);
+      foreach ($entityNames as $value) {
+        unset($newRevisionParams[$value . '_revision_id']);
+      }
+      $newRevisionParams['jobcontract_id'] = $localJobContractId;
+      $newRevisionParams = $this->validateFields('HRJobContractRevision', $newRevisionParams);
+      $newRevisionInstance = CRM_Hrjobcontract_BAO_HRJobContractRevision::create($newRevisionParams);
+
+      if (!empty($this->_previousRevision['imported']['id'])) {
+        foreach ($entityNames as $value) {
+          $field = $value . '_revision_id';
+          $newRevisionInstance->$field = $this->_previousRevision['local'][$value];
+        }
+        $newRevisionInstance->save();
+      }
+    }
+
+    return $newRevisionInstance;
+  }
+
+  /**
+   * @param $revisionParams
+   * @param $localJobContractId
+   * @param $ei
+   * @param $revisionId
+   * @param $newRevisionInstance
+   * @return mixed
+   */
+  private function importRelatedEntities($revisionParams, $localJobContractId, $ei, $revisionId, $newRevisionInstance) {
+    foreach ($this->_entity as $entity) {
+      if (in_array($entity, array('HRJobContract', 'HRJobContractRevision'))) {
+        continue;
+      }
+
+      $entityClass = 'CRM_Hrjobcontract_BAO_' . $entity;
+      $tableName = _civicrm_get_table_name($entity);
+
+      if (empty($revisionParams[$tableName . '_revision_id'])) {
+        continue;
+      }
+
+      $params = $this->getEntityParams($entity);
+      $params['HRJobContract-jobcontract_id'] = $localJobContractId;
+
+      foreach ($params as $key => $value) {
+        $params[$key] = $ei->import($tableName, str_replace($entity . '-', '', $key), $value);
+      }
+
+      $params = $this->formatDateParams($entity, $params);
+      $params = $this->validateFields($entity, $params);
+
+
+      $entityInstance = null;
+      if ($revisionParams[$tableName . '_revision_id'] === $revisionId) {
+        if ($tableName === 'leave' || ($this->_previousRevision['imported'][$tableName] !== $revisionId)) {
+          if (!empty($newRevisionInstance)) {
+            $params['HRJobContract-jobcontract_revision_id'] = $newRevisionInstance->id;
+          }
+          else {
+            $params['HRJobContract-jobcontract_revision_id'] = $this->_previousRevision['local'][$tableName];
+          }
+          if ($tableName === 'leave') {
+            if(!isset($params['HrJobLeave-leave_amount'])) {
+              continue;
+            }
+
+            foreach ($params['HrJobLeave-leave_amount'] as $leaveTypeId => $leaveAmount) {
+              $params['HrJobLeave-leave_type'] = $leaveTypeId;
+              $params['HrJobLeave-leave_amount'] = $leaveAmount;
+              $entityParams = array();
+              foreach($params as $key => $value) {
+                $entityParams[str_replace('HrJobLeave-', '', $key)] = $value;
+              }
+              $entityParams['import'] = 1;
+              $entityParams['jobcontract_id'] = $localJobContractId;
+              $entityParams['jobcontract_revision_id'] = $newRevisionInstance->id;
+              $entityInstance = CRM_Hrjobcontract_BAO_HRJobLeave::create($entityParams);
+            }
+          }
+          else {
+            $entityParams = array();
+
+            foreach($params as $key => $value) {
+              if(strpos($key, $entity) !== 0) {
+                continue;
+              }
+
+              $entityParams[str_replace($entity.'-', '', $key)] = $value;
+            }
+
+            if(count($entityParams) === 0) {
+              continue;
+            }
+
+            $entityParams['import'] = 1;
+            $entityParams['jobcontract_id'] = $localJobContractId;
+            $entityParams['jobcontract_revision_id'] = $newRevisionInstance->id;
+
+            $entityInstance = call_user_func(array($entityClass, 'create'), $entityParams);
+          }
+          $this->_previousRevision['local'][$tableName] = $entityInstance->jobcontract_revision_id;
+        }
+      }
+      $this->_previousRevision['imported'][$tableName] = $revisionParams[$tableName . '_revision_id'];
+    }
   }
 }

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Parser/BaseClass.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Parser/BaseClass.php
@@ -67,6 +67,7 @@ class CRM_Hrjobcontract_Import_Parser_BaseClass extends CRM_Hrjobcontract_Import
     $this->setFields();
     $fields = $this->_fields;
     $this->_fields = array();
+
     foreach ($fields as $name => $field) {
       $field['type'] = CRM_Utils_Array::value('type', $field, CRM_Utils_Type::T_INT);
       $field['dataPattern'] = CRM_Utils_Array::value('dataPattern', $field, '//');

--- a/hrjobcontract/templates/CRM/Hrjobcontract/Import/Form/MapField.tpl
+++ b/hrjobcontract/templates/CRM/Hrjobcontract/Import/Form/MapField.tpl
@@ -46,7 +46,7 @@
    </tr>
    <tr>
      <td>{* Table for mapping data to CRM fields *}
-         {include file="CRM/Event/Import/Form/MapTable.tpl}
+         {include file="CRM/Event/Import/Form/MapTable.tpl"}
      </td>
    </tr>
    <tr>


### PR DESCRIPTION
Job role couldn't be imported before.
1. Changed type of job role's `start_date` and `end_date` from `TIMESTAMP` to `DATETIME`
2. Import now uses HrJobRole instead of the (not used anymore) HrJobContractRole
3. All fields appear on the list of fields to import (before, if there were fields with the same name in different entities, only one of them would appear)