### PR TITLE
PCHR-846 - Length of Service

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobDetails.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobDetails.php
@@ -63,6 +63,7 @@ class CRM_Hrjobcontract_BAO_HRJobDetails extends CRM_Hrjobcontract_DAO_HRJobDeta
         $contract->id = $revision['jobcontract_id'];
         $contract->find(true);
         CRM_Hrjobcontract_JobContractDates::setDates($contract->contact_id, $revision['jobcontract_id'], $instance->period_start_date, $instance->period_end_date);
+        CRM_Hrjobcontract_BAO_HRJobContract::updateLengthOfService($contract->contact_id);
         
         return $instance;
     }

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -946,6 +946,8 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     $this->upgrade_1006();
     $this->upgrade_1008();
     $this->upgrade_1009();
+    $this->upgrade_1011();
+    $this->upgrade_1012();
   }
   
   function upgrade_1001() {
@@ -1173,6 +1175,14 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     CRM_Core_BAO_Navigation::resetNavigation();
 
     return TRUE;
+  }
+
+  /**
+   * Install 'length_of_service' Custom Field for 'Individual' Contact entity.
+   */
+  function upgrade_1012() {
+      $this->executeCustomDataFile('xml/length_of_service.xml');
+      return TRUE;
   }
           
   function decToFraction($fte) {

--- a/hrjobcontract/api/v3/HRJobContract.php
+++ b/hrjobcontract/api/v3/HRJobContract.php
@@ -112,14 +112,10 @@ function civicrm_api3_h_r_job_contract_getlengthofservice($params) {
 
 function civicrm_api3_h_r_job_contract_updatelengthofservice($params) {
   if (empty($params['contact_id'])) {
-    throw new API_Exception(ts("Please specify 'contact_id' value."));
+    $result = CRM_Hrjobcontract_BAO_HRJobContract::updateLengthOfServiceAllContacts();
+  } else {
+    $result = CRM_Hrjobcontract_BAO_HRJobContract::updateLengthOfService($params['contact_id']);
   }
-  $result = CRM_Hrjobcontract_BAO_HRJobContract::updateLengthOfService($params['contact_id']);
-  return civicrm_api3_create_success($result, $params);
-}
-
-function civicrm_api3_h_r_job_contract_updatelengthofserviceallcontacts($params) {
-  $result = CRM_Hrjobcontract_BAO_HRJobContract::updateLengthOfServiceAllContacts();
   return civicrm_api3_create_success($result, $params);
 }
 

--- a/hrjobcontract/api/v3/HRJobContract.php
+++ b/hrjobcontract/api/v3/HRJobContract.php
@@ -102,6 +102,27 @@ function civicrm_api3_h_r_job_contract_deletecontractpermanently($params) {
   return _civicrm_hrjobcontract_api3_deletecontractpermanently($params);
 }
 
+function civicrm_api3_h_r_job_contract_getlengthofservice($params) {
+  if (empty($params['contact_id'])) {
+    throw new API_Exception(ts("Please specify 'contact_id' value."));
+  }
+  $result = CRM_Hrjobcontract_BAO_HRJobContract::getLengthOfService($params['contact_id']);
+  return civicrm_api3_create_success($result, $params);
+}
+
+function civicrm_api3_h_r_job_contract_updatelengthofservice($params) {
+  if (empty($params['contact_id'])) {
+    throw new API_Exception(ts("Please specify 'contact_id' value."));
+  }
+  $result = CRM_Hrjobcontract_BAO_HRJobContract::updateLengthOfService($params['contact_id']);
+  return civicrm_api3_create_success($result, $params);
+}
+
+function civicrm_api3_h_r_job_contract_updatelengthofserviceallcontacts($params) {
+  $result = CRM_Hrjobcontract_BAO_HRJobContract::updateLengthOfServiceAllContacts();
+  return civicrm_api3_create_success($result, $params);
+}
+
 /**
  * @see _civicrm_api3_generic_getlist_params.
  *

--- a/hrjobcontract/hrjobcontract.php
+++ b/hrjobcontract/hrjobcontract.php
@@ -127,9 +127,13 @@ function hrjobcontract_civicrm_uninstall() {
 
   //delete all option group and values
   CRM_Core_DAO::executeQuery("DELETE FROM civicrm_option_group WHERE name IN ('job_contracts', 'hoursType', 'pay_scale','hours_location', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_end_reason', 'hrjc_contract_type', 'hrjc_level_type', 'hrjc_department', 'hrjc_hours_type', 'hrjc_pay_grade', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_location', 'hrjc_pension_type', 'hrjc_region', 'hrjc_pay_scale')");
-  
+
   //delete job contract files to entities relations
   CRM_Core_DAO::executeQuery("DELETE FROM civicrm_entity_file WHERE entity_table LIKE 'civicrm_hrjobcontract_%'");
+
+  // delete 'length_of_service' Custom Group
+  $customGroup = civicrm_api3('CustomGroup', 'getsingle', array('return' => "id",'name' => "Contact_Length_Of_Service",));
+  civicrm_api3('CustomGroup', 'delete', array('id' => $customGroup['id']));
 
   return _hrjobcontract_civix_civicrm_uninstall();
 }
@@ -172,7 +176,7 @@ function _hrjobcontract_setActiveFields($setActive) {
   //disable/enable customgroup and customvalue
   $sql = "UPDATE civicrm_custom_field JOIN civicrm_custom_group ON civicrm_custom_group.id = civicrm_custom_field.custom_group_id SET civicrm_custom_field.is_active = {$setActive} WHERE civicrm_custom_group.name = 'HRJobContract_Summary'";
   CRM_Core_DAO::executeQuery($sql);
-  CRM_Core_DAO::executeQuery("UPDATE civicrm_custom_group SET is_active = {$setActive} WHERE name = 'HRJobContract_Summary'");
+  CRM_Core_DAO::executeQuery("UPDATE civicrm_custom_group SET is_active = {$setActive} WHERE name IN ('HRJobContract_Summary', 'Contact_Length_Of_Service')");
 
   //disable/enable optionGroup and optionValue
   $query = "UPDATE civicrm_option_value JOIN civicrm_option_group ON civicrm_option_group.id = civicrm_option_value.option_group_id SET civicrm_option_value.is_active = {$setActive} WHERE civicrm_option_group.name IN ('job_contracts', 'hoursType', 'pay_scale','hours_location', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_end_reason', 'hrjc_contract_type', 'hrjc_level_type', 'hrjc_department', 'hrjc_hours_type', 'hrjc_pay_grade', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_location', 'hrjc_pension_type', 'hrjc_region', 'hrjc_pay_scale')";

--- a/hrjobcontract/xml/length_of_service.xml
+++ b/hrjobcontract/xml/length_of_service.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="iso-8859-1" ?>
+
+<CustomData>
+  <CustomGroups>
+    <CustomGroup>
+      <name>Contact_Length_Of_Service</name>
+      <title>Contact Length of Service</title>
+      <extends>Individual</extends>
+      <style>Inline</style>
+      <collapse_display>0</collapse_display>
+      <help_pre></help_pre>
+      <help_post></help_post>
+      <weight>14</weight>
+      <is_active>1</is_active>
+      <table_name>civicrm_value_length_of_service_11</table_name>
+      <is_multiple>0</is_multiple>
+      <collapse_adv_display>0</collapse_adv_display>
+      <is_reserved>0</is_reserved>
+    </CustomGroup>
+  </CustomGroups>
+  <CustomFields>
+    <CustomField>
+      <name>Length_Of_Service</name>
+      <label>Length of Service</label>
+      <data_type>Int</data_type>
+      <html_type>Text</html_type>
+      <is_required>0</is_required>
+      <is_searchable>1</is_searchable>
+      <is_search_range>0</is_search_range>
+      <weight>1</weight>
+      <is_active>1</is_active>
+      <is_view>0</is_view>
+      <text_length>16</text_length>
+      <note_columns>60</note_columns>
+      <note_rows>4</note_rows>
+      <column_name>length_of_service</column_name>
+      <custom_group_name>Contact_Length_Of_Service</custom_group_name>
+      <in_selector>1</in_selector>
+    </CustomField>
+  </CustomFields>
+</CustomData>


### PR DESCRIPTION
Implementing 'length of service' Custom Field for Contact entity and creating three custom API calls on HRJobContract CiviCRM entity.

Custom Length of Service API calls:

**Update the Length of Service value(s)**
entity: HRJobContract
action: updatelengthofservice
params: contact_id (optional)
description: automatically updates Length of Service value for specific Contact ID or Length of Service for all Contacts if no 'contact_id' is provided.
example:
```
CRM.api3('HRJobContract', 'updatelengthofservice', {
  "sequential": 1,
  "contact_id": 49 // optional
}).done(function(result) {
  // do something
});
```
// response:
```
{
	"is_error":0,
	"version":3,
	"count":1,
	"values":true
}
```

**Calculate the Length of Service for specified Contact**
entity: HRJobContract
action: getlengthofservice
params: contact_id (required)
description: calculates and returns Length of Service (for specified Contact ID) in days as Integer
example:
```
CRM.api3('HRJobContract', 'getlengthofservice', {
  "sequential": 1,
  "contact_id": 49
}).done(function(result) {
  // do something
});
```
// response:
```
{
	"is_error":0,
	"version":3,
	"count":1,
	"values":387
}
```