### PR TITLE
PCHR-851: Removes rejected leaves from the Calendar in Absences tab of the contact

### DIFF
--- a/hrabsence/api/v3/Activity/Getabsences.php
+++ b/hrabsence/api/v3/Activity/Getabsences.php
@@ -69,12 +69,12 @@ function civicrm_api3_activity_getabsences($params) {
       '#typeId' => array_search('Absence', $activityTypes)
     ));
 
-  if(isset($params['status_id'])){
-    // Handle only single value != case for now
+  if(isset($params['status_id'])) {
+    //Handles only != and "NOT IN" operators for now
     $statusId = (array) $params['status_id'];
     $operator = key($statusId);
-    if($operator == '!=') {
-      $select->where('request.status_id != #statusId', array('#statusId' => $statusId));
+    if($operator == '!=' || $operator == 'NOT IN') {
+      $select->where('request.status_id NOT IN(#statusId)', array('#statusId' => $statusId[$operator]));
     }
   }
 

--- a/hrabsence/js/app.js
+++ b/hrabsence/js/app.js
@@ -88,7 +88,7 @@ CRM.HRAbsenceApp.module('Main', function(Main, HRAbsenceApp, Backbone, Marionett
     calendarAbsenceCriteria = new HRAbsenceApp.Models.AbsenceCriteria({
       target_contact_id: CRM.absenceApp.contactId,
       options: {'absence-range': 1},
-      status_id:{'!=':3}
+      status_id:{'NOT IN':[3, 9]} //3: Cancelled, 9: Rejected
     });
     absenceCollection = new HRAbsenceApp.Models.AbsenceCollection([], {
       crmCriteriaModel: absenceCriteria,

--- a/hrabsence/tests/phpunit/api/v3/ActivityGetAbsencesTest.php
+++ b/hrabsence/tests/phpunit/api/v3/ActivityGetAbsencesTest.php
@@ -239,4 +239,49 @@ class api_v3_ActivityGetAbsencesTest extends CiviUnitTestCase {
       }
     }
   }
+
+  public function testStatusIdParameter() {
+    $allActivities = $this->callAPISuccess('Activity', self::ACTION, array('sequential' => 1));
+    $totalNumberOfActivities = $allActivities['count'];
+
+    // Change the status of the first returned Activity
+    // to 3 and filter it out using the != operator
+    $firstActivityId = $allActivities['values'][0]['id'];
+    $this->callAPISuccess('Activity', 'create', array(
+      'id' => $firstActivityId,
+      'status_id' => 3
+    ));
+    $activities = $this->callAPISuccess('Activity', self::ACTION, array(
+      'status_id' => array('!=' => 3),
+    ));
+    $this->assertCount($totalNumberOfActivities - 1, $activities['values']);
+    foreach($activities['values'] as $activity) {
+      $this->assertNotEquals($firstActivityId, $activity['id']);
+    }
+
+    // Change the status of the first returned Activity
+    // to 4 and filter it out using the != operator
+    $secondActivityId = $allActivities['values'][1]['id'];
+    $this->callAPISuccess('Activity', 'create', array(
+        'id' => $secondActivityId,
+        'status_id' => 4
+    ));
+    $activities = $this->callAPISuccess('Activity', self::ACTION, array(
+        'status_id' => array('!=' => 4),
+    ));
+    $this->assertCount($totalNumberOfActivities - 1, $activities['values']);
+    foreach($activities['values'] as $activity) {
+      $this->assertNotEquals($secondActivityId, $activity['id']);
+    }
+
+    // Filter out Activities with status 3 or 4, using the NOT IN operator
+    $activities = $this->callAPISuccess('Activity', self::ACTION, array(
+        'status_id' => array('NOT IN' => array(3, 4)),
+    ));
+    $this->assertCount($totalNumberOfActivities - 2, $activities['values']);
+    foreach($activities['values'] as $activity) {
+      $this->assertNotEquals($firstActivityId, $activity['id']);
+      $this->assertNotEquals($secondActivityId, $activity['id']);
+    }
+  }
 }


### PR DESCRIPTION
Now, besides the cancelled leaves, the calendar will also not show the rejected ones.

I've updated the Activity.getAbsences API action to handle multiples IDs passed to the status_id parameter. It now supports the != and the "NOT IN" operators.

Bellow are some screenshots showing the results:

Given 3 leave requests (one rejected, one cancelled and one waiting approval)
![captura de tela 2016-04-01 as 15 29 25](https://cloud.githubusercontent.com/assets/388373/14216461/48778390-f81f-11e5-8c14-c4b7b9b2fd5e.png)

Before the change, the calendar was showing the rejected request:
![captura de tela 2016-04-01 as 15 30 46](https://cloud.githubusercontent.com/assets/388373/14216509/90ffc6a4-f81f-11e5-8891-e9ef81422e87.png)

After the change, the rejected request is longer displayed:
![captura de tela 2016-04-01 as 15 29 37](https://cloud.githubusercontent.com/assets/388373/14216526/b3255474-f81f-11e5-958d-ec95d656a019.png)

