### PR TITLE
PCHR-921: Remove warnings on Contact page

### DIFF
--- a/uk.co.compucorp.civicrm.hrnavigation/CRM/Core/BAO/Navigation.php
+++ b/uk.co.compucorp.civicrm.hrnavigation/CRM/Core/BAO/Navigation.php
@@ -586,7 +586,13 @@ ORDER BY parent_id, weight";
       $homeIcon = '<img src="' . $config->userFrameworkResourceURL . 'i/logo16px.png" style="vertical-align:middle;" />';
       self::retrieve($homeParams, $homeNav);
       if ($homeNav) {
-        list($path, $q) = explode('?', $homeNav['url']);
+        if (array_key_exists('query', parse_url($homeNav['url']))) {
+          list($path, $q) = explode('?', $homeNav['url']);
+        } else {
+          $q = NULL;
+          $path = $homeNav['url'];
+        }
+
         $homeURL = CRM_Utils_System::url($path, $q);
         $homeLabel = $homeNav['label'];
         // CRM-6804 (we need to special-case this as we don’t ts()-tag variables)


### PR DESCRIPTION
#### Problem
We have this error appearing on the civihr pages:
```
Notice: Undefined offset: 1 in CRM_Core_BAO_Navigation::createNavigation() (line 656 of /var/www/civicrm-buildkit/build/hr16/sites/all/modules/civicrm/CRM/Core/BAO/Navigation.php).
```
This started to happen after the work PCHR-343 was merged, which changes the CiviHR homepage from `civicrm/dashboard?reset=1` to `civicrm/tasksassignments/dashboard#/tasks` (see [this file](https://github.com/compucorp/civihr-tasks-assignments/blob/develop/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/DashboardSwitcher.php)), basically making T&A the CiviHR dashboard

The hrnavigation code was still tring to split the url using the `?` querystring delimiter, but given that the T&A url doesn't have one, the offset notice was thrown

#### Solution
Simply checking if the url has a querystring before splitting it by `?` solves the issue