### PR TITLE
PCHR-982: Rename job contract import page title to 'Import Job Contracts'

### DIFF
--- a/hrjobcontract/xml/Menu/import.xml
+++ b/hrjobcontract/xml/Menu/import.xml
@@ -3,7 +3,7 @@
   <item>
     <path>civicrm/job/import</path>
     <page_callback>CRM_Hrjobcontract_Import_Controller</page_callback>
-    <title>JOB Import</title>
+    <title>Import Job Contracts</title>
     <access_arguments>administer CiviCRM</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
Changing Import job contracts page title from "JOB import" to "Import Job Contracts"

### Before
![selection_006](https://cloud.githubusercontent.com/assets/6275540/14705381/df650b18-07c1-11e6-97a3-68977d044585.png)


### After

![selection_007](https://cloud.githubusercontent.com/assets/6275540/14705392/ea890b34-07c1-11e6-91f8-a857dc2472fd.png)
