### PR TITLE
PCHR-1116: Error installing hr16 with civicrm 4.7.7

### DIFF
--- a/hrcase/hrcase.php
+++ b/hrcase/hrcase.php
@@ -71,6 +71,9 @@ function hrcase_civicrm_postInstall() {
       $import->run($file);
     }
   }
+
+  updateEntityColumnValues();
+
   $scheduleActions = hrcase_getActionsSchedule();
   foreach($scheduleActions as $actionName=>$scheduleAction) {
   	$result = civicrm_api3('action_schedule', 'get', array('name' => $actionName));
@@ -465,4 +468,23 @@ function activityCreatedByTaskandAssignments($activity_type_id) {
   }
 
   return FALSE;
+}
+
+/**
+ * Update extends_entity_column_value values in civicrm_custom_group table for both (Exiting & Joining)
+ * custom groups to point for related case ID instead of its name since using the name only
+ * is no longer work with civicrm 4.7.7+.
+ *
+ */
+function updateEntityColumnValues()  {
+  $caseTypes = CRM_Case_PseudoConstant::caseType('name');
+  $exitingValue = array_search('Exiting', $caseTypes);
+  $exitingValue = CRM_Core_DAO::VALUE_SEPARATOR . $exitingValue . CRM_Core_DAO::VALUE_SEPARATOR;
+  $joiningValue = array_search('Joining', $caseTypes);
+  $joiningValue = CRM_Core_DAO::VALUE_SEPARATOR . $joiningValue . CRM_Core_DAO::VALUE_SEPARATOR;
+
+  $sql = "UPDATE civicrm_custom_group SET extends_entity_column_value = '{$exitingValue}' WHERE extends_entity_column_value = 'Exiting'";
+  CRM_Core_DAO::executeQuery($sql);
+  $sql = "UPDATE civicrm_custom_group SET extends_entity_column_value = '{$joiningValue}' WHERE extends_entity_column_value = 'Joining'";
+  CRM_Core_DAO::executeQuery($sql);
 }


### PR DESCRIPTION
## Problem

The following error interrupts the install process of the {{hr16}} type build via buildkit:

`WD php: CRM_Core_Exception: Invalid Entity Filter in CRM_Core_BAO_CustomGroup::validateSubTypeByEntity() [error]`


The error appears when installing CiviHR via the following command:

**civibuild create hr163 --type hr16 --civi-ver 4.7.7 --url http://localhost:8124**

What happen is at the point where the builkit is about to enable **entity api extenision** the error is thrown ... This is what happen that cause the installation to fail :

1- **civicrm-drupal** module and specifically  in **civicrm.views.inc** file, its take advantage of **CRM_Core_BAO_CustomGroup::getTree** method which its implementation changed in civicrm 4.7.7+ due to some security updates.

2- due to these updates the following method **validateSubTypeByEntity()** is called inside **getTree()** .

3- some invalid values are passed to **validateSubTypeByEntity()** which came from **hrcase** extension . **hrcase** create two cusom groups   (**Exiting Data** & **Joining_Data**) which are stored in **civicrm_custom_group** table but in the column ( **extends_entity_column_value** ) the name of the related case is stored instead of its ID which cause validateSubTypeByEntity() to fail and terminate buildkit installation process.


## solution

in **postInstall** hook for hrcase extension , I update  ( **extends_entity_column_value** ) values for both (**Exiting Data** & **Joining_Data**) to contain the related case ID instead of its name.
