### PR TITLE
PCHR-804: Fixed PHP warnings in hrjobcontract import

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobDetails.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobDetails.php
@@ -35,7 +35,7 @@ class CRM_Hrjobcontract_BAO_HRJobDetails extends CRM_Hrjobcontract_DAO_HRJobDeta
         ));
         if (!empty($revision['values'][0])) {
             $revisionData = array_shift($revision['values']);
-            if (!$revisionData['effective_date']) {
+            if (empty($revisionData['effective_date'])) {
                 civicrm_api3('HRJobContractRevision', 'create', array(
                     'id' => $revisionData['id'],
                     'effective_date' => $instance->period_start_date,

--- a/hrjobcontract/CRM/Hrjobcontract/ExportImportValuesConverter.php
+++ b/hrjobcontract/CRM/Hrjobcontract/ExportImportValuesConverter.php
@@ -175,6 +175,10 @@ class CRM_Hrjobcontract_ExportImportValuesConverter
     }
     public function details_location_import($value)
     {
+        if(!isset($this->_locationOptionsFlipped[$value])) {
+            return null;
+        }
+
         return $this->_locationOptionsFlipped[$value];
     }
     

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Parser/Api.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Parser/Api.php
@@ -52,9 +52,12 @@ class CRM_Hrjobcontract_Import_Parser_Api extends CRM_Hrjobcontract_Import_Parse
         $this->_requiredFields[] = $key;
       }
 
-      if (CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_TIME | CRM_Utils_Type::T_DATE
-        || CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_DATE
-      ) {
+      $fieldType = CRM_Utils_Array::value('type', $field);
+      $dateFieldTypes = array(
+        CRM_Utils_Type::T_DATE | CRM_Utils_Type::T_TIME,
+        CRM_Utils_Type::T_DATE
+      );
+      if ($fieldType !== null && in_array($fieldType, $dateFieldTypes)) {
         $this->_dateFields[] = $key;
       }
     }
@@ -193,6 +196,7 @@ class CRM_Hrjobcontract_Import_Parser_Api extends CRM_Hrjobcontract_Import_Parse
       if(!in_array($key, $this->_dateFields)) {
         continue;
       }
+
       CRM_Utils_Date::convertToDefaultDate($params, $dateType, $key);
       $params[$key] = CRM_Utils_Date::processDate($params[$key]);
     }


### PR DESCRIPTION
Fixed some warnings occurring on import of a hrjobcontract. 
Some of them were caused by invalid handling of date fields (too much fields were considered to be date/time, and therefore they were converted to the start of Unix epoch).
Others were caused by invalid array lookups.