### PR TITLE
PCHR-889: Fix the search description for Job Roles regions on the Adv. Search

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/Query.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/Query.php
@@ -129,7 +129,7 @@ class CRM_Hrjobroles_BAO_Query extends CRM_Contact_BAO_Query_Interface {
                 $this->buildMultiValueClause($query, $value, $locationOptions, $fieldTitle, $grouping, $whereField);
                 return;
             case 'hrjobroles_region':
-                $regionOptions = $this->getDepartmentOptions();
+                $regionOptions = $this->getRegionOptions();
                 $this->buildMultiValueClause($query, $value, $regionOptions, $fieldTitle, $grouping, $whereField);
                 return;
             case 'hrjobroles_department':
@@ -241,7 +241,7 @@ class CRM_Hrjobroles_BAO_Query extends CRM_Contact_BAO_Query_Interface {
             );
 
             $form->addElement('text', 'hrjobroles_funder', ts('Funder (Complete OR Partial Name)'), CRM_Core_DAO::getAttribute('CRM_Hrjobroles_DAO_HRJobRoles', 'funder'));
-            
+
             $form->add('select', 'hrjobroles_funder_val_type', ts('Funder Value Type'), $this->fundindAndCostCentresOptions, FALSE,
                 array('id' => 'hrjobroles_funder_val_type', 'placeholder' => ts('- select - '))
             );

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/Query.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/Query.php
@@ -295,7 +295,7 @@ class CRM_Hrjobroles_BAO_Query extends CRM_Contact_BAO_Query_Interface {
      */
     private function getLocationOptions() {
         if(empty($this->locationOptions)) {
-            $this->locationOptions = $this->getOptionsWithIDAsKeyFor('CRM_Hrjobcontract_DAO_HRJobDetails', 'location');
+            $this->locationOptions = $this->getOptionsWithIDAsKeyFor('CRM_Hrjobroles_DAO_HrJobRoles', 'location');
         }
 
         return $this->locationOptions;
@@ -306,7 +306,7 @@ class CRM_Hrjobroles_BAO_Query extends CRM_Contact_BAO_Query_Interface {
      */
     private function getRegionOptions() {
         if(empty($this->regionOptions)) {
-            $this->regionOptions = $this->getOptionsWithIDAsKeyFor('CRM_Hrjobcontract_DAO_HRJobRole', 'region');
+            $this->regionOptions = $this->getOptionsWithIDAsKeyFor('CRM_Hrjobroles_DAO_HrJobRoles', 'region');
         }
 
         return $this->regionOptions;
@@ -317,7 +317,7 @@ class CRM_Hrjobroles_BAO_Query extends CRM_Contact_BAO_Query_Interface {
      */
     private function getDepartmentOptions() {
         if(empty($this->departmentOptions)) {
-            $this->departmentOptions = $this->getOptionsWithIDAsKeyFor('CRM_Hrjobcontract_DAO_HRJobRole', 'department');
+            $this->departmentOptions = $this->getOptionsWithIDAsKeyFor('CRM_Hrjobroles_DAO_HrJobRoles', 'department');
         }
 
         return $this->departmentOptions;
@@ -328,7 +328,7 @@ class CRM_Hrjobroles_BAO_Query extends CRM_Contact_BAO_Query_Interface {
      */
     private function getLevelTypeOptions() {
         if(empty($this->levelTypeOptions)) {
-            $this->levelTypeOptions = $this->getOptionsWithIDAsKeyFor('CRM_Hrjobcontract_DAO_HRJobRole', 'level_type');
+            $this->levelTypeOptions = $this->getOptionsWithIDAsKeyFor('CRM_Hrjobroles_DAO_HrJobRoles', 'level_type');
         }
 
         return $this->levelTypeOptions;

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/DAO/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/DAO/HrJobRoles.php
@@ -339,6 +339,9 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
           'headerPattern' => '',
           'dataPattern' => '',
           'export' => true,
+          'pseudoconstant' => array(
+            'optionGroupName' => 'hrjc_region',
+          ),
         ) ,
         'hrjc_role_department' => array(
           'name' => 'department',
@@ -351,6 +354,9 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
           'headerPattern' => '',
           'dataPattern' => '',
           'export' => true,
+          'pseudoconstant' => array(
+            'optionGroupName' => 'hrjc_department',
+          ),
         ) ,
         'hrjc_level_type' => array(
           'name' => 'level_type',
@@ -363,6 +369,9 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
           'headerPattern' => '',
           'dataPattern' => '',
           'export' => true,
+          'pseudoconstant' => array(
+            'optionGroupName' => 'hrjc_level_type',
+          ),
         ) ,
         'manager_contact_id' => array(
           'name' => 'manager_contact_id',
@@ -493,6 +502,9 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
           'headerPattern' => '',
           'dataPattern' => '',
           'export' => true,
+          'pseudoconstant' => array(
+            'optionGroupName' => 'hrjc_location',
+          ),
         ) ,
         'hrjc_role_start_date' => array(
           'name' => 'start_date',


### PR DESCRIPTION
When searching for Job Role Regions, the search values where not displayed on the
search description. For example, when searching for the "South America" region, the user would see this:

![captura de tela 2016-05-31 as 15 08 05](https://cloud.githubusercontent.com/assets/388373/15685311/83e91cda-2741-11e6-90e1-76ec621e1309.png)

instead, they should see this:

![captura de tela 2016-05-31 as 15 06 17](https://cloud.githubusercontent.com/assets/388373/15685261/4eedc148-2741-11e6-9fbd-7a4ebbad1400.png)

This was happening because instead of the Region Options, we were passing the
list of Department Options to the method that builds the description making impossible
to get the correct name of the selected region.

It was also made an small change to the CRM_Hrjobroles_BAO_Query class to remove a dependency on the CRM_Hrjobcontracts_BAO_HrJobRole BAO to load the options to the location, department, region and level type fields.