### PR TITLE
PCHR-891: Complete Job Contract and Role Export Feature

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/Query.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/Query.php
@@ -37,9 +37,18 @@ class CRM_Hrjobroles_BAO_Query extends CRM_Contact_BAO_Query_Interface {
         '1' => '%'
     );
 
+    /**
+     * @var array A list of fields available while importing/exporting
+     */
+    private $hrjobRoleFields = array();
+
+
     public function &getFields() {
-        $arr = array();
-        return $arr;
+        if (empty($this->hrjobRoleFields)) {
+            $this->hrjobRoleFields = CRM_Hrjobroles_DAO_HrJobRoles::export();
+        }
+
+        return $this->hrjobRoleFields;
     }
 
     /**
@@ -53,7 +62,7 @@ class CRM_Hrjobroles_BAO_Query extends CRM_Contact_BAO_Query_Interface {
         $from = '';
         switch ($name) {
             case 'civicrm_contact':
-                $from .= " $side JOIN civicrm_hrjobroles hrjobroles ON hrjobcontract.id = hrjobroles.job_contract_id ";
+                $from .= " $side JOIN civicrm_hrjobroles ON hrjobcontract.id = civicrm_hrjobroles.job_contract_id ";
                 break;
         }
 
@@ -88,7 +97,7 @@ class CRM_Hrjobroles_BAO_Query extends CRM_Contact_BAO_Query_Interface {
         $fieldsKeys = CRM_Hrjobroles_BAO_HrJobRoles::fieldKeys();
         $field = substr($name, 11);
         $fieldKey = isset($fieldsKeys[$field]) ? $fieldsKeys[$field] : '';
-        $whereField = 'hrjobroles.'.$field;
+        $whereField = 'civicrm_hrjobroles.'.$field;
         if($fieldKey) {
             $fieldTitle = $fields[$fieldKey]['title'];
         } else {

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/DAO/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/DAO/HrJobRoles.php
@@ -270,6 +270,9 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
           'name' => 'id',
           'type' => CRM_Utils_Type::T_INT,
           'required' => true,
+          'export' => true,
+          'title' => 'Job Role ID',
+          'where' => 'civicrm_hrjobroles.id'
         ) ,
         'job_contract_id' => array(
           'name' => 'job_contract_id',
@@ -286,12 +289,16 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
           'size' => CRM_Utils_Type::HUGE,
           'import' => true,
           'default' => 'NULL',
+          'export' => true,
+          'where' => 'civicrm_hrjobroles.title'
         ) ,
         'description' => array(
           'name' => 'description',
           'type' => CRM_Utils_Type::T_TEXT,
           'title' => ts('Job Role Description') ,
           'import' => true,
+          'export' => true,
+          'where' => 'civicrm_hrjobroles.description'
         ) ,
         'status' => array(
           'name' => 'status',
@@ -300,16 +307,20 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
           'maxlength' => 255,
           'size' => CRM_Utils_Type::HUGE,
           'default' => 'NULL',
+          'export' => true,
+          'where' => 'civicrm_hrjobroles.status'
         ) ,
         'hrjc_role_hours' => array(
           'name' => 'hours',
           'type' => CRM_Utils_Type::T_FLOAT,
-          'title' => ts('Amount') ,
+          'title' => ts('Job Role Hours'),
+          'export' => true,
+          'where' => 'civicrm_hrjobroles.hours'
         ) ,
         'hrjc_role_unit' => array(
           'name' => 'role_hours_unit',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Hours Unit') ,
+          'title' => ts('Job Role Hours Unit') ,
           'maxlength' => 63,
           'size' => CRM_Utils_Type::BIG,
           'where' => 'civicrm_hrjobroles.role_hours_unit',
@@ -320,7 +331,7 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
         'hrjc_region' => array(
           'name' => 'region',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Region') ,
+          'title' => ts('Job Role Region') ,
           'maxlength' => 127,
           'size' => CRM_Utils_Type::HUGE,
           'import' => true,
@@ -332,7 +343,7 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
         'hrjc_role_department' => array(
           'name' => 'department',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Department') ,
+          'title' => ts('Job Role Department') ,
           'maxlength' => 127,
           'size' => CRM_Utils_Type::HUGE,
           'import' => true,
@@ -344,7 +355,7 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
         'hrjc_level_type' => array(
           'name' => 'level_type',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Level') ,
+          'title' => ts('Job Role Level') ,
           'maxlength' => 63,
           'size' => CRM_Utils_Type::BIG,
           'import' => true,
@@ -362,21 +373,25 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
         'functional_area' => array(
           'name' => 'functional_area',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Functional Area') ,
+          'title' => ts('Job Role Functional Area') ,
           'maxlength' => 127,
           'size' => CRM_Utils_Type::HUGE,
+          'where' => 'civicrm_hrjobroles.functional_area',
+          'export' => true,
         ) ,
         'organization' => array(
           'name' => 'organization',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Organization') ,
+          'title' => ts('Job Role Organization') ,
           'maxlength' => 127,
           'size' => CRM_Utils_Type::HUGE,
+          'where' => 'civicrm_hrjobroles.organization',
+          'export' => true,
         ) ,
         'hrjc_cost_center' => array(
           'name' => 'cost_center',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Cost Center') ,
+          'title' => ts('Job Role Cost Center') ,
           'maxlength' => 255,
           'size' => CRM_Utils_Type::HUGE,
           'import' => true,
@@ -388,7 +403,7 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
         'hrjc_cost_center_val_type' => array(
           'name' => 'cost_center_val_type',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Cost Center value type') ,
+          'title' => ts('Job Role Cost Center value type') ,
           'maxlength' => 127,
           'size' => CRM_Utils_Type::HUGE,
           'import' => true,
@@ -400,7 +415,7 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
         'hrjc_role_percent_pay_cost_center' => array(
           'name' => 'percent_pay_cost_center',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Percent of Pay Assigned to this cost center') ,
+          'title' => ts('Job Role Percent of Pay Assigned to this cost center') ,
           'maxlength' => 255,
           'size' => CRM_Utils_Type::HUGE,
           'import' => true,
@@ -412,7 +427,7 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
         'hrjc_role_amount_pay_cost_center' => array(
           'name' => 'amount_pay_cost_center',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Amount of Pay Assigned to this cost center') ,
+          'title' => ts('Job Role Amount of Pay Assigned to this cost center') ,
           'maxlength' => 255,
           'size' => CRM_Utils_Type::HUGE,
           'import' => true,
@@ -424,15 +439,17 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
         'funder' => array(
           'name' => 'funder',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Funder Contact ID') ,
+          'title' => ts('Job Role Funders') ,
           'maxlength' => 255,
           'size' => CRM_Utils_Type::HUGE,
           'import' => true,
+          'export' => true,
+          'where' => 'civicrm_hrjobroles.funder'
         ) ,
         'hrjc_funder_val_type' => array(
           'name' => 'funder_val_type',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Funder value type') ,
+          'title' => ts('Job Role Funder value type') ,
           'maxlength' => 127,
           'size' => CRM_Utils_Type::HUGE,
           'import' => true,
@@ -444,7 +461,7 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
         'hrjc_role_percent_pay_funder' => array(
           'name' => 'percent_pay_funder',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Percent of Pay Assigned to this funder') ,
+          'title' => ts('Job Role Percent of Pay Assigned to this funder') ,
           'maxlength' => 255,
           'size' => CRM_Utils_Type::HUGE,
           'import' => true,
@@ -456,7 +473,7 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
         'hrjc_role_amount_pay_funder' => array(
           'name' => 'amount_pay_funder',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Amount of Pay Assigned to this funder') ,
+          'title' => ts('Job Role Amount of Pay Assigned to this funder') ,
           'maxlength' => 255,
           'size' => CRM_Utils_Type::HUGE,
           'import' => true,
@@ -468,7 +485,7 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
         'location' => array(
           'name' => 'location',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Location') ,
+          'title' => ts('Job Role Location') ,
           'maxlength' => 127,
           'size' => CRM_Utils_Type::HUGE,
           'import' => true,
@@ -480,7 +497,7 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
         'hrjc_role_start_date' => array(
           'name' => 'start_date',
           'type' => CRM_Utils_Type::T_DATE | CRM_Utils_Type::T_TIME,
-          'title' => ts('Start Date') ,
+          'title' => ts('Job Role Start Date') ,
           'import' => true,
           'where' => 'civicrm_hrjobroles.start_date',
           'headerPattern' => '',
@@ -491,7 +508,7 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
         'hrjc_role_end_date' => array(
           'name' => 'end_date',
           'type' => CRM_Utils_Type::T_DATE | CRM_Utils_Type::T_TIME,
-          'title' => ts('End Date') ,
+          'title' => ts('Job Role End Date') ,
           'import' => true,
           'where' => 'civicrm_hrjobroles.end_date',
           'headerPattern' => '',

--- a/com.civicrm.hrjobroles/xml/schema/CRM/Hrjobroles/HrJobRoles.xml
+++ b/com.civicrm.hrjobroles/xml/schema/CRM/Hrjobroles/HrJobRoles.xml
@@ -10,9 +10,11 @@
 
     <field>
         <name>id</name>
+        <type>Job Role ID</type>
         <type>int unsigned</type>
         <required>true</required>
         <comment>Unique HrJobRoles ID</comment>
+        <export>true</export>
         <add>4.5</add>
     </field>
     <primaryKey>
@@ -42,6 +44,7 @@
         <default>NULL</default>
         <comment>Title or Project name for the Job Role.</comment>
         <add>4.5</add>
+        <export>true</export>
     </field>
 
     <field>
@@ -49,6 +52,7 @@
         <title>Job Role Description</title>
         <type>text</type>
         <comment>Negotiated name for the role</comment>
+        <export>true</export>
     </field>
 
     <field>
@@ -58,21 +62,23 @@
         <length>255</length>
         <default>NULL</default>
         <comment>Job Role Status (Active / Inactive)</comment>
+        <export>true</export>
         <add>4.5</add>
     </field>
 
     <field>
         <name>hours</name>
-        <title>Amount</title>
+        <title>Job Role Hours</title>
         <type>float</type>
         <default>0</default>
         <comment>Amount of time allocated for work (in a given week)</comment>
+        <export>true</export>
         <uniqueName>hrjc_role_hours</uniqueName>
     </field>
 
     <field>
         <name>role_hours_unit</name>
-        <title>Hours Unit</title>
+        <title>Job Role Hours Unit</title>
         <type>varchar</type>
         <length>63</length>
         <comment>Period during which hours are allocated (eg 5 hours per day; 5 hours per week)</comment>
@@ -83,7 +89,7 @@
 
     <field>
         <name>region</name>
-        <title>Region</title>
+        <title>Job Role Region</title>
         <type>varchar</type>
         <length>127</length>
         <export>true</export>
@@ -98,7 +104,7 @@
 
     <field>
         <name>department</name>
-        <title>Department</title>
+        <title>Job Role Department</title>
         <type>varchar</type>
         <length>127</length>
         <export>true</export>
@@ -113,7 +119,7 @@
 
     <field>
         <name>level_type</name>
-        <title>Level</title>
+        <title>Job Role Level</title>
         <type>varchar</type>
         <length>63</length>
         <comment>Junior manager, senior manager, etc.</comment>
@@ -141,9 +147,10 @@
 
     <field>
         <name>functional_area</name>
-        <title>Functional Area</title>
+        <title>Job Role Functional Area</title>
         <type>varchar</type>
         <length>127</length>
+        <export>true</export>
     </field>
     <index>
         <name>index_functional_area</name>
@@ -152,9 +159,10 @@
 
     <field>
         <name>organization</name>
-        <title>Organization</title>
+        <title>Job Role Organization</title>
         <type>varchar</type>
         <length>127</length>
+        <export>true</export>
     </field>
     <index>
         <name>index_organization</name>
@@ -163,7 +171,7 @@
 
     <field>
         <name>cost_center</name>
-        <title>Cost Center</title>
+        <title>Job Role Cost Center</title>
         <type>varchar</type>
         <length>255</length>
         <comment>List of Cost Center option group values</comment>
@@ -178,7 +186,7 @@
 
     <field>
         <name>cost_center_val_type</name>
-        <title>Cost Center value type</title>
+        <title>Job Role Cost Center value type</title>
         <type>varchar</type>
         <length>127</length>
         <comment>Cost Center value type (fixed or %)</comment>
@@ -193,7 +201,7 @@
 
     <field>
         <name>percent_pay_cost_center</name>
-        <title>Percent of Pay Assigned to this cost center</title>
+        <title>Job Role Percent of Pay Assigned to this cost center</title>
         <type>varchar</type>
         <length>255</length>
         <default>0</default>
@@ -205,7 +213,7 @@
 
     <field>
         <name>amount_pay_cost_center</name>
-        <title>Amount of Pay Assigned to this cost center</title>
+        <title>Job Role Amount of Pay Assigned to this cost center</title>
         <type>varchar</type>
         <length>255</length>
         <default>0</default>
@@ -217,16 +225,17 @@
 
     <field>
         <name>funder</name>
-        <title>Funder Contact ID</title>
+        <title>Job Role Funders</title>
         <type>varchar</type>
         <length>255</length>
         <default>0</default>
         <comment>List of attached Funder contact IDs</comment>
+        <export>true</export>
     </field>
 
     <field>
         <name>funder_val_type</name>
-        <title>Funder value type</title>
+        <title>Job Role Funder value type</title>
         <type>varchar</type>
         <length>127</length>
         <comment>Funder value type (fixed or %)</comment>
@@ -241,7 +250,7 @@
 
     <field>
         <name>percent_pay_funder</name>
-        <title>Percent of Pay Assigned to this funder</title>
+        <title>Job Role Percent of Pay Assigned to this funder</title>
         <type>varchar</type>
         <length>255</length>
         <default>0</default>
@@ -253,7 +262,7 @@
 
     <field>
         <name>amount_pay_funder</name>
-        <title>Amount of Pay Assigned to this funder</title>
+        <title>Job Role Amount of Pay Assigned to this funder</title>
         <type>varchar</type>
         <length>255</length>
         <default>0</default>
@@ -265,7 +274,7 @@
 
     <field>
         <name>location</name>
-        <title>Location</title>
+        <title>Job Role Location</title>
         <type>varchar</type>
         <length>127</length>
         <comment>Main work location</comment>
@@ -279,7 +288,7 @@
 
     <field>
         <name>start_date</name>
-        <title>Start Date</title>
+        <title>Job Role Start Date</title>
         <type>timestamp</type>
         <default>0</default>
         <comment>Start Date of the job role</comment>
@@ -290,7 +299,7 @@
 
     <field>
         <name>end_date</name>
-        <title>End Date</title>
+        <title>Job Role End Date</title>
         <type>timestamp</type>
         <default>0</default>
         <comment>End Date of the job role</comment>

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/Query.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/Query.php
@@ -51,30 +51,27 @@ class CRM_Hrjobcontract_BAO_Query extends CRM_Contact_BAO_Query_Interface {
   function &getFields() {
     if (!self::$_hrjobFields) {
       self::$_hrjobFields = CRM_Hrjobcontract_BAO_HRJobDetails::export();
-      self::$_hrjobFields['hrjobcontract_role_manager_contact'] =
-        array(
-          'name'  => 'manager_contact',
-          'title' => 'Job Manager',
-          'type'  => CRM_Utils_Type::T_STRING,
-          'where' => 'civicrm_hrjobcontract_role_manager.display_name'
-        );
       self::$_hrjobFields = array_merge(self::$_hrjobFields, CRM_Hrjobcontract_BAO_HRJobHealth::export());
       self::$_hrjobFields = array_merge(self::$_hrjobFields, CRM_Hrjobcontract_BAO_HRJobHour::export());
-
-      // special case to check for existence of health record entry
-      /*self::$_hrjobFields['hrjobcontract_health_is_healthcare'] =
-        array(
-          'name'  => 'is_healthcare',
-          'title' => 'Is health care',
-          'type'  => CRM_Utils_Type::T_BOOLEAN,
-          'where' => 'civicrm_hrjobcontract_health.id'
-        );*/
-      
       self::$_hrjobFields = array_merge(self::$_hrjobFields, CRM_Hrjobcontract_BAO_HRJobLeave::export());
       self::$_hrjobFields = array_merge(self::$_hrjobFields, CRM_Hrjobcontract_BAO_HRJobPay::export());
       self::$_hrjobFields = array_merge(self::$_hrjobFields, CRM_Hrjobcontract_BAO_HRJobPension::export());
       self::$_hrjobFields = array_merge(self::$_hrjobFields, CRM_Hrjobcontract_BAO_HRJobRole::export());
+
+      self::$_hrjobFields['hrjobcontract_role_manager_contact'] = array(
+          'name'  => 'manager_contact',
+          'title' => 'Job Manager',
+          'type'  => CRM_Utils_Type::T_STRING,
+          'where' => 'civicrm_hrjobcontract_role_manager.display_name'
+      );
+      self::$_hrjobFields['hrjobcontract_id'] = array(
+          'name'  => 'contract_id',
+          'title' => 'Contract ID',
+          'type'  => CRM_Utils_Type::T_INT,
+          'where' => 'hrjobcontract.id'
+      );
     }
+
     return self::$_hrjobFields;
   }
 


### PR DESCRIPTION
### Problem

The Contract ID and the Job Role fields weren't available to be included in the file exported from the Advanced Search

### Solution

The fields were configured to be available to the exported file. The Job Role fields were prefixed with 'Job Role' so they could be easily found on the list:

![captura de tela 2016-04-15 as 16 18 13](https://cloud.githubusercontent.com/assets/388373/14572531/b7e50872-0325-11e6-9e39-a1c3aaa535db.png)

