### PR TITLE
PCHR-868: import job role page

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/HrJobRoles.php
@@ -2,11 +2,12 @@
 
 class CRM_Hrjobroles_BAO_HrJobRoles extends CRM_Hrjobroles_DAO_HrJobRoles {
 
+
   /**
    * Create a new HrJobRoles based on array-data
    *
    * @param array $params key-value pairs
-   * @return CRM_Hrjobroles_DAO_HrJobRoles|NULL
+   * @return CRM_Activity_DAO_HrJobRoles|NULL
    */
   public static function create($params) {
     $entityName = 'HrJobRoles';
@@ -21,7 +22,63 @@ class CRM_Hrjobroles_BAO_HrJobRoles extends CRM_Hrjobroles_DAO_HrJobRoles {
     return $instance;
   }
 
-  public static function importableFields() {
-    return static::import();
+  /**
+   * Get options for a given job roles field along with their database IDs.
+   *
+   * @param String $fieldName
+   *
+   * @return Array
+   */
+  public static function buildDbOptions($fieldName) {
+    $queryParam = array(1 => array($fieldName, 'String'));
+    $query = "SELECT cpv.id, cpv.label from civicrm_option_value cpv
+              LEFT JOIN civicrm_option_group cpg on cpv.option_group_id = cpg.id
+              WHERE cpg.name = %1";
+    $options = array();
+    $result = CRM_Core_DAO::executeQuery($query, $queryParam);
+    while ($result->fetch()) {
+      $options[] =  array( 'id'=>$result->id, 'label'=>strtolower($result->label) );
+    }
+    return $options;
   }
+
+  /**
+   * Check Contact if exist   .
+   *
+   * @param String $searchValue
+   * @param String $searchField
+   * @return Integer ( Contact ID or 0 if not exist)
+   */
+  public static function checkContact($searchValue, $searchField) {
+    $queryParam = array(1 => array($searchValue, 'String'));
+    $query = "SELECT id from civicrm_contact where ".$searchField." = %1";
+    $result = CRM_Core_DAO::executeQuery($query, $queryParam);
+    $result->fetch() ? $result->id : 0;
+  }
+
+
+  /**
+   * Check Job Contract if exist   .
+   *
+   * @param Integer $contractID
+   * @return array|0 ( return 0 if not exist or an array contain some contract details if exist )
+   */
+  public static function checkContract($contractID) {
+    if ( !CRM_Utils_Rule::positiveInteger($contractID))  {
+      return 0;
+    }
+    $queryParam = array(1 => array($contractID, 'Integer'));
+    $query = "SELECT chrjcd.period_start_date, chrjcd.period_end_date from civicrm_hrjobcontract_revision chrjcr
+              left join civicrm_hrjobcontract_details chrjcd on chrjcr.id=chrjcd.jobcontract_revision_id
+              where  chrjcr.jobcontract_id = %1 order by chrjcr.id desc limit 1";
+    $result = CRM_Core_DAO::executeQuery($query, $queryParam);
+    $result->fetch() ? $result : 0;
+  }
+
+  public static function importableFields() {
+    $fields = array('' => array('title' => ts('- do not import -')));
+    return array_merge($fields, static::import());
+  }
+
+
 }

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/DAO/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/DAO/HrJobRoles.php
@@ -275,6 +275,7 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
           'name' => 'job_contract_id',
           'type' => CRM_Utils_Type::T_INT,
           'title' => ts('Job Id') ,
+          'import' => true,
           'required' => true,
         ) ,
         'title' => array(
@@ -283,12 +284,14 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
           'title' => ts('Job Role Title') ,
           'maxlength' => 255,
           'size' => CRM_Utils_Type::HUGE,
+          'import' => true,
           'default' => 'NULL',
         ) ,
         'description' => array(
           'name' => 'description',
           'type' => CRM_Utils_Type::T_TEXT,
           'title' => ts('Job Role Description') ,
+          'import' => true,
         ) ,
         'status' => array(
           'name' => 'status',
@@ -309,7 +312,6 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
           'title' => ts('Hours Unit') ,
           'maxlength' => 63,
           'size' => CRM_Utils_Type::BIG,
-          'import' => true,
           'where' => 'civicrm_hrjobroles.role_hours_unit',
           'headerPattern' => '',
           'dataPattern' => '',
@@ -425,6 +427,7 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
           'title' => ts('Funder Contact ID') ,
           'maxlength' => 255,
           'size' => CRM_Utils_Type::HUGE,
+          'import' => true,
         ) ,
         'hrjc_funder_val_type' => array(
           'name' => 'funder_val_type',

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Controller.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Controller.php
@@ -1,7 +1,7 @@
 <?php
 /*
  +--------------------------------------------------------------------+
- | CiviHR version 1.4                                                |
+ | CiviCRM version 4.5                                                |
  +--------------------------------------------------------------------+
  | Copyright CiviCRM LLC (c) 2004-2014                                |
  +--------------------------------------------------------------------+
@@ -28,32 +28,31 @@
 /**
  *
  * @package CRM
- * @copyright CiviCRM LLC (c) 2004-2013
+ * @copyright CiviCRM LLC (c) 2004-2014
  * $Id$
  *
  */
+class CRM_Hrjobroles_Import_Controller extends CRM_Core_Controller {
 
-/**
- * This class gets the name of the file to upload
- */
-class CRM_Hrjobcontract_Import_Form_DataSource extends CRM_Hrjobcontract_Import_Form_DataSourceBaseClass {
-  public $_parser = 'CRM_Hrjobcontract_Import_Parser_Api';
-  protected $_enableContactOptions = FALSE;
-  protected $_userContext = 'civicrm/job/import';
-  protected $_mappingType = 'Import Job';
-  protected $_entity = array('HRJobContract', 'HRJobContractRevision', 'HRJobDetails', 'HRJobPay', 'HRJobHealth', 'HRJobPension', 'HRJobHour', 'HRJobLeave');
   /**
-  * Include duplicate options
-  */
-  protected $isDuplicateOptions = FALSE;
-
-    /**
-   * Function to actually build the form - this appears to be entirely code that should be in a shared baseclass in core
-   *
-   * @return None
-   * @access public
+   * class constructor
    */
-  public function buildQuickForm() {
-    parent::buildQuickForm();
+  function __construct($title = NULL, $action = CRM_Core_Action::NONE, $modal = TRUE) {
+    parent::__construct($title, $modal);
+
+    // lets get around the time limit issue if possible, CRM-2113
+    if (!ini_get('safe_mode')) {
+      set_time_limit(0);
+    }
+
+    $this->_stateMachine = new CRM_Import_StateMachine($this, $action);
+
+    // create and instantiate the pages
+    $this->addPages($this->_stateMachine, $action);
+
+    // add all the actions
+    $config = CRM_Core_Config::singleton();
+    $this->addActions($config->uploadDir, array('uploadFile'));
   }
 }
+

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Field.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Field.php
@@ -1,0 +1,128 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.5                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2014                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2014
+ * $Id$
+ *
+ */
+class CRM_Hrjobroles_Import_Field {
+
+  /**#@+
+   * @access protected
+   * @var string
+   */
+
+  /**
+   * name of the field
+   */
+  public $_name;
+
+  /**
+   * title of the field to be used in display
+   */
+  public $_title;
+
+  /**
+   * type of field
+   * @var enum
+   */
+  public $_type;
+
+  /**
+   * is this field required
+   * @var boolean
+   */
+  public $_required;
+
+  /**
+   * data to be carried for use by a derived class
+   * @var object
+   */
+  public $_payload;
+
+  /**
+   * regexp to match the CSV header of this column/field
+   * @var string
+   */
+  public $_headerPattern;
+
+  /**
+   * regexp to match the pattern of data from various column/fields
+   * @var string
+   */
+  public $_dataPattern;
+
+  /**
+   * value of this field
+   * @var object
+   */
+  public $_value;
+
+  /**
+   * @param $name
+   * @param $title
+   * @param int $type
+   * @param string $headerPattern
+   * @param string $dataPattern
+   */
+  function __construct($name, $title, $type = CRM_Utils_Type::T_INT, $headerPattern = '//', $dataPattern = '//') {
+    $this->_name = $name;
+    $this->_title = $title;
+    $this->_type = $type;
+    $this->_headerPattern = $headerPattern;
+    $this->_dataPattern = $dataPattern;
+
+    $this->_value = NULL;
+  }
+
+  function resetValue() {
+    $this->_value = NULL;
+  }
+
+  /**
+   * the value is in string format. convert the value to the type of this field
+   * and set the field value with the appropriate type
+   */
+  function setValue($value) {
+    $this->_value = $value;
+  }
+
+  /**
+   * @return bool
+   */
+  function validate() {
+
+    if (CRM_Utils_System::isNull($this->_value)) {
+      return TRUE;
+    }
+    return TRUE;
+  }
+}
+

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/DataSource.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/DataSource.php
@@ -1,0 +1,176 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.5                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2014                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2014
+ * $Id$
+ *
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Hrjobroles_Import_Form_DataSource extends CRM_Core_Form {
+
+  /**
+   * Function to set variables up before form is built
+   *
+   * @return void
+   * @access public
+   */
+  public function preProcess() {
+    $session = CRM_Core_Session::singleton();
+    $session->pushUserContext(CRM_Utils_System::url('civicrm/jobroles/import'));
+    // check for post max size
+    CRM_Core_Config_Defaults::formatUnitSize(ini_get('post_max_size'), TRUE);
+  }
+
+  /**
+   * Function to actually build the form
+   *
+   * @return void
+   * @access public
+   */
+  public function buildQuickForm() {
+    //Setting Upload File Size
+    $config = CRM_Core_Config::singleton();
+
+    $uploadFileSize = CRM_Core_Config_Defaults::formatUnitSize($config->maxFileSize.'m');
+    $uploadSize = round(($uploadFileSize / (1024 * 1024)), 2);
+
+    $this->assign('uploadSize', $uploadSize);
+    $this->setMaxFileSize($uploadFileSize);
+    $this->add('File', 'uploadFile', ts('Import Data File'), 'size=30 maxlength=255', TRUE);
+    $this->addRule('uploadFile', ts('File size should be less than %1 MBytes (%2 bytes)', array(1 => $uploadSize, 2 => $uploadFileSize)), 'maxfilesize', $uploadFileSize);
+    $this->addRule('uploadFile', ts('A valid file must be uploaded.'), 'uploadedfile');
+    $this->addRule('uploadFile', ts('Input file must be in CSV format'), 'utf8File');
+
+    $this->addElement('checkbox', 'skipColumnHeader', ts('First row contains column headers'));
+
+    $duplicateOptions = array();
+    $duplicateOptions[] = $this->createElement('radio',
+      NULL, NULL, ts('Skip'), CRM_Import_Parser::DUPLICATE_SKIP
+    );
+    $duplicateOptions[] = $this->createElement('radio',
+      NULL, NULL, ts('Update'), CRM_Import_Parser::DUPLICATE_UPDATE
+    );
+    $duplicateOptions[] = $this->createElement('radio',
+      NULL, NULL, ts('Fill'), CRM_Import_Parser::DUPLICATE_FILL
+    );
+
+    $this->addGroup($duplicateOptions, 'onDuplicate',
+      ts('On duplicate entries')
+    );
+
+    //get the saved mapping details
+    $mappingArray = CRM_Core_BAO_Mapping::getMappings(CRM_Core_OptionGroup::getValue('mapping_type',
+        'Import Job Roles',
+        'name'
+      ));
+    $this->assign('savedMapping', $mappingArray);
+    $this->add('select', 'savedMapping', ts('Mapping Option'), array('' => ts('- select -')) + $mappingArray);
+
+    if ($loadeMapping = $this->get('loadedMapping')) {
+      $this->assign('loadedMapping', $loadeMapping);
+      $this->setDefaults(array('savedMapping' => $loadeMapping));
+    }
+
+    $this->setDefaults(array(
+      'onDuplicate' =>
+        CRM_Import_Parser::DUPLICATE_SKIP,
+      ));
+
+    //build date formats
+    CRM_Core_Form_Date::buildAllowedDateFormats($this);
+
+    $this->addButtons(array(
+        array(
+          'type' => 'upload',
+          'name' => ts('Continue >>'),
+          'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
+          'isDefault' => TRUE,
+        ),
+        array(
+          'type' => 'cancel',
+          'name' => ts('Cancel'),
+        ),
+      )
+    );
+  }
+
+  /**
+   * Process the uploaded file
+   *
+   * @return void
+   * @access public
+   */
+  public function postProcess() {
+    $this->controller->resetPage('MapField');
+
+    $fileName         = $this->controller->exportValue($this->_name, 'uploadFile');
+    $skipColumnHeader = $this->controller->exportValue($this->_name, 'skipColumnHeader');
+    $onDuplicate      = $this->controller->exportValue($this->_name, 'onDuplicate');
+    $dateFormats      = $this->controller->exportValue($this->_name, 'dateFormats');
+    $savedMapping     = $this->controller->exportValue($this->_name, 'savedMapping');
+
+    $this->set('onDuplicate', $onDuplicate);
+    $this->set('dateFormats', $dateFormats);
+    $this->set('savedMapping', $savedMapping);
+
+    $session = CRM_Core_Session::singleton();
+    $session->set("dateTypes", $dateFormats);
+
+    $config = CRM_Core_Config::singleton();
+    $seperator = $config->fieldSeparator;
+
+    $mapper = array();
+
+    $parser = new CRM_Hrjobroles_Import_Parser_HrJobRoles($mapper);
+    $parser->setMaxLinesToProcess(100);
+    $parser->run($fileName, $seperator,
+      $mapper,
+      $skipColumnHeader,
+      CRM_Import_Parser::MODE_MAPFIELD
+    );
+
+    // add all the necessary variables to the form
+    $parser->set($this);
+  }
+
+  /**
+   * Return a descriptive name for the page, used in wizard header
+   *
+   * @return string
+   * @access public
+   */
+  public function getTitle() {
+    return ts('Upload Data');
+  }
+}
+

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/MapField.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/MapField.php
@@ -1,0 +1,441 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.5                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2014                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2014
+ * $Id$
+ *
+ */
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Hrjobroles_Import_Form_MapField extends CRM_Import_Form_MapField {
+  /**
+   * Function to set variables up before form is built
+   *
+   * @return void
+   * @access public
+   */
+  public function preProcess() {
+    $this->_mapperFields = $this->get('fields');
+    unset($this->_mapperFields['id']);
+    asort($this->_mapperFields);
+
+    $this->_columnCount = $this->get('columnCount');
+    $this->assign('columnCount', $this->_columnCount);
+    $this->_dataValues = $this->get('dataValues');
+    $this->assign('dataValues', $this->_dataValues);
+
+    $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
+
+    if ($skipColumnHeader) {
+      $this->assign('skipColumnHeader', $skipColumnHeader);
+      $this->assign('rowDisplayCount', 3);
+      /* if we had a column header to skip, stash it for later */
+
+      $this->_columnHeaders = $this->_dataValues[0];
+    }
+    else {
+      $this->assign('rowDisplayCount', 2);
+    }
+    $highlightedFields = array();
+    $requiredFields = array('job_contract_id', 'title');
+    foreach ($requiredFields as $val) {
+      $highlightedFields[] = $val;
+    }
+    $this->assign('highlightedFields', $highlightedFields);
+  }
+
+  /**
+   * Function to actually build the form
+   *
+   * @return void
+   * @access public
+   */
+  public function buildQuickForm() {
+    //to save the current mappings
+    if (!$this->get('savedMapping')) {
+      $saveDetailsName = ts('Save this field mapping');
+      $this->applyFilter('saveMappingName', 'trim');
+      $this->add('text', 'saveMappingName', ts('Name'));
+      $this->add('text', 'saveMappingDesc', ts('Description'));
+    }
+    else {
+      $savedMapping = $this->get('savedMapping');
+      //mapping is to be loaded from database
+
+      list($mappingName, $mappingContactType, $mappingLocation, $mappingPhoneType, $mappingRelation) = CRM_Core_BAO_Mapping::getMappingFields($savedMapping);
+
+      //get loaded Mapping Fields
+      $mappingName        = CRM_Utils_Array::value('1', $mappingName);
+      $mappingContactType = CRM_Utils_Array::value('1', $mappingContactType);
+      $mappingLocation    = CRM_Utils_Array::value('1', $mappingLocation);
+      $mappingPhoneType   = CRM_Utils_Array::value('1', $mappingPhoneType);
+      $mappingRelation    = CRM_Utils_Array::value('1', $mappingRelation);
+
+      $this->assign('loadedMapping', $savedMapping);
+      $this->set('loadedMapping', $savedMapping);
+
+      $params         = array('id' => $savedMapping);
+      $temp           = array();
+      $mappingDetails = CRM_Core_BAO_Mapping::retrieve($params, $temp);
+
+      $this->assign('savedName', $mappingDetails->name);
+
+      $this->add('hidden', 'mappingId', $savedMapping);
+
+      $this->addElement('checkbox', 'updateMapping', ts('Update this field mapping'), NULL);
+      $saveDetailsName = ts('Save as a new field mapping');
+      $this->add('text', 'saveMappingName', ts('Name'));
+      $this->add('text', 'saveMappingDesc', ts('Description'));
+    }
+
+    $this->addElement('checkbox', 'saveMapping', $saveDetailsName, NULL, array('onclick' => "showSaveDetails(this)"));
+
+    $this->addFormRule(array('CRM_Hrjobroles_Import_Form_MapField', 'formRule'));
+
+    //-------- end of saved mapping stuff ---------
+
+    $defaults = array();
+    $mapperKeys = array_keys($this->_mapperFields);
+
+    $hasHeaders       = !empty($this->_columnHeaders);
+    $headerPatterns   = $this->get('headerPatterns');
+    $dataPatterns     = $this->get('dataPatterns');
+    $hasLocationTypes = $this->get('fieldTypes');
+
+
+    /* Initialize all field usages to false */
+
+    foreach ($mapperKeys as $key) {
+      $this->_fieldUsed[$key] = FALSE;
+    }
+    $this->_location_types = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
+    $sel1 = $this->_mapperFields;
+
+    $sel2[''] = NULL;
+
+    $js = "<script type='text/javascript'>\n";
+    $formName = 'document.forms.' . $this->_name;
+
+    //used to warn for mismatch column count or mismatch mapping
+    $warning = 0;
+
+
+    for ($i = 0; $i < $this->_columnCount; $i++) {
+      $sel = &$this->addElement('hierselect', "mapper[$i]", ts('Mapper for Field %1', array(1 => $i)), NULL);
+      $jsSet = FALSE;
+      if ($this->get('savedMapping')) {
+        if (isset($mappingName[$i])) {
+          if ($mappingName[$i] != ts('- do not import -')) {
+
+            $mappingHeader = array_keys($this->_mapperFields, $mappingName[$i]);
+
+            if (!isset($locationId) || !$locationId) {
+              $js .= "{$formName}['mapper[$i][1]'].style.display = 'none';\n";
+            }
+
+            if (!isset($phoneType) || !$phoneType) {
+              $js .= "{$formName}['mapper[$i][2]'].style.display = 'none';\n";
+            }
+
+            $js .= "{$formName}['mapper[$i][3]'].style.display = 'none';\n";
+            $defaults["mapper[$i]"] = array(
+              $mappingHeader[0],
+              (isset($locationId)) ? $locationId : "",
+              (isset($phoneType)) ? $phoneType : "",
+            );
+            $jsSet = TRUE;
+          }
+          else {
+            $defaults["mapper[$i]"] = array();
+          }
+          if (!$jsSet) {
+            for ($k = 1; $k < 4; $k++) {
+              $js .= "{$formName}['mapper[$i][$k]'].style.display = 'none';\n";
+            }
+          }
+        }
+        else {
+          // this load section to help mapping if we ran out of saved columns when doing Load Mapping
+          $js .= "swapOptions($formName, 'mapper[$i]', 0, 3, 'hs_mapper_" . $i . "_');\n";
+
+          if ($hasHeaders) {
+            $defaults["mapper[$i]"] = array(
+              $this->defaultFromHeader($this->_columnHeaders[$i],
+                $headerPatterns
+              ));
+          }
+          else {
+            $defaults["mapper[$i]"] = array($this->defaultFromData($dataPatterns, $i));
+          }
+        }
+        //end of load mapping
+      }
+      else {
+        $js .= "swapOptions($formName, 'mapper[$i]', 0, 3, 'hs_mapper_" . $i . "_');\n";
+        if ($hasHeaders) {
+          // Infer the default from the skipped headers if we have them
+          $defaults["mapper[$i]"] = array(
+            $this->defaultFromHeader($this->_columnHeaders[$i],
+              $headerPatterns
+            ),
+            //                     $defaultLocationType->id
+            0,
+          );
+        }
+        else {
+          // Otherwise guess the default from the form of the data
+          $defaults["mapper[$i]"] = array(
+            $this->defaultFromData($dataPatterns, $i),
+            //                     $defaultLocationType->id
+            0,
+          );
+        }
+      }
+
+      $sel->setOptions(array($sel1, $sel2, (isset($sel3)) ? $sel3 : "", (isset($sel4)) ? $sel4 : ""));
+    }
+    $js .= "</script>\n";
+    $this->assign('initHideBoxes', $js);
+
+    //set warning if mismatch in more than
+    if (isset($mappingName)) {
+      if (($this->_columnCount != count($mappingName))) {
+        $warning++;
+      }
+    }
+    if ($warning != 0 && $this->get('savedMapping')) {
+      $session = CRM_Core_Session::singleton();
+      $session->setStatus(ts('The data columns in this import file appear to be different from the saved mapping. Please verify that you have selected the correct saved mapping before continuing.'));
+    }
+    else {
+      $session = CRM_Core_Session::singleton();
+      $session->setStatus(NULL);
+    }
+
+    $this->setDefaults($defaults);
+
+    $this->addButtons(array(
+        array(
+          'type' => 'back',
+          'name' => ts('<< Previous'),
+        ),
+        array(
+          'type' => 'next',
+          'name' => ts('Continue >>'),
+          'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
+          'isDefault' => TRUE,
+        ),
+        array(
+          'type' => 'cancel',
+          'name' => ts('Cancel'),
+        ),
+      )
+    );
+  }
+
+  /**
+   * global validation rules for the form
+   *
+   * @param array $fields posted values of the form
+   *
+   * @return array list of errors to be posted back to the form
+   * @static
+   * @access public
+   */
+  static function formRule($fields) {
+    $errors = array();
+    // define so we avoid notices below
+    $errors['_qf_default'] = '';
+
+    $fieldMessage = NULL;
+    if (!array_key_exists('savedMapping', $fields)) {
+      $importKeys = array();
+      foreach ($fields['mapper'] as $mapperPart) {
+        $importKeys[] = $mapperPart[0];
+      }
+      // FIXME: should use the schema titles, not redeclare them
+      $requiredFields = array(
+        'job_contract_id' => ts('Contract ID'),
+        'title' => ts('Job Role Title')
+      );
+
+
+      foreach ($requiredFields as $field => $title) {
+        if (!in_array($field, $importKeys)) {
+            $errors['_qf_default'] .= ts('Missing required field: %1', array(1 => $title)) . '<br />';
+        }
+      }
+
+      if (in_array('hrjc_cost_center', $importKeys))  {
+        if (!in_array('hrjc_cost_center_val_type', $importKeys))  {
+          $errors['_qf_default'] .= ts('Missing required field: %1', array(1 => 'Cost center value type')) . '<br />';
+        }
+        if (!in_array('hrjc_role_amount_pay_cost_center', $importKeys) &&  !in_array('hrjc_role_percent_pay_cost_center', $importKeys))  {
+          $errors['_qf_default'] .= ts('Missing one of these fields: (%1) | (%2)', array(1 => 'Amount of Pay Assigned to this cost center', 2 => 'Percent of Pay Assigned to this cost center')) . '<br />';
+        }
+      }
+
+      if (in_array('funder', $importKeys))  {
+        if (!in_array('hrjc_funder_val_type', $importKeys))  {
+          $errors['_qf_default'] .= ts('Missing required field: %1', array(1 => 'Funder value type')) . '<br />';
+        }
+        if (!in_array('hrjc_role_amount_pay_funder', $importKeys) && !in_array('hrjc_role_percent_pay_funder', $importKeys))  {
+          $errors['_qf_default'] .= ts('Missing one of these fields: (%1) | (%2)', array(1 => 'Amount of Pay Assigned to this funder', 2 => 'Percent of Pay Assigned to this funder')) . '<br />';
+        }
+      }
+
+    }
+
+
+    if (!empty($fields['saveMapping'])) {
+      $nameField = CRM_Utils_Array::value('saveMappingName', $fields);
+      if (empty($nameField)) {
+        $errors['saveMappingName'] = ts('Name is required to save Import Mapping');
+      }
+      else {
+        $mappingTypeId = CRM_Core_OptionGroup::getValue('mapping_type', 'Import Job Roles', 'name');
+        if (CRM_Core_BAO_Mapping::checkMapping($nameField, $mappingTypeId)) {
+          $errors['saveMappingName'] = ts('Duplicate Import Mapping Name');
+        }
+      }
+    }
+
+    if (empty($errors['_qf_default'])) {
+      unset($errors['_qf_default']);
+    }
+    if (!empty($errors)) {
+      if (!empty($errors['saveMappingName'])) {
+        $_flag = 1;
+        $assignError = new CRM_Core_Page();
+        $assignError->assign('mappingDetailsError', $_flag);
+      }
+      return $errors;
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Process the mapped fields and map it into the uploaded file
+   * preview the file and extract some summary statistics
+   *
+   * @return void
+   * @access public
+   */
+  public function postProcess() {
+    $params = $this->controller->exportValues('MapField');
+    //reload the mapfield if load mapping is pressed
+    if (!empty($params['savedMapping'])) {
+      $this->set('savedMapping', $params['savedMapping']);
+      $this->controller->resetPage($this->_name);
+      return;
+    }
+
+    $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
+    $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
+
+    $config = CRM_Core_Config::singleton();
+    $seperator = $config->fieldSeparator;
+
+    $mapper          = array();
+    $mapperKeys      = $this->controller->exportValue($this->_name, 'mapper');
+    $mapperKeysMain  = array();
+
+
+    for ($i = 0; $i < $this->_columnCount; $i++) {
+      $mapper[$i] = $this->_mapperFields[$mapperKeys[$i][0]];
+      $mapperKeysMain[$i] = $mapperKeys[$i][0];
+    }
+
+    $this->set('mapper', $mapper);
+    // store mapping Id to display it in the preview page
+    if (!empty($params['mappingId'])) {
+      $this->set('loadMappingId', $params['mappingId']);
+    }
+
+    //Updating Mapping Records
+    if (!empty($params['updateMapping'])) {
+
+      $mappingFields = new CRM_Core_DAO_MappingField();
+      $mappingFields->mapping_id = $params['mappingId'];
+      $mappingFields->find();
+
+      $mappingFieldsId = array();
+      while ($mappingFields->fetch()) {
+        if ($mappingFields->id) {
+          $mappingFieldsId[$mappingFields->column_number] = $mappingFields->id;
+        }
+      }
+
+      for ($i = 0; $i < $this->_columnCount; $i++) {
+        $updateMappingFields = new CRM_Core_DAO_MappingField();
+        $updateMappingFields->id = $mappingFieldsId[$i];
+        $updateMappingFields->mapping_id = $params['mappingId'];
+        $updateMappingFields->column_number = $i;
+
+        $updateMappingFields->name = $mapper[$i];
+        $updateMappingFields->save();
+      }
+    }
+
+    //Saving Mapping Details and Records
+    if (!empty($params['saveMapping'])) {
+      $mappingParams = array(
+        'name' => $params['saveMappingName'],
+        'description' => $params['saveMappingDesc'],
+        'mapping_type_id' => CRM_Core_OptionGroup::getValue('mapping_type',
+          'Import Job Roles',
+          'name'
+        ),
+      );
+      $saveMapping = CRM_Core_BAO_Mapping::add($mappingParams);
+
+      for ($i = 0; $i < $this->_columnCount; $i++) {
+        $saveMappingFields = new CRM_Core_DAO_MappingField();
+        $saveMappingFields->mapping_id = $saveMapping->id;
+        $saveMappingFields->column_number = $i;
+
+        $saveMappingFields->name = $mapper[$i];
+        $saveMappingFields->save();
+      }
+      $this->set('savedMapping', $saveMappingFields->mapping_id);
+    }
+
+
+    $parser = new CRM_Hrjobroles_Import_Parser_HrJobRoles($mapperKeysMain);
+    $parser->run($fileName, $seperator, $mapper, $skipColumnHeader,
+      CRM_Import_Parser::MODE_PREVIEW
+    );
+
+    // add all the necessary variables to the form
+    $parser->set($this);
+  }
+}
+

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/Preview.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/Preview.php
@@ -1,0 +1,179 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.5                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2014                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2014
+ * $Id$
+ *
+ */
+
+/**
+ * This class previews the uploaded file and returns summary
+ * statistics
+ */
+class CRM_Hrjobroles_Import_Form_Preview extends CRM_Import_Form_Preview {
+
+  /**
+   * Function to set variables up before form is built
+   *
+   * @return void
+   * @access public
+   */
+  public function preProcess() {
+    $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
+
+    //get the data from the session
+    $dataValues       = $this->get('dataValues');
+    $mapper           = $this->get('mapper');
+    $invalidRowCount  = $this->get('invalidRowCount');
+    $conflictRowCount = $this->get('conflictRowCount');
+    $mismatchCount    = $this->get('unMatchCount');
+
+    //get the mapping name displayed if the mappingId is set
+    $mappingId = $this->get('loadMappingId');
+    if ($mappingId) {
+      $mapDAO = new CRM_Core_DAO_Mapping();
+      $mapDAO->id = $mappingId;
+      $mapDAO->find(TRUE);
+      $this->assign('loadedMapping', $mappingId);
+      $this->assign('savedName', $mapDAO->name);
+    }
+
+    if ($skipColumnHeader) {
+      $this->assign('skipColumnHeader', $skipColumnHeader);
+      $this->assign('rowDisplayCount', 3);
+    }
+    else {
+      $this->assign('rowDisplayCount', 2);
+    }
+
+    if ($invalidRowCount) {
+      $urlParams = 'type=' . CRM_Import_Parser::ERROR . '&parser=CRM_Hrjobroles_Import_Parser';
+      $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
+    }
+
+    if ($conflictRowCount) {
+      $urlParams = 'type=' . CRM_Import_Parser::CONFLICT . '&parser=CRM_Hrjobroles_Import_Parser';
+      $this->set('downloadConflictRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
+    }
+
+    if ($mismatchCount) {
+      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Hrjobroles_Import_Parser';
+      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
+    }
+
+    $properties = array(
+      'mapper',
+      'dataValues', 'columnCount',
+      'totalRowCount', 'validRowCount',
+      'invalidRowCount', 'conflictRowCount',
+      'downloadErrorRecordsUrl',
+      'downloadConflictRecordsUrl',
+      'downloadMismatchRecordsUrl',
+    );
+
+    foreach ($properties as $property) {
+      $this->assign($property, $this->get($property));
+    }
+  }
+
+  /**
+   * Process the mapped fields and map it into the uploaded file
+   * preview the file and extract some summary statistics
+   *
+   * @return void
+   * @access public
+   */
+  public function postProcess() {
+    $fileName         = $this->controller->exportValue('DataSource', 'uploadFile');
+    $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
+    $invalidRowCount  = $this->get('invalidRowCount');
+    $conflictRowCount = $this->get('conflictRowCount');
+    $onDuplicate      = $this->get('onDuplicate');
+
+    $config = CRM_Core_Config::singleton();
+    $seperator = $config->fieldSeparator;
+
+    $mapper = $this->controller->exportValue('MapField', 'mapper');
+    $mapperKeys = array();
+
+    foreach ($mapper as $key => $value) {
+      $mapperKeys[$key] = $mapper[$key][0];
+    }
+
+    $parser = new CRM_Hrjobroles_Import_Parser_HrJobRoles($mapperKeys);
+
+    $mapFields = $this->get('fields');
+
+    foreach ($mapper as $key => $value) {
+      $header = array();
+      if (isset($mapFields[$mapper[$key][0]])) {
+        $header[] = $mapFields[$mapper[$key][0]];
+      }
+      $mapperFields[] = implode(' - ', $header);
+    }
+    $parser->run($fileName, $seperator,
+      $mapperFields,
+      $skipColumnHeader,
+      CRM_Import_Parser::MODE_IMPORT,
+      $onDuplicate
+    );
+
+    // add all the necessary variables to the form
+    $parser->set($this, CRM_Import_Parser::MODE_IMPORT);
+
+    // check if there is any error occured
+
+    $errorStack = CRM_Core_Error::singleton();
+    $errors = $errorStack->getErrors();
+    $errorMessage = array();
+
+    if (is_array($errors)) {
+      foreach ($errors as $key => $value) {
+        $errorMessage[] = $value['message'];
+      }
+
+      $errorFile = $fileName['name'] . '.error.log';
+
+      if ($fd = fopen($errorFile, 'w')) {
+        fwrite($fd, implode('\n', $errorMessage));
+      }
+      fclose($fd);
+
+      $this->set('errorFile', $errorFile);
+      $urlParams = 'type=' . CRM_Import_Parser::ERROR . '&parser=CRM_Hrjobroles_Import_Parser';
+      $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
+      $urlParams = 'type=' . CRM_Import_Parser::CONFLICT . '&parser=CRM_Hrjobroles_Import_Parser';
+      $this->set('downloadConflictRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
+      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Hrjobroles_Import_Parser';
+      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
+    }
+  }
+}
+

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/Summary.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/Summary.php
@@ -1,0 +1,105 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.5                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2014                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2014
+ * $Id$
+ *
+ */
+
+/**
+ * This class summarizes the import results
+ */
+class CRM_Hrjobroles_Import_Form_Summary extends CRM_Import_Form_Summary {
+
+  /**
+   * Function to set variables up before form is built
+   *
+   * @return void
+   * @access public
+   */
+  public function preProcess() {
+
+    // set the error message path to display
+    $errorFile = $this->assign('errorFile', $this->get('errorFile'));
+
+    $totalRowCount = $this->get('totalRowCount');
+    $relatedCount = $this->get('relatedCount');
+    $totalRowCount += $relatedCount;
+    $this->set('totalRowCount', $totalRowCount);
+
+    $invalidRowCount = $this->get('invalidRowCount');
+    $conflictRowCount = $this->get('conflictRowCount');
+    $duplicateRowCount = $this->get('duplicateRowCount');
+    $onDuplicate = $this->get('onDuplicate');
+    $mismatchCount = $this->get('unMatchCount');
+    if ($duplicateRowCount > 0) {
+      $urlParams = 'type=' . CRM_Import_Parser::DUPLICATE . '&parser=CRM_Hrjobroles_Import_Parser';
+      $this->set('downloadDuplicateRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
+    }
+    elseif ($mismatchCount) {
+      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Hrjobroles_Import_Parser';
+      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
+    }
+    else {
+      $duplicateRowCount = 0;
+      $this->set('duplicateRowCount', $duplicateRowCount);
+    }
+
+    $this->assign('dupeError', FALSE);
+
+    if ($onDuplicate == CRM_Import_Parser::DUPLICATE_UPDATE) {
+      $dupeActionString = ts('These records have been updated with the imported data.');
+    }
+    elseif ($onDuplicate == CRM_Import_Parser::DUPLICATE_FILL) {
+      $dupeActionString = ts('These records have been filled in with the imported data.');
+    }
+    else {
+      /* Skip by default */
+
+      $dupeActionString = ts('These records have not been imported.');
+
+      $this->assign('dupeError', TRUE);
+
+      /* only subtract dupes from successful import if we're skipping */
+
+      $this->set('validRowCount', $totalRowCount - $invalidRowCount -
+        $conflictRowCount - $duplicateRowCount - $mismatchCount
+      );
+    }
+    $this->assign('dupeActionString', $dupeActionString);
+
+    $properties = array('totalRowCount', 'validRowCount', 'invalidRowCount', 'conflictRowCount', 'downloadConflictRecordsUrl', 'downloadErrorRecordsUrl', 'duplicateRowCount', 'downloadDuplicateRecordsUrl', 'downloadMismatchRecordsUrl', 'groupAdditions', 'unMatchCount');
+    foreach ($properties as $property) {
+      $this->assign($property, $this->get($property));
+    }
+  }
+
+}
+

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Parser.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Parser.php
@@ -1,0 +1,405 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.5                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2014                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2014
+ * $Id$
+ *
+ */
+
+
+abstract class CRM_Hrjobroles_Import_Parser extends CRM_Import_Parser {
+
+  protected $_fileName;
+
+  /**#@+
+   * @access protected
+   * @var integer
+   */
+
+  /**
+   * imported file size
+   */
+  protected $_fileSize;
+
+  /**
+   * seperator being used
+   */
+  protected $_seperator;
+
+  /**
+   * total number of lines in file
+   */
+  protected $_lineCount;
+
+  /**
+   * whether the file has a column header or not
+   *
+   * @var boolean
+   */
+  protected $_haveColumnHeader;
+
+  /**
+   * @param $fileName
+   * @param string $seperator
+   * @param $mapper
+   * @param bool $skipColumnHeader
+   * @param int $mode
+   * @param int $onDuplicate
+   *
+   * @return mixed
+   * @throws Exception
+   */
+  function run($fileName,
+    $seperator = ',',
+    &$mapper,
+    $skipColumnHeader = FALSE,
+    $mode = self::MODE_PREVIEW,
+    $onDuplicate = self::DUPLICATE_SKIP
+  ) {
+    if (!is_array($fileName)) {
+      CRM_Core_Error::fatal();
+    }
+    $fileName = $fileName['name'];
+
+    $this->init();
+
+    $this->_haveColumnHeader = $skipColumnHeader;
+
+    $this->_seperator = $seperator;
+
+    $fd = fopen($fileName, "r");
+    if (!$fd) {
+      return FALSE;
+    }
+
+    $this->_lineCount = $this->_warningCount = 0;
+    $this->_invalidRowCount = $this->_validCount = 0;
+    $this->_totalCount = $this->_conflictCount = 0;
+
+    $this->_errors = array();
+    $this->_warnings = array();
+    $this->_conflicts = array();
+
+    $this->_fileSize = number_format(filesize($fileName) / 1024.0, 2);
+
+    if ($mode == self::MODE_MAPFIELD) {
+      $this->_rows = array();
+    }
+    else {
+      $this->_activeFieldCount = count($this->_activeFields);
+    }
+
+    while (!feof($fd)) {
+      $this->_lineCount++;
+
+      $values = fgetcsv($fd, 8192, $seperator);
+      if (!$values) {
+        continue;
+      }
+
+      self::encloseScrub($values);
+
+      // skip column header if we're not in mapfield mode
+      if ($mode != self::MODE_MAPFIELD && $skipColumnHeader) {
+        $skipColumnHeader = FALSE;
+        continue;
+      }
+
+      /* trim whitespace around the values */
+
+      $empty = TRUE;
+      foreach ($values as $k => $v) {
+        $values[$k] = trim($v, " \t\r\n");
+      }
+
+      if (CRM_Utils_System::isNull($values)) {
+        continue;
+      }
+
+      $this->_totalCount++;
+
+      if ($mode == self::MODE_MAPFIELD) {
+        $returnCode = $this->mapField($values);
+      }
+      elseif ($mode == self::MODE_PREVIEW) {
+        $returnCode = $this->preview($values);
+      }
+      elseif ($mode == self::MODE_SUMMARY) {
+        $returnCode = $this->summary($values);
+      }
+      elseif ($mode == self::MODE_IMPORT) {
+        $returnCode = $this->import($onDuplicate, $values);
+      }
+      else {
+        $returnCode = self::ERROR;
+      }
+
+      // note that a line could be valid but still produce a warning
+      if ($returnCode & self::VALID) {
+        $this->_validCount++;
+        if ($mode == self::MODE_MAPFIELD) {
+          $this->_rows[] = $values;
+          $this->_activeFieldCount = max($this->_activeFieldCount, count($values));
+        }
+      }
+
+      if ($returnCode & self::WARNING) {
+        $this->_warningCount++;
+        if ($this->_warningCount < $this->_maxWarningCount) {
+          $this->_warningCount[] = $line;
+        }
+      }
+
+      if ($returnCode & self::ERROR) {
+        $this->_invalidRowCount++;
+        if ($this->_invalidRowCount < $this->_maxErrorCount) {
+          $recordNumber = $this->_lineCount;
+          if ($this->_haveColumnHeader) {
+            $recordNumber--;
+          }
+          array_unshift($values, $recordNumber);
+          $this->_errors[] = $values;
+        }
+      }
+
+      if ($returnCode & self::CONFLICT) {
+        $this->_conflictCount++;
+        $recordNumber = $this->_lineCount;
+        if ($this->_haveColumnHeader) {
+          $recordNumber--;
+        }
+        array_unshift($values, $recordNumber);
+        $this->_conflicts[] = $values;
+      }
+
+      if ($returnCode & self::DUPLICATE) {
+        if ($returnCode & self::MULTIPLE_DUPE) {
+          /* TODO: multi-dupes should be counted apart from singles
+                     * on non-skip action */
+        }
+        $this->_duplicateCount++;
+        $recordNumber = $this->_lineCount;
+        if ($this->_haveColumnHeader) {
+          $recordNumber--;
+        }
+        array_unshift($values, $recordNumber);
+        $this->_duplicates[] = $values;
+        if ($onDuplicate != self::DUPLICATE_SKIP) {
+          $this->_validCount++;
+        }
+      }
+
+      // we give the derived class a way of aborting the process
+      // note that the return code could be multiple code or'ed together
+      if ($returnCode & self::STOP) {
+        break;
+      }
+
+      // if we are done processing the maxNumber of lines, break
+      if ($this->_maxLinesToProcess > 0 && $this->_validCount >= $this->_maxLinesToProcess) {
+        break;
+      }
+    }
+
+    fclose($fd);
+
+
+    if ($mode == self::MODE_PREVIEW || $mode == self::MODE_IMPORT) {
+      $customHeaders = $mapper;
+
+
+      if ($this->_invalidRowCount) {
+        // removed view url for invlaid contacts
+        $headers = array_merge(array(ts('Line Number'),
+            ts('Reason'),
+          ),
+          $customHeaders
+        );
+        $this->_errorFileName = self::errorFileName(self::ERROR);
+        self::exportCSV($this->_errorFileName, $headers, $this->_errors);
+      }
+      if ($this->_conflictCount) {
+        $headers = array_merge(array(ts('Line Number'),
+            ts('Reason'),
+          ),
+          $customHeaders
+        );
+        $this->_conflictFileName = self::errorFileName(self::CONFLICT);
+        self::exportCSV($this->_conflictFileName, $headers, $this->_conflicts);
+      }
+      if ($this->_duplicateCount) {
+        $headers = array_merge(array(ts('Line Number'),
+            ts('Reason'),
+          ),
+          $customHeaders
+        );
+
+        $this->_duplicateFileName = self::errorFileName(self::DUPLICATE);
+        self::exportCSV($this->_duplicateFileName, $headers, $this->_duplicates);
+      }
+    }
+
+    return $this->fini();
+  }
+
+  /**
+   * Given a list of the importable field keys that the user has selected
+   * set the active fields array to this list
+   *
+   * @param array mapped array of values
+   *
+   * @return void
+   * @access public
+   */
+  function setActiveFields($fieldKeys) {
+    $this->_activeFieldCount = count($fieldKeys);
+    foreach ($fieldKeys as $key) {
+      if (empty($this->_fields[$key])) {
+        $this->_activeFields[] = new CRM_Hrjobroles_Import_Field('', ts('- do not import -'));
+      }
+      else {
+        $this->_activeFields[] = clone($this->_fields[$key]);
+      }
+    }
+  }
+
+  /**
+   * function to format the field values for input to the api
+   *
+   * @return array (reference ) associative array of name/value pairs
+   * @access public
+   */
+  function &getActiveFieldParams() {
+    $params = array();
+    for ($i = 0; $i < $this->_activeFieldCount; $i++) {
+      if (isset($this->_activeFields[$i]->_value)
+        && !isset($params[$this->_activeFields[$i]->_name])
+        && !isset($this->_activeFields[$i]->_related)
+      ) {
+
+        $params[$this->_activeFields[$i]->_name] = $this->_activeFields[$i]->_value;
+      }
+    }
+    return $params;
+  }
+
+  /**
+   * @param $name
+   * @param $title
+   * @param int $type
+   * @param string $headerPattern
+   * @param string $dataPattern
+   */
+  function addField($name, $title, $type = CRM_Utils_Type::T_INT, $headerPattern = '//', $dataPattern = '//') {
+    if (empty($name)) {
+      $this->_fields['doNotImport'] = new CRM_Hrjobroles_Import_Field($name, $title, $type, $headerPattern, $dataPattern);
+    }
+    else {
+        $this->_fields[$name] = new CRM_Hrjobroles_Import_Field($name, $title, $type, $headerPattern, $dataPattern);
+    }
+  }
+
+  /**
+   * Store parser values
+   *
+   * @param CRM_Core_Session $store
+   *
+   * @param int $mode
+   *
+   * @return void
+   * @access public
+   */
+  function set($store, $mode = self::MODE_SUMMARY) {
+    $store->set('fileSize', $this->_fileSize);
+    $store->set('lineCount', $this->_lineCount);
+    $store->set('seperator', $this->_seperator);
+    $store->set('fields', $this->getSelectValues());
+    $store->set('fieldTypes', $this->getSelectTypes());
+
+    $store->set('headerPatterns', $this->getHeaderPatterns());
+    $store->set('dataPatterns', $this->getDataPatterns());
+    $store->set('columnCount', $this->_activeFieldCount);
+
+    $store->set('totalRowCount', $this->_totalCount);
+    $store->set('validRowCount', $this->_validCount);
+    $store->set('invalidRowCount', $this->_invalidRowCount);
+    $store->set('conflictRowCount', $this->_conflictCount);
+
+    if ($this->_invalidRowCount) {
+      $store->set('errorsFileName', $this->_errorFileName);
+    }
+    if ($this->_conflictCount) {
+      $store->set('conflictsFileName', $this->_conflictFileName);
+    }
+    if (isset($this->_rows) && !empty($this->_rows)) {
+      $store->set('dataValues', $this->_rows);
+    }
+
+    if ($mode == self::MODE_IMPORT) {
+      $store->set('duplicateRowCount', $this->_duplicateCount);
+      if ($this->_duplicateCount) {
+        $store->set('duplicatesFileName', $this->_duplicateFileName);
+      }
+    }
+  }
+
+  /**
+   * Export data to a CSV file
+   *
+   * @param $fileName
+   * @param array $header
+   * @param data $data
+   *
+   * @internal param string $filename
+   * @return void
+   * @access public
+   */
+  static function exportCSV($fileName, $header, $data) {
+    $output = array();
+    $fd = fopen($fileName, 'w');
+
+    foreach ($header as $key => $value) {
+      $header[$key] = "\"$value\"";
+    }
+    $config = CRM_Core_Config::singleton();
+    $output[] = implode($config->fieldSeparator, $header);
+
+    foreach ($data as $datum) {
+      foreach ($datum as $key => $value) {
+        $datum[$key] = "\"$value\"";
+      }
+      $output[] = implode($config->fieldSeparator, $datum);
+    }
+    fwrite($fd, implode("\n", $output));
+    fclose($fd);
+  }
+
+}
+

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Parser/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Parser/HrJobRoles.php
@@ -1,0 +1,401 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.5                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2014                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2014
+ * $Id$
+ *
+ */
+
+require_once 'api/api.php';
+
+/**
+ * class to parse activity csv files
+ */
+class CRM_Hrjobroles_Import_Parser_HrJobRoles extends CRM_Hrjobroles_Import_Parser {
+
+  protected $_mapperKeys;
+
+
+  /**
+   * Array of select lists options in job roles page
+   *
+   * @var array
+   */
+
+  private $_optionsList;
+
+  /**
+   * Array of parameters to be imported
+   *
+   * @var array
+   */
+
+  private $_params;
+
+  /**
+   * Array of successfully imported activity id's
+   *
+   * @array
+   */
+  protected $_newJobRole;
+
+  /**
+   * class constructor
+   */
+  function __construct(&$mapperKeys) {
+    parent::__construct();
+    $this->_mapperKeys = &$mapperKeys;
+  }
+
+  /**
+   * the initializer code, called before the processing
+   *
+   * @return void
+   * @access public
+   */
+  function init() {
+    $fields = CRM_Hrjobroles_BAO_HrJobRoles::importableFields();
+
+    foreach ($fields as $name => $field) {
+      $field['type'] = CRM_Utils_Array::value('type', $field, CRM_Utils_Type::T_INT);
+      $field['dataPattern'] = CRM_Utils_Array::value('dataPattern', $field, '//');
+      $field['headerPattern'] = CRM_Utils_Array::value('headerPattern', $field, '//');
+      $this->addField($name, $field['title'], $field['type'], $field['headerPattern'], $field['dataPattern']);
+    }
+
+    $this->_newJobRole = array();
+
+    $this->setActiveFields($this->_mapperKeys);
+
+
+    // Fetch select list options from the database and cache them
+    $this->_optionsList['location'] = CRM_Hrjobroles_BAO_HrJobRoles::buildDbOptions('hrjc_location');
+    $this->_optionsList['region'] = CRM_Hrjobroles_BAO_HrJobRoles::buildDbOptions('hrjc_region');
+    $this->_optionsList['hrjc_role_department'] = CRM_Hrjobroles_BAO_HrJobRoles::buildDbOptions('hrjc_department');
+    $this->_optionsList['hrjc_level_type'] = CRM_Hrjobroles_BAO_HrJobRoles::buildDbOptions('hrjc_level_type');
+    $this->_optionsList['hrjc_cost_center'] = CRM_Hrjobroles_BAO_HrJobRoles::buildDbOptions('cost_centres');
+
+  }
+
+  /**
+   * handle the values in mapField mode
+   *
+   * @param array $values the array of values belonging to this line
+   *
+   * @return boolean
+   * @access public
+   */
+  function mapField(&$values) {
+    return CRM_Import_Parser::VALID;
+  }
+
+  /**
+   * handle the values in preview mode
+   *
+   * @param array $values the array of values belonging to this line
+   *
+   * @return boolean      the result of this processing
+   * @access public
+   */
+  function preview(&$values) {
+    return $this->summary($values);
+  }
+
+  /**
+   * handle the values in summary mode
+   *
+   * @param array $values the array of values belonging to this line
+   *
+   * @return boolean      the result of this processing
+   * @access public
+   */
+  function summary(&$values) {
+    $erroneousField = NULL;
+    $this->setActiveFieldValues($values, $erroneousField);
+
+    $params = &$this->getActiveFieldParams();
+
+    $errorMessage = NULL;
+
+    //for date-Formats
+    $session = CRM_Core_Session::singleton();
+    $dateType = $session->get('dateTypes');
+
+    $contractDetails = CRM_Hrjobroles_BAO_HrJobRoles::checkContract($params['job_contract_id']);
+    if ($contractDetails == 0)  {
+      CRM_Contact_Import_Parser_Contact::addToErrorMsg('job contract ID is not found', $errorMessage);
+    }
+    else  {
+
+      // check some parameters if they are valid
+
+      foreach ($params as $key => $val) {
+        switch($key)  {
+          case 'title':
+            if (empty($val)) {
+                CRM_Contact_Import_Parser_Contact::addToErrorMsg('job role title is required', $errorMessage);
+            }
+            break;
+          case 'hrjc_role_start_date':
+            if ($val) {
+              $dateValue = CRM_Utils_Date::formatDate($val, $dateType);
+              if ($dateValue) {
+                $params[$key] = $dateValue;
+              }
+              else {
+                CRM_Contact_Import_Parser_Contact::addToErrorMsg('start date is not a valid date', $errorMessage);
+              }
+            }
+            break;
+          case 'hrjc_role_end_date':
+            if ($val) {
+              $dateValue = CRM_Utils_Date::formatDate($val, $dateType);
+              if ($dateValue) {
+                $params[$key] = $dateValue;
+              }
+              else {
+                CRM_Contact_Import_Parser_Contact::addToErrorMsg('end date is not a valid date', $errorMessage);
+              }
+            }
+            break;
+          case 'hrjc_role_amount_pay_cost_center':
+            if ( !filter_var($val, FILTER_VALIDATE_FLOAT) || $val < 0)  {
+              CRM_Contact_Import_Parser_Contact::addToErrorMsg('Amount of Pay Assigned to cost center should be positive number', $errorMessage);
+            }
+            break;
+          case 'hrjc_role_amount_pay_funder':
+            if ( !filter_var($val, FILTER_VALIDATE_FLOAT) || $val < 0 )  {
+              CRM_Contact_Import_Parser_Contact::addToErrorMsg('Amount of Pay Assigned to funder should be positive number', $errorMessage);
+            }
+            break;
+          case 'hrjc_role_percent_pay_cost_center':
+            if ( !CRM_Utils_Rule::positiveInteger($val))  {
+              CRM_Contact_Import_Parser_Contact::addToErrorMsg('Percent of Pay Assigned to cost center should be positive number', $errorMessage);
+            }
+            break;
+          case 'hrjc_role_percent_pay_funder':
+            if ( !filter_var($val, FILTER_VALIDATE_FLOAT) || $val < 0 )  {
+              CRM_Contact_Import_Parser_Contact::addToErrorMsg('Percent of Pay Assigned to funder should be positive number', $errorMessage);
+            }
+            break;
+          case 'hrjc_funder_val_type':
+            if ( $val != 0 && $val != 1)  {
+              CRM_Contact_Import_Parser_Contact::addToErrorMsg('funder value type should be either 0 or 1', $errorMessage);
+            }
+            break;
+          case 'hrjc_cost_center_val_type':
+            if ( $val != 0 && $val != 1)  {
+              CRM_Contact_Import_Parser_Contact::addToErrorMsg('cost center value type should be either 0 or 1', $errorMessage);
+            }
+            break;
+          case 'location':
+            if ( !empty($val)) {
+              $optionID = $this->getOptionKey($key, $val);
+              if ($optionID != 0) {
+                $params[$key] = $optionID;
+              } else {
+                CRM_Contact_Import_Parser_Contact::addToErrorMsg('location is not found', $errorMessage);
+              }
+            }
+            break;
+          case 'region':
+            if ( !empty($val)) {
+              $optionID = $this->getOptionKey($key, $val);
+              if ($optionID != 0) {
+                $params[$key] = $optionID;
+              } else {
+                CRM_Contact_Import_Parser_Contact::addToErrorMsg('region is not found', $errorMessage);
+              }
+            }
+            break;
+          case 'hrjc_role_department':
+            if ( !empty($val)) {
+              $optionID = $this->getOptionKey($key, $val);
+              if ($optionID != 0) {
+                $params[$key] = $optionID;
+              } else {
+                CRM_Contact_Import_Parser_Contact::addToErrorMsg('department is not found', $errorMessage);
+              }
+            }
+            break;
+          case 'hrjc_level_type':
+            if ( !empty($val)) {
+              $optionID = $this->getOptionKey($key, $val);
+              if ($optionID != 0) {
+                $params[$key] = $optionID;
+              } else {
+                CRM_Contact_Import_Parser_Contact::addToErrorMsg('level type is not found', $errorMessage);
+              }
+            }
+            break;
+          case 'hrjc_cost_center':
+            if ( !empty($val)) {
+              $optionID = $this->getOptionKey($key, $val);
+              if ($optionID != 0) {
+                $params[$key] = $optionID;
+              } else {
+                CRM_Contact_Import_Parser_Contact::addToErrorMsg('cost center is not found', $errorMessage);
+              }
+            }
+            break;
+        }
+      }
+
+      // check if job role start and end dates if exist matches or within contract start and end dates
+
+      $contractStartDate = CRM_Utils_Date::formatDate($contractDetails->period_start_date, $dateType);
+      $contractEndDate = CRM_Utils_Date::formatDate($contractDetails->period_end_date, $dateType);
+
+      if (isset($params['hrjc_role_start_date']))  {
+        $roleStartDate = $params['hrjc_role_start_date'];
+        if ($roleStartDate < $contractStartDate)  {
+          CRM_Contact_Import_Parser_Contact::addToErrorMsg('job role start date should not be before contract start date', $errorMessage);
+        }
+        if (isset($contractEndDate) && ($roleStartDate > $contractEndDate) )  {
+          CRM_Contact_Import_Parser_Contact::addToErrorMsg('job role start date should not be after contract end date', $errorMessage);
+        }
+      }
+      else  {
+        $params['hrjc_role_start_date'] = $contractStartDate;
+      }
+
+      if (isset($params['hrjc_role_end_date']))  {
+        $roleEndDate = $params['hrjc_role_end_date'];
+        if ($roleEndDate <=  $params['hrjc_role_start_date'])  {
+          CRM_Contact_Import_Parser_Contact::addToErrorMsg('job role end date should not be before or equal job role start date', $errorMessage);
+        }
+        if (isset($contractEndDate) && $roleEndDate > $contractEndDate)  {
+          CRM_Contact_Import_Parser_Contact::addToErrorMsg('job role end date should not be after contract end date', $errorMessage);
+        }
+      }
+      elseif (isset($contractEndDate))  {
+        $params['hrjc_role_start_date'] = $contractEndDate;
+      }
+
+      if (!empty($params['funder'])) {
+        $funder_value = $params['funder'];
+        if (is_numeric ($funder_value))  {
+          $search_field = 'id';
+        }
+        else {
+          $search_field = 'display_name';
+        }
+
+        $result = CRM_Hrjobroles_BAO_HrJobRoles::checkContact($funder_value, $search_field);
+        if ($result != 0)  {
+          $params['funder'] = $result;
+        }
+        else  {
+          CRM_Contact_Import_Parser_Contact::addToErrorMsg('funder is not an existing contact', $errorMessage);
+        }
+      }
+
+    }
+
+
+    if ($errorMessage) {
+      $tempMsg = "Invalid value for field(s) : $errorMessage";
+      array_unshift($values, $tempMsg);
+      $errorMessage = NULL;
+      return CRM_Import_Parser::ERROR;
+    }
+
+    $this->_params = $params;
+
+    return CRM_Import_Parser::VALID;
+  }
+
+  /**
+   * handle the values in import mode
+   *
+   * @param int $onDuplicate the code for what action to take on duplicates
+   * @param array $values the array of values belonging to this line
+   *
+   * @return boolean      the result of this processing
+   * @access public
+   */
+  function import($onDuplicate, &$values) {
+    // first make sure this is a valid line
+    $response = $this->summary($values);
+
+    if ($response != CRM_Import_Parser::VALID) {
+      return $response;
+    }
+    $params = $this->_params;
+
+
+    $params['version'] = 3;
+    $newJobRole = civicrm_api('HrJobRoles', 'create', $params);
+
+      if (!empty($newJobRole['is_error'])) {
+        array_unshift($values, $newJobRole['error_message']);
+        return CRM_Import_Parser::ERROR;
+      }
+
+    $this->_params = NULL;
+    $this->_newJobRole[] = $newJobRole['id'];
+    return CRM_Import_Parser::VALID;
+
+  }
+
+  /**
+   * the initializer code, called before the processing
+   *
+   * @return void
+   * @access public
+   */
+  function fini() {}
+
+
+  /**
+   * get the option database ID given its label or ID
+   * @param String|Integer $option
+   * @param String|Integer $value
+   * @return Integer
+   * @access private
+   */
+   private function getOptionKey($option, $value)  {
+     if (is_numeric ($value)) {
+       $search_field = 'id';
+     }
+     else {
+       $search_field = 'label';
+     }
+     $index = array_search(strtolower($value), array_column($this->_optionsList[$option], $search_field));
+     if ($index !== FALSE)  {
+       return (int) $this->_optionsList[$option][$index]['id'];
+     }
+     else {
+       return 0;
+     }
+  }
+
+}
+

--- a/com.civicrm.hrjobroles/hrjobroles.php
+++ b/com.civicrm.hrjobroles/hrjobroles.php
@@ -107,6 +107,30 @@ function hrjobroles_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   _hrjobroles_civix_civicrm_alterSettingsFolders($metaDataFolders);
 }
 
+
+function hrjobroles_civicrm_navigationMenu( &$params ) {
+  // Add sub-menu
+  $navId = CRM_Core_DAO::singleValueQuery("SELECT max(id) FROM civicrm_navigation");
+  if (is_integer($navId)) {
+    $navId++;
+  }
+  $topMenuID =  CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'job_contracts', 'id', 'name');
+  $parentID =  CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'import_export_job_contracts', 'id', 'name');
+  $params[$topMenuID]['child'][$parentID]['child'][$navId] = array(
+    'attributes' => array(
+      'label' => "Import Job Roles",
+      'name' => "import_job_roles",
+      'url' => "civicrm/jobroles/import",
+      'permission' => NULL,
+      'operator' => 'OR',
+      'separator' => NULL,
+      'parentID' => $parentID,
+      'navID' => $navId,
+      'active' => 1
+      )
+    );
+}
+
 /**
  * @param $tabs
  * @param $contactID

--- a/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/DataSource.hlp
+++ b/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/DataSource.hlp
@@ -1,0 +1,40 @@
+{*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.4                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2013                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*}
+{htxt id="id-upload-title"}
+  {ts}Activity Import{/ts}
+{/htxt}
+{htxt id="id-upload"}
+    <p>
+    {ts}The Activity Import Wizard allows you to easily upload activity from other applications into CiviCRM. Contacts must already exist in your CiviCRM database prior to importing activities for them. Use Import Contacts to create contact records first, if necessary. Then you can match activities to contacts by Email Address, CiviCRM Contact ID, or an External Identifier (see the TIP below).{/ts}
+    </p>
+    <p>
+    {ts}Files to be imported must be in the 'comma-separated-values' format (CSV). Most applications will allow you to export records in this format. Consult the documentation for your application if you're not sure how to do this. Save this file to your local hard drive (or an accessible drive on your network) - and you are now ready for step 1 (Upload Data).{/ts}
+    </p>
+    <p>
+        <strong>{ts}TIP - Matching Activities to Contact Records{/ts}</strong><br />
+        {ts}CiviCRM allows you to indicate which contact each activity record belongs to using either the unique CiviCRM-assigned Contact ID, a unique External ID which you assign, OR your configured Unsupervised Duplicate Matching Rule set (which uses email addresses by default). You must include at least one of these values as a column in your import file. If you are synchronizing (or migrating) contacts from another application to CiviCRM, and that application has assigned a unique ID to each contact, you can import that value into CiviCRM's External ID field. Then you can use that unique key as the 'match to contact' value when importing related data such as Activities.{/ts}
+    <p>
+{/htxt}

--- a/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/DataSource.tpl
+++ b/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/DataSource.tpl
@@ -1,0 +1,67 @@
+{*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.5                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2014                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*}
+{* Activity Import Wizard - Step 1 (upload data file) *}
+{* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller *}
+<div class="crm-block crm-form-block crm-activity-import-uploadfile-form-block">
+
+ {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
+ {include file="CRM/common/WizardHeader.tpl"}
+
+ <div id="help">
+    <p>
+    {ts}The API Import Wizard allows you to easily upload data against any API create method from other applications into CiviHR. Files to be imported must be in the 'comma-separated-values' format (CSV) and must contain data needed to match the data to an existing record in your CiviHR database.{/ts}
+    </p>
+ </div>
+ <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
+ <div id="upload-file">
+ <h3>{ts}Upload Data File{/ts}</h3>
+      <table class="form-layout-compressed">
+        <tr class="crm-activity-import-uploadfile-form-block-uploadFile">
+           <td class="label">{$form.uploadFile.label}</td>
+           <td>{$form.uploadFile.html}<br />
+                <span class="description">{ts}File format must be comma-separated-values (CSV).{/ts}</span><br /><span>{ts 1=$uploadSize}Maximum Upload File Size: %1 MB{/ts}</span>
+           </td>
+        </tr>
+        <tr class="crm-activity-import-uploadfile-form-block-skipColumnHeader">
+           <td class="label"></td>
+           <td>{$form.skipColumnHeader.html}{$form.skipColumnHeader.label}<br />
+               <span class="description">{ts}Check this box if the first row of your file consists of field names (Example: 'Contact ID', 'Activity Type', 'Activity Date').{/ts}</span>
+           </td>
+        </tr>
+        <tr>{include file="CRM/Core/Date.tpl"}</tr>
+        {if $savedMapping}
+        <tr class="crm-activity-import-uploadfile-form-block-savedMapping">
+        <td>{if $loadedMapping}{ts}Select a Different Field Mapping{/ts}{else}{ts}Load Saved Field Mapping{/ts}{/if}</td>
+           <td>{$form.savedMapping.html}<br />
+              <span class="description">{ts}Select Saved Mapping or Leave blank to create a new One.{/ts}</span>
+{/if}
+           </td>
+        </tr>
+ </table>
+ <div class="spacer"></div>
+ </div>
+ <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+</div>

--- a/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/MapField.tpl
+++ b/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/MapField.tpl
@@ -1,0 +1,55 @@
+{*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.5                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2014                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*}
+<div class="crm-block crm-form-block crm-activity-import-mapfield-form-block">
+{* Activity Import Wizard - Step 2 (map incoming data fields) *}
+{* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller *}
+
+ {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
+ {include file="CRM/common/WizardHeader.tpl"}
+
+ <div id="help">
+    <p>{ts}Review the values shown below from the first 2 rows of your import file and select the matching CiviCRM database fields from the drop-down lists in the right-hand column. Select '- do not import -' for any columns in the import file that you want ignored.{/ts}</p>
+    {if $savedMapping}
+    <p>{ts}Click 'Load Saved Field Mapping' if data has been previously imported from the same source. You can then select the saved import mapping setup and load it automatically.{/ts}<p>
+    {/if}
+    <p>{ts}If you think you may be importing additional data from the same data source, check 'Save this field mapping' at the bottom of the page before continuing. The saved mapping can then be easily reused the next time data is imported.{/ts}</p>
+</div>
+<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
+ {* Table for mapping data to CRM fields *}
+ {include file="CRM/Activity/Import/Form/MapTable.tpl}
+ <br />
+
+<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+ {$initHideBoxes}
+{literal}
+<script type="text/javascript" >
+if ( document.getElementsByName("saveMapping")[0].checked ) {
+    document.getElementsByName("updateMapping")[0].checked = true;
+    document.getElementsByName("saveMapping")[0].checked = false;
+}
+</script>
+{/literal}
+</div>

--- a/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/MapTable.tpl
+++ b/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/MapTable.tpl
@@ -1,0 +1,121 @@
+{*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.5                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2014                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*}
+{* Activity Import Wizard - Data Mapping table used by MapFields.tpl and Preview.tpl *}
+<div class="crm-block crm-form-block crm-activity_map_table-form-block">
+
+ <div id="map-field">
+    {strip}
+    <table>
+    {if $loadedMapping}
+        <tr class="columnheader-dark"><th colspan="4">{ts 1=$savedName}Saved Field Mapping: %1{/ts}</td></tr>
+    {/if}
+        <tr class="columnheader">
+            {section name=rows loop=$rowDisplayCount}
+       {if $skipColumnHeader }
+                   { if $smarty.section.rows.iteration == 1 }
+                     <th>{ts}Column Headers{/ts}</th>
+                   {else}
+                     <th>{ts 1=$smarty.section.rows.iteration}Import Data (row %1){/ts}</th>
+                   {/if}
+          {else}
+                  <th>{ts 1=$smarty.section.rows.iteration}Import Data (row %1){/ts}</th>
+                {/if}
+            {/section}
+
+            <th>{ts}Matching CiviCRM Field{/ts}</th>
+        </tr>
+
+        {*Loop on columns parsed from the import data rows*}
+        {section name=cols loop=$columnCount}
+            {assign var="i" value=$smarty.section.cols.index}
+            <tr style="border-bottom: 1px solid #92B6EC;">
+
+                {section name=rows loop=$rowDisplayCount}
+                    {assign var="j" value=$smarty.section.rows.index}
+                    <td class="{if $skipColumnHeader AND $smarty.section.rows.iteration == 1}even-row labels{else}odd-row{/if}">{$dataValues[$j][$i]}</td>
+                {/section}
+
+                {* Display mapper <select> field for 'Map Fields', and mapper value for 'Preview' *}
+                <td class="form-item even-row
+                    {if $wizard.currentStepName == 'Preview'}labels{/if}">
+                    {if $wizard.currentStepName == 'Preview'}
+                        {$mapper[$i]}
+                    {else}
+                        {$form.mapper[$i].html}
+                    {/if}
+                </td>
+
+            </tr>
+        {/section}
+
+    </table>
+  {/strip}
+
+    {if $wizard.currentStepName != 'Preview'}
+    <div>
+
+      {if $loadedMapping}
+          <span>{$form.updateMapping.html} &nbsp;&nbsp; {$form.updateMapping.label}</span>
+      {/if}
+      <span>{$form.saveMapping.html} &nbsp;&nbsp; {$form.saveMapping.label}</span>
+      <div id="saveDetails" class="form-item">
+          <table>
+                  <tr class="crm-activity_map_table-form-block-saveMappingName">
+             <td>{$form.saveMappingName.label}</td>
+                     <td>{$form.saveMappingName.html}</td>
+                  </tr>
+                  <tr class="crm-activity_map_table-form-block-saveMappingDesc">
+             <td>{$form.saveMappingDesc.label}</td>
+                     <td>{$form.saveMappingDesc.html}</td>
+                 </tr>
+            </table>
+      </div>
+      <script type="text/javascript">
+             {if $mappingDetailsError }
+                cj('#saveDetails').show();
+             {else}
+              cj('#saveDetails').hide();
+             {/if}
+
+           {literal}
+            function showSaveDetails(chkbox) {
+             if (chkbox.checked) {
+              document.getElementById("saveDetails").style.display = "block";
+              document.getElementById("saveMappingName").disabled = false;
+              document.getElementById("saveMappingDesc").disabled = false;
+             } else {
+              document.getElementById("saveDetails").style.display = "none";
+              document.getElementById("saveMappingName").disabled = true;
+              document.getElementById("saveMappingDesc").disabled = true;
+             }
+             }
+             {/literal}
+       {include file="CRM/common/highLightImport.tpl"}
+      </script>
+    </div>
+    {/if}
+ </div>
+</div>

--- a/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/Preview.tpl
+++ b/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/Preview.tpl
@@ -1,0 +1,95 @@
+{*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.5                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2014                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*}
+{* Activity Import Wizard - Step 3 (preview import results prior to actual data loading) *}
+{* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller *}
+<div class="crm-block crm-form-block crm-activity-import-preview-form-block">
+
+ {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
+ {include file="CRM/common/WizardHeader.tpl"}
+
+ <div id="help">
+    <p>
+    {ts}The information below previews the results of importing your data in CiviCRM. Review the totals to ensure that they represent your expected results.{/ts}
+    </p>
+
+    {if $invalidRowCount}
+        <p class="error">
+        {ts 1=$invalidRowCount 2=$downloadErrorRecordsUrl}CiviCRM has detected invalid data or formatting errors in %1 records. If you continue, these records will be skipped. OR, you can download a file with just these problem records - <a href='%2'>Download Errors</a>. Then correct them in the original import file, cancel this import and begin again at step 1.{/ts}
+        </p>
+    {/if}
+
+    {if $conflictRowCount}
+        <p class="error">
+        {ts 1=$conflictRowCount 2=$downloadConflictRecordsUrl}CiviCRM has detected %1 records with conflicting transaction ids within this data file. If you continue, these records will be skipped. OR, you can download a file with just these problem records - <a href='%2'>Download Conflicts</a>. Then correct them in the original import file, cancel this import and begin again at step 1.{/ts}
+        </p>
+    {/if}
+
+
+    <p>{ts}Click 'Import Now' if you are ready to proceed.{/ts}</p>
+ </div>
+ <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
+ {* Summary Preview (record counts) *}
+ <table id="preview-counts" class="report">
+    <tr><td class="label">{ts}Total Rows{/ts}</td>
+        <td class="data">{$totalRowCount}</td>
+        <td class="explanation">{ts}Total rows (activity records) in uploaded file.{/ts}</td>
+    </tr>
+
+    {if $invalidRowCount}
+    <tr class="error"><td class="label">{ts}Rows with Errors{/ts}</td>
+        <td class="data">{$invalidRowCount}</td>
+        <td class="explanation">{ts}Rows with invalid data in one or more fields. These rows will be skipped (not imported).{/ts}
+            {if $invalidRowCount}
+                <div class="action-link"><a href="{$downloadErrorRecordsUrl}">&raquo; {ts}Download Errors{/ts}</a></div>
+            {/if}
+        </td>
+    </tr>
+    {/if}
+
+   {if $conflictRowCount}
+    <tr class="error"><td class="label">{ts}Conflicting Rows{/ts}</td>
+        <td class="data">{$conflictRowCount}</td>
+        <td class="explanation">{ts}Rows with conflicting transaction ids within this file. These rows will be skipped (not imported).{/ts}
+            {if $conflictRowCount}
+                <p><a href="{$downloadConflictRecordsUrl}">{ts}Download Conflicts{/ts}</a></p>
+            {/if}
+        </td>
+    </tr>
+    {/if}
+
+    <tr><td class="label">{ts}Valid Rows{/ts}</td>
+        <td class="data">{$validRowCount}</td>
+        <td class="explanation">{ts}Total rows to be imported.{/ts}</td>
+    </tr>
+ </table>
+ <br />
+
+ {* Table for mapping preview *}
+ {include file="CRM/Activity/Import/Form/MapTable.tpl}
+ <br />
+
+ <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+ </div>

--- a/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/Summary.tpl
+++ b/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/Summary.tpl
@@ -1,0 +1,134 @@
+{*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.5                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2014                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*}
+{* Activity Import Wizard - Step 4 (summary of import results AFTER actual data loading) *}
+{* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller *}
+<div class="crm-block crm-form-block crm-activity-import-summary-form-block">
+
+ {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
+ {include file="CRM/common/WizardHeader.tpl"}
+
+ <div id="help">
+    <p>
+    {ts}<strong>Import has completed successfully.</strong> The information below summarizes the results.{/ts}
+    </p>
+
+   {if $unMatchCount }
+        <p class="error">
+        {ts count=$unMatchCount plural='CiviCRM has detected mismatched activity IDs. These records have not been Updated.'}CiviCRM has detected mismatched activity ID. This record have not been updated.{/ts}
+        </p>
+        <p class="error">
+        {ts 1=$downloadMismatchRecordsUrl}You can <a href='%1'>Download Mismatched Activity records</a>. You may then correct them, and import the new file with the corrected data.{/ts}
+        </p>
+    {/if}
+
+    {if $invalidRowCount }
+        <p class="error">
+        {ts count=$invalidRowCount plural='CiviCRM has detected invalid data and/or formatting errors in %count records. These records have not been imported.'}CiviCRM has detected invalid data and/or formatting errors in one record. This record have not been imported.{/ts}
+        </p>
+        <p class="error">
+        {ts 1=$downloadErrorRecordsUrl}You can <a href='%1'>Download Errors</a>. You may then correct them, and import the new file with the corrected data.{/ts}
+        </p>
+    {/if}
+
+    {if $conflictRowCount}
+        <p class="error">
+        {ts count=$conflictRowCount plural='CiviCRM has detected %count records with conflicting transaction IDs within this data file or relative to existing activity records. These records have not been imported.'}CiviCRM has detected one record with conflicting transaction ID within this data file or relative to existing activity records. This record have not been imported.{/ts}
+        </p>
+        <p class="error">
+        {ts 1=$downloadConflictRecordsUrl}You can <a href='%1'>Download Conflicts</a>. You may then review these records to determine if they are actually conflicts, and correct the transaction IDs for those that are not.{/ts}
+        </p>
+    {/if}
+
+    {if $duplicateRowCount}
+        <p {if $dupeError}class="error"{/if}>
+        {ts count=$duplicateRowCount plural='CiviCRM has detected %count records which are duplicates of existing CiviCRM activity records.'}CiviCRM has detected one record which is a duplicate of existing CiviCRM activity record.{/ts} {$dupeActionString}
+        </p>
+        <p {if $dupeError}class="error"{/if}>
+        {ts 1=$downloadDuplicateRecordsUrl}You can <a href='%1'>Download Duplicates</a>. You may then review these records to determine if they are actually duplicates, and correct the transaction IDs for those that are not.{/ts}
+        </p>
+    {/if}
+ </div>
+ <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
+ {* Summary of Import Results (record counts) *}
+ <table id="summary-counts" class="report">
+    <tr><td class="label">{ts}Total Rows{/ts}</td>
+        <td class="data">{$totalRowCount}</td>
+        <td class="explanation">{ts}Total rows (activity records) in uploaded file.{/ts}</td>
+    </tr>
+
+    {if $invalidRowCount }
+    <tr class="error"><td class="label">{ts}Invalid Rows (skipped){/ts}</td>
+        <td class="data">{$invalidRowCount}</td>
+        <td class="explanation">{ts}Rows with invalid data in one or more fields. These rows will be skipped (not imported).{/ts}
+            {if $invalidRowCount}
+                <p><a href="{$downloadErrorRecordsUrl}">{ts}Download Errors{/ts}</a></p>
+            {/if}
+        </td>
+    </tr>
+    {/if}
+
+    {if $unMatchCount }
+    <tr class="error"><td class="label">{ts}Mismatched Rows (skipped){/ts}</td>
+        <td class="data">{$unMatchCount}</td>
+        <td class="explanation">{ts}Rows with mismatched activity IDs (NOT updated).{/ts}
+            {if $unMatchCount}
+                <p><a href="{$downloadMismatchRecordsUrl}">{ts}Download Mismatched Activity records{/ts}</a></p>
+            {/if}
+        </td>
+    </tr>
+    {/if}
+
+    {if $conflictRowCount}
+    <tr class="error"><td class="label">{ts}Conflicting Rows (skipped){/ts}</td>
+        <td class="data">{$conflictRowCount}</td>
+        <td class="explanation">{ts}Rows with conflicting transaction IDs (NOT imported).{/ts}
+            {if $conflictRowCount}
+                <p><a href="{$downloadConflictRecordsUrl}">{ts}Download Conflicts{/ts}</a></p>
+            {/if}
+        </td>
+    </tr>
+    {/if}
+
+    {if $duplicateRowCount}
+    <tr class="error"><td class="label">{ts}Duplicate Rows{/ts}</td>
+        <td class="data">{$duplicateRowCount}</td>
+        <td class="explanation">{ts}Rows which are duplicates of existing CiviCRM activity records.{/ts} {$dupeActionString}
+            {if $duplicateRowCount}
+                <p><a href="{$downloadDuplicateRecordsUrl}">{ts}Download Duplicates{/ts}</a></p>
+            {/if}
+        </td>
+    </tr>
+    {/if}
+
+    <tr><td class="label">{ts}Records Imported{/ts}</td>
+        <td class="data">{$validRowCount}</td>
+        <td class="explanation">{ts}Rows imported successfully.{/ts}</td>
+    </tr>
+
+ </table>
+
+ <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+ </div>

--- a/com.civicrm.hrjobroles/xml/Menu/hrjobroles.xml
+++ b/com.civicrm.hrjobroles/xml/Menu/hrjobroles.xml
@@ -6,4 +6,10 @@
     <title>JobRoles</title>
     <access_arguments>access CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/job-roles</path>
+    <page_callback>CRM_Hrjobroles_Page_JobRoles</page_callback>
+    <title>JobRoles</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
 </menu>

--- a/com.civicrm.hrjobroles/xml/Menu/import.xml
+++ b/com.civicrm.hrjobroles/xml/Menu/import.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<menu>
+  <item>
+    <path>civicrm/jobroles/import</path>
+    <page_callback>CRM_Hrjobroles_Import_Controller</page_callback>
+    <title>JOB Import</title>
+    <access_arguments>administer CiviCRM</access_arguments>
+  </item>
+</menu>


### PR DESCRIPTION
## Problem


Currently all Job Roles related fields are in Import Job Contract page. However, Roles needs to be imported after Job Contracts are created / imported so we need to :
- Create a new "Import Job Roles" page.
- Remove Job Role related fields from "Import Job Contract" page.

![selection_003](https://cloud.githubusercontent.com/assets/17959662/14101956/1efead60-f598-11e5-8b9a-f8832ae50c3a.png)

![screenshot from 2016-03-29 08 17 36](https://cloud.githubusercontent.com/assets/17959662/14101962/238dcce4-f598-11e5-89d6-2fb99bcf777e.png)




## Solution

- a separate "Import Job Roles" page is created .
- Job Role related fields are removed from "Import Job Contract" page.


--------
**The new "import job roles" page**

![selection_004](https://cloud.githubusercontent.com/assets/17959662/14102244/9ab6c9fa-f599-11e5-9f02-89868cfc1c15.png)

![screenshot from 2016-03-29 08 26 08](https://cloud.githubusercontent.com/assets/17959662/14102186/4a677a62-f599-11e5-964b-e64daf7192f8.png)

**"import job contracts" page after roles related fields have been removed**
![screenshot from 2016-03-29 08 25 37](https://cloud.githubusercontent.com/assets/17959662/14102211/72fa4d60-f599-11e5-80e8-70952dc310cd.png)
