### PR TITLE
PCHR-860: Fix bug in my absences to use title instead of name

### DIFF
--- a/hrabsence/CRM/HRAbsence/BAO/HRAbsenceType.php
+++ b/hrabsence/CRM/HRAbsence/BAO/HRAbsenceType.php
@@ -44,7 +44,7 @@ class CRM_HRAbsence_BAO_HRAbsenceType extends CRM_HRAbsence_DAO_HRAbsenceType {
     $activityTypesResult = civicrm_api3('activity_type', 'get', array());
     if (CRM_Utils_Array::value('allow_debits', $params) && empty($params['debit_activity_type_id'])) {
       $weight = count($activityTypesResult["values"]);
-      $debitActivityLabel = $params['name'];
+      $debitActivityLabel = $params['title'];
       $debitActivityTypeId = array_search($debitActivityLabel, $activityTypesResult["values"]);
       if (!$debitActivityTypeId) {
         $weight = $weight + 1;
@@ -64,7 +64,7 @@ class CRM_HRAbsence_BAO_HRAbsenceType extends CRM_HRAbsence_DAO_HRAbsenceType {
     }
     if (CRM_Utils_Array::value('allow_credits', $params) && empty($params["credit_activity_type_id"])) {
       $weight = count($activityTypesResult["values"]);
-      $creditActivityLabel = ts('%1 (Credit)', array(1 => $params["name"]));
+      $creditActivityLabel = ts('%1 (Credit)', array(1 => $params["title"]));
       $creditActivityTypeId = array_search($creditActivityLabel, $activityTypesResult["values"]);
       if (!$creditActivityTypeId) {
         $weight = $weight + 1;


### PR DESCRIPTION
## Problem :

When you add new absence type with spaces , and then you visit "my absences" or any other contact "absences tab" . the name ( which contains underscores ) of the absence type appears instead of the title  . 

<img width="731" alt="before" src="https://cloud.githubusercontent.com/assets/17959662/13950141/29bd7078-f021-11e5-9e51-40aa2b2ee4e2.png">

## Solution :

I've changed the logic that retrieve absence types list to use "title" field instead of "name".

![selection_001](https://cloud.githubusercontent.com/assets/17959662/13950230/9e6d44c0-f021-11e5-9cca-53b406f9e906.png)

![selection_002](https://cloud.githubusercontent.com/assets/17959662/13950235/a7a47d10-f021-11e5-96bc-bb15b99bc444.png)

