### PR TITLE
PCHR-921: fix contact page warnings

### DIFF
--- a/hrjobcontract/CRM/Contact/Form/Inline/CustomData.php
+++ b/hrjobcontract/CRM/Contact/Form/Inline/CustomData.php
@@ -100,11 +100,12 @@ class CRM_Contact_Form_Inline_CustomData extends CRM_Contact_Form_Inline {
     // Get the form values and groupTree
     $params = $this->controller->exportValues($this->_name);
     CRM_Core_BAO_CustomValueTable::postProcess($params,
-      $this->_groupTree[$this->_groupID]['fields'],
       'civicrm_contact',
       $this->_contactId,
       $this->_entityType
     );
+
+    $this->log();
 
     // reset the group contact cache for this group
     CRM_Contact_BAO_GroupContactCache::remove();

--- a/hrjobcontract/templates/CRM/Contact/Page/View/Summary.tpl
+++ b/hrjobcontract/templates/CRM/Contact/Page/View/Summary.tpl
@@ -1,8 +1,8 @@
 {*
  +--------------------------------------------------------------------+
- | CiviCRM version 4.5                                                |
+ | CiviCRM version 4.7                                                |
  +--------------------------------------------------------------------+
- | Copyright CiviCRM LLC (c) 2004-2014                                |
+ | Copyright CiviCRM LLC (c) 2004-2016                                |
  +--------------------------------------------------------------------+
  | This file is a part of CiviCRM.                                    |
  |                                                                    |
@@ -27,8 +27,6 @@
 {if $action eq 2}
   {include file="CRM/Contact/Form/Contact.tpl"}
 {else}
-
-  {include file="CRM/common/wysiwyg.tpl" includeWysiwygEditor=true}
 
   <div class="crm-summary-contactname-block crm-inline-edit-container">
     <div class="crm-summary-block" id="contactname-block">
@@ -57,37 +55,34 @@
           {* Include Edit button if contact has 'edit contacts' permission OR user is viewing their own contact AND has 'edit my contact' permission. CRM_Contact_Page_View::checkUserPermission handles this and assigns $permission true as needed. *}
           {if $permission EQ 'edit'}
             <li>
-              {assign var='editParams' value=$urlParams|cat:"&action=update&cid=$contactId"}
-              <a href="{crmURL p='civicrm/contact/add' q=$editParams}" class="edit button" title="{ts}Edit{/ts}">
-              <span><div class="icon edit-icon"></div>{ts}Edit{/ts}</span>
-              </a>
+              {crmButton p='civicrm/contact/add' q="$urlParams&action=update&cid=$contactId" class="edit"}
+                {ts}Edit{/ts}
+              {/crmButton}
             </li>
           {/if}
         {/if}
 
         {* Check for permissions to provide Restore and Delete Permanently buttons for contacts that are in the trash. *}
-        {if (call_user_func(array('CRM_Core_Permission','check'), 'access deleted contacts') and
-          $is_deleted)}
+        {if call_user_func(array('CRM_Core_Permission','check'), 'access deleted contacts') and $is_deleted}
           <li class="crm-contact-restore">
-            <a href="{crmURL p='civicrm/contact/view/delete' q="reset=1&cid=$contactId&restore=1"}" class="delete button" title="{ts}Restore{/ts}">
-              <span><div class="icon restore-icon"></div>{ts}Restore from Trash{/ts}</span>
-            </a>
+            {crmButton p='civicrm/contact/view/delete' q="reset=1&cid=$contactId&restore=1" class="delete" icon="undo"}
+              {ts}Restore from Trash{/ts}
+            {/crmButton}
           </li>
 
           {if call_user_func(array('CRM_Core_Permission','check'), 'delete contacts')}
             <li class="crm-contact-permanently-delete">
-              <a href="{crmURL p='civicrm/contact/view/delete' q="reset=1&delete=1&cid=$contactId&skip_undelete=1"}" class="delete button" title="{ts}Delete Permanently{/ts}">
-                <span><div class="icon delete-icon"></div>{ts}Delete Permanently{/ts}</span>
-              </a>
+              {crmButton p='civicrm/contact/view/delete' q="reset=1&delete=1&cid=$contactId&skip_undelete=1" class="delete" icon="trash"}
+                {ts}Delete Permanently{/ts}
+              {/crmButton}
             </li>
           {/if}
 
         {elseif call_user_func(array('CRM_Core_Permission','check'), 'delete contacts')}
-          {assign var='deleteParams' value="&reset=1&delete=1&cid=$contactId"}
           <li class="crm-delete-action crm-contact-delete">
-            <a href="{crmURL p='civicrm/contact/view/delete' q=$deleteParams}" class="delete button" title="{ts}Delete{/ts}">
-              <span><div class="icon delete-icon"></div>{ts}Delete Contact{/ts}</span>
-            </a>
+            {crmButton p='civicrm/contact/view/delete' q="&reset=1&delete=1&cid=$contactId" class="delete" icon="trash"}
+              {ts}Delete Contact{/ts}
+            {/crmButton}
           </li>
         {/if}
 
@@ -98,28 +93,26 @@
           </li>
         {else}
           {if $nextContactID}
-            {assign var='viewParams' value=$urlParams|cat:"&cid=$nextContactID"}
             <li class="crm-next-action">
-              <a href="{crmURL p='civicrm/contact/view' q=$viewParams}" class="view button" title="{$nextContactName}">
-                <span title="{$nextContactName}"><div class="icon next-icon"></div>{ts}Next{/ts}</span>
-              </a>
+              {crmButton p='civicrm/contact/view' q="$urlParams&cid=$nextContactID" class="view" title=$nextContactName icon="chevron-right"}
+                {ts}Next{/ts}
+              {/crmButton}
             </li>
           {/if}
           {if $prevContactID}
-            {assign var='viewParams' value=$urlParams|cat:"&cid=$prevContactID"}
             <li class="crm-previous-action">
-              <a href="{crmURL p='civicrm/contact/view' q=$viewParams}" class="view button" title="{$prevContactName}">
-                <span title="{$prevContactName}"><div class="icon previous-icon"></div>{ts}Previous{/ts}</span>
-              </a>
+              {crmButton p='civicrm/contact/view' q="$urlParams&cid=$prevContactID" class="view" title=$prevContactName icon="chevron-left"}
+                {ts}Previous{/ts}
+              {/crmButton}
             </li>
           {/if}
         {/if}
 
         {if !empty($groupOrganizationUrl)}
           <li class="crm-contact-associated-groups">
-            <a href="{$groupOrganizationUrl}" class="associated-groups button" title="{ts}Associated Multi-Org Group{/ts}">
-              <span><div class="icon associated-groups-icon"></div>{ts}Associated Multi-Org Group{/ts}</span>
-            </a>
+            {crmButton href=$groupOrganizationUrl class="associated-groups" icon="cubes"}
+              {ts}Associated Multi-Org Group{/ts}
+            {/crmButton}
           </li>
         {/if}
       </ul>
@@ -187,7 +180,7 @@
                     </div>
                     <div class="crm-summary-row">
                       <div class="crm-label">
-                        {ts}CiviCRM ID{/ts}{if !empty($userRecordUrl)} / {ts}User ID{/ts}{/if}
+                        {ts}Contact ID{/ts}{if !empty($userRecordUrl)} / {ts}User ID{/ts}{/if}
                       </div>
                       <div class="crm-content">
                         <span class="crm-contact-contact_id">{$contactId}</span>


### PR DESCRIPTION
**hrjobcontract** extension override the following files : 

hrjobcontract/CRM/Contact/Form/Inline/CustomData.php

hrjobcontract/templates/CRM/Contact/Page/View/Summary.tpl

which were taken form civicrm 4.5 , i just updated them to work with 4.7 which resulted in fixing this error :

**User warning: Smarty error: unable to read resource: "CRM/common/wysiwyg.tpl"**

when viewing contact summary page since **wysiwyg.tpl** is not exist anymore in 4.7.