### PR TITLE
PCHR-954: Create the Absence Period form

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
@@ -196,7 +196,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    *
    * @return int the maximum weight
    */
-  private static function getMaxWeight() {
+  public static function getMaxWeight() {
     $tableName = self::getTableName();
     $query = "SELECT MAX(weight) as max_weight FROM {$tableName}";
     $dao = CRM_Core_DAO::executeQuery($query);
@@ -221,5 +221,51 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
     $parsed = date_parse($date);
 
     return $parsed['warning_count'] == 0 && $parsed['error_count'] == 0;
+  }
+
+  /**
+   * Returns an array containing all the fields values for the
+   * AbsencePeriod with the given ID.
+   *
+   * This method is mainly used by the AbsencePeriod form, so it
+   * can get the data to fill its fields.
+   *
+   * An empty array is returned if it is not possible to load
+   * the data.
+   *
+   * @param int $id The id of the AbsencePeriod to retrieve the values
+   *
+   * @return array An array containing the values
+   */
+  public static function getValuesArray($id) {
+    try {
+      $result = civicrm_api3('AbsencePeriod', 'getsingle', ['id' => $id]);
+      return $result;
+    } catch (CiviCRM_API3_Exception $ex) {
+      return [];
+    }
+  }
+
+  /**
+   * This method returns the most recent date that can be used as a Start Date.
+   *
+   * The returned date is maximum End Date of all existing Absence Period + 1 day.
+   *
+   * If there's no existing Absence Period, the current date is returned
+   *
+   * @return string The most recent start date available in Y-m-d format
+   */
+  public static function getMostRecentStartDateAvailable()
+  {
+    $tableName = self::getTableName();
+    $query = "SELECT MAX(end_date) as latest_end_date FROM {$tableName}";
+    $dao = CRM_Core_DAO::executeQuery($query);
+    if($dao->fetch() && $dao->latest_end_date) {
+      $latestEndDate = new DateTime($dao->latest_end_date);
+      $latestEndDate->add(new DateInterval('P1D'));
+      return $latestEndDate->format('Y-m-d');
+    }
+
+    return date('Y-m-d');
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
@@ -80,7 +80,9 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
       );
     }
 
-    if(!self::isValidDate($params['start_date']) || !self::isValidDate($params['end_date'])) {
+    $startDateIsValid = CRM_HRLeaveAndAbsences_Validator_Date::isValid($params['start_date']);
+    $endDateIsValid = CRM_HRLeaveAndAbsences_Validator_Date::isValid($params['end_date']);
+    if(!$startDateIsValid || !$endDateIsValid) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsencePeriodException(
         'Both the start and end dates should be valid'
       );
@@ -205,22 +207,6 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
     }
 
     return 0;
-  }
-
-  /**
-   * This uses PHP's date_parse to check if the given date is valid.
-   *
-   * The date will be valid it no error or warning is found while parsing it.
-   *
-   * @param $date The date to be checked
-   *
-   * @return bool
-   */
-  private static function isValidDate($date)
-  {
-    $parsed = date_parse($date);
-
-    return $parsed['warning_count'] == 0 && $parsed['error_count'] == 0;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
@@ -116,7 +116,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
       2 => [$params['start_date'], 'String'],
     ];
 
-    if(!empty($query['id'])) {
+    if(!empty($params['id'])) {
       $query .= ' AND (id != %3)';
       $queryParams[3] = [$params['id'], 'Integer'];
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsencePeriod.php
@@ -31,6 +31,7 @@ class CRM_HRLeaveAndAbsences_Form_AbsencePeriod extends CRM_Core_Form {
     if (empty($this->defaultValues)) {
       if ($this->_id) {
         $this->defaultValues = CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::getValuesArray($this->_id);
+        $this->defaultValues['_id'] = $this->_id;
       }
       else {
         $this->defaultValues = [
@@ -54,6 +55,7 @@ class CRM_HRLeaveAndAbsences_Form_AbsencePeriod extends CRM_Core_Form {
     $this->addButtons($this->getAvailableButtons());
 
     CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/hrleaveandabsences.css');
+    CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/hrleaveandabsences.form.absenceperiod.js');
     parent::buildQuickForm();
   }
 
@@ -100,6 +102,9 @@ class CRM_HRLeaveAndAbsences_Form_AbsencePeriod extends CRM_Core_Form {
    * Adds all the fields to the form
    */
   private function addFields() {
+    // This hidden field is used to get the AbsencePeriod
+    // id when validating the Order number before submitting the form
+    $this->add('hidden', '_id');
     $this->add(
       'text',
       'title',

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsencePeriod.php
@@ -179,16 +179,33 @@ class CRM_HRLeaveAndAbsences_Form_AbsencePeriod extends CRM_Core_Form {
   }
 
   /**
-   * Validates if the Start Date is less than the End Date
+   * Validates if Start and End Dates are valid and if Start Date is less than
+   * End Date
    *
    * @param array $values An array containing all the form's fields values
    * @param array $errors A reference to the errors array where errors will be
    *                      added if dates are invalid
    */
   private function validatePeriodDates($values, &$errors) {
+    if(empty($values['start_date']) || empty($values['end_date'])) {
+      return;
+    }
+
+    $startDateIsValid = CRM_HRLeaveAndAbsences_Validator_Date::isValid($values['start_date']);
+    $endDateIsValid = CRM_HRLeaveAndAbsences_Validator_Date::isValid($values['end_date']);
+
+    if(!$startDateIsValid) {
+      $errors['start_date'] = ts('Start Date should be a valid date');
+    }
+
+    if(!$endDateIsValid) {
+      $errors['end_date'] = ts('End Date should be a valid date');
+    }
+
+    $datesAreValid = $startDateIsValid && $endDateIsValid;
     $startDate = strtotime($values['start_date']);
     $endDate = strtotime($values['end_date']);
-    if($startDate >= $endDate) {
+    if($datesAreValid && $startDate >= $endDate) {
       $errors['start_date'] = ts('Start Date should be less than End Date');
     }
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsencePeriod.php
@@ -1,0 +1,204 @@
+<?php
+
+require_once 'CRM/Core/Form.php';
+
+/**
+ * Form controller class
+ *
+ * @see https://wiki.civicrm.org/confluence/display/CRMDOC/QuickForm+Reference
+ */
+class CRM_HRLeaveAndAbsences_Form_AbsencePeriod extends CRM_Core_Form {
+
+  /**
+   * When in edit mode, this is the ID of the AbsencePeriod being edited
+   *
+   * @var int
+   */
+  protected $_id = null;
+
+  /**
+   * An array used to store the loaded AbsencePeriods's default values, so we
+   * only need to load them once.
+   *
+   * @var array
+   */
+  private $defaultValues = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setDefaultValues() {
+    if (empty($this->defaultValues)) {
+      if ($this->_id) {
+        $this->defaultValues = CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::getValuesArray($this->_id);
+      }
+      else {
+        $this->defaultValues = [
+          'start_date' => CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::getMostRecentStartDateAvailable(),
+          'weight' => CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::getMaxWeight() + 1
+        ];
+      }
+    }
+
+    return $this->defaultValues;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildQuickForm() {
+    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+
+    $this->addFields();
+    $this->addFieldsRules();
+    $this->addButtons($this->getAvailableButtons());
+
+    CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/hrleaveandabsences.css');
+    parent::buildQuickForm();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function postProcess() {
+    if ($this->_action & (CRM_Core_Action::ADD | CRM_Core_Action::UPDATE)) {
+      // store the submitted values in an array
+      $params = $this->exportValues();
+
+      if ($this->_action & CRM_Core_Action::UPDATE) {
+        $params['id'] = $this->_id;
+      }
+
+      $actionDescription = ($this->_action & CRM_Core_Action::UPDATE) ? 'updated' : 'created';
+      try {
+        $absenceType = CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::create($params);
+        CRM_Core_Session::setStatus(
+          ts("The Absence Period '%1' has been $actionDescription.", [1 => $absenceType->title]),
+          'Success',
+          'success'
+        );
+      } catch (CRM_HRLeaveAndAbsences_Exception_InvalidAbsencePeriodException $ex) {
+        $message = ts("The Absence Period could not be $actionDescription.");
+        $message .= ' ' . $ex->getMessage();
+        CRM_Core_Session::setStatus($message, 'Error', 'error');
+      }
+
+      $url = CRM_Utils_System::url('civicrm/admin/leaveandabsences/periods', 'reset=1&action=browse');
+      $session = CRM_Core_Session::singleton();
+      $session->replaceUserContext($url);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefaultEntity() {
+    return 'AbsencePeriod';
+  }
+
+  /**
+   * Adds all the fields to the form
+   */
+  private function addFields() {
+    $this->add(
+      'text',
+      'title',
+      ts('Title'),
+      $this->getDAOFieldAttributes('title'),
+      true
+    );
+    $this->add(
+      'datepicker',
+      'start_date',
+      ts('Start Date'),
+      $this->getDAOFieldAttributes('start_date'),
+      true,
+      ['time' => false]
+    );
+    $this->add(
+      'datepicker',
+      'end_date',
+      ts('End Date'),
+      $this->getDAOFieldAttributes('end_date'),
+      true,
+      ['time' => false]
+    );
+    $this->add(
+      'number',
+      'weight',
+      ts('Order'),
+      $this->getDAOFieldAttributes('weight'),
+      true
+    );
+  }
+
+  /**
+   * A helper method to call the CRM_Core_DAO::getAttribute to get the
+   * fields attributes of the AbsencePeriod BAO
+   *
+   * @param $field - The name of a field of the AbsencePeriod BAO
+   *
+   * @return array - The attributes returned by CRM_Core_DAO::getAttribute
+   */
+  private function getDAOFieldAttributes($field) {
+    $dao = 'CRM_HRLeaveAndAbsences_DAO_AbsencePeriod';
+    return CRM_Core_DAO::getAttribute($dao, $field);
+  }
+
+  /**
+   * Add validation rules for the fields on this form.
+   */
+  private function addFieldsRules() {
+    $this->addRule('weight', ts('The Order should be a positive number'), 'positiveInteger');
+    $this->addFormRule([$this, 'formRules']);
+  }
+
+  /**
+   * Execute validations concerning all the form fields.
+   *
+   * Different from regular field rules, Form Rules can be used for validations
+   * that depends on multiple fields,(for example, if field X is not empty,
+   * then Y is required). Here, we use it to validate the dates, because start
+   * date can't be greater or equal to end date.
+   *
+   * @param array $values An array containing all the form's fields values
+   *
+   * @return array|bool Returns true if form is valid. Otherwise, an
+   *                    array containing all the validation errors is returned.
+   */
+  public function formRules($values) {
+    $errors = [];
+    $this->validatePeriodDates($values, $errors);
+
+    return empty($errors) ? true : $errors;
+  }
+
+  /**
+   * Validates if the Start Date is less than the End Date
+   *
+   * @param array $values An array containing all the form's fields values
+   * @param array $errors A reference to the errors array where errors will be
+   *                      added if dates are invalid
+   */
+  private function validatePeriodDates($values, &$errors) {
+    $startDate = strtotime($values['start_date']);
+    $endDate = strtotime($values['end_date']);
+    if($startDate >= $endDate) {
+      $errors['start_date'] = ts('Start Date should be less than End Date');
+    }
+  }
+
+  /**
+   * Get the list of action buttons available to this form
+   *
+   * @return array
+   */
+  private function getAvailableButtons() {
+    $buttons = [
+      ['type' => 'next', 'name' => ts('Save'), 'isDefault' => true],
+      ['type' => 'cancel', 'name' => ts('Cancel')],
+    ];
+
+    return $buttons;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.php
@@ -105,7 +105,7 @@ class CRM_HRLeaveAndAbsences_Page_AbsencePeriod extends CRM_Core_Page_Basic {
    * @access public
    */
   public function editForm() {
-    return '';
+    return 'CRM_HRLeaveAndAbsences_Form_AbsencePeriod';
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Validator/Date.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Validator/Date.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * A simple validator with a single isValid method that checks
+ * if a date is valid.
+ */
+class CRM_HRLeaveAndAbsences_Validator_Date {
+
+  /**
+   * Check if the given date is valid according to the give format.
+   *
+   * If no format is given, then the default Y-m-d format will be used.
+   *
+   * Please check http://php.net/manual/en/datetime.createfromformat.php for a
+   * list of valid date formats.
+   *
+   * @param string $date - The date to be validated
+   * @param string $format - The format to check the date against
+   *
+   * @return bool
+   */
+  public static function isValid($date, $format = 'Y-m-d')
+  {
+    $dateTime = DateTime::createFromFormat($format, $date);
+
+    // PHP automatically converts some invalid dates to valid ones, like
+    // 2016-02-30 to 2016-03-01. That's why we should also check if the
+    // returned DateTime object is the same as the given date.
+    return $dateTime && $dateTime->format($format) == $date;
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.absenceperiod.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.absenceperiod.js
@@ -1,0 +1,148 @@
+// Create the namespaces if they don't exist
+CRM.HRLeaveAndAbsencesApp = CRM.HRLeaveAndAbsencesApp || {};
+CRM.HRLeaveAndAbsencesApp.Form = CRM.HRLeaveAndAbsencesApp.Form || {};
+
+
+/**
+ * This class represents the AbsencePeriod form.
+ *
+ * It wraps the form#AbsencePeriod element and handle things like
+ * adding event listeners to it, updating fields values, showing
+ * confirmation and more.
+ */
+CRM.HRLeaveAndAbsencesApp.Form.AbsencePeriod = (function($) {
+
+  /**
+   * Creates a new AbsencePeriod form object for the given form Element
+   *
+   * @constructor
+   */
+  function AbsencePeriod() {
+    this._formElement = $('form#AbsencePeriod');
+    this._saveButton = $('#_qf_AbsencePeriod_next-bottom');
+    this._addEventListeners();
+  }
+
+  /**
+   * Add events listeners to events specific to the form.
+   *
+   * @private
+   */
+  AbsencePeriod.prototype._addEventListeners = function() {
+    this._saveButton.on('click', this._onSaveButtonClick.bind(this));
+  };
+
+  /**
+   * Event handler called when the form's save button has been clicked
+   *
+   * @param event
+   * @private
+   */
+  AbsencePeriod.prototype._onSaveButtonClick = function(event) {
+    event.preventDefault();
+    this._setSaveButtonValidatingState();
+    this._validateOrder();
+  };
+
+  /**
+   * Checks if there's another Absence Period with the same
+   * Order number as the one the user is trying to add/edit.
+   *
+   * @private
+   */
+  AbsencePeriod.prototype._validateOrder = function() {
+    var id = null;
+    var params = {
+      weight: document.getElementById('weight').value
+    };
+
+    if((id = document.getElementsByName('_id')[0].value)) {
+      params.id = {"!=": id};
+    }
+
+    CRM.api3('AbsencePeriod', 'getcount', params)
+      .done(this._validateOrderAPICallback.bind(this))
+  };
+
+  /**
+   * This is the callback for the API call made by the validaOrder method.
+   *
+   * If the returned data shows we have another AbsencePeriod with the same
+   * Order number, then a confirmation message is displayed. Otherwise, we
+   * just submit the form.
+   *
+   * @param {Object} data - The JSON data returned by the API call
+   * @private
+   */
+  AbsencePeriod.prototype._validateOrderAPICallback = function(data) {
+    this._unsetSaveButtonValidatingState();
+    if(data.result > 0) {
+      this._showConfirmation();
+    } else {
+      this._submitForm();
+    }
+  };
+
+  /**
+   * Uses the CRM.confirm to ask the user confirmation if they really want to
+   * save this Absence Period witht the same Order number of another existing
+   * Period.
+   *
+   * @private
+   */
+  AbsencePeriod.prototype._showConfirmation = function() {
+    var confirmationMessage = 'Another period has this order number. ' +
+                              'If you choose to continue all periods ' +
+                              'with the same or greater order number ' +
+                              'will be increased by 1 and hence will ' +
+                              'follow this period';
+    CRM.confirm({
+      title: ts('Alert'),
+      message: ts(confirmationMessage),
+      width: '30%',
+      options: {
+        yes: ts('Yes'),
+        no: ts('No')
+      }
+    })
+    .on('crmConfirm:yes', this._submitForm.bind(this))
+  };
+
+  /**
+   * Submits the form by calling the form submit method.
+   *
+   * We need this because, in order to validate the Order number,
+   * the event of the submit button was canceled on its onclick event handler.
+   *
+   * @private
+   */
+  AbsencePeriod.prototype._submitForm = function() {
+    this._formElement.submit();
+  };
+
+  /**
+   * Sets the Save button on the Validating state. That is, after the user clicks it
+   * we disable the button (so it can't be clicked more than once) and change its
+   * value to an text indicating that the validation is running.
+   *
+   * @private
+   */
+  AbsencePeriod.prototype._setSaveButtonValidatingState = function() {
+    this._saveButton.attr('disabled', 'disabled');
+    this._saveButton.val(ts('Validating order...'));
+  };
+
+  /**
+   * Removes the Validating state of the Save button. This means the button will
+   * be enabled again and its value will be changed to "Save".
+   *
+   * @private
+   */
+  AbsencePeriod.prototype._unsetSaveButtonValidatingState = function() {
+    this._saveButton.removeAttr('disabled');
+    this._saveButton.val(ts('Save'));
+  };
+
+
+  return AbsencePeriod;
+})(CRM.$);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsencePeriod.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsencePeriod.tpl
@@ -1,0 +1,23 @@
+<h1 class="title">{if $action eq 1}{ts}New Absence Period{/ts}{elseif $action eq 2}{ts}Edit Absence Period{/ts}{/if}</h1>
+
+<div class="crm-block crm-form-block crm-absence-period-form-block crm-leave-and-absences-form-block">
+  <table class="form-layout">
+    <tr>
+      <td class="label">{$form.title.label}</td>
+      <td class="html-adjust">{$form.title.html}</td>
+    </tr>
+    <tr>
+      <td class="label">{$form.start_date.label}</td>
+      <td class="html-adjust">{$form.start_date.html}</td>
+    </tr>
+    <tr>
+      <td class="label">{$form.end_date.label}</td>
+      <td class="html-adjust">{$form.end_date.html}</td>
+    </tr>
+    <tr>
+      <td class="label">{$form.weight.label}</td>
+      <td class="html-adjust">{$form.weight.html}</td>
+    </tr>
+  </table>
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+</div>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsencePeriod.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsencePeriod.tpl
@@ -19,5 +19,12 @@
       <td class="html-adjust">{$form.weight.html}</td>
     </tr>
   </table>
+  {literal}
+    <script type="text/javascript">
+      CRM.$(function () {
+        var form = new CRM.HRLeaveAndAbsencesApp.Form.AbsencePeriod();
+      });
+    </script>
+  {/literal}
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.tpl
@@ -1,49 +1,49 @@
 {if $action eq 1 or $action eq 2 or $action eq 8}
-    {* The form template will be here *}
+  {include file="CRM/HRLeaveAndAbsences/Form/AbsencePeriod.tpl"}
 {else}
-    {if $rows}
-        <div id="ltype">
-            <div class="form-item">
-                {strip}
-                    <table cellpadding="0" cellspacing="0" border="0" class="hrleaveandabsences-entity-list">
-                        <thead class="sticky">
-                            <th>{ts}Title{/ts}</th>
-                            <th>{ts}Start Date{/ts}</th>
-                            <th>{ts}End Date{/ts}</th>
-                            <th>{ts}Order{/ts}</th>
-                            <th></th>
-                        </thead>
-                        {foreach from=$rows item=row}
-                            <tr id="AbsencePeriod-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {$row.class}{if NOT $row.is_active} disabled{/if}">
-                                <td data-field="title">{$row.title}</td>
-                                <td>{$row.start_date|crmDate}</td>
-                                <td>{$row.end_date|crmDate}</td>
-                                <td>{$row.weight}</td>
-                                <td>{$row.action|replace:'xx':$row.id}</td>
-                            </tr>
-                        {/foreach}
-                    </table>
-                {/strip}
+  {if $rows}
+    <div id="ltype">
+      <div class="form-item">
+        {strip}
+          <table cellpadding="0" cellspacing="0" border="0" class="hrleaveandabsences-entity-list">
+            <thead class="sticky">
+            <th>{ts}Title{/ts}</th>
+            <th>{ts}Start Date{/ts}</th>
+            <th>{ts}End Date{/ts}</th>
+            <th>{ts}Order{/ts}</th>
+            <th></th>
+            </thead>
+            {foreach from=$rows item=row}
+              <tr id="AbsencePeriod-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {$row.class}{if NOT $row.is_active} disabled{/if}">
+                <td data-field="title">{$row.title}</td>
+                <td>{$row.start_date|crmDate}</td>
+                <td>{$row.end_date|crmDate}</td>
+                <td>{$row.weight}</td>
+                <td>{$row.action|replace:'xx':$row.id}</td>
+              </tr>
+            {/foreach}
+          </table>
+        {/strip}
 
-                {if $action ne 1 and $action ne 2}
-                    <div class="action-link">
-                        <a href="{crmURL q="action=add&reset=1"}" class="button"><span><div class="icon add-icon"></div>{ts}Add new entitlement period{/ts}</span></a>
-                    </div>
-                {/if}
-            </div>
-        </div>
-        {literal}
-        <script type="text/javascript">
-            CRM.$(function() {
-                var listPage = new CRM.HRLeaveAndAbsencesApp.ListPage(CRM.$('.hrleaveandabsences-entity-list'));
-            });
-        </script>
-        {/literal}
-    {else}
-        <div class="messages status no-popup">
-            <div class="icon inform-icon"></div>
-            {capture assign=crmURL}{crmURL q="action=add&reset=1"}{/capture}
-            {ts 1=$crmURL}There are no Absence Periods entered. You can <a href='%1'>add one</a>.{/ts}
-        </div>
-    {/if}
+        {if $action ne 1 and $action ne 2}
+          <div class="action-link">
+            <a href="{crmURL q="action=add&reset=1"}" class="button"><span><div class="icon add-icon"></div>{ts}Add new entitlement period{/ts}</span></a>
+          </div>
+        {/if}
+      </div>
+    </div>
+  {literal}
+    <script type="text/javascript">
+      CRM.$(function () {
+        var listPage = new CRM.HRLeaveAndAbsencesApp.ListPage(CRM.$('.hrleaveandabsences-entity-list'));
+      });
+    </script>
+  {/literal}
+  {else}
+    <div class="messages status no-popup">
+      <div class="icon inform-icon"></div>
+      {capture assign=crmURL}{crmURL q="action=add&reset=1"}{/capture}
+      {ts 1=$crmURL}There are no Absence Periods entered. You can<a href='%1'>add one</a>.{/ts}
+    </div>
+  {/if}
 {/if}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
@@ -131,6 +131,36 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends CiviUnitTestCase impl
     ]);
   }
 
+  public function testPeriodCannotOverlapWithItself()
+  {
+    $params = [
+      'title' => 'Period 1',
+      'start_date' => date('Y-m-d'),
+      'end_date' => date('Y-m-d', strtotime('+1 day')),
+      'weight' => 1
+    ];
+    $period = CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::create($params);
+
+    $period = $this->findPeriodByID($period->id);
+    $this->assertEquals($params['title'], $period->title);
+    $this->assertEquals($params['start_date'], $period->start_date);
+    $this->assertEquals($params['end_date'], $period->end_date);
+    $this->assertEquals($params['weight'], $period->weight);
+
+    // Saving the period keeping its start and end dates should not
+    // throw an InvalidAbsencePeriod exception saying it overlaps
+    // with another period (itself)
+    $params['title'] = 'Period 1 Updated';
+    $params['id'] = $period->id;
+    CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::create($params);
+
+    $period = $this->findPeriodByID($period->id);
+    $this->assertEquals($params['title'], $period->title);
+    $this->assertEquals($params['start_date'], $period->start_date);
+    $this->assertEquals($params['end_date'], $period->end_date);
+    $this->assertEquals($params['weight'], $period->weight);
+  }
+
   /**
    * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidAbsencePeriodException
    * @expectedExceptionMessage Both the start and end dates should be valid

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
@@ -161,6 +161,47 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends CiviUnitTestCase impl
     ]);
   }
 
+  public function testGetValuesArrayShouldReturnAbsencePeriodValues()
+  {
+    $params = [
+      'title' => 'Period Title',
+      'start_date' => date('Y-m-d'),
+      'end_date' => date('Y-m-d', strtotime('+6 months'))
+    ];
+    $entity = $this->createBasicPeriod($params);
+    $values = CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::getValuesArray($entity->id);
+    $this->assertEquals($params['title'], $values['title']);
+    $this->assertEquals($params['start_date'], $values['start_date']);
+    $this->assertEquals($params['end_date'], $values['end_date']);
+  }
+
+  public function testItCanReturnTheMostRecentStartDateAvailable()
+  {
+    $date = CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::getMostRecentStartDateAvailable();
+    $this->assertEquals(date('Y-m-d'), $date);
+
+    $this->createBasicPeriod([
+      'start_date' => '2015-01-01',
+      'end_date' => '2015-12-31',
+    ]);
+    $date = CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::getMostRecentStartDateAvailable();
+    $this->assertEquals('2016-01-01', $date);
+
+    $this->createBasicPeriod([
+      'start_date' => '2014-01-01',
+      'end_date' => '2014-01-31',
+    ]);
+    $date = CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::getMostRecentStartDateAvailable();
+    $this->assertEquals('2016-01-01', $date);
+
+    $this->createBasicPeriod([
+      'start_date' => '2016-01-01',
+      'end_date' => '2016-12-31',
+    ]);
+    $date = CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::getMostRecentStartDateAvailable();
+    $this->assertEquals('2017-01-01', $date);
+  }
+
   private function createBasicPeriod($params = array()) {
     $basicRequiredFields = [
         'title' => 'Type ' . microtime(),

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
@@ -299,6 +299,12 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends CiviUnitTestCase impl
       ['2015-02-31', '2014-01-01'],
       ['2015-01-01', '2015-13-01'],
       ['2015-02-31', 'dafsfdasfdasfdsafsd'],
+      ['31/02/2015', 'dafsfdasfdasfdsafsd'],
+      ['10/03/2014', '11/03/2015'],
+      ['10/03/2014', '2015-01-01'],
+      ['03/2017', '2020-10-11'],
+      ['2020-10-11', '2016'],
+      ['2020-10-11', '03/2017'],
     ];
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Validator/DateTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Validator/DateTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Validator_DateTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_BAO_DateTest extends PHPUnit_Framework_TestCase implements HeadlessInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->installMe(__DIR__)->apply();
+  }
+
+  /**
+   * @dataProvider datesDataProvider
+   */
+  public function testCanValidateDateInDefaultFormat($date, $expectedResult)
+  {
+    $valid = CRM_HRLeaveAndAbsences_Validator_Date::isValid($date);
+    $this->assertEquals($expectedResult, $valid);
+  }
+
+  /**
+   * @dataProvider datesDataProviderInDifferentFormats
+   */
+  public function testCanValidateDateInDifferentFormats($date, $format)
+  {
+    $valid = CRM_HRLeaveAndAbsences_Validator_Date::isValid($date, $format);
+    $this->assertTrue($valid);
+  }
+
+  public function datesDataProvider()
+  {
+    return [
+      [date('Y-m-d'), true],
+      [date('Y-m'), false],
+      [date('Y'), false],
+      [date('m'), false],
+      ['reqwreqwfdssafdsa', false],
+      [12312321321, false],
+      [null, false],
+      ['April 1st', false],
+      ['2016-02-30', false],
+      ['2013-04-31', false],
+      ['2009-07-51', false],
+      ['2051-13-01', false],
+    ];
+  }
+
+  public function datesDataProviderInDifferentFormats()
+  {
+    return [
+      [date('d/m/Y'), 'd/m/Y'],
+      [date('Y-m'),'Y-m'],
+      [date('Y'), 'Y'],
+      [date('m'), 'm'],
+    ];
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/WebTest/AbsencePeriod/FormTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/WebTest/AbsencePeriod/FormTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+
+/**
+ * Class WebTest_AbsencePeriod_FormTest
+ *
+ * @group headless
+ */
+class WebTest_AbsencePeriod_FormTest extends CiviSeleniumTestCase implements HeadlessInterface {
+
+  private $formUrl = 'admin/leaveandabsences/periods';
+  private $addUrlParams = 'action=add&reset=1';
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->installMe(__DIR__)->apply();
+  }
+
+  private function loginAsAdmin() {
+    if (is_null($this->loggedInAs)) {
+      $this->webtestLogin('admin');
+    }
+  }
+
+  public function testAddAnEmptyType() {
+    $this->loginAsAdmin();
+    $this->openAddForm();
+    $this->type('start_date', '');
+    $this->type('weight', '');
+    $this->submitAndWait('AbsencePeriod');
+    $this->assertTrue($this->isTextPresent('Title is a required field.'));
+    $this->assertTrue($this->isTextPresent('Start Date is a required field.'));
+    $this->assertTrue($this->isTextPresent('End Date is a required field.'));
+    $this->assertTrue($this->isTextPresent('Order is a required field.'));
+  }
+
+  public function testCanAddPeriodWithMinimumRequiredFields() {
+    $this->loginAsAdmin();
+    $title = $this->addAbsencePeriod();
+    $firstTdOfLastRow = 'xpath=//div[@class="form-item"]/table/tbody/tr[last()]/td[1]';
+    $this->assertElementContainsText($firstTdOfLastRow, $title);
+  }
+
+  public function testStartDateShouldBeLessThanEndDate() {
+    $this->loginAsAdmin();
+    $this->openAddForm();
+    $this->type('start_date', date('Y-m-d'));
+    $this->type('end_date', date('Y-m-d', strtotime('-1 day')));
+    $this->submitAndWait('AbsencePeriod');
+    $this->assertTrue($this->isTextPresent('Start Date should be less than End Date'));
+  }
+
+  private function openAddForm() {
+    $this->openCiviPage($this->formUrl, $this->addUrlParams);
+  }
+
+  private function addAbsencePeriod() {
+    $this->openAddForm();
+
+    $title = 'Title ' . microtime();
+    $this->type('title', $title);
+
+    $endDate = new DateTime($this->getValue('start_date'));
+    $endDate->add(new DateInterval('P1D'));
+    $this->type('end_date', $endDate->format('Y-m-d'));
+
+    $this->submitAndWait('AbsencePeriod');
+
+    return $title;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/WebTest/AbsencePeriod/FormTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/WebTest/AbsencePeriod/FormTest.php
@@ -74,6 +74,39 @@ class WebTest_AbsencePeriod_FormTest extends CiviSeleniumTestCase implements Hea
     $this->assertElementContainsText($confirmationDialog, $confirmationMessage);
   }
 
+  public function testStartAndEndDatesShouldBeValidDates()
+  {
+    $this->loginAsAdmin();
+    $this->openAddForm();
+
+    $randomString = CRM_Utils_String::createRandom(rand(1, 10), 'abcdefghijklmnopqrstuvwxyz');
+    $this->type('start_date', $randomString);
+    $this->type('end_date', $randomString);
+    $this->submitAndWait('AbsencePeriod');
+    $this->assertTrue($this->isTextPresent('Start Date should be a valid date'));
+    $this->assertTrue($this->isTextPresent('End Date should be a valid date'));
+
+    $randomNumber = rand(1, PHP_INT_MAX);
+    $this->type('start_date', $randomNumber);
+    $this->type('end_date', $randomNumber);
+    $this->submitAndWait('AbsencePeriod');
+    $this->assertTrue($this->isTextPresent('Start Date should be a valid date'));
+    $this->assertTrue($this->isTextPresent('End Date should be a valid date'));
+
+    $incompleteDate = '2016-01';
+    $this->type('start_date', $incompleteDate);
+    $this->type('end_date', $incompleteDate);
+    $this->submitAndWait('AbsencePeriod');
+    $this->assertTrue($this->isTextPresent('Start Date should be a valid date'));
+    $this->assertTrue($this->isTextPresent('End Date should be a valid date'));
+
+    $this->type('start_date', '2016-02-32');
+    $this->type('end_date', '2016-41-01');
+    $this->submitAndWait('AbsencePeriod');
+    $this->assertTrue($this->isTextPresent('Start Date should be a valid date'));
+    $this->assertTrue($this->isTextPresent('End Date should be a valid date'));
+  }
+
   private function openAddForm() {
     $this->openCiviPage($this->formUrl, $this->addUrlParams);
   }


### PR DESCRIPTION
This is new Absence Period form for the Leaves and Absences extension. It's a quite simple form, with just 4 fields. All of them are mandatory. When adding a new Absence Period, the start date is automatically filled with the most recent date available, which can be:
- The current date, if there's no other Absence Period
- The maximum end date among all the existing Absence Periods + 1 day

The order number is also automatically filled following these rules:
- It's value is 1 if there's no other Absence Period
- It's value is the maximum weight among all the existing Absence Period + 1

This is how the form looks like:
![captura de tela 2016-05-31 as 07 34 50](https://cloud.githubusercontent.com/assets/388373/15671753/d83c9828-2702-11e6-8b0d-6768c1579869.png)
