### PR TITLE
PCHR-1109: Add the getNumberOfWorkingDays method to the AbsencePeriod

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/PublicHoliday.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/PublicHoliday.php
@@ -68,4 +68,39 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
     }
   }
 
+  /**
+   * Returns the number of active Public Holidays between the given
+   * start and end dates (inclusive)
+   *
+   * @param $startDate The start date of the period
+   * @param $endDate The end date of the period
+   * @param bool $excludeWeekends When true it will not count Public Holidays that fall on a weekend. It's false by default
+   *
+   * @return int The Number of Public Holidays for the given Period
+   */
+  public static function getNumberOfPublicHolidaysForPeriod($startDate, $endDate, $excludeWeekends = false)
+  {
+    $startDate = CRM_Utils_Date::processDate($startDate, null, false, 'Ymd');
+    $endDate = CRM_Utils_Date::processDate($endDate, null, false, 'Ymd');
+
+    $tableName = self::getTableName();
+    $query = "
+      SELECT COUNT(*) as public_holidays
+      FROM {$tableName}
+      WHERE date >= %1 AND date <= %2 AND is_active = 1
+    ";
+
+    if($excludeWeekends) {
+      $query .= ' AND DAYOFWEEK(date) BETWEEN 2 AND 6';
+    }
+
+    $queryParams = [
+      1 => [$startDate, 'Date'],
+      2 => [$endDate, 'Date'],
+    ];
+    $dao = CRM_Core_DAO::executeQuery($query, $queryParams);
+    $dao->fetch(true);
+
+    return (int)$dao->public_holidays;
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/PublicHolidayTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/PublicHolidayTest.php
@@ -60,4 +60,97 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends PHPUnit_Framework_Tes
     ]);
   }
 
+  public function testGetNumberOfPublicHolidaysForPeriod()
+  {
+    $this->createBasicPublicHoliday(['date' => CRM_Utils_Date::processDate('2016-01-01')]);
+    $this->createBasicPublicHoliday(['date' => CRM_Utils_Date::processDate('2016-03-25')]);
+    $this->createBasicPublicHoliday(['date' => CRM_Utils_Date::processDate('2016-05-02')]);
+    $this->createBasicPublicHoliday(['date' => CRM_Utils_Date::processDate('2016-05-30')]);
+    $this->createBasicPublicHoliday(['date' => CRM_Utils_Date::processDate('2016-08-29')]);
+    $this->createBasicPublicHoliday(['date' => CRM_Utils_Date::processDate('2016-12-25')]);
+    $this->createBasicPublicHoliday(['date' => CRM_Utils_Date::processDate('2016-12-26')]);
+    $this->createBasicPublicHoliday(['date' => CRM_Utils_Date::processDate('2016-12-27')]);
+
+    $this->assertEquals(
+      8,
+      CRM_HRLeaveAndAbsences_BAO_PublicHoliday::getNumberOfPublicHolidaysForPeriod('2016-01-01', '2016-12-31')
+    );
+
+    $this->assertEquals(
+      1,
+      CRM_HRLeaveAndAbsences_BAO_PublicHoliday::getNumberOfPublicHolidaysForPeriod('2016-01-01', '2016-01-31')
+    );
+
+    $this->assertEquals(
+      0,
+      CRM_HRLeaveAndAbsences_BAO_PublicHoliday::getNumberOfPublicHolidaysForPeriod('2016-02-01', '2016-02-29')
+    );
+
+    $this->assertEquals(
+      1,
+      CRM_HRLeaveAndAbsences_BAO_PublicHoliday::getNumberOfPublicHolidaysForPeriod('2016-02-02', '2016-03-31')
+    );
+
+    $this->assertEquals(
+      3,
+      CRM_HRLeaveAndAbsences_BAO_PublicHoliday::getNumberOfPublicHolidaysForPeriod('2016-04-01', '2016-08-30')
+    );
+
+    $this->assertEquals(
+      3,
+      CRM_HRLeaveAndAbsences_BAO_PublicHoliday::getNumberOfPublicHolidaysForPeriod('2016-08-30', '2016-12-28')
+    );
+  }
+
+  public function testGetNumberOfPublicHolidaysDoesntCountNonActiveHolidays()
+  {
+    $this->createBasicPublicHoliday([
+      'date' => CRM_Utils_Date::processDate('2016-02-01')
+    ]);
+    $this->createBasicPublicHoliday([
+      'date'      => CRM_Utils_Date::processDate('2016-07-25'),
+      'is_active' => FALSE
+    ]);
+    $this->createBasicPublicHoliday([
+      'date' => CRM_Utils_Date::processDate('2016-04-02')
+    ]);
+
+    $this->assertEquals(
+      2,
+      CRM_HRLeaveAndAbsences_BAO_PublicHoliday::getNumberOfPublicHolidaysForPeriod('2016-02-01', '2016-12-31')
+    );
+  }
+
+  public function testGetNumberOfPublicHolidaysCanExcludeWeekendsFromCount()
+  {
+    $this->createBasicPublicHoliday([
+      'date' => CRM_Utils_Date::processDate('2016-02-01')
+    ]);
+    $this->createBasicPublicHoliday([
+      'date' => CRM_Utils_Date::processDate('2016-06-04') // Saturday
+    ]);
+    $this->createBasicPublicHoliday([
+      'date' => CRM_Utils_Date::processDate('2016-04-13')
+    ]);
+    $this->createBasicPublicHoliday([
+      'date' => CRM_Utils_Date::processDate('2016-05-15') // Sunday
+    ]);
+
+    $this->assertEquals(
+      2,
+      CRM_HRLeaveAndAbsences_BAO_PublicHoliday::getNumberOfPublicHolidaysForPeriod('2016-02-01', '2016-12-31', true)
+    );
+  }
+
+  private function createBasicPublicHoliday($params)
+  {
+    $basicRequiredFields = [
+      'title' => 'Type ' . microtime(),
+      'date' => CRM_Utils_Date::processDate(date('Y-m-d')),
+    ];
+
+    $params = array_merge($basicRequiredFields, $params);
+    return CRM_HRLeaveAndAbsences_BAO_PublicHoliday::create($params);
+  }
+
 }


### PR DESCRIPTION
The number of Working Days is given by:
Number of days in a Period - Number of weekend days - public holidays

If a public holiday falls on a weekend, it's not counted twice.

In order to get the number of public holidays between two dates, I added the
getNumberOfPublicHolidaysForPeriod method to the PublicHoliday BAO.