### PR TITLE
PCHR-953: Create Absence Periods list page

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Page_AbsencePeriod
+ *
+ * This is the class that handles requests to the Absence Period list and form
+ * pages.
+ */
+class CRM_HRLeaveAndAbsences_Page_AbsencePeriod extends CRM_Core_Page_Basic {
+
+  /**
+   * A list of links available as actions to the items on the page list
+   *
+   * @var array
+   */
+  private $links = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function run() {
+    CRM_Utils_System::setTitle(ts('Absence Periods'));
+    parent::run();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function browse() {
+    $object = new CRM_HRLeaveAndAbsences_BAO_AbsencePeriod();
+    $object->orderBy('weight');
+    $object->find();
+    $rows = [];
+    while($object->fetch()) {
+      $rows[$object->id] = [];
+
+      CRM_Core_DAO::storeValues($object, $rows[$object->id]);
+
+      $rows[$object->id]['action'] = CRM_Core_Action::formLink(
+        $this->links(),
+        $this->calculateLinksMask($object),
+        ['id' => $object->id]
+      );
+    }
+
+    $returnURL = CRM_Utils_System::url('civicrm/admin/leaveandabsences/periods', 'reset=1');
+    CRM_Utils_Weight::addOrder($rows, 'CRM_HRLeaveAndAbsences_DAO_AbsencePeriod', 'id', $returnURL);
+
+    CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/hrleaveandabsences.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
+
+    $this->assign('rows', $rows);
+  }
+
+  /**
+   * name of the BAO to perform various DB manipulations
+   *
+   * @return string
+   * @access public
+   */
+  public function getBAOName() {
+    return 'CRM_HRLeaveAndAbsences_BAO_AbsencePeriod';
+  }
+
+  /**
+   * An array of all action links available to the items on the list page
+   *
+   * @return array
+   */
+  public function &links() {
+    if(empty($this->links)) {
+      $this->links = [
+        CRM_Core_Action::UPDATE  => [
+          'name'  => ts('Edit'),
+          'url'   => 'civicrm/admin/leaveandabsences/periods',
+          'qs'    => 'action=update&id=%%id%%&reset=1',
+          'title' => ts('Edit Absence Period'),
+        ],
+        CRM_Core_Action::DELETE  => [
+          'name'  => ts('Delete'),
+          'class' => 'civihr-delete',
+          'title' => ts('Delete Absence Period'),
+        ]
+      ];
+    }
+
+    return $this->links;
+  }
+
+  /**
+   * userContext to pop back to
+   *
+   * @param int $mode mode that we are in
+   *
+   * @return string
+   * @access public
+   */
+  public function userContext($mode = null) {
+    return 'civicrm/admin/leaveandabsences/periods';
+  }
+
+  /**
+   * Name of the edit form class
+   *
+   * @return string
+   * @access public
+   */
+  public function editForm() {
+    return '';
+  }
+
+  /**
+   * Name of the form
+   *
+   * @return string
+   * @access public
+   */
+  public function editName() {
+    return 'Absence Periods';
+  }
+
+  /**
+   * Calculates the links bitmask for the items on the list page
+   *
+   * @return number The links bitmask
+   */
+  private function calculateLinksMask() {
+    $mask = array_sum(array_keys($this->links()));
+
+    return $mask;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -68,7 +68,7 @@ function _hrleaveandabsences_create_administer_menu_tree($leaveAndAbsencesAdminN
       array(
           'label'      => ts('Leave/Absence Periods'),
           'name'       => 'leave_and_absence_periods',
-          'url'        => 'civicrm/admin/leaveandabsences/periods',
+          'url'        => 'civicrm/admin/leaveandabsences/periods?action=browse&reset=1',
           'permission' => 'administer leave and absences',
       ),
       array(

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.tpl
@@ -1,0 +1,49 @@
+{if $action eq 1 or $action eq 2 or $action eq 8}
+    {* The form template will be here *}
+{else}
+    {if $rows}
+        <div id="ltype">
+            <div class="form-item">
+                {strip}
+                    <table cellpadding="0" cellspacing="0" border="0" class="hrleaveandabsences-entity-list">
+                        <thead class="sticky">
+                            <th>{ts}Title{/ts}</th>
+                            <th>{ts}Start Date{/ts}</th>
+                            <th>{ts}End Date{/ts}</th>
+                            <th>{ts}Order{/ts}</th>
+                            <th></th>
+                        </thead>
+                        {foreach from=$rows item=row}
+                            <tr id="AbsencePeriod-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {$row.class}{if NOT $row.is_active} disabled{/if}">
+                                <td data-field="title">{$row.title}</td>
+                                <td>{$row.start_date|crmDate}</td>
+                                <td>{$row.end_date|crmDate}</td>
+                                <td>{$row.weight}</td>
+                                <td>{$row.action|replace:'xx':$row.id}</td>
+                            </tr>
+                        {/foreach}
+                    </table>
+                {/strip}
+
+                {if $action ne 1 and $action ne 2}
+                    <div class="action-link">
+                        <a href="{crmURL q="action=add&reset=1"}" class="button"><span><div class="icon add-icon"></div>{ts}Add new entitlement period{/ts}</span></a>
+                    </div>
+                {/if}
+            </div>
+        </div>
+        {literal}
+        <script type="text/javascript">
+            CRM.$(function() {
+                var listPage = new CRM.HRLeaveAndAbsencesApp.ListPage(CRM.$('.hrleaveandabsences-entity-list'));
+            });
+        </script>
+        {/literal}
+    {else}
+        <div class="messages status no-popup">
+            <div class="icon inform-icon"></div>
+            {capture assign=crmURL}{crmURL q="action=add&reset=1"}{/capture}
+            {ts 1=$crmURL}There are no Absence Periods entered. You can <a href='%1'>add one</a>.{/ts}
+        </div>
+    {/if}
+{/if}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/Menu/hrleaveandabsences.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/Menu/hrleaveandabsences.xml
@@ -12,4 +12,10 @@
     <title>Work Patterns</title>
     <access_arguments>administer leave and absences</access_arguments>
   </item>
+  <item>
+    <path>civicrm/admin/leaveandabsences/periods</path>
+    <page_callback>CRM_HRLeaveAndAbsences_Page_AbsencePeriod</page_callback>
+    <title>Absence Periods</title>
+    <access_arguments>administer leave and absences</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
This is how the list looks like:

![captura de tela 2016-05-27 as 10 01 36](https://cloud.githubusercontent.com/assets/388373/15608744/35c98852-23f2-11e6-8678-3e916113378f.png)


The list contains only four fields:
- Title
- Start Date
- End Date
- Order

When there's more than one period, their order can be changed,
by clicking on the arrow on the Order column, to move it up or down.

The Start and End date columns use the crmDate smarty filter to
make sure the dates follow the default date format selected in CiviCRM
settings.