### PR TITLE
PCHR-841: Job contract reason for end

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobDetails.php
+++ b/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobDetails.php
@@ -130,7 +130,7 @@ class CRM_Hrjobcontract_DAO_HRJobDetails extends CRM_Hrjobcontract_DAO_Base
   /**
    * Job Contract End reason
    * 
-   * @var date
+   * @var int
    */
   public $end_reason;
   /**

--- a/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobDetails.php
+++ b/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobDetails.php
@@ -128,6 +128,12 @@ class CRM_Hrjobcontract_DAO_HRJobDetails extends CRM_Hrjobcontract_DAO_Base
    */
   public $period_end_date;
   /**
+   * Job Contract End reason
+   * 
+   * @var date
+   */
+  public $end_reason;
+  /**
    * Amount of time allocated for notice period. Number part without the unit e.g 3 in 3 Weeks.
    *
    * @var float
@@ -279,6 +285,18 @@ class CRM_Hrjobcontract_DAO_HRJobDetails extends CRM_Hrjobcontract_DAO_Base
                   'dataPattern' => '',
                   'headerPattern' => '/^contract\s?end\s?date/i',
                 ) ,
+                'hrjobcontract_details_end_reason' => array(
+                  'name' => 'end_reason',
+                  'type' => CRM_Utils_Type::T_INT,
+                  'title' => ts('End reason') ,
+                  'required' => false,
+                  'export' => true,
+                  'import' => true,
+                  'pseudoconstant' => array(
+                    'optionGroupName' => 'hrjc_contract_end_reason',
+                  ),
+                  'headerPattern' => '/^end\s?reason/i',
+                ) ,
                 'hrjobcontract_details_notice_amount' => array(
                   'name' => 'notice_amount',
                   'type' => CRM_Utils_Type::T_FLOAT,
@@ -373,6 +391,7 @@ class CRM_Hrjobcontract_DAO_HRJobDetails extends CRM_Hrjobcontract_DAO_Base
                 'contract_type' => 'hrjobcontract_details_contract_type',
                 'period_start_date' => 'hrjobcontract_details_period_start_date',
                 'period_end_date' => 'hrjobcontract_details_period_end_date',
+                'end_reason' => 'hrjobcontract_details_end_reason',
                 'notice_amount' => 'hrjobcontract_details_notice_amount',
                 'notice_unit' => 'hrjobcontract_details_notice_unit',
                 'notice_amount_employee' => 'hrjobcontract_details_notice_amount_employee',

--- a/hrjobcontract/CRM/Hrjobcontract/Page/JobContractTab.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Page/JobContractTab.php
@@ -85,7 +85,8 @@ class CRM_Hrjobcontract_Page_JobContractTab extends CRM_Core_Page {
         "location",
         'notice_unit',
         'notice_unit_employee',
-        'department'
+        'department',
+        'hrjc_contract_end_reason' => 'end_reason',
       ),
       'HRJobHour' => array(
         'hours_type',
@@ -216,6 +217,20 @@ class CRM_Hrjobcontract_Page_JobContractTab extends CRM_Core_Page {
       $change_reason[$val['value']] = $val['name'];
     }
     return $change_reason;
+  }
+  
+  /**
+   * Get a reasons for job contract end
+   */
+  static function getContractEndReasons() {
+    $end_reason = array();
+    $result = civicrm_api3('OptionValue', 'get', array(
+      'option_group_id' =>'hrjc_contract_end_reason',
+    ));
+    foreach ($result['values'] as $key => $val) {
+      $end_reason[$val['value']] = $val['name'];
+    }
+    return $end_reason;
   }
   
   /**

--- a/hrjobcontract/CRM/Hrjobcontract/Report/Form/Summary.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Report/Form/Summary.php
@@ -276,6 +276,11 @@ class CRM_Hrjobcontract_Report_Form_Summary extends CRM_Report_Form {
                     'no_repeat' => TRUE,
                     'dbAlias' => 'hrjobcontract_details_civireport.period_end_date',
                 ),
+                'details_end_reason' => array(
+                    'title' => ts('End reason'),
+                    'no_repeat' => TRUE,
+                    'name' => 'end_reason',
+                ),
                 'details_notice_amount' => array(
                     'title' => ts('Notice Period from Employer (Amount)'),
                     'no_repeat' => TRUE,

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1117,7 +1117,10 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
    * @return boolean TRUE
    */
   function upgrade_1011() {
+    // Adding 'end_reason' field into the 'civicrm_hrjobcontract_details' db table.
     CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_hrjobcontract_details` ADD `end_reason` INT(3) NULL DEFAULT NULL AFTER `period_end_date`");
+
+    // Creating Option Group named 'hrjc_contract_end_reason' for storing Contract End reason values.
     $optionGroupID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'hrjc_contract_end_reason', 'id', 'name');
     if (!$optionGroupID) {
         $params = array(
@@ -1127,11 +1130,13 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
           'is_reserved' => 1,
         );
         civicrm_api3('OptionGroup', 'create', $params);
+        // An array with three detault Contract End reasons:
         $optionsValue = array(
             1 => 'Voluntary',
             2 => 'Involuntary',
             3 => 'Planned',
         );
+        // Attaching the Option Values to the Option Group.
         foreach ($optionsValue as $key => $value) {
           $opValueParams = array(
             'option_group_id' => 'hrjc_contract_end_reason',
@@ -1143,6 +1148,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
         }
     }
 
+    // Adding newly created Option Group into the Administration Menu (Dropdown Options).
     $administerNavId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Dropdown Options', 'id', 'name');
     $jobContractOptionsMenuTree = array();
     $result = civicrm_api3('OptionGroup', 'get', array(
@@ -1162,6 +1168,8 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
       $menuItems['is_active'] = 1;
       CRM_Core_BAO_Navigation::add($menuItems);
     }
+
+    // Refreshing the Navigation menu.
     CRM_Core_BAO_Navigation::resetNavigation();
 
     return TRUE;

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1128,9 +1128,9 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
         );
         civicrm_api3('OptionGroup', 'create', $params);
         $optionsValue = array(
-            1 => 'End Reason 1',
-            2 => 'End Reason 2',
-            3 => 'End Reason 3',
+            1 => 'Voluntary',
+            2 => 'Involuntary',
+            3 => 'Planned',
         );
         foreach ($optionsValue as $key => $value) {
           $opValueParams = array(

--- a/hrjobcontract/hrjobcontract.php
+++ b/hrjobcontract/hrjobcontract.php
@@ -110,7 +110,7 @@ function hrjobcontract_civicrm_uninstall() {
   if (!empty($jobContractMenu)) {
     CRM_Core_BAO_Navigation::processDelete($jobContractMenu);
   }
-  CRM_Core_DAO::executeQuery("DELETE FROM civicrm_navigation WHERE name IN ('job_contracts', 'import_export_job_contracts', 'jobImport', 'hoursType', 'pay_scale','hours_location', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason')");
+  CRM_Core_DAO::executeQuery("DELETE FROM civicrm_navigation WHERE name IN ('job_contracts', 'import_export_job_contracts', 'jobImport', 'hoursType', 'pay_scale','hours_location', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_end_reason')");
   CRM_Core_BAO_Navigation::resetNavigation();
 
   //delete custom groups and field
@@ -126,7 +126,7 @@ function hrjobcontract_civicrm_uninstall() {
   }
 
   //delete all option group and values
-  CRM_Core_DAO::executeQuery("DELETE FROM civicrm_option_group WHERE name IN ('job_contracts', 'hoursType', 'pay_scale','hours_location', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_type', 'hrjc_level_type', 'hrjc_department', 'hrjc_hours_type', 'hrjc_pay_grade', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_location', 'hrjc_pension_type', 'hrjc_region', 'hrjc_pay_scale')");
+  CRM_Core_DAO::executeQuery("DELETE FROM civicrm_option_group WHERE name IN ('job_contracts', 'hoursType', 'pay_scale','hours_location', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_end_reason', 'hrjc_contract_type', 'hrjc_level_type', 'hrjc_department', 'hrjc_hours_type', 'hrjc_pay_grade', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_location', 'hrjc_pension_type', 'hrjc_region', 'hrjc_pay_scale')");
   
   //delete job contract files to entities relations
   CRM_Core_DAO::executeQuery("DELETE FROM civicrm_entity_file WHERE entity_table LIKE 'civicrm_hrjobcontract_%'");
@@ -141,7 +141,7 @@ function hrjobcontract_civicrm_uninstall() {
  */
 function hrjobcontract_civicrm_enable() {
   //Enable the Navigation menu and submenus
-  $sql = "UPDATE civicrm_navigation SET is_active=1 WHERE name IN ('job_contracts', 'hoursType', 'hours_location', 'pay_scale', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason')";
+  $sql = "UPDATE civicrm_navigation SET is_active=1 WHERE name IN ('job_contracts', 'hoursType', 'hours_location', 'pay_scale', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_end_reason')";
   CRM_Core_DAO::executeQuery($sql);
   CRM_Core_BAO_Navigation::resetNavigation();
     
@@ -156,7 +156,7 @@ function hrjobcontract_civicrm_enable() {
  */
 function hrjobcontract_civicrm_disable() {
   //Disable the Navigation menu and submenus
-  $sql = "UPDATE civicrm_navigation SET is_active=0 WHERE name IN ('job_contracts', 'hoursType', 'hours_location', 'pay_scale', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason')";
+  $sql = "UPDATE civicrm_navigation SET is_active=0 WHERE name IN ('job_contracts', 'hoursType', 'hours_location', 'pay_scale', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_end_reason')";
   CRM_Core_DAO::executeQuery($sql);
   CRM_Core_BAO_Navigation::resetNavigation();
   
@@ -175,9 +175,9 @@ function _hrjobcontract_setActiveFields($setActive) {
   CRM_Core_DAO::executeQuery("UPDATE civicrm_custom_group SET is_active = {$setActive} WHERE name = 'HRJobContract_Summary'");
 
   //disable/enable optionGroup and optionValue
-  $query = "UPDATE civicrm_option_value JOIN civicrm_option_group ON civicrm_option_group.id = civicrm_option_value.option_group_id SET civicrm_option_value.is_active = {$setActive} WHERE civicrm_option_group.name IN ('job_contracts', 'hoursType', 'pay_scale','hours_location', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_type', 'hrjc_level_type', 'hrjc_department', 'hrjc_hours_type', 'hrjc_pay_grade', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_location', 'hrjc_pension_type', 'hrjc_region', 'hrjc_pay_scale')";
+  $query = "UPDATE civicrm_option_value JOIN civicrm_option_group ON civicrm_option_group.id = civicrm_option_value.option_group_id SET civicrm_option_value.is_active = {$setActive} WHERE civicrm_option_group.name IN ('job_contracts', 'hoursType', 'pay_scale','hours_location', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_end_reason', 'hrjc_contract_type', 'hrjc_level_type', 'hrjc_department', 'hrjc_hours_type', 'hrjc_pay_grade', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_location', 'hrjc_pension_type', 'hrjc_region', 'hrjc_pay_scale')";
   CRM_Core_DAO::executeQuery($query);
-  CRM_Core_DAO::executeQuery("UPDATE civicrm_option_group SET is_active = {$setActive} WHERE name IN ('job_contracts', 'hoursType', 'pay_scale','hours_location', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_type', 'hrjc_level_type', 'hrjc_department', 'hrjc_hours_type', 'hrjc_pay_grade', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_location', 'hrjc_pension_type', 'hrjc_region', 'hrjc_pay_scale')");
+  CRM_Core_DAO::executeQuery("UPDATE civicrm_option_group SET is_active = {$setActive} WHERE name IN ('job_contracts', 'hoursType', 'pay_scale','hours_location', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_end_reason', 'hrjc_contract_type', 'hrjc_level_type', 'hrjc_department', 'hrjc_hours_type', 'hrjc_pay_grade', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_location', 'hrjc_pension_type', 'hrjc_region', 'hrjc_pay_scale')");
 }
 
 /**

--- a/hrjobcontract/js/src/job-contract/controllers/contract.js
+++ b/hrjobcontract/js/src/job-contract/controllers/contract.js
@@ -145,7 +145,7 @@ define([
                     options = {
                         controller: 'ModalContractCtrl',
                         targetDomEl: $rootElement.find('div').eq(0),
-                        templateUrl: settings.pathApp+'views/modalForm.html?v=4444',
+                        templateUrl: settings.pathApp+'views/modalForm.html?v=4448',
                         windowClass: 'modal-contract',
                         size: 'lg',
                         resolve: {

--- a/hrjobcontract/js/src/job-contract/controllers/form/form-general.js
+++ b/hrjobcontract/js/src/job-contract/controllers/form/form-general.js
@@ -52,8 +52,14 @@ define([
             });
 
             $scope.$watch('entity.details.period_end_date', function(){
-                $scope.dpDateStartMax = entityDetails.period_end_date ? moment(entityDetails.period_end_date).subtract(1, 'day').format() : '';
+                if (entityDetails.period_end_date) {
+                    $scope.dpDateStartMax = moment(entityDetails.period_end_date).subtract(1, 'day').format();  
+                } else {
+                    $scope.dpDateStartMax = '';
+                    entityDetails.end_reason = '';
+                }
                 $scope.duration = duration(entityDetails.period_start_date, entityDetails.period_end_date);
+
             });
 
             $scope.$watch('entity.details.position', function(newVal, oldVal){

--- a/hrjobcontract/js/src/job-contract/controllers/form/form-general.js
+++ b/hrjobcontract/js/src/job-contract/controllers/form/form-general.js
@@ -55,11 +55,10 @@ define([
                 if (entityDetails.period_end_date) {
                     $scope.dpDateStartMax = moment(entityDetails.period_end_date).subtract(1, 'day').format();  
                 } else {
-                    $scope.dpDateStartMax = '';
-                    entityDetails.end_reason = '';
+                    $scope.dpDateStartMax = null;
+                    entityDetails.end_reason = null;
                 }
                 $scope.duration = duration(entityDetails.period_start_date, entityDetails.period_end_date);
-
             });
 
             $scope.$watch('entity.details.position', function(newVal, oldVal){

--- a/hrjobcontract/views/contractList.html
+++ b/hrjobcontract/views/contractList.html
@@ -96,7 +96,7 @@
                         <div class="col-xs-12">
                             <tabset>
                                 <tab heading="Summary">
-                                    <div ng-include src="pathTpl + 'contractSummary.html?v=446465'"></div>
+                                    <div ng-include src="pathTpl + 'contractSummary.html?v=446466'"></div>
                                 </tab>
                                 <tab heading="Full History" disabled="!revisionDataList.length">
                                     <div ng-include src="pathTpl + 'contractRevisionList.html?v=87654354'"></div>

--- a/hrjobcontract/views/contractSummary.html
+++ b/hrjobcontract/views/contractSummary.html
@@ -53,6 +53,7 @@
                             <span class="subfield">({{details.period_start_date | formatDate}} - {{details.period_end_date | formatDate}})</span>
                             <span ng-if="details.notice_amount" class="subfield"><strong>Notice <span ng-if="details.notice_amount_employee">(From Employer)</span>:</strong> {{details.notice_amount}} {{options.details.notice_unit[details.notice_unit]}}(s)</span>
                             <span ng-if="details.notice_amount_employee" class="subfield"><strong>Notice <span>(From Employee)</span>:</strong> {{details.notice_amount_employee}} {{options.details.notice_unit_employee[details.notice_unit_employee]}}(s)</span>
+                            <span ng-if="details.end_reason" class="subfield"><strong>End Reason:</strong> {{options.details.end_reason[details.end_reason]}}</span>
                         </p>
                     </div>
                     <div class="col-sm-2">

--- a/hrjobcontract/views/modalForm.html
+++ b/hrjobcontract/views/modalForm.html
@@ -118,6 +118,20 @@
                                     <p class="form-control-static">{{duration}}</p>
                                 </div>
                             </div>
+                            <div class="form-group required" hrjc-validate ng-show="!!entity.details.period_end_date">
+                                <label for="{{prefix}}end-reason" class="col-sm-4 control-label">Contract End Reason</label>
+
+                                <div class="col-sm-5">
+                                    <div class="chr_custom-select chr_custom-select--full">
+                                        <select id="{{prefix}}end-reason" class="form-control" name="detailsEndReason"
+                                                ng-model="entity.details.end_reason"
+                                                ng-options="key as value for (key, value) in options.details.end_reason"
+                                                ng-disabled="isDisabled" ng-required="!!entity.details.period_end_date">
+                                            <option value="">- select -</option>
+                                        </select>
+                                    </div>
+                                </div>
+                            </div>
                             <div class="form-group" hrjc-validate>
                                 <label for="{{prefix}}notice-amount" class="col-sm-4 control-label">Notice Period from Employer</label>
 


### PR DESCRIPTION
- Adding new 'end_reason' field for HRJobContract Details entity.
- Creating new 'hrjc_contract_end_reason' Option Group containing three Contract End reasons.
- Adding the 'hrjc_contract_end_reason' Option Group to the CiviCRM Administration menu (under Dropdown Options).

Job Contract Summary page (before):
![job-contract-summary-before](https://cloud.githubusercontent.com/assets/8986209/13115425/117330e6-d598-11e5-915e-a89849b41601.png)
Job Contract Summary page (after) - notice there is a new 'End reason' label under 'Contract Dates' section:
![job-contract-summary-after](https://cloud.githubusercontent.com/assets/8986209/13115426/11da7e54-d598-11e5-81dd-c6942c6eaca1.png)
Job Contract Details page (before):
![job-contract-details-before](https://cloud.githubusercontent.com/assets/8986209/13115429/13d1e260-d598-11e5-86fb-e913b362632e.png)
Job Contract Details page (after) - notice there is a new 'Contract End Reason' dropdown field after setting Contract End Date:
![job-contract-details-after](https://cloud.githubusercontent.com/assets/8986209/13115433/1656f5d4-d598-11e5-8481-900a05762dd4.png)



