### PR TITLE
PCHR-1150: installing org.civicrm.hrstaffdir throwing an error

### DIFF
--- a/hrstaffdir/xml/auto_install.xml
+++ b/hrstaffdir/xml/auto_install.xml
@@ -212,7 +212,7 @@
       <profile_group_name>Directory</profile_group_name>
     </ProfileField>
     <ProfileField>
-      <field_name>custom.civicrm_value_jobcontract_summary_10.final_termination_date_57</field_name>
+      <field_name>hrjobcontract_details_period_end_date</field_name>
       <is_active>1</is_active>
       <is_view>1</is_view>
       <is_required>0</is_required>
@@ -222,7 +222,7 @@
       <visibility>Public Pages and Listings</visibility>
       <in_selector>0</in_selector>
       <is_searchable>0</is_searchable>
-      <label>Final Termination Date</label>
+      <label>Contract End Date</label>
       <field_type>Individual</field_type>
       <is_multi_summary>0</is_multi_summary>
       <profile_group_name>Directory</profile_group_name>


### PR DESCRIPTION
## Problem 

When trying to install org.civicrm.hrstaffdir extension the following error is thrown :

**A fatal error was triggered: Could not find custom field for custom.civicrm_value_jobcontract_summary_10.final_termination_date_57**

The issue is when trying to install the extension , Its run this file  (**auto_install.xml**) which is still use 
**Final Termination Date** which is removed in this ticket  PCHR-774 .

## Solution 

I replaced **final termination date** with **job contract end date** .