### PR TITLE
PCHR-865 - Implementing 'effective_end_date' revision field

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContractRevision.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContractRevision.php
@@ -8,6 +8,7 @@ class CRM_Hrjobcontract_BAO_HRJobContractRevision extends CRM_Hrjobcontract_DAO_
    * Create a new HRJobContractRevision based on array-data
    *
    * @param array $params key-value pairs
+   * 
    * @return CRM_HRJobContract_DAO_HRJobContractRevision|NULL
    *
    */
@@ -30,15 +31,72 @@ class CRM_Hrjobcontract_BAO_HRJobContractRevision extends CRM_Hrjobcontract_DAO_
         $params['modified_date'] = $now;
     }
 
+    if (empty($params['jobcontract_id']) && $hook === 'edit') {
+        $revision = new $className();
+        $revision->id = $params['id'];
+        $revision->find(TRUE);
+        $params['jobcontract_id'] = $revision->jobcontract_id;
+    }
+
     CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
     $instance = new $className();
     $instance->copyValues($params);
     $instance->save();
+    if (!empty($instance->jobcontract_id)) {
+      self::updateEffectiveEndDates($instance->jobcontract_id);
+    }
     CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
 
     return $instance;
   }
-  
+
+  /**
+   * Update Revision's effective end dates for given Job Contract ID.
+   * 
+   * @param int $jobcontractId
+   */
+  public static function updateEffectiveEndDates($jobcontractId) {
+    $query = "SELECT id, effective_date FROM civicrm_hrjobcontract_revision " .
+             "WHERE jobcontract_id = %1 " .
+             "AND deleted = 0 " .
+             "ORDER BY effective_date DESC, id DESC";
+    $params = array(
+      1 => array($jobcontractId, 'Integer'),
+    );
+    $revisions = CRM_Core_DAO::executeQuery($query, $params);
+    $previousEffectiveDate = null;
+    // Updating 'effective_end_date' of each revision by 'effective_date' - 1 DAY
+    // of the next (newer) revision.
+    while ($revisions->fetch()) {
+      if ($previousEffectiveDate) {
+        $effectiveEndDate = $revisions->effective_date;
+        if ($previousEffectiveDate !== $revisions->effective_date) {
+          $effectiveEndDate = date('Y-m-d', strtotime($previousEffectiveDate) - 3600 * 24);
+        }
+        $updateQuery = "UPDATE civicrm_hrjobcontract_revision SET " .
+                       "effective_end_date = %1 " .
+                       "WHERE id = %2";
+        $updateParams = array(
+          1 => array($effectiveEndDate, 'String'),
+          2 => array($revisions->id, 'Integer'),
+        );
+        CRM_Core_DAO::executeQuery($updateQuery, $updateParams);
+        // If 'effective_date' is equal to previous effective date
+        // we mark this revision as overrided by the one newly created.
+        if ($previousEffectiveDate === $revisions->effective_date) {
+          $updateOverridedQuery = "UPDATE civicrm_hrjobcontract_revision SET " .
+                  "overrided = 1 " .
+                  "WHERE id = %1";
+          $updateOverridedParams = array(
+            1 => array($revisions->id, 'Integer'),
+          );
+          CRM_Core_DAO::executeQuery($updateOverridedQuery, $updateOverridedParams);
+        }
+      }
+      $previousEffectiveDate = $revisions->effective_date;
+    }
+  }
+
   static function importableFields($contactType = 'HRJobContractRevision',
     $status          = FALSE,
     $showAll         = FALSE,


### PR DESCRIPTION
- Adding a new field called 'effective_end_date' to Job Contract Revision entity which keep an end of revision effective date if there is any newer revision.
- Creating Upgrader script which populates 'effective_end_date' values for every existing Job Contract revisions.
- Value of the field is automatically generated while saving Job Contract's revision.

The new field is designed mostly to handle Reports requirements but it can also be used with any other cases in the future.