### PR TITLE
PCHR-1009 - Removing old Job_Summary data migration when installing the extension.

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -317,13 +317,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
         CRM_Core_DAO::executeQuery($updateRevisionQuery, $updateRevisionParams);
 
     }
-    
-    // Migrating Job_Summary data:
-    if ($tableExists['civicrm_value_job_summary_10'])
-    {
-        CRM_Core_DAO::executeQuery('INSERT INTO civicrm_value_jobcontract_summary_10 SELECT * FROM civicrm_value_job_summary_10');
-    }
-      
+
     return true;
   }
   


### PR DESCRIPTION
There was still 'Job_Summary' data migrating from old HRJob extension when installing new HRJobContract. It was causing an error during buildkit installation when using current 'develop' branch. We don't use Job Summary data anymore so the data migration is now removed from the installer.