### PR TITLE
PCHR-799: import contracts revision

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContractRevision.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContractRevision.php
@@ -13,7 +13,7 @@ class CRM_Hrjobcontract_BAO_HRJobContractRevision extends CRM_Hrjobcontract_DAO_
    */
   public static function create($params) {
     global $user;
-    
+
     $params['editor_uid'] = $user->uid;
     $className = 'CRM_Hrjobcontract_DAO_HRJobContractRevision';
     $entityName = 'HRJobContractRevision';

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Form/DataSourceBaseClass.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Form/DataSourceBaseClass.php
@@ -98,6 +98,19 @@ class CRM_Hrjobcontract_Import_Form_DataSourceBaseClass extends CRM_Core_Form {
     $this->addRule('uploadFile', ts('Input file must be in CSV format'), 'utf8File');
 
     $this->addElement('checkbox', 'skipColumnHeader', ts('First row contains column headers'));
+
+    $importModeOptions = array();
+    $importModeOptions[] = $this->createElement('radio',
+      NULL, NULL, ts('Import Contracts'), CRM_Hrjobcontract_Import_Parser::IMPORT_CONTRACTS
+    );
+    $importModeOptions[] = $this->createElement('radio',
+      NULL, NULL, ts('Import Contracts Revision'), CRM_Hrjobcontract_Import_Parser::IMPORT_REVISIONS
+    );
+
+    $this->addGroup($importModeOptions, 'importMode',
+      ts('Import Mode')
+    );
+
     if($this->isDuplicateOptions) {
       $duplicateOptions = array();
       $duplicateOptions[] = $this->createElement('radio',
@@ -126,6 +139,11 @@ class CRM_Hrjobcontract_Import_Form_DataSourceBaseClass extends CRM_Core_Form {
       $this->assign('loadedMapping', $loadeMapping);
       $this->setDefaults(array('savedMapping' => $loadeMapping));
     }
+
+    $this->setDefaults(array(
+      'importMode' =>
+        CRM_Hrjobcontract_Import_Parser::IMPORT_CONTRACTS,
+    ));
 
     $this->setDefaults(array(
       'onDuplicate' =>
@@ -167,12 +185,14 @@ class CRM_Hrjobcontract_Import_Form_DataSourceBaseClass extends CRM_Core_Form {
 
     $fileName         = $this->controller->exportValue($this->_name, 'uploadFile');
     $skipColumnHeader = $this->controller->exportValue($this->_name, 'skipColumnHeader');
+    $importMode       = $this->controller->exportValue($this->_name, 'importMode');
     $onDuplicate      = $this->controller->exportValue($this->_name, 'onDuplicate');
     $contactType      = $this->controller->exportValue($this->_name, 'contactType');
     $dateFormats      = $this->controller->exportValue($this->_name, 'dateFormats');
     $savedMapping     = $this->controller->exportValue($this->_name, 'savedMapping');
 
     $this->set('onDuplicate', $onDuplicate);
+    $this->set('importMode', $importMode);
     $this->set('contactType', $contactType);
     $this->set('dateFormats', $dateFormats);
     $this->set('savedMapping', $savedMapping);

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Form/MapFieldBaseClass.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Form/MapFieldBaseClass.php
@@ -69,16 +69,27 @@ class CRM_Hrjobcontract_Import_Form_MapFieldBaseClass extends CRM_Import_Form_Ma
   public function preProcess() {
     $this->_mapperFields = $this->get('fields');
     $this->_entity = $this->get('_entity');
-    $this->_highlightedFields = array(
-      'HRJobContract-contact_id',
-      'HRJobContract-email',
-      'HRJobContract-external_identifier',
+    $this->_importMode = $this->get('importMode');
 
+    $this->_highlightedFields = array(
       'HRJobDetails-position',
       'HRJobDetails-contract_type',
       'HRJobDetails-period_start_date',
       'HRJobDetails-title'
     );
+    if ($this->_importMode == CRM_Hrjobcontract_Import_Parser::IMPORT_CONTRACTS) {
+      $this->_highlightedFields = array_merge($this->_highlightedFields, array(
+        'HRJobContract-contact_id',
+        'HRJobContract-email',
+        'HRJobContract-external_identifier'
+      ));
+    }
+    elseif ($this->_importMode == CRM_Hrjobcontract_Import_Parser::IMPORT_REVISIONS) {
+      $this->_highlightedFields = array_merge($this->_highlightedFields, array(
+        'HRJobContractRevision-jobcontract_id',
+        'HRJobContractRevision-effective_date'
+      ));
+    }
 
     $this->_columnCount = $this->get('columnCount');
     $this->assign('columnCount', $this->_columnCount);
@@ -311,6 +322,13 @@ class CRM_Hrjobcontract_Import_Form_MapFieldBaseClass extends CRM_Import_Form_Ma
         'HRJobDetails-period_start_date' => ts('Contract Start Date')
       );
 
+     if ($self->_importMode == CRM_Hrjobcontract_Import_Parser::IMPORT_REVISIONS) {
+        $requiredFields = array_merge($requiredFields, array(
+          'HRJobContractRevision-jobcontract_id' => ts('Contract ID'),
+          'HRJobContractRevision-effective_date' => ts('Job Title')
+        ));
+      }
+
       $missingNames = array();
       $errorRequired = FALSE;
       foreach ($requiredFields as $field => $title) {
@@ -330,6 +348,7 @@ class CRM_Hrjobcontract_Import_Form_MapFieldBaseClass extends CRM_Import_Form_Ma
         !in_array('HRJobContract-contact_id', $importKeys)
         && !in_array('HRJobContract-email', $importKeys)
         && !in_array('HRJobContract-external_identifier', $importKeys)
+        && $self->_importMode == CRM_Hrjobcontract_Import_Parser::IMPORT_CONTRACTS
       ) {
         $errors['_qf_default'] = ts('Contact ID, Email or External Identifier is required.');
       }

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Form/PreviewBaseClass.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Form/PreviewBaseClass.php
@@ -123,6 +123,7 @@ class CRM_Hrjobcontract_Import_Form_Previewbaseclass extends CRM_Import_Form_Pre
     $invalidRowCount  = $this->get('invalidRowCount');
     $conflictRowCount = $this->get('conflictRowCount');
     $onDuplicate      = $this->get('onDuplicate');
+    $importMode       = $this->get('importMode');
     $entity           = $this->get('_entity');
 
     $config = CRM_Core_Config::singleton();
@@ -161,8 +162,8 @@ class CRM_Hrjobcontract_Import_Form_Previewbaseclass extends CRM_Import_Form_Pre
       $mapperFields,
       $skipColumnHeader,
       CRM_Import_Parser::MODE_IMPORT,
-      $this->get('contactType'),
-      $onDuplicate
+      $onDuplicate,
+      $importMode
     );
 
     // add all the necessary variables to the form

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Parser.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Parser.php
@@ -35,6 +35,11 @@
 
 
 abstract class CRM_Hrjobcontract_Import_Parser extends CRM_Import_Parser {
+  /**
+   * Import Modes
+   */
+  CONST IMPORT_CONTRACTS = 1, IMPORT_REVISIONS = 2;
+
 
   protected $_fileName;
 
@@ -73,7 +78,8 @@ abstract class CRM_Hrjobcontract_Import_Parser extends CRM_Import_Parser {
     &$mapper,
     $skipColumnHeader = FALSE,
     $mode = self::MODE_PREVIEW,
-    $onDuplicate = self::DUPLICATE_SKIP
+    $onDuplicate = self::DUPLICATE_SKIP,
+    $importMode  = self::IMPORT_CONTRACTS
   ) {
     if (!is_array($fileName)) {
       CRM_Core_Error::fatal();
@@ -147,6 +153,7 @@ abstract class CRM_Hrjobcontract_Import_Parser extends CRM_Import_Parser {
         $returnCode = $this->summary($values);
       }
       elseif ($mode == self::MODE_IMPORT) {
+        $values['importMode'] = $importMode;
         $returnCode = $this->import($onDuplicate, $values);
       }
       else {

--- a/hrjobcontract/templates/CRM/Hrjobcontract/Import/Form/DataSource.tpl
+++ b/hrjobcontract/templates/CRM/Hrjobcontract/Import/Form/DataSource.tpl
@@ -61,6 +61,11 @@
                 </span>
             </td>
   </tr>
+   <tr class="crm-import-form-block-importMode">
+       <td class="label">{$form.importMode.label}</td>
+       <td>{$form.importMode.html}</td>
+       </td>
+   </tr>
   <tr class="crm-api-import-uploadfile-form-block-onDuplicate">
             <td class="label">{$form.onDuplicate.label}</td>
       <td>{$form.onDuplicate.html}</td>


### PR DESCRIPTION
Allowing users to be able to import job contracts revision by introducing a new "import mode" checkbox at "contracts import" page.

![selection_002](https://cloud.githubusercontent.com/assets/17959662/14276307/0c2b5ec6-fb16-11e5-848c-fb34764c8b9a.png)

![screenshot from 2016-04-05 09 59 16](https://cloud.githubusercontent.com/assets/17959662/14276314/184ec8fa-fb16-11e5-8bf5-97f1aacacacf.png)