### PR TITLE
PCHR-891: Fix Job Contracts fields configuration for export

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobDetails.php
+++ b/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobDetails.php
@@ -296,6 +296,7 @@ class CRM_Hrjobcontract_DAO_HRJobDetails extends CRM_Hrjobcontract_DAO_Base
                     'optionGroupName' => 'hrjc_contract_end_reason',
                   ),
                   'headerPattern' => '/^end\s?reason/i',
+                  'where' => 'civicrm_hrjobcontract_details.end_reason'
                 ) ,
                 'hrjobcontract_details_notice_amount' => array(
                   'name' => 'notice_amount',

--- a/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobHealth.php
+++ b/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobHealth.php
@@ -231,6 +231,7 @@ class CRM_Hrjobcontract_DAO_HRJobHealth extends CRM_Hrjobcontract_DAO_Base
                 'export' => true,
                 'import' => true,
                 'headerPattern' => '/^healthcare\s?dependents/i',
+                'where' => 'civicrm_hrjobcontract_health.dependents'
               ) ,
               'hrjobcontract_health_health_provider_life_insurance' => array(
                 'name' => 'provider_life_insurance',
@@ -276,6 +277,7 @@ class CRM_Hrjobcontract_DAO_HRJobHealth extends CRM_Hrjobcontract_DAO_Base
                 'export' => true,
                 'import' => true,
                 'headerPattern' => '/^life\s?insurance\s?dependents/i',
+                'where' => 'civicrm_hrjobcontract_health.dependents_life_insurance'
               ) ,
             )
         );

--- a/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobPay.php
+++ b/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobPay.php
@@ -286,6 +286,7 @@ class CRM_Hrjobcontract_DAO_HRJobPay extends CRM_Hrjobcontract_DAO_Base
                 'import' => false,
                 'default' => '1',
                 'headerPattern' => '/^estimated\s?auto\s?pay/i',
+                'where' => 'civicrm_hrjobcontract_pay.pay_is_auto_est'
               ) ,
               'hrjobcontract_pay_annual_benefits' => array(
                 'name' => 'annual_benefits',

--- a/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobRole.php
+++ b/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobRole.php
@@ -236,6 +236,7 @@ class CRM_Hrjobcontract_DAO_HRJobRole extends CRM_Hrjobcontract_DAO_Base
                   'maxlength' => 127,
                   'size' => CRM_Utils_Type::HUGE,
                   'headerPattern' => '/^role\s?title/i',
+                  'where' => 'civicrm_hrjobcontract_role.title'
                 ) ,
                 'hrjobcontract_role_description' => array(
                   'name' => 'description',
@@ -244,6 +245,7 @@ class CRM_Hrjobcontract_DAO_HRJobRole extends CRM_Hrjobcontract_DAO_Base
                   'export' => true,
                   'import' => true,
                   'headerPattern' => '/^role\s?description/i',
+                  'where' => 'civicrm_hrjobcontract_role.description',
                 ) ,
                 'hrjobcontract_role_role_hours' => array(
                   'name' => 'hours',
@@ -252,6 +254,7 @@ class CRM_Hrjobcontract_DAO_HRJobRole extends CRM_Hrjobcontract_DAO_Base
                   'export' => true,
                   'import' => true,
                   'headerPattern' => '/^role\s?hours\s?amount/i',
+                  'where' => 'civicrm_hrjobcontract_role.hours'
                 ) ,
                 'hrjobcontract_role_role_unit' => array(
                   'name' => 'role_hours_unit',
@@ -332,6 +335,7 @@ class CRM_Hrjobcontract_DAO_HRJobRole extends CRM_Hrjobcontract_DAO_Base
                   'import' => true,
                   'FKClassName' => 'CRM_Contact_DAO_Contact',
                   'headerPattern' => '/^manager\s?contact\s?id/i',
+                  'where' => 'civicrm_hrjobcontract_role.manager_contact_id'
                 ) ,
                 'hrjobcontract_role_functional_area' => array(
                   'name' => 'functional_area',
@@ -342,6 +346,7 @@ class CRM_Hrjobcontract_DAO_HRJobRole extends CRM_Hrjobcontract_DAO_Base
                   'maxlength' => 127,
                   'size' => CRM_Utils_Type::HUGE,
                   'headerPattern' => '/^functional\s?area/i',
+                  'where' => 'civicrm_hrjobcontract_role.functional_area'
                 ) ,
                 'hrjobcontract_role_organization' => array(
                   'name' => 'organization',
@@ -352,6 +357,7 @@ class CRM_Hrjobcontract_DAO_HRJobRole extends CRM_Hrjobcontract_DAO_Base
                   'maxlength' => 127,
                   'size' => CRM_Utils_Type::HUGE,
                   'headerPattern' => '/^organization/i',
+                  'where' => 'civicrm_hrjobcontract_role.organization'
                 ) ,
                 'hrjobcontract_role_cost_center' => array(
                   'name' => 'cost_center',
@@ -362,6 +368,7 @@ class CRM_Hrjobcontract_DAO_HRJobRole extends CRM_Hrjobcontract_DAO_Base
                   'maxlength' => 127,
                   'size' => CRM_Utils_Type::HUGE,
                   'headerPattern' => '/^cost\s?center/i',
+                  'where' => 'civicrm_hrjobcontract_role.cost_center'
                 ) ,
                 'hrjobcontract_role_funder' => array(
                   'name' => 'funder',


### PR DESCRIPTION
The CRM_Hrjobcontract_BAO_Query class relies on the 'where' property
of the fields to build the field list of the SELECT clause of the query used
to export contacts. Some of the Contracts fields didn't have this property
and when one of it was selected to be included in the exported
file, the built SQL query ended up incomplete giving a DB Syntax error.