### PR TITLE
PCHR-1119: Fix L&A errors on CiviCRM 4.7

### DIFF
--- a/doc/DEVELOP.md
+++ b/doc/DEVELOP.md
@@ -51,20 +51,36 @@ schema, be sure to:
 ## Test
 
 To run the unit-tests, one must configure CiviCRM to run unit-tests, install
-civix, and link civix to CiviCRM. To validate that the link is setup, run:
+cv, and populate the cv vars file. To do that, run:
 
 ```bash
-user@host:/path/to/civihr/hrjob$ civix civicrm:ping
-Ping successful
+$ cv vars:fill
+Site: /path/to/your/installation/sites/default/civicrm.settings.php
+These fields were missing. Setting defaults:
+{
+    "ADMIN_EMAIL": "admin@example.com",
+    "ADMIN_PASS": "t0ps3cr3t",
+    "ADMIN_USER": "admin",
+    "CMS_TITLE": "Untitled installation",
+    "DEMO_EMAIL": "demo@example.com",
+    "DEMO_PASS": "t0ps3cr3t",
+    "DEMO_USER": "demo",
+    "SITE_TOKEN": "38022b28355040d28e1f6dd2f7248b96",
+    "TEST_DB_DSN": "mysql://dbUser:dbPass@dbHost/dbName?new_link=true"
+}
+Please edit /home/user/.cv.json
 ```
 
-To execute particular tests, use "civix test":
+As the command output suggests, you need to edit "~/.cv.json" with your installation ADMIN_PASS, DEMO_PASS
+and TEST_DB_DSN. You'll also need to add the "CMS_URL" option with the URL of you installation.
+
+To execute particular tests, use "phpunit4":
 
 ```bash
-user@host:/path/to/civihr/hrjob$ civix test api_v3_HRJobTest
+user@host:/path/to/civihr/hrjob$ phpunit4 tests/phpunit/api/v3/HRJobTest.php
 Adding Individual
 Adding Organization
-PHPUnit 3.6.10 by Sebastian Bergmann.
+PHPUnit 4.8.21 by Sebastian Bergmann.
 
 .
 Installing civicrm_tests_dev database
@@ -75,10 +91,16 @@ Time: 24 seconds, Memory: 28.25Mb
 OK (1 test, 4 assertions)
 ```
 
-(Note: Civix's design assumes that there are two databases. The "live database"
-used with "civix civicrm:ping" is part of a fully-functioning CiviCRM/CiviHR installation.
-The "headless testing database" is only used for testing -- it is conventionally
-called "civicrm_tests_dev".)
+To run all the tests for an extension, just run "phpunit4" without passing the test file:
+
+```bash
+user@host:/path/to/civihr/hrjob$ phpunit4
+```
+
+(Note: We're assuming that there are two databases. The "live database",
+used with "civix civicrm:ping", which is part of a fully-functioning CiviCRM/CiviHR installation.
+The "headless testing database" is, which is the one you configured in the "TEST_DB_DSN" option
+of the ~/.cv.json file.)
 
 (Note: For "hrjob", there's an extra pre-requisite: before running tests, run
 "hrjob/bin/setup.sh {CIVICRM_ROOT}".)

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
@@ -87,6 +87,14 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultEntity()
+    {
+      return 'AbsenceType';
+    }
+
     private function getMonthsOptions()
     {
         return [

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -275,6 +275,30 @@ function hrleaveandabsences_civicrm_entityTypes(&$entityTypes) {
       'class' => 'CRM_HRLeaveAndAbsences_DAO_AbsenceType',
       'table' => 'civicrm_hrleaveandabsences_absence_type',
   );
+
+  $entityTypes[] = array(
+    'name'  => 'NotificationReceiver',
+    'class' => 'CRM_HRLeaveAndAbsences_DAO_NotificationReceiver',
+    'table' => 'civicrm_hrleaveandabsences_notification_receiver',
+  );
+
+  $entityTypes[] = array(
+    'name'  => 'WorkPattern',
+    'class' => 'CRM_HRLeaveAndAbsences_DAO_WorkPattern',
+    'table' => 'civicrm_hrleaveandabsences_work_pattern',
+  );
+
+  $entityTypes[] = array(
+    'name'  => 'WorkWeek',
+    'class' => 'CRM_HRLeaveAndAbsences_DAO_WorkWeek',
+    'table' => 'civicrm_hrleaveandabsences_work_week',
+  );
+
+  $entityTypes[] = array(
+    'name'  => 'WorkDay',
+    'class' => 'CRM_HRLeaveAndAbsences_DAO_WorkDay',
+    'table' => 'civicrm_hrleaveandabsences_work_day',
+  );
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/phpunit.xml.dist
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="tests/phpunit/bootstrap.php"
+>
+  <testsuites>
+    <testsuite name="Leave and Absences Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments></arguments>
+    </listener>
+  </listeners>
+</phpunit>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -1,8 +1,13 @@
 <?php
 
-require_once 'CiviTest/CiviUnitTestCase.php';
+use Civi\Test\HeadlessInterface;
 
-class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends CiviUnitTestCase {
+/**
+ * Class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends CiviUnitTestCase implements HeadlessInterface {
 
   private $allColors = [
       '#5A6779', '#E5807F', '#ECA67F', '#8EC68A', '#C096AA', '#9579A8', '#42B0CB',
@@ -15,6 +20,10 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends CiviUnitTestCase {
     'civicrm_hrleaveandabsences_notification_receiver',
     'civicrm_hrleaveandabsences_absence_type',
   ];
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->installMe(__DIR__)->apply();
+  }
 
   public function setUp() {
     parent::setUp();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/NotificationReceiverTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/NotificationReceiverTest.php
@@ -1,14 +1,23 @@
 <?php
 
-require_once 'CiviTest/CiviUnitTestCase.php';
+use Civi\Test\HeadlessInterface;
 
-class CRM_HRLeaveAndAbsences_BAO_NotificationReceiverTest extends CiviUnitTestCase {
+/**
+ * Class CRM_HRLeaveAndAbsences_BAO_NotificationReceiverTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_BAO_NotificationReceiverTest extends CiviUnitTestCase implements HeadlessInterface {
 
   private $absenceType = null;
 
   protected $_tablesToTruncate = [
     'civicrm_hrleaveandabsences_notification_receiver'
   ];
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->installMe(__DIR__)->apply();
+  }
 
   public function setUp()
   {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkDayTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkDayTest.php
@@ -1,10 +1,14 @@
 <?php
 
+use Civi\Test\HeadlessInterface;
 
-require_once 'CiviTest/CiviUnitTestCase.php';
+/**
+ * Class CRM_HRLeaveAndAbsences_BAO_WorkDayTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends CiviUnitTestCase implements HeadlessInterface {
 
-class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends CiviUnitTestCase
-{
     protected $_tablesToTruncate = [
         'civicrm_hrleaveandabsences_work_day',
         'civicrm_hrleaveandabsences_work_week',
@@ -12,6 +16,10 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends CiviUnitTestCase
 
     protected $workPattern = null;
     protected $workWeek = null;
+
+    public function setUpHeadless() {
+      return \Civi\Test::headless()->installMe(__DIR__)->apply();
+    }
 
     public function setUp()
     {
@@ -55,7 +63,7 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends CiviUnitTestCase
     {
         $this->createBasicWorkDay(['time_to' => $time]);
     }
-    
+
     /**
      * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException
      * @expectedExceptionMessage Time From, Time To and Break are required for Working Days
@@ -89,7 +97,7 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends CiviUnitTestCase
         ];
         $this->createBasicWorkDay($params);
     }
-    
+
     /**
      * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException
      * @expectedExceptionMessage Time From should be less than Time To

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
@@ -1,14 +1,23 @@
 <?php
 
-require_once 'CiviTest/CiviUnitTestCase.php';
+use Civi\Test\HeadlessInterface;
 
-class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends CiviUnitTestCase
+/**
+ * Class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends CiviUnitTestCase implements HeadlessInterface
 {
     protected $_tablesToTruncate = [
         'civicrm_hrleaveandabsences_work_pattern',
         'civicrm_hrleaveandabsences_work_week',
         'civicrm_hrleaveandabsences_work_day',
     ];
+
+    public function setUpHeadless() {
+      return \Civi\Test::headless()->installMe(__DIR__)->apply();
+    }
 
     public function testWeightShouldAlwaysBeMaxWeightPlus1OnCreate()
     {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkWeekTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkWeekTest.php
@@ -1,8 +1,13 @@
 <?php
 
-require_once 'CiviTest/CiviUnitTestCase.php';
+use Civi\Test\HeadlessInterface;
 
-class CRM_HRLeaveAndAbsences_BAO_WorkWeekTest extends CiviUnitTestCase
+/**
+ * Class CRM_HRLeaveAndAbsences_BAO_WorkWeekTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_BAO_WorkWeekTest extends CiviUnitTestCase implements HeadlessInterface
 {
     protected $_tablesToTruncate = [
         'civicrm_hrleaveandabsences_work_day',
@@ -11,6 +16,10 @@ class CRM_HRLeaveAndAbsences_BAO_WorkWeekTest extends CiviUnitTestCase
     ];
 
     protected $workPattern = null;
+
+    public function setUpHeadless() {
+      return \Civi\Test::headless()->installMe(__DIR__)->apply();
+    }
 
     public function setUp()
     {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/WebTest/AbsenceType/FormTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/WebTest/AbsenceType/FormTest.php
@@ -1,12 +1,21 @@
 <?php
 
-require_once 'CiviTest/CiviSeleniumTestCase.php';
+use Civi\Test\HeadlessInterface;
 
-class WebTest_AbsenceType_FormTest extends CiviSeleniumTestCase {
+/**
+ * Class WebTest_AbsenceType_FormTest
+ *
+ * @group headless
+ */
+class WebTest_AbsenceType_FormTest extends CiviSeleniumTestCase implements HeadlessInterface {
 
     private $formUrl = 'admin/leaveandabsences/types';
     private $addUrlParams = 'action=add&reset=1';
     private $editUrlParams = 'action=update&reset=1';
+
+    public function setUpHeadless() {
+      return \Civi\Test::headless()->installMe(__DIR__)->apply();
+    }
 
     private function loginAsAdmin()
     {
@@ -26,14 +35,14 @@ class WebTest_AbsenceType_FormTest extends CiviSeleniumTestCase {
         $this->assertFalse($this->isVisible('max_leave_accrual'));
         $this->assertFalse($this->isVisible('allow_accrue_in_the_past'));
         $this->assertFalse($this->isVisible('accrual_expiration_duration'));
-        $this->assertFalse($this->isVisible('accrual_expiration_unit'));
+        $this->assertFalse($this->isVisible('s2id_accrual_expiration_unit'));
 
         // When allow accruals request is checked, some fields become visible
         $this->click('allow_accruals_request');
         $this->assertTrue($this->isVisible('max_leave_accrual'));
         $this->assertTrue($this->isVisible('allow_accrue_in_the_past'));
         $this->assertFalse($this->isVisible('accrual_expiration_duration'));
-        $this->assertFalse($this->isVisible('accrual_expiration_unit'));
+        $this->assertFalse($this->isVisible('s2id_accrual_expiration_unit'));
         $this->assertTrue($this->isChecked('accrual_never_expire'));
 
         // When Never expire is not checked, the expiration fields become visible
@@ -41,7 +50,7 @@ class WebTest_AbsenceType_FormTest extends CiviSeleniumTestCase {
         $this->assertTrue($this->isVisible('max_leave_accrual'));
         $this->assertTrue($this->isVisible('allow_accrue_in_the_past'));
         $this->assertTrue($this->isVisible('accrual_expiration_duration'));
-        $this->assertTrue($this->isVisible('accrual_expiration_unit'));
+        $this->assertTrue($this->isVisible('s2id_accrual_expiration_unit'));
         $this->assertElementValueEquals('accrual_expiration_duration', '');
         $this->select('accrual_expiration_unit', "value=1");
 
@@ -50,7 +59,7 @@ class WebTest_AbsenceType_FormTest extends CiviSeleniumTestCase {
         $this->assertTrue($this->isVisible('max_leave_accrual'));
         $this->assertTrue($this->isVisible('allow_accrue_in_the_past'));
         $this->assertFalse($this->isVisible('accrual_expiration_duration'));
-        $this->assertFalse($this->isVisible('accrual_expiration_unit'));
+        $this->assertFalse($this->isVisible('s2id_accrual_expiration_unit'));
     }
 
     public function testCarryForwardFieldsVisibility()
@@ -63,17 +72,17 @@ class WebTest_AbsenceType_FormTest extends CiviSeleniumTestCase {
         $this->assertFalse($this->isChecked('allow_carry_forward'));
         $this->assertFalse($this->isVisible('max_number_of_days_to_carry_forward'));
         $this->assertFalse($this->isVisible('carry_forward_expiration_duration'));
-        $this->assertFalse($this->isVisible('carry_forward_expiration_unit'));
+        $this->assertFalse($this->isVisible('s2id_carry_forward_expiration_unit'));
         $this->assertFalse($this->isVisible('carry_forward_expiration_day'));
-        $this->assertFalse($this->isVisible('carry_forward_expiration_month'));
+        $this->assertFalse($this->isVisible('s2id_carry_forward_expiration_month'));
 
         // When carry forward is checked, shome fields become visible
         $this->click('allow_carry_forward');
         $this->assertTrue($this->isVisible('max_number_of_days_to_carry_forward'));
         $this->assertFalse($this->isVisible('carry_forward_expiration_duration'));
-        $this->assertFalse($this->isVisible('carry_forward_expiration_unit'));
+        $this->assertFalse($this->isVisible('s2id_carry_forward_expiration_unit'));
         $this->assertFalse($this->isVisible('carry_forward_expiration_day'));
-        $this->assertFalse($this->isVisible('carry_forward_expiration_month'));
+        $this->assertFalse($this->isVisible('s2id_carry_forward_expiration_month'));
         $this->assertTrue($this->isChecked('carry_forward_never_expire'));
         $this->assertFalse($this->isChecked('carry_forward_expire_after_duration'));
         $this->assertFalse($this->isChecked('carry_forward_expire_after_date'));
@@ -82,9 +91,9 @@ class WebTest_AbsenceType_FormTest extends CiviSeleniumTestCase {
         $this->click('carry_forward_expire_after_duration');
         $this->assertTrue($this->isVisible('max_number_of_days_to_carry_forward'));
         $this->assertTrue($this->isVisible('carry_forward_expiration_duration'));
-        $this->assertTrue($this->isVisible('carry_forward_expiration_unit'));
+        $this->assertTrue($this->isVisible('s2id_carry_forward_expiration_unit'));
         $this->assertFalse($this->isVisible('carry_forward_expiration_day'));
-        $this->assertFalse($this->isVisible('carry_forward_expiration_month'));
+        $this->assertFalse($this->isVisible('s2id_carry_forward_expiration_month'));
         $this->assertFalse($this->isChecked('carry_forward_never_expire'));
         $this->assertTrue($this->isChecked('carry_forward_expire_after_duration'));
         $this->assertFalse($this->isChecked('carry_forward_expire_after_date'));
@@ -93,9 +102,9 @@ class WebTest_AbsenceType_FormTest extends CiviSeleniumTestCase {
         $this->click('carry_forward_expire_after_date');
         $this->assertTrue($this->isVisible('max_number_of_days_to_carry_forward'));
         $this->assertFalse($this->isVisible('carry_forward_expiration_duration'));
-        $this->assertFalse($this->isVisible('carry_forward_expiration_unit'));
+        $this->assertFalse($this->isVisible('s2id_carry_forward_expiration_unit'));
         $this->assertTrue($this->isVisible('carry_forward_expiration_day'));
-        $this->assertTrue($this->isVisible('carry_forward_expiration_month'));
+        $this->assertTrue($this->isVisible('s2id_carry_forward_expiration_month'));
         $this->assertFalse($this->isChecked('carry_forward_never_expire'));
         $this->assertFalse($this->isChecked('carry_forward_expire_after_duration'));
         $this->assertTrue($this->isChecked('carry_forward_expire_after_date'));
@@ -104,9 +113,9 @@ class WebTest_AbsenceType_FormTest extends CiviSeleniumTestCase {
         $this->click('carry_forward_never_expire');
         $this->assertTrue($this->isVisible('max_number_of_days_to_carry_forward'));
         $this->assertFalse($this->isVisible('carry_forward_expiration_duration'));
-        $this->assertFalse($this->isVisible('carry_forward_expiration_unit'));
+        $this->assertFalse($this->isVisible('s2id_carry_forward_expiration_unit'));
         $this->assertFalse($this->isVisible('carry_forward_expiration_day'));
-        $this->assertFalse($this->isVisible('carry_forward_expiration_month'));
+        $this->assertFalse($this->isVisible('s2id_carry_forward_expiration_month'));
         $this->assertTrue($this->isChecked('carry_forward_never_expire'));
         $this->assertFalse($this->isChecked('carry_forward_expire_after_duration'));
         $this->assertFalse($this->isChecked('carry_forward_expire_after_date'));

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/WebTest/WorkPattern/FormTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/WebTest/WorkPattern/FormTest.php
@@ -1,7 +1,10 @@
 <?php
 
-require_once 'CiviTest/CiviSeleniumTestCase.php';
-
+/**
+ * Class WebTest_WorkPattern_FormTest
+ *
+ * @group headless
+ */
 class WebTest_WorkPattern_FormTest extends CiviSeleniumTestCase {
 
     private $formUrl = 'admin/leaveandabsences/work_patterns';

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
@@ -1,0 +1,49 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+eval(cv('php:boot --level=full -t', 'phpcode'));
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}


### PR DESCRIPTION
After moving the development to CiviCRM 4.7 some errors were found on this extension:

### Adding/Editing Absence Types
**Problem**: When adding or editing an Absence Type, the following happened: Exception: "Cannot determine default entity. CRM_HRLeaveAndAbsences_Form_AbsenceType should implement getDefaultEntity()."
**Solution**: Added the getDefaultEntity() to the CRM_HRLeaveAndAbsences_Form_AbsenceType class

### Editing existing Work Patterns
**Problems**:
1. When editing an existing Work Pattern, a black page was displayed and the server response had the status code of 500. The webserver error log had the message: PHP Fatal error: Class name must be a valid object or a string in /vagrant/hr16/sites/all/modules/civicrm/Civi/API/SelectQuery.php on line 99.
2. Trying to disable a Work Pattern or set it as default, by clicking on the actions of the list page, resulted in the error: Class "" does not map to an entity
3. Trying to delete a Work Pattern, by clicking on the Delete action of the list page, resulted in the following error: No delete method found

**Solution**: The solution was the same for all the problems. All of theses were caused by failures on API calls. I had to add the WorkPattern entities to the hook_civicrm_entityType hook implementation, so the WorkPattern APIs would work.

### Running tests
**Problem**: Due to some changes on how to create and run tests on 4.7, it wasn't possible to run the extension's tests.
**Solution**:  I updated the tests to remove some unnecessary code and added the new HeadlessInterface and the setupHeadless method to install the extension on the test database before running the tests.

