### PR TITLE
PCHR-995 : Remove -select- option from regions and locations select boxes

### DIFF
--- a/contactaccessrights/CRM/Contactaccessrights/Form/ManageRights.php
+++ b/contactaccessrights/CRM/Contactaccessrights/Form/ManageRights.php
@@ -185,8 +185,6 @@ class CRM_Contactaccessrights_Form_ManageRights extends CRM_Core_Form {
    */
   private function getOptions($optionGroupName) {
     try {
-      $options = ['' => ts('- select -')];
-
       $result = civicrm_api3('OptionValue', 'get', ['sequential' => 1, 'option_group_name' => $optionGroupName]);
 
       foreach ($result['values'] as $option) {


### PR DESCRIPTION
## Problem
in contacts manage access popup , the -select- option was appearing in both region and location select boxes and you can even choose it.

![selection_011](https://cloud.githubusercontent.com/assets/6275540/14743199/0e384df0-08a9-11e6-9657-257e4a9a0490.png)

![selection_012](https://cloud.githubusercontent.com/assets/6275540/14743202/136acdde-08a9-11e6-8f0f-83ef4e80d7da.png)



## Solution
the -select- option was removed from options list array.

![selection_013](https://cloud.githubusercontent.com/assets/6275540/14743208/195b0510-08a9-11e6-9c08-5bffddacab8a.png)
