### PR TITLE
PCHR-1072: Fix vancancy form issues after 4.7 migration

### DIFF
--- a/hrrecruitment/CRM/HRRecruitment/Form/HRVacancy.php
+++ b/hrrecruitment/CRM/HRRecruitment/Form/HRVacancy.php
@@ -136,12 +136,12 @@ class CRM_HRRecruitment_Form_HRVacancy extends CRM_Core_Form {
     $this->addSelect('location', array('label' => ts('Location'), 'entity' => 'HRJobDetails', 'field' => 'location'));
     $this->add('text', 'salary', ts('Salary'), $attributes['salary']);
 
-    $this->addWysiwyg('description', ts('Description'), array('rows' => 2, 'cols' => 40));
-    $this->addWysiwyg('benefits', ts('Benefits'), array('rows' => 2, 'cols' => 40));
-    $this->addWysiwyg('requirements', ts('Requirements'), array('rows' => 2, 'cols' => 40));
+    $this->add('wysiwyg', 'description', ts('Description'), array('rows' => 2, 'cols' => 40));
+    $this->add('wysiwyg', 'benefits', ts('Benefits'), array('rows' => 2, 'cols' => 40));
+    $this->add('wysiwyg', 'requirements', ts('Requirements'), array('rows' => 2, 'cols' => 40));
 
-    $this->addDateTime('start_date', ts('Start Date'), FALSE, array('formatType' => 'activityDateTime'));
-    $this->addDateTime('end_date', ts('End Date'), FALSE, array('formatType' => 'activityDateTime'));
+    $this->add('datepicker', 'start_date', ts('Start Date'), FALSE, array('formatType' => 'activityDateTime'));
+    $this->add('datepicker', 'end_date', ts('End Date'), FALSE, array('formatType' => 'activityDateTime'));
 
     $include = & $this->addElement('advmultiselect', 'stages',
       '', CRM_Core_OptionGroup::values('case_status', FALSE, FALSE, FALSE, " AND grouping = 'Vacancy'"),
@@ -274,5 +274,12 @@ class CRM_HRRecruitment_Form_HRVacancy extends CRM_Core_Form {
       }
       CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url('civicrm/vacancy/find', $urlParams));
     }
+  }
+
+  /**
+   * Classes extending CRM_Core_Form should implement this method.
+   */
+  public function getDefaultEntity() {
+    return 'HRVacancy';
   }
 }

--- a/hrrecruitment/templates/CRM/HRRecruitment/Form/HRVacancy.tpl
+++ b/hrrecruitment/templates/CRM/HRRecruitment/Form/HRVacancy.tpl
@@ -57,11 +57,11 @@
     </tr>
     <tr>
       <td class="label">{$form.start_date.label}</td>
-      <td>{include file="CRM/common/jcalendar.tpl" elementName=start_date}</td>
+      <td>{$form.start_date.html}</td>
     </tr>
     <tr>
       <td class="label">{$form.end_date.label}</td>
-      <td>{include file="CRM/common/jcalendar.tpl" elementName=end_date}</td>
+      <td>{$form.end_date.html}</td>
     </tr>
     <tr>
       <td class="label">{$form.status_id.label}</td>


### PR DESCRIPTION
## Problem

After 4.7 migration , If you tried to create a new vacancy or vacancy template the page will not open and an HTTP 500 error page will appear instead. The problem was due to the following :

1- the usage of addWysiwyg() which is removed from 4.7 .
2- `$this->addSelect('status_id', array(), TRUE);` was not passing the entity name in parameters and addSelect() method in QuickForm class require an entity name to be able to fetch select list options .

## Solution 

1- addWysiwyg() get replaced with add('wysiwyg', ... ) which is the new way to add wysiwyg editor to the form. 

2- for addSelect issue and since there is a new method in QuickForm called getDefaultEntity()  (which is required to be implemented in any class that extend CRM_CORE_FORM ) I just let the method to return the default entity name  which is "HRVacancy" which will be used in addSelect method in case there is no entity name passed (This problem wasn't in 4.5 maybe because 4.5 addSelect() implementation was using the caller class name which is changed in 4.7).

3- Also I've replaced the deprecated method addDateTime() by add('datepicker' .... ) .. (The old way don't cause any problem in fact civicrm 4.7 still use it in many places but it is better to stop using deprecated methods since they may be removed in the next version).
