### PR TITLE
PCHR-1043 - missing CRM_Case_BAO_Case::addCaseToContact() method

### DIFF
--- a/hrrecruitment/CRM/HRRecruitment/Form/Application.php
+++ b/hrrecruitment/CRM/HRRecruitment/Form/Application.php
@@ -219,7 +219,11 @@ class CRM_HRRecruitment_Form_Application extends CRM_Core_Form {
           'case_id' => $caseObj->id,
           'contact_id' => $applicantID,
         );
-        CRM_Case_BAO_Case::addCaseToContact($contactParams);
+        if (is_callable('CRM_Case_BAO_Case::addCaseToContact')) {
+            CRM_Case_BAO_Case::addCaseToContact($contactParams);
+        } else {
+            CRM_Case_BAO_CaseContact::create($contactParams);
+        }
 
         $xmlProcessor = new CRM_Case_XMLProcessor_Process();
         $xmlProcessorParams = array(

--- a/hrsampledata/GenerateHRData.php
+++ b/hrsampledata/GenerateHRData.php
@@ -1433,7 +1433,11 @@ class GenerateHRData {
               'case_id' => $caseObj->id,
               'contact_id' => $applicantID,
             );
-            CRM_Case_BAO_Case::addCaseToContact($contactParams);
+            if (is_callable('CRM_Case_BAO_Case::addCaseToContact')) {
+                CRM_Case_BAO_Case::addCaseToContact($contactParams);
+            } else {
+                CRM_Case_BAO_CaseContact::create($contactParams);
+            }
 
             $xmlProcessor = new CRM_Case_XMLProcessor_Process();
             $xmlProcessorParams = array(


### PR DESCRIPTION
Using CRM_Case_BAO_CaseContact class if CRM_Case_BAO_Case::addCaseToContact method is not available.

CRM_Case_BAO_CaseContact is a new class which comes in CiviCRM 4.7 while CRM_Case_BAO_Case::addCaseToContact is CiviCRM 4.5 / 4.6 method which we were originally using when developing the extensions.