### PR TITLE
PCHR-892: Cleaning contracts import validation

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/HrJobRoles.php
@@ -56,25 +56,6 @@ class CRM_Hrjobroles_BAO_HrJobRoles extends CRM_Hrjobroles_DAO_HrJobRoles {
     return $result->fetch() ? $result->id : 0;
   }
 
-
-  /**
-   * Check Job Contract if exist   .
-   *
-   * @param Integer $contractID
-   * @return array|0 ( return 0 if not exist or an array contain some contract details if exist )
-   */
-  public static function checkContract($contractID) {
-    if ( !CRM_Utils_Rule::positiveInteger($contractID))  {
-      return 0;
-    }
-    $queryParam = array(1 => array($contractID, 'Integer'));
-    $query = "SELECT chrjcd.period_start_date, chrjcd.period_end_date from civicrm_hrjobcontract_revision chrjcr
-              left join civicrm_hrjobcontract_details chrjcd on chrjcr.id=chrjcd.jobcontract_revision_id
-              where  chrjcr.jobcontract_id = %1 order by chrjcr.id desc limit 1";
-    $result = CRM_Core_DAO::executeQuery($query, $queryParam);
-    return $result->fetch() ? $result : 0;
-  }
-
   public static function importableFields() {
     $fields = array('' => array('title' => ts('- do not import -')));
     return array_merge($fields, static::import());

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Parser/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Parser/HrJobRoles.php
@@ -148,7 +148,7 @@ class CRM_Hrjobroles_Import_Parser_HrJobRoles extends CRM_Hrjobroles_Import_Pars
     $session = CRM_Core_Session::singleton();
     $dateType = $session->get('dateTypes');
 
-    $contractDetails = CRM_Hrjobroles_BAO_HrJobRoles::checkContract($params['job_contract_id']);
+    $contractDetails = CRM_Hrjobcontract_BAO_HRJobContract::checkContract($params['job_contract_id']);
     if ($contractDetails == 0)  {
       CRM_Contact_Import_Parser_Contact::addToErrorMsg('job contract ID is not found', $errorMessage);
     }

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
@@ -319,6 +319,24 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
   }
 
   /**
+   * Check Job Contract if exist   .
+   *
+   * @param Integer $contractID
+   * @return array|0 ( return 0 if not exist or an array contain some contract details if exist )
+   */
+  public static function checkContract($contractID) {
+    if ( !CRM_Utils_Rule::positiveInteger($contractID))  {
+      return 0;
+    }
+    $queryParam = array(1 => array($contractID, 'Integer'));
+    $query = "SELECT chrjcd.period_start_date, chrjcd.period_end_date from civicrm_hrjobcontract_revision chrjcr
+              left join civicrm_hrjobcontract_details chrjcd on chrjcr.id=chrjcd.jobcontract_revision_id
+              where  chrjcr.jobcontract_id = %1 order by chrjcr.id desc limit 1";
+    $result = CRM_Core_DAO::executeQuery($query, $queryParam);
+    return $result->fetch() ? $result : 0;
+  }
+
+  /**
    * combine all the importable fields from the lower levels object
    *
    * The ordering is important, since currently we do not have a weight

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobHealth.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobHealth.php
@@ -56,6 +56,35 @@ class CRM_Hrjobcontract_BAO_HRJobHealth extends CRM_Hrjobcontract_DAO_HRJobHealt
 
 
   /**
+   * Check insurance provider if exist   .
+   *
+   * @param String $searchValue
+   * @param String $providerType
+   * @return Integer ( Provider ID or 0 if not exist)
+   */
+  public static function checkProvider($searchValue, $providerType) {
+    if (is_numeric ($searchValue))  {
+      $searchField = 'id';
+    }
+    else {
+      $searchField = 'display_name';
+    }
+    $queryParam = array(1 => array($searchValue, 'String'));
+    $query = "SELECT id,contact_sub_type FROM civicrm_contact WHERE {$searchField} = %1 " .
+             " AND is_deleted = 0".
+             " LIMIT 1";
+    $result = CRM_Core_DAO::executeQuery($query, $queryParam);
+    if ($result->fetch()) {
+      $entitySubType = explode(CRM_Core_DAO::VALUE_SEPARATOR,
+        trim($result->contact_sub_type, CRM_Core_DAO::VALUE_SEPARATOR)
+      );
+      return in_array($providerType, $entitySubType) ? $result->id : 0;
+    }
+
+    return 0;
+  }
+
+  /**
    * combine all the importable fields from the lower levels object
    *
    * The ordering is important, since currently we do not have a weight

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Parser/BaseClass.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Parser/BaseClass.php
@@ -39,6 +39,15 @@
 class CRM_Hrjobcontract_Import_Parser_BaseClass extends CRM_Hrjobcontract_Import_Parser {
   protected $_mapperKeys;
 
+  /**
+   * Array of select lists options in job roles page
+   *
+   * @var array
+   */
+
+  private $_optionsList;
+
+
   private $_contactIdIndex;
 
   /**
@@ -76,6 +85,24 @@ class CRM_Hrjobcontract_Import_Parser_BaseClass extends CRM_Hrjobcontract_Import
     }
     $this->setActiveFields($this->_mapperKeys);
     $this->setActiveFieldLocationTypes($this->_mapperLocType);
+
+    // Fetch select list options from the database and cache them
+    $this->_optionsList['HRJobHour-hours_unit'] = CRM_Hrjobcontract_SelectValues::commonUnit();
+    $this->_optionsList['HRJobHour-hours_type'] = CRM_Hrjobcontract_SelectValues::buildDbOptions('hrjc_hours_type');
+    $this->_optionsList['HRJobHour-location_standard_hours'] = CRM_Hrjobcontract_SelectValues::buildHourLocations();
+    $this->_optionsList['HRJobPension-pension_type'] = CRM_Hrjobcontract_SelectValues::buildDbOptions('hrjc_pension_type');
+    $this->_optionsList['HRJobHealth-plan_type'] = CRM_Hrjobcontract_SelectValues::planType();
+    $this->_optionsList['HRJobHealth-plan_type_life_insurance'] = CRM_Hrjobcontract_SelectValues::planTypeLifeInsurance();
+    $this->_optionsList['HRJobPay-pay_cycle'] = CRM_Hrjobcontract_SelectValues::buildDbOptions('hrjc_pay_cycle');
+    $this->_optionsList['HRJobPay-pay_scale'] = CRM_Hrjobcontract_SelectValues::buildPayScales();
+    $this->_optionsList['HRJobPay-pay_currency'] = CRM_Hrjobcontract_SelectValues::buildCurrency();
+    $this->_optionsList['HRJobPay-pay_unit'] = CRM_Hrjobcontract_SelectValues::payUnit();
+    $this->_optionsList['HRJobDetails-contract_type'] = CRM_Hrjobcontract_SelectValues::buildDbOptions('hrjc_contract_type');
+    $this->_optionsList['HRJobDetails-location'] = CRM_Hrjobcontract_SelectValues::buildDbOptions('hrjc_location');
+    $this->_optionsList['HRJobDetails-notice_unit_employee'] = $this->_optionsList['HRJobHour-hours_unit'];
+    $this->_optionsList['HRJobDetails-notice_unit'] = $this->_optionsList['HRJobHour-hours_unit'];
+    $this->_optionsList['HRJobDetails-end_reason'] = CRM_Hrjobcontract_SelectValues::buildDbOptions('hrjc_contract_end_reason');
+    $this->_optionsList['HRJobContractRevision-change_reason'] = CRM_Hrjobcontract_SelectValues::buildDbOptions('hrjc_revision_change_reason');
   }
   /**
    * Set fields to an array of importable fields
@@ -147,4 +174,40 @@ class CRM_Hrjobcontract_Import_Parser_BaseClass extends CRM_Hrjobcontract_Import
    * @access public
    */
   function fini() {}
+
+  /**
+   * confirm and get option database ID or label given its ID or label
+   * @param String|Integer $option
+   * @param String|Integer $value
+   * @param String $returnField
+   * @return Integer|String
+   * @access private
+   */
+  protected function getOptionKey($option, $value, $returnField = 'id')  {
+    $search_field = 'label';
+    if (is_numeric ($value)) {
+      $search_field = 'id';
+    }
+    $index = array_search(strtolower($value), array_map('strtolower', array_column($this->_optionsList[$option], $search_field)) );
+    if ($index !== FALSE)  {
+      return $this->_optionsList[$option][$index][$returnField];
+    }
+    return 0;
+  }
+
+  /**
+   * get static option ID given its Key
+   * @param String|Integer $option
+   * @param String|Integer $value
+   * @return Integer
+   * @access private
+   */
+  protected function getStaticOptionKey($option, $value)  {
+    $key = array_search(strtolower($value), array_map('strtolower', $this->_optionsList[$option]));
+    if ($key !== FALSE)  {
+      return $key;
+    }
+    return FALSE;
+  }
+
 }

--- a/hrjobcontract/CRM/Hrjobcontract/SelectValues.php
+++ b/hrjobcontract/CRM/Hrjobcontract/SelectValues.php
@@ -112,4 +112,80 @@ class CRM_Hrjobcontract_SelectValues {
     }
     return $commonUnit;
   }
+
+  /**
+   * Get options for a given job roles field along with their database IDs.
+   * @param String $fieldName
+   * @return array
+   */
+  public static function buildDbOptions($fieldName) {
+    $queryParam = array(1 => array($fieldName, 'String'));
+    $query = "SELECT cpv.id, cpv.value, cpv.label from civicrm_option_value cpv
+              LEFT JOIN civicrm_option_group cpg on cpv.option_group_id = cpg.id
+              WHERE cpg.name = %1";
+    $options = array();
+    $result = CRM_Core_DAO::executeQuery($query, $queryParam);
+    while ($result->fetch()) {
+      $options[] =  array( 'id'=>$result->id, 'label'=>$result->label, 'value'=>$result->value );
+    }
+    return $options;
+  }
+
+  /**
+   * Get Contract pay scales (grades) list.
+   * @return array
+   */
+  public static function buildPayScales() {
+    $query = "SELECT id,pay_scale,pay_grade,currency,amount,periodicity from civicrm_hrpay_scale ".
+             " WHERE is_active=1";
+    $options = array();
+    $result = CRM_Core_DAO::executeQuery($query);
+    while ($result->fetch()) {
+      $label = $result->pay_scale." - ".$result->pay_grade." - ".$result->currency." ".$result->amount." per ".$result->periodicity;
+      $options[] =  array( 'id'=>$result->id, 'label'=> $label);
+    }
+    return $options;
+  }
+
+  /**
+   * Get enabled currencies
+   * @return array
+   */
+  public static function buildCurrency()
+  {
+    //currencies_enabled
+    $groupData = civicrm_api3('OptionGroup', 'get', array(
+      'sequential' => 1,
+      'name' => "currencies_enabled",
+      'return' => 'id'
+    ));
+    $currenciesData = civicrm_api3('OptionValue', 'get', array(
+      'sequential' => 1,
+      'option_group_id' => $groupData['id'],
+      'return' => "value"
+    ));
+    $currencies = array();
+    foreach($currenciesData['values'] as $item)  {
+      $value = $item['value'];
+      $currencies[] =  array( 'id'=>$value, 'label'=> $value);
+    }
+    return $currencies;
+  }
+
+  /**
+   * Get contract hours location
+   * @return array
+   */
+  public static function buildHourLocations()
+  {
+    $query = "SELECT id,location,standard_hours,periodicity from civicrm_hrhours_location ".
+      " WHERE is_active=1";
+    $options = array();
+    $result = CRM_Core_DAO::executeQuery($query);
+    while ($result->fetch()) {
+      $label = $result->location." - ".$result->standard_hours." hours per ".$result->periodicity;
+      $options[] =  array( 'id'=>$result->id, 'label'=> $label);
+    }
+    return $options;
+  }
 }


### PR DESCRIPTION
When importing contracts , many of  validation rules are incorrect because they are relying on field type attribute from DAO file. also i fixed  other issues in contract import such as the error page that appear if the health or life insurance provider field is empty.