### PR TITLE
PCHR-1069: Fix import appraisals issues after 4.7 migration

### DIFF
--- a/uk.co.compucorp.civicrm.appraisals/CRM/Appraisals/Import/Form/DataSourceBaseClass.php
+++ b/uk.co.compucorp.civicrm.appraisals/CRM/Appraisals/Import/Form/DataSourceBaseClass.php
@@ -80,12 +80,8 @@ class CRM_Appraisals_Import_Form_DataSourceBaseClass extends CRM_Core_Form {
   public function buildQuickForm() {
     //Setting Upload File Size
     $config = CRM_Core_Config::singleton();
-    if ($config->maxImportFileSize >= 8388608) {
-      $uploadFileSize = 8388608;
-    }
-    else {
-      $uploadFileSize = $config->maxImportFileSize;
-    }
+
+    $uploadFileSize = CRM_Utils_Number::formatUnitSize($config->maxFileSize . 'm', TRUE);
     $uploadSize = round(($uploadFileSize / (1024 * 1024)), 2);
 
     $this->assign('uploadSize', $uploadSize);

--- a/uk.co.compucorp.civicrm.appraisals/templates/CRM/Appraisals/Import/Form/DataSource.tpl
+++ b/uk.co.compucorp.civicrm.appraisals/templates/CRM/Appraisals/Import/Form/DataSource.tpl
@@ -30,9 +30,9 @@
  {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
  {include file="CRM/common/WizardHeader.tpl"}
 
- <div id="help">
-    {ts}The API Import Wizard allows you to easily upload data against any API create method from other applications into CiviCRM.{/ts}
-    {ts}Files to be imported must be in the 'comma-separated-values' format (CSV) and must contain data needed to match the data to an existing record in your CiviCRM database.{/ts} {help id='upload'}
+ <div class="help">
+    {ts}The API Import Wizard allows you to easily upload data against any API create method from other applications into CiviHR.{/ts}
+    {ts}Files to be imported must be in the 'comma-separated-values' format (CSV) and must contain data needed to match the data to an existing record in your CiviHR database.{/ts} {help id='upload'}
  </div>
  <div id="upload-file" class="form-item">
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>

--- a/uk.co.compucorp.civicrm.appraisals/templates/CRM/Appraisals/Import/Form/MapField.tpl
+++ b/uk.co.compucorp.civicrm.appraisals/templates/CRM/Appraisals/Import/Form/MapField.tpl
@@ -28,8 +28,8 @@
 <div class="crm-block crm-form-block crm-import-mapfield-form-block">
 {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
 {include file="CRM/common/WizardHeader.tpl"}
-<div id="help">
-    <p>{ts}Review the values shown below from the first 2 rows of your import file and select the matching CiviCRM database fields from the drop-down lists in the right-hand column. Select '- do not import -' for any columns in the import file that you want ignored.{/ts}</p>
+<div class="help">
+    <p>{ts}Review the values shown below from the first 2 rows of your import file and select the matching CiviHR database fields from the drop-down lists in the right-hand column. Select '- do not import -' for any columns in the import file that you want ignored.{/ts}</p>
     {if $savedMapping}
     <p>{ts}Click 'Load Saved Field Mapping' if data has been previously imported from the same source. You can then select the saved import mapping setup and load it automatically.{/ts}<p>
     {/if}
@@ -46,7 +46,7 @@
    </tr>
    <tr>
      <td>{* Table for mapping data to CRM fields *}
-         {include file="CRM/Event/Import/Form/MapTable.tpl}
+         {include file="CRM/Event/Import/Form/MapTable.tpl"}
      </td>
    </tr>
    <tr>

--- a/uk.co.compucorp.civicrm.appraisals/templates/CRM/Appraisals/Import/Form/Preview.tpl
+++ b/uk.co.compucorp.civicrm.appraisals/templates/CRM/Appraisals/Import/Form/Preview.tpl
@@ -30,20 +30,20 @@
  {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
  {include file="CRM/common/WizardHeader.tpl"}
 
-<div id="help">
+<div class="help">
     <p>
-    {ts}The information below previews the results of importing your data in CiviCRM. Review the totals to ensure that they represent your expected results.{/ts}
+    {ts}The information below previews the results of importing your data in CiviHR. Review the totals to ensure that they represent your expected results.{/ts}
     </p>
 
     {if $invalidRowCount}
         <p class="error">
-        {ts 1=$invalidRowCount 2=$downloadErrorRecordsUrl}CiviCRM has detected invalid data or formatting errors in %1 records. If you continue, these records will be skipped. OR, you can download a file with just these problem records - <a href='%2'>Download Errors</a>. Then correct them in the original import file, cancel this import and begin again at step 1.{/ts}
+        {ts 1=$invalidRowCount 2=$downloadErrorRecordsUrl}CiviHR has detected invalid data or formatting errors in %1 records. If you continue, these records will be skipped. OR, you can download a file with just these problem records - <a href='%2'>Download Errors</a>. Then correct them in the original import file, cancel this import and begin again at step 1.{/ts}
         </p>
     {/if}
 
     {if $conflictRowCount}
         <p class="error">
-        {ts 1=$conflictRowCount 2=$downloadConflictRecordsUrl}CiviCRM has detected %1 records with conflicting transaction ids within this data file. If you continue, these records will be skipped. OR, you can download a file with just these problem records - <a href='%2'>Download Conflicts</a>. Then correct them in the original import file, cancel this import and begin again at step 1.{/ts}
+        {ts 1=$conflictRowCount 2=$downloadConflictRecordsUrl}CiviHR has detected %1 records with conflicting transaction ids within this data file. If you continue, these records will be skipped. OR, you can download a file with just these problem records - <a href='%2'>Download Conflicts</a>. Then correct them in the original import file, cancel this import and begin again at step 1.{/ts}
         </p>
     {/if}
 

--- a/uk.co.compucorp.civicrm.appraisals/templates/CRM/Appraisals/Import/Form/Summary.tpl
+++ b/uk.co.compucorp.civicrm.appraisals/templates/CRM/Appraisals/Import/Form/Summary.tpl
@@ -31,14 +31,14 @@
  {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
  {include file="CRM/common/WizardHeader.tpl"}
 
-<div id="help">
+<div class="help">
     <p>
     <strong>{ts}Import has completed successfully.{/ts}</strong> {ts}The information below summarizes the results.{/ts}
     </p>
 
    {if $unMatchCount }
         <p class="error">
-        {ts count=$unMatchCount plural='CiviCRM has detected mismatched participant IDs. These records have not been Updated.'}CiviCRM has detected mismatched participant ID. This record have not been updated.{/ts}
+        {ts count=$unMatchCount plural='CiviHR has detected mismatched participant IDs. These records have not been Updated.'}CiviHR has detected mismatched participant ID. This record have not been updated.{/ts}
         </p>
         <p class="error">
         {ts 1=$downloadMismatchRecordsUrl}You can <a href="%1">Download Mismatched Participantss</a>. You may then correct them, and import the new file with the corrected data.{/ts}
@@ -47,7 +47,7 @@
 
     {if $invalidRowCount }
         <p class="error">
-        {ts count=$invalidRowCount plural='CiviCRM has detected invalid data and/or formatting errors in %count records. These records have not been imported.'}CiviCRM has detected invalid data and/or formatting errors in one record. This record have not been imported.{/ts}
+        {ts count=$invalidRowCount plural='CiviHR has detected invalid data and/or formatting errors in %count records. These records have not been imported.'}CiviHR has detected invalid data and/or formatting errors in one record. This record have not been imported.{/ts}
         </p>
         <p class="error">
         {ts 1=$downloadErrorRecordsUrl}You can <a href="%1">Download Errors</a>. You may then correct them, and import the new file with the corrected data.{/ts}
@@ -56,7 +56,7 @@
 
     {if $conflictRowCount}
         <p class="error">
-        {ts count=$conflictRowCount plural='CiviCRM has detected %count records with conflicting transaction IDs within this data file or relative to existing participant records. These records have not been imported.'}CiviCRM has detected one record with conflicting transaction ID within this data file or relative to existing particpant records. This record have not been imported.{/ts}
+        {ts count=$conflictRowCount plural='CiviHR has detected %count records with conflicting transaction IDs within this data file or relative to existing participant records. These records have not been imported.'}CiviHR has detected one record with conflicting transaction ID within this data file or relative to existing particpant records. This record have not been imported.{/ts}
         </p>
         <p class="error">
         {ts 1=$downloadConflictRecordsUrl}You can <a href="%1">Download Conflicts</a>. You may then review these records to determine if they are actually conflicts, and correct the transaction IDs for those that are not.{/ts}
@@ -65,7 +65,7 @@
 
     {if $duplicateRowCount}
         <p {if $dupeError}class="error"{/if}>
-        {ts count=$duplicateRowCount plural='CiviCRM has detected %count records which are duplicates of existing CiviCRM participant records.'}CiviCRM has detected one record which is a duplicate of existing CiviCRM participant record.{/ts} {$dupeActionString}
+        {ts count=$duplicateRowCount plural='CiviHR has detected %count records which are duplicates of existing CiviHR participant records.'}CiviHR has detected one record which is a duplicate of existing CiviHR participant record.{/ts} {$dupeActionString}
         </p>
         <p {if $dupeError}class="error"{/if}>
         {ts 1=$downloadDuplicateRecordsUrl}You can <a href="%1">Download Duplicates</a>. You may then review these records to determine if they are actually duplicates, and correct the transaction IDs for those that are not.{/ts}
@@ -119,7 +119,7 @@
     {if $duplicateRowCount}
     <tr class="error"><td class="label">{ts}Duplicate Rows{/ts}</td>
         <td class="data">{$duplicateRowCount}</td>
-        <td class="explanation">{ts}Rows which are duplicates of existing CiviCRM records.{/ts} {$dupeActionString}
+        <td class="explanation">{ts}Rows which are duplicates of existing CiviHR records.{/ts} {$dupeActionString}
             {if $duplicateRowCount}
                 <p><a href="{$downloadDuplicateRecordsUrl}">{ts}Download Duplicates{/ts}</a></p>
             {/if}


### PR DESCRIPTION
## Problem
After migrating to civicrm 4.7 , The  appraisals import page is no longer opening and   this exception is thrown 

`Cannot read unrecognized property CRM_Core_Config::$maxImportFileSize.`

The problem was in this file :

**uk.co.compucorp.appraisals/CRM/Import/Form/DataSourceBaseClass.php**

Specifically in these lines :
 
`    if ($config->maxImportFileSize >= 8388608) {
      $uploadFileSize = 8388608;
    }
    else {
      $uploadFileSize = $config->maxImportFileSize;
    }`

But since **CRM_Core_Config** is no longer have this property `maxImportFileSize` , The error is thrown.

## Solution

I modified  the DataSourceBaseClass.php class to to use this formula instead ( which is the same used in the core import files ) :

    `$uploadFileSize = CRM_Utils_Number::formatUnitSize($config->maxFileSize . 'm', TRUE);
    $uploadSize = round(($uploadFileSize / (1024 * 1024)), 2);`

I also done some minor changes in template files.