### PR TITLE
PCHR-618: Set contact summary tab to be the default one

### DIFF
--- a/contactsummary/contactsummary.php
+++ b/contactsummary/contactsummary.php
@@ -127,9 +127,12 @@ function contactsummary_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
  */
 function contactsummary_civicrm_pageRun($page) {
     if ($page instanceof CRM_Contact_Page_View_Summary) {
-        CRM_Core_Resources::singleton()->addVars('contactsummary', array(
-            'baseURL' => CRM_Extension_System::singleton()->getMapper()->keyToUrl('org.civicrm.contactsummary')
-        ));
+        CRM_Core_Resources::singleton()
+          ->addVars('contactsummary', array(
+            'baseURL' => CRM_Extension_System::singleton()->getMapper()->keyToUrl('org.civicrm.contactsummary')))
+          ->addSetting(array(
+            'tabSettings' => array('active' => CRM_Utils_Request::retrieve('selectedChild', 'String', $this, FALSE, 'contactsummary')),
+          ));
 
         $script = <<<EOT
             window.setTimeout(function() {
@@ -154,6 +157,6 @@ function contactsummary_civicrm_tabs(&$tabs) {
     'id'     => 'contactsummary',
     'url'    => CRM_Utils_System::url('civicrm/contact-summary'),
     'title'  => ts('Contact Summary'),
-    'weight' => 1
+    'weight' => -1
   );
 }

--- a/contactsummary/js/src/contact-summary.js
+++ b/contactsummary/js/src/contact-summary.js
@@ -6,7 +6,5 @@ require.config({
 });
 
 require(['contact-summary/app'], function () {
-    document.addEventListener('contactsummaryLoad', function () {
-        angular.bootstrap(document.getElementById('contactsummary'), ['contactsummary']);
-    });
+    angular.bootstrap(document.getElementById('contactsummary'), ['contactsummary']);
 });

--- a/hrjobcontract/templates/CRM/Contact/Page/View/Summary.tpl
+++ b/hrjobcontract/templates/CRM/Contact/Page/View/Summary.tpl
@@ -130,12 +130,6 @@
   <div class="crm-block crm-content-block crm-contact-page crm-inline-edit-container">
     <div id="mainTabContainer">
       <ul class="crm-contact-tabs-list">
-        <li id="tab_summary" class="crm-tab-button ui-corner-all">
-          <a href="#contact-summary" title="{ts}Summary{/ts}">
-            <span> </span> {ts}Summary{/ts}
-            <em></em>
-          </a>
-        </li>
         {foreach from=$allTabs key=tabName item=tabValue}
           <li id="tab_{$tabValue.id}" class="crm-tab-button ui-corner-all crm-count-{$tabValue.count}{if isset($tabValue.class)} {$tabValue.class}{/if}">
             <a href="{$tabValue.url}" title="{$tabValue.title}">


### PR DESCRIPTION
## Problem
Contact "Personal Details" tab is the first and default tab in contact summary page but "Contact Summary" tab is needed to be the first instead.

![selection_004](https://cloud.githubusercontent.com/assets/6275540/14439137/90b89478-0021-11e6-8dda-eb09e1fd8c10.png)


## Solution 
Civicrm Core files are altered and the patch submitted to Civi-Core both master and 4.5 versions (https://issues.civicrm.org/jira/browse/CRM-18390)  Also currently **jobcontract** extension override the summary page template file . So this file is used  **hrjobcontract/templates/CRM/Contact/Page/View/Summary.tpl**  as a template file instead of this **CRM/Contact/Page/View/Summary.tpl** which means that i have to remove the hardcoded summary tab from their too.



![selection_006](https://cloud.githubusercontent.com/assets/6275540/14439135/88e80bf2-0021-11e6-800a-467372e785f6.png)


## Related Links
- CiviCRM Jira : https://issues.civicrm.org/jira/browse/CRM-18390
- CiviCore patch (Master) : https://github.com/civicrm/civicrm-core/pull/8110https://github.com/civicrm/civicrm-core/pull/8110
- CiviCore patch (4.5) : https://github.com/civicrm/civicrm-core/pull/8109
