### PR TITLE
PCHR-997: new permission - manage roles and Teams

### DIFF
--- a/contactaccessrights/contactaccessrights.php
+++ b/contactaccessrights/contactaccessrights.php
@@ -59,6 +59,16 @@ function contactaccessrights_civicrm_disable() {
 }
 
 /**
+ * Implements hook_civicrm_permission().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_permission
+ */
+function contactaccessrights_civicrm_permission(&$permissions) {
+  $prefix = ts('CiviHRContactAccessRights') . ': ';
+  $permissions['administer roles and teams'] = $prefix . ts('Administer roles and teams');
+}
+
+/**
  * Implements hook_civicrm_upgrade().
  *
  * @param $op    string, the type of operation being performed; 'check' or 'enqueue'
@@ -189,11 +199,13 @@ function contactaccessrights_civicrm_aclWhereClause($type, &$tables, &$whereTabl
  * @param int   $contactID ID of the contact whose summary page is being viewed.
  */
 function contactaccessrights_civicrm_summaryActions(&$actions, $contactID) {
-  $actions['casework'] = array(
-    'title'  => 'Manage roles and teams',
-    'weight' => 999,
-    'ref'    => 'manage-contact-access-rights',
-    'key'    => 'manage-contact-access-rights',
-    'href'   => "/civicrm/admin/contact-access-rights/manage?"
-  );
+  if (CRM_Core_Permission::check('administer roles and teams')) {
+    $actions['casework'] = array(
+      'title'  => 'Manage roles and teams',
+      'weight' => 999,
+      'ref'    => 'manage-contact-access-rights',
+      'key'    => 'manage-contact-access-rights',
+      'href'   => "/civicrm/admin/contact-access-rights/manage?"
+    );
+  }
 }

--- a/contactaccessrights/xml/Menu/contactaccessrights.xml
+++ b/contactaccessrights/xml/Menu/contactaccessrights.xml
@@ -4,6 +4,6 @@
     <path>civicrm/admin/contact-access-rights/manage</path>
     <page_callback>CRM_Contactaccessrights_Form_ManageRights</page_callback>
     <title>ManageRights</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>administer roles and teams</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
## The Problem

On contact summary page , anybody can see "**manage roles and teams**" link in action menu 

![selection_004](https://cloud.githubusercontent.com/assets/6275540/14814004/405df640-0b9c-11e6-9b98-4e27efaa5685.png)

and if it clicked the following modal will appear to allow the user to manage that contact roles and teams :

![selection_005](https://cloud.githubusercontent.com/assets/6275540/14814028/668ee6f8-0b9c-11e6-8cc0-9ee0f9575162.png)

or even by using the link directly : <civicrm URL>/admin/contact-access-rights/manage?&cid=CONTACT_ID a similer page will opened. 

But this is not correct behavior  , only specific users should be allowed to see the screens above .

## The Solution

A new permission created named "administer roles and teams" and only users with that permission are allowed to see the action bar menu or even access the page directly from the browser. Also this permission is set to be enabled by default for "civihr_admin" and "administer" Drupal roles.

![selection_003](https://cloud.githubusercontent.com/assets/6275540/14814216/3c250ac2-0b9d-11e6-87a3-a086502df34f.png)


## Related PRs

https://github.com/compucorp/civihr-employee-portal/pull/115
