### PR TITLE
PCHR-880: Fix the wrong data inserted in contracts after importing them

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Import/Parser/Api.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Parser/Api.php
@@ -172,12 +172,6 @@ class CRM_Hrjobcontract_Import_Parser_Api extends CRM_Hrjobcontract_Import_Parse
       return CRM_Import_Parser::ERROR;
     }
 
-    foreach ($entityNames as $value) {
-        $field = $value . '_revision_id';
-        $contractRevison->$field = $this->_previousRevision['local'][$value];
-    }
-    $contractRevison->save();
-
     $this->_previousRevision['imported']['id'] = $revisionId;
   }
 


### PR DESCRIPTION
#### The Problem 

When importing contracts from "import job contracts" page , the inserted contracts are different from the imported ones.

**sample file**
![selection_004](https://cloud.githubusercontent.com/assets/17959662/14212836/76577bda-f83d-11e5-8d04-0475e60509c7.png)

**when viewing them**
![selection_005](https://cloud.githubusercontent.com/assets/17959662/14212914/d2565762-f83d-11e5-97e0-606ec7c5a703.png)

The source of problem was when importing new contracts , the revision IDs  inserted in the database are wrong and refer to previously inserted contracts .
