### PR TITLE
PCHR-889: Exclude deleted contracts from the query of the advanced search

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/BAO/Query.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/Query.php
@@ -317,7 +317,7 @@ class CRM_Hrjobcontract_BAO_Query extends CRM_Contact_BAO_Query_Interface {
     
     switch ($name) {
       case 'civicrm_contact':
-        $from .= " $side JOIN civicrm_hrjobcontract hrjobcontract ON hrjobcontract.contact_id = contact_a.id
+        $from .= " $side JOIN civicrm_hrjobcontract hrjobcontract ON hrjobcontract.contact_id = contact_a.id AND hrjobcontract.deleted = 0
             $side JOIN civicrm_hrjobcontract_revision rev ON rev.jobcontract_id = hrjobcontract.id "
               . " AND rev.id = (SELECT id FROM civicrm_hrjobcontract_revision WHERE jobcontract_id = hrjobcontract.id "
               . " AND effective_date <= '" . date('Y-m-d') . "' ORDER BY id DESC LIMIT 1) ";


### PR DESCRIPTION
The JOIN clause that joined the contact table with the contract table would match every
contract for the given contact, even the deleted ones. Since the job roles are related to the
contract, this would also affect job roles searchs. A search for it could result in matches for
roles related to deleted contracts.