### PR TITLE
PCHR-1068: Fix import job role issues 4.7 migration

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Controller.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Controller.php
@@ -1,9 +1,9 @@
 <?php
 /*
  +--------------------------------------------------------------------+
- | CiviCRM version 4.5                                                |
+ | CiviCRM version 4.7                                                |
  +--------------------------------------------------------------------+
- | Copyright CiviCRM LLC (c) 2004-2014                                |
+ | Copyright CiviCRM LLC (c) 2004-2016                                |
  +--------------------------------------------------------------------+
  | This file is a part of CiviCRM.                                    |
  |                                                                    |
@@ -23,21 +23,23 @@
  | GNU Affero General Public License or the licensing of CiviCRM,     |
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
-*/
+ */
 
 /**
  *
  * @package CRM
- * @copyright CiviCRM LLC (c) 2004-2014
- * $Id$
- *
+ * @copyright CiviCRM LLC (c) 2004-2016
  */
 class CRM_Hrjobroles_Import_Controller extends CRM_Core_Controller {
 
   /**
-   * class constructor
+   * Class constructor.
+   *
+   * @param string $title
+   * @param bool|int $action
+   * @param bool $modal
    */
-  function __construct($title = NULL, $action = CRM_Core_Action::NONE, $modal = TRUE) {
+  public function __construct($title = NULL, $action = CRM_Core_Action::NONE, $modal = TRUE) {
     parent::__construct($title, $modal);
 
     // lets get around the time limit issue if possible, CRM-2113
@@ -54,5 +56,5 @@ class CRM_Hrjobroles_Import_Controller extends CRM_Core_Controller {
     $config = CRM_Core_Config::singleton();
     $this->addActions($config->uploadDir, array('uploadFile'));
   }
-}
 
+}

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Field.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Field.php
@@ -1,9 +1,9 @@
 <?php
 /*
  +--------------------------------------------------------------------+
- | CiviCRM version 4.5                                                |
+ | CiviCRM version 4.7                                                |
  +--------------------------------------------------------------------+
- | Copyright CiviCRM LLC (c) 2004-2014                                |
+ | Copyright CiviCRM LLC (c) 2004-2016                                |
  +--------------------------------------------------------------------+
  | This file is a part of CiviCRM.                                    |
  |                                                                    |
@@ -23,76 +23,70 @@
  | GNU Affero General Public License or the licensing of CiviCRM,     |
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
-*/
+ */
 
 /**
  *
  * @package CRM
- * @copyright CiviCRM LLC (c) 2004-2014
- * $Id$
- *
+ * @copyright CiviCRM LLC (c) 2004-2016
  */
 class CRM_Hrjobroles_Import_Field {
 
-  /**#@+
-   * @access protected
-   * @var string
-   */
-
   /**
-   * name of the field
+   * @var string
+   *   Name of the field
    */
   public $_name;
 
   /**
-   * title of the field to be used in display
+   * Title of the field to be used in display
    */
   public $_title;
 
   /**
-   * type of field
+   * Type of field
    * @var enum
    */
   public $_type;
 
   /**
-   * is this field required
+   * Is this field required
    * @var boolean
    */
   public $_required;
 
   /**
-   * data to be carried for use by a derived class
+   * Data to be carried for use by a derived class
    * @var object
    */
   public $_payload;
 
   /**
-   * regexp to match the CSV header of this column/field
+   * Regexp to match the CSV header of this column/field
    * @var string
    */
   public $_headerPattern;
 
   /**
-   * regexp to match the pattern of data from various column/fields
+   * Regexp to match the pattern of data from various column/fields
    * @var string
    */
   public $_dataPattern;
 
   /**
-   * value of this field
+   * Value of this field
    * @var object
    */
   public $_value;
 
   /**
-   * @param $name
+   * @param string $name
    * @param $title
    * @param int $type
    * @param string $headerPattern
    * @param string $dataPattern
    */
-  function __construct($name, $title, $type = CRM_Utils_Type::T_INT, $headerPattern = '//', $dataPattern = '//') {
+  public function __construct($name, $title, $type = CRM_Utils_Type::T_INT, $headerPattern = '//', $dataPattern = '//') {
     $this->_name = $name;
     $this->_title = $title;
     $this->_type = $type;
@@ -102,27 +96,28 @@ class CRM_Hrjobroles_Import_Field {
     $this->_value = NULL;
   }
 
-  function resetValue() {
+  public function resetValue() {
     $this->_value = NULL;
   }
 
   /**
-   * the value is in string format. convert the value to the type of this field
+   * The value is in string format. convert the value to the type of this field
    * and set the field value with the appropriate type
+   * @param $value
    */
-  function setValue($value) {
+  public function setValue($value) {
     $this->_value = $value;
   }
 
   /**
    * @return bool
    */
-  function validate() {
+  public function validate() {
 
     if (CRM_Utils_System::isNull($this->_value)) {
       return TRUE;
     }
     return TRUE;
   }
-}
 
+}

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/DataSource.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/DataSource.php
@@ -1,9 +1,9 @@
 <?php
 /*
  +--------------------------------------------------------------------+
- | CiviCRM version 4.5                                                |
+ | CiviCRM version 4.7                                                |
  +--------------------------------------------------------------------+
- | Copyright CiviCRM LLC (c) 2004-2014                                |
+ | Copyright CiviCRM LLC (c) 2004-2016                                |
  +--------------------------------------------------------------------+
  | This file is a part of CiviCRM.                                    |
  |                                                                    |
@@ -23,56 +23,30 @@
  | GNU Affero General Public License or the licensing of CiviCRM,     |
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
-*/
+ */
 
 /**
  *
  * @package CRM
- * @copyright CiviCRM LLC (c) 2004-2014
- * $Id$
- *
+ * @copyright CiviCRM LLC (c) 2004-2016
  */
 
 /**
- * This class gets the name of the file to upload
+ * This class gets the name of the file to upload.
  */
-class CRM_Hrjobroles_Import_Form_DataSource extends CRM_Core_Form {
+class CRM_Hrjobroles_Import_Form_DataSource extends CRM_Import_Form_DataSource {
+
+  const PATH = 'civicrm/jobroles/import';
+
+  const IMPORT_ENTITY = 'Import Job Roles';
 
   /**
-   * Function to set variables up before form is built
-   *
-   * @return void
-   * @access public
-   */
-  public function preProcess() {
-    $session = CRM_Core_Session::singleton();
-    $session->pushUserContext(CRM_Utils_System::url('civicrm/jobroles/import'));
-    // check for post max size
-    CRM_Core_Config_Defaults::formatUnitSize(ini_get('post_max_size'), TRUE);
-  }
-
-  /**
-   * Function to actually build the form
-   *
-   * @return void
-   * @access public
+   * Build the form object.
    */
   public function buildQuickForm() {
-    //Setting Upload File Size
-    $config = CRM_Core_Config::singleton();
+    parent::buildQuickForm();
 
-    $uploadFileSize = CRM_Core_Config_Defaults::formatUnitSize($config->maxFileSize.'m');
-    $uploadSize = round(($uploadFileSize / (1024 * 1024)), 2);
-
-    $this->assign('uploadSize', $uploadSize);
-    $this->setMaxFileSize($uploadFileSize);
-    $this->add('File', 'uploadFile', ts('Import Data File'), 'size=30 maxlength=255', TRUE);
-    $this->addRule('uploadFile', ts('File size should be less than %1 MBytes (%2 bytes)', array(1 => $uploadSize, 2 => $uploadFileSize)), 'maxfilesize', $uploadFileSize);
-    $this->addRule('uploadFile', ts('A valid file must be uploaded.'), 'uploadedfile');
-    $this->addRule('uploadFile', ts('Input file must be in CSV format'), 'utf8File');
-
-    $this->addElement('checkbox', 'skipColumnHeader', ts('First row contains column headers'));
-
+    // FIXME: This 'onDuplicate' form element is never used -- copy/paste error?
     $duplicateOptions = array();
     $duplicateOptions[] = $this->createElement('radio',
       NULL, NULL, ts('Skip'), CRM_Import_Parser::DUPLICATE_SKIP
@@ -87,90 +61,19 @@ class CRM_Hrjobroles_Import_Form_DataSource extends CRM_Core_Form {
     $this->addGroup($duplicateOptions, 'onDuplicate',
       ts('On duplicate entries')
     );
-
-    //get the saved mapping details
-    $mappingArray = CRM_Core_BAO_Mapping::getMappings(CRM_Core_OptionGroup::getValue('mapping_type',
-        'Import Job Roles',
-        'name'
-      ));
-    $this->assign('savedMapping', $mappingArray);
-    $this->add('select', 'savedMapping', ts('Mapping Option'), array('' => ts('- select -')) + $mappingArray);
-
-    if ($loadeMapping = $this->get('loadedMapping')) {
-      $this->assign('loadedMapping', $loadeMapping);
-      $this->setDefaults(array('savedMapping' => $loadeMapping));
-    }
-
-    $this->setDefaults(array(
-      'onDuplicate' =>
-        CRM_Import_Parser::DUPLICATE_SKIP,
-      ));
-
-    //build date formats
-    CRM_Core_Form_Date::buildAllowedDateFormats($this);
-
-    $this->addButtons(array(
-        array(
-          'type' => 'upload',
-          'name' => ts('Continue >>'),
-          'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
-          'isDefault' => TRUE,
-        ),
-        array(
-          'type' => 'cancel',
-          'name' => ts('Cancel'),
-        ),
-      )
-    );
   }
 
   /**
-   * Process the uploaded file
-   *
-   * @return void
-   * @access public
+   * Process the uploaded file.
    */
   public function postProcess() {
-    $this->controller->resetPage('MapField');
+    $this->storeFormValues(array(
+      'onDuplicate',
+      'dateFormats',
+      'savedMapping',
+    ));
 
-    $fileName         = $this->controller->exportValue($this->_name, 'uploadFile');
-    $skipColumnHeader = $this->controller->exportValue($this->_name, 'skipColumnHeader');
-    $onDuplicate      = $this->controller->exportValue($this->_name, 'onDuplicate');
-    $dateFormats      = $this->controller->exportValue($this->_name, 'dateFormats');
-    $savedMapping     = $this->controller->exportValue($this->_name, 'savedMapping');
-
-    $this->set('onDuplicate', $onDuplicate);
-    $this->set('dateFormats', $dateFormats);
-    $this->set('savedMapping', $savedMapping);
-
-    $session = CRM_Core_Session::singleton();
-    $session->set("dateTypes", $dateFormats);
-
-    $config = CRM_Core_Config::singleton();
-    $seperator = $config->fieldSeparator;
-
-    $mapper = array();
-
-    $parser = new CRM_Hrjobroles_Import_Parser_HrJobRoles($mapper);
-    $parser->setMaxLinesToProcess(100);
-    $parser->run($fileName, $seperator,
-      $mapper,
-      $skipColumnHeader,
-      CRM_Import_Parser::MODE_MAPFIELD
-    );
-
-    // add all the necessary variables to the form
-    $parser->set($this);
+    $this->submitFileForMapping('CRM_Hrjobroles_Import_Parser_HrJobRoles');
   }
 
-  /**
-   * Return a descriptive name for the page, used in wizard header
-   *
-   * @return string
-   * @access public
-   */
-  public function getTitle() {
-    return ts('Upload Data');
-  }
 }
-

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/MapField.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/MapField.php
@@ -244,11 +244,11 @@ class CRM_Hrjobroles_Import_Form_MapField extends CRM_Import_Form_MapField {
     $this->addButtons(array(
         array(
           'type' => 'back',
-          'name' => ts('<< Previous'),
+          'name' => ts('Previous'),
         ),
         array(
           'type' => 'next',
-          'name' => ts('Continue >>'),
+          'name' => ts('Continue'),
           'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
           'isDefault' => TRUE,
         ),

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/Preview.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/Preview.php
@@ -90,9 +90,12 @@ class CRM_Hrjobroles_Import_Form_Preview extends CRM_Import_Form_Preview {
 
     $properties = array(
       'mapper',
-      'dataValues', 'columnCount',
-      'totalRowCount', 'validRowCount',
-      'invalidRowCount', 'conflictRowCount',
+      'dataValues',
+      'columnCount',
+      'totalRowCount',
+      'validRowCount',
+      'invalidRowCount',
+      'conflictRowCount',
       'downloadErrorRecordsUrl',
       'downloadConflictRecordsUrl',
       'downloadMismatchRecordsUrl',

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/Summary.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/Summary.php
@@ -95,7 +95,19 @@ class CRM_Hrjobroles_Import_Form_Summary extends CRM_Import_Form_Summary {
     }
     $this->assign('dupeActionString', $dupeActionString);
 
-    $properties = array('totalRowCount', 'validRowCount', 'invalidRowCount', 'conflictRowCount', 'downloadConflictRecordsUrl', 'downloadErrorRecordsUrl', 'duplicateRowCount', 'downloadDuplicateRecordsUrl', 'downloadMismatchRecordsUrl', 'groupAdditions', 'unMatchCount');
+    $properties = array(
+      'totalRowCount',
+      'validRowCount',
+      'invalidRowCount',
+      'conflictRowCount',
+      'downloadConflictRecordsUrl',
+      'downloadErrorRecordsUrl',
+      'duplicateRowCount',
+      'downloadDuplicateRecordsUrl',
+      'downloadMismatchRecordsUrl',
+      'groupAdditions',
+      'unMatchCount'
+    );
     foreach ($properties as $property) {
       $this->assign($property, $this->get($property));
     }

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Parser/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Parser/HrJobRoles.php
@@ -33,7 +33,6 @@
  *
  */
 
-require_once 'api/api.php';
 
 /**
  * class to parse activity csv files
@@ -409,12 +408,9 @@ class CRM_Hrjobroles_Import_Parser_HrJobRoles extends CRM_Hrjobroles_Import_Pars
   }
 
   /**
-   * the initializer code, called before the processing
-   *
-   * @return void
-   * @access public
+   * Function of undocumented functionality required by the interface.
    */
-  function fini() {}
+   protected function fini() {}
 
 
   /**

--- a/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/DataSource.tpl
+++ b/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/DataSource.tpl
@@ -23,37 +23,41 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{* Activity Import Wizard - Step 1 (upload data file) *}
+{* Job Roles Import Wizard - Step 1 (upload data file) *}
 {* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller *}
-<div class="crm-block crm-form-block crm-activity-import-uploadfile-form-block">
+<div class="crm-block crm-form-block crm-jobroles-import-uploadfile-form-block">
 
  {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
  {include file="CRM/common/WizardHeader.tpl"}
 
- <div id="help">
-    <p>
-    {ts}The API Import Wizard allows you to easily upload data against any API create method from other applications into CiviHR. Files to be imported must be in the 'comma-separated-values' format (CSV) and must contain data needed to match the data to an existing record in your CiviHR database.{/ts}
-    </p>
+ <div class="help">
+   <p>
+     {ts}The Job Roles Import Wizard allows you to easily upload Job Roles from other applications into CiviHR. Job Contracts must already exist in your CiviHR database prior to importing Job Roles.{/ts}
+   </p>
  </div>
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
  <div id="upload-file">
  <h3>{ts}Upload Data File{/ts}</h3>
       <table class="form-layout-compressed">
-        <tr class="crm-activity-import-uploadfile-form-block-uploadFile">
+        <tr class="crm-jobroles-import-uploadfile-form-block-uploadFile">
            <td class="label">{$form.uploadFile.label}</td>
            <td>{$form.uploadFile.html}<br />
                 <span class="description">{ts}File format must be comma-separated-values (CSV).{/ts}</span><br /><span>{ts 1=$uploadSize}Maximum Upload File Size: %1 MB{/ts}</span>
            </td>
         </tr>
-        <tr class="crm-activity-import-uploadfile-form-block-skipColumnHeader">
+        <tr class="crm-jobroles-import-uploadfile-form-block-skipColumnHeader">
            <td class="label"></td>
            <td>{$form.skipColumnHeader.html}{$form.skipColumnHeader.label}<br />
-               <span class="description">{ts}Check this box if the first row of your file consists of field names (Example: 'Contact ID', 'Activity Type', 'Activity Date').{/ts}</span>
+               <span class="description">{ts}Check this box if the first row of your file consists of field names (Example: 'Contract ID', 'Role Title', 'Start Date').{/ts}</span>
            </td>
+        </tr>
+        <tr class="crm-import-datasource-form-block-fieldSeparator">
+          <td class="label">{$form.fieldSeparator.label} {help id='id-fieldSeparator' file='CRM/Contact/Import/Form/DataSource'}</td>
+          <td>{$form.fieldSeparator.html}</td>
         </tr>
         <tr>{include file="CRM/Core/Date.tpl"}</tr>
         {if $savedMapping}
-        <tr class="crm-activity-import-uploadfile-form-block-savedMapping">
+        <tr class="crm-jobroles-import-uploadfile-form-block-savedMapping">
         <td>{if $loadedMapping}{ts}Select a Different Field Mapping{/ts}{else}{ts}Load Saved Field Mapping{/ts}{/if}</td>
            <td>{$form.savedMapping.html}<br />
               <span class="description">{ts}Select Saved Mapping or Leave blank to create a new One.{/ts}</span>

--- a/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/MapField.tpl
+++ b/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/MapField.tpl
@@ -23,15 +23,15 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-<div class="crm-block crm-form-block crm-activity-import-mapfield-form-block">
-{* Activity Import Wizard - Step 2 (map incoming data fields) *}
+<div class="crm-block crm-form-block crm-jobroles-import-mapfield-form-block">
+{* Job Roles Import Wizard - Step 2 (map incoming data fields) *}
 {* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller *}
 
  {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
  {include file="CRM/common/WizardHeader.tpl"}
 
- <div id="help">
-    <p>{ts}Review the values shown below from the first 2 rows of your import file and select the matching CiviCRM database fields from the drop-down lists in the right-hand column. Select '- do not import -' for any columns in the import file that you want ignored.{/ts}</p>
+ <div class="help">
+    <p>{ts}Review the values shown below from the first 2 rows of your import file and select the matching CiviHR database fields from the drop-down lists in the right-hand column. Select '- do not import -' for any columns in the import file that you want ignored.{/ts}</p>
     {if $savedMapping}
     <p>{ts}Click 'Load Saved Field Mapping' if data has been previously imported from the same source. You can then select the saved import mapping setup and load it automatically.{/ts}<p>
     {/if}
@@ -39,7 +39,7 @@
 </div>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
  {* Table for mapping data to CRM fields *}
- {include file="CRM/Activity/Import/Form/MapTable.tpl}
+ {include file="CRM/Hrjobroles/Import/Form/MapTable.tpl"}
  <br />
 
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>

--- a/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/MapTable.tpl
+++ b/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/MapTable.tpl
@@ -23,8 +23,8 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{* Activity Import Wizard - Data Mapping table used by MapFields.tpl and Preview.tpl *}
-<div class="crm-block crm-form-block crm-activity_map_table-form-block">
+{* Job Roles Import Wizard - Data Mapping table used by MapFields.tpl and Preview.tpl *}
+<div class="crm-block crm-form-block crm-jobroles_map_table-form-block">
 
  <div id="map-field">
     {strip}
@@ -45,7 +45,7 @@
                 {/if}
             {/section}
 
-            <th>{ts}Matching CiviCRM Field{/ts}</th>
+            <th>{ts}Matching CiviHR Field{/ts}</th>
         </tr>
 
         {*Loop on columns parsed from the import data rows*}
@@ -83,11 +83,11 @@
       <span>{$form.saveMapping.html} &nbsp;&nbsp; {$form.saveMapping.label}</span>
       <div id="saveDetails" class="form-item">
           <table>
-                  <tr class="crm-activity_map_table-form-block-saveMappingName">
+                  <tr class="crm-jobroles_map_table-form-block-saveMappingName">
              <td>{$form.saveMappingName.label}</td>
                      <td>{$form.saveMappingName.html}</td>
                   </tr>
-                  <tr class="crm-activity_map_table-form-block-saveMappingDesc">
+                  <tr class="crm-jobroles_map_table-form-block-saveMappingDesc">
              <td>{$form.saveMappingDesc.label}</td>
                      <td>{$form.saveMappingDesc.html}</td>
                  </tr>

--- a/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/Preview.tpl
+++ b/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/Preview.tpl
@@ -23,27 +23,27 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{* Activity Import Wizard - Step 3 (preview import results prior to actual data loading) *}
+{* Job roles Import Wizard - Step 3 (preview import results prior to actual data loading) *}
 {* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller *}
-<div class="crm-block crm-form-block crm-activity-import-preview-form-block">
+<div class="crm-block crm-form-block crm-jobroles-import-preview-form-block">
 
  {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
  {include file="CRM/common/WizardHeader.tpl"}
 
- <div id="help">
+ <div class="help">
     <p>
-    {ts}The information below previews the results of importing your data in CiviCRM. Review the totals to ensure that they represent your expected results.{/ts}
+    {ts}The information below previews the results of importing your data in CiviHR. Review the totals to ensure that they represent your expected results.{/ts}
     </p>
 
     {if $invalidRowCount}
         <p class="error">
-        {ts 1=$invalidRowCount 2=$downloadErrorRecordsUrl}CiviCRM has detected invalid data or formatting errors in %1 records. If you continue, these records will be skipped. OR, you can download a file with just these problem records - <a href='%2'>Download Errors</a>. Then correct them in the original import file, cancel this import and begin again at step 1.{/ts}
+        {ts 1=$invalidRowCount 2=$downloadErrorRecordsUrl}CiviHR has detected invalid data or formatting errors in %1 records. If you continue, these records will be skipped. OR, you can download a file with just these problem records - <a href='%2'>Download Errors</a>. Then correct them in the original import file, cancel this import and begin again at step 1.{/ts}
         </p>
     {/if}
 
     {if $conflictRowCount}
         <p class="error">
-        {ts 1=$conflictRowCount 2=$downloadConflictRecordsUrl}CiviCRM has detected %1 records with conflicting transaction ids within this data file. If you continue, these records will be skipped. OR, you can download a file with just these problem records - <a href='%2'>Download Conflicts</a>. Then correct them in the original import file, cancel this import and begin again at step 1.{/ts}
+        {ts 1=$conflictRowCount 2=$downloadConflictRecordsUrl}CiviHR has detected %1 records with conflicting transaction ids within this data file. If you continue, these records will be skipped. OR, you can download a file with just these problem records - <a href='%2'>Download Conflicts</a>. Then correct them in the original import file, cancel this import and begin again at step 1.{/ts}
         </p>
     {/if}
 
@@ -55,7 +55,7 @@
  <table id="preview-counts" class="report">
     <tr><td class="label">{ts}Total Rows{/ts}</td>
         <td class="data">{$totalRowCount}</td>
-        <td class="explanation">{ts}Total rows (activity records) in uploaded file.{/ts}</td>
+        <td class="explanation">{ts}Total rows (Job Role records) in uploaded file.{/ts}</td>
     </tr>
 
     {if $invalidRowCount}
@@ -88,7 +88,7 @@
  <br />
 
  {* Table for mapping preview *}
- {include file="CRM/Activity/Import/Form/MapTable.tpl}
+ {include file="CRM/Hrjobroles/Import/Form/MapTable.tpl"}
  <br />
 
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>

--- a/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/Summary.tpl
+++ b/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/Summary.tpl
@@ -23,30 +23,30 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{* Activity Import Wizard - Step 4 (summary of import results AFTER actual data loading) *}
+{* Job Roles Import Wizard - Step 4 (summary of import results AFTER actual data loading) *}
 {* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller *}
-<div class="crm-block crm-form-block crm-activity-import-summary-form-block">
+<div class="crm-block crm-form-block crm-jobroles-import-summary-form-block">
 
  {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
  {include file="CRM/common/WizardHeader.tpl"}
 
- <div id="help">
+ <div class="help">
     <p>
     {ts}<strong>Import has completed successfully.</strong> The information below summarizes the results.{/ts}
     </p>
 
    {if $unMatchCount }
         <p class="error">
-        {ts count=$unMatchCount plural='CiviCRM has detected mismatched activity IDs. These records have not been Updated.'}CiviCRM has detected mismatched activity ID. This record have not been updated.{/ts}
+        {ts count=$unMatchCount plural='CiviHR has detected mismatched job role IDs. These records have not been Updated.'}CiviHR has detected mismatched job role ID. This record have not been updated.{/ts}
         </p>
         <p class="error">
-        {ts 1=$downloadMismatchRecordsUrl}You can <a href='%1'>Download Mismatched Activity records</a>. You may then correct them, and import the new file with the corrected data.{/ts}
+        {ts 1=$downloadMismatchRecordsUrl}You can <a href='%1'>Download Mismatched job role records</a>. You may then correct them, and import the new file with the corrected data.{/ts}
         </p>
     {/if}
 
     {if $invalidRowCount }
         <p class="error">
-        {ts count=$invalidRowCount plural='CiviCRM has detected invalid data and/or formatting errors in %count records. These records have not been imported.'}CiviCRM has detected invalid data and/or formatting errors in one record. This record have not been imported.{/ts}
+        {ts count=$invalidRowCount plural='CiviHR has detected invalid data and/or formatting errors in %count records. These records have not been imported.'}CiviHR has detected invalid data and/or formatting errors in one record. This record have not been imported.{/ts}
         </p>
         <p class="error">
         {ts 1=$downloadErrorRecordsUrl}You can <a href='%1'>Download Errors</a>. You may then correct them, and import the new file with the corrected data.{/ts}
@@ -55,7 +55,7 @@
 
     {if $conflictRowCount}
         <p class="error">
-        {ts count=$conflictRowCount plural='CiviCRM has detected %count records with conflicting transaction IDs within this data file or relative to existing activity records. These records have not been imported.'}CiviCRM has detected one record with conflicting transaction ID within this data file or relative to existing activity records. This record have not been imported.{/ts}
+        {ts count=$conflictRowCount plural='CiviHR has detected %count records with conflicting transaction IDs within this data file or relative to existing job role records. These records have not been imported.'}CiviHR has detected one record with conflicting transaction ID within this data file or relative to existing job role records. This record have not been imported.{/ts}
         </p>
         <p class="error">
         {ts 1=$downloadConflictRecordsUrl}You can <a href='%1'>Download Conflicts</a>. You may then review these records to determine if they are actually conflicts, and correct the transaction IDs for those that are not.{/ts}
@@ -64,7 +64,7 @@
 
     {if $duplicateRowCount}
         <p {if $dupeError}class="error"{/if}>
-        {ts count=$duplicateRowCount plural='CiviCRM has detected %count records which are duplicates of existing CiviCRM activity records.'}CiviCRM has detected one record which is a duplicate of existing CiviCRM activity record.{/ts} {$dupeActionString}
+        {ts count=$duplicateRowCount plural='CiviHR has detected %count records which are duplicates of existing CiviHR job role records.'}CiviHR has detected one record which is a duplicate of existing CiviHR job role record.{/ts} {$dupeActionString}
         </p>
         <p {if $dupeError}class="error"{/if}>
         {ts 1=$downloadDuplicateRecordsUrl}You can <a href='%1'>Download Duplicates</a>. You may then review these records to determine if they are actually duplicates, and correct the transaction IDs for those that are not.{/ts}
@@ -76,7 +76,7 @@
  <table id="summary-counts" class="report">
     <tr><td class="label">{ts}Total Rows{/ts}</td>
         <td class="data">{$totalRowCount}</td>
-        <td class="explanation">{ts}Total rows (activity records) in uploaded file.{/ts}</td>
+        <td class="explanation">{ts}Total rows (job role records) in uploaded file.{/ts}</td>
     </tr>
 
     {if $invalidRowCount }
@@ -93,9 +93,9 @@
     {if $unMatchCount }
     <tr class="error"><td class="label">{ts}Mismatched Rows (skipped){/ts}</td>
         <td class="data">{$unMatchCount}</td>
-        <td class="explanation">{ts}Rows with mismatched activity IDs (NOT updated).{/ts}
+        <td class="explanation">{ts}Rows with mismatched job role IDs (NOT updated).{/ts}
             {if $unMatchCount}
-                <p><a href="{$downloadMismatchRecordsUrl}">{ts}Download Mismatched Activity records{/ts}</a></p>
+                <p><a href="{$downloadMismatchRecordsUrl}">{ts}Download Mismatched job role records{/ts}</a></p>
             {/if}
         </td>
     </tr>
@@ -115,7 +115,7 @@
     {if $duplicateRowCount}
     <tr class="error"><td class="label">{ts}Duplicate Rows{/ts}</td>
         <td class="data">{$duplicateRowCount}</td>
-        <td class="explanation">{ts}Rows which are duplicates of existing CiviCRM activity records.{/ts} {$dupeActionString}
+        <td class="explanation">{ts}Rows which are duplicates of existing CiviHR job role records.{/ts} {$dupeActionString}
             {if $duplicateRowCount}
                 <p><a href="{$downloadDuplicateRecordsUrl}">{ts}Download Duplicates{/ts}</a></p>
             {/if}


### PR DESCRIPTION
## Problem
After migrating to civicrm 4.7 , The job roles page is no longer opening and through an HTTP 500 error page . The problem was in this file :

**com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/DataSource.php**

Specifically in this line :
 
**CRM_Core_Config_Defaults::formatUnitSize(ini_get('post_max_size'), TRUE);** 

But since **CRM_Core_Config_Defaults** class is no longer exist in 4.7 the code was failing and the error page appear. 

## Solution

I modified  the DataSource.php Form to extend the core class CRM_Import_Form_DataSource instead of CRM_Core_Form , Where the implementation is a little bit diffrent and using :

 **CRM_Utils_Number::formatUnitSize(ini_get('post_max_size'), TRUE);** 

Instead of **CRM_Core_Config_Defaults::formatUnitSize(ini_get('post_max_size'), TRUE);**  .

I also done some refactoring so the code adhere to 4.7 changes.