### PR TITLE
PCHR-1151: Unset already exist case types in hrcase extenison

### DIFF
--- a/hrcase/hrcase.php
+++ b/hrcase/hrcase.php
@@ -370,6 +370,19 @@ function hrcase_civicrm_post( $op, $objectName, $objectId, &$objectRef ) {
  */
 function hrcase_civicrm_caseTypes(&$caseTypes) {
   _hrcase_civix_civicrm_caseTypes($caseTypes);
+  /* Here we fetch all current case types and remove the ones
+   * that that already exist , for example task assignment extension
+   * create a case type called "joining" and since hrcase extension try to create
+   * a case type with similar name A database exception thrown
+   * and the installation of hrcase extension fail in case task
+   * assignment extension enabled before it
+  */
+  $caseTypesList = CRM_Case_PseudoConstant::caseType('name');
+  foreach($caseTypes as $key => $item)  {
+    if (in_array($key, $caseTypesList))  {
+      unset($caseTypes[$key]);
+    }
+  }
 }
 
 function hrcase_getActionsSchedule($getNamesOnly = FALSE) {


### PR DESCRIPTION
## :x:  Problem

When trying to install/enable **hrcase** extension after  enabling/installing **uk.co.compucorp.civicrm.tasksassignment** extension the following error is thrown :

`API error: DB Error: already exists`

 And the installation/enabling process for **hrcase** fail. This also affect installing civihr via the buildkit as described in the ticket description.

:computer: Technically speaking , The error appear due to the following :

1- When installing **uk.co.compucorp.civicrm.tasksassignment* extension it is create a bunch of case types two of these case types have the following name ( **exiting** , **joining** ).
2- when installing **hrcase** assignment extension after it ...  it also try to create a bunch of case types and two of these also have similar names ( **exiting** , **joining** ).
3- since **civicrm_case_type** table have a **unique constraint** set on "**name**" column and these similar case types are already created by task assignment extensions the error is thrown .

## :white_check_mark:  Solution 

Now ... I wasn't able to catch the exception in **hrcase**  extension since the creation of these case types happen through  (**hrcase_civicrm_caseTypes**) but this hook only define the list of case types going to be created by the extension and the actual creation happen in another core script which I don't have control over ... To solve this I did the following inside (**hrcase_civicrm_caseTypes**)  hook : 

1- get all current installed case types ( which include the ones created by task assignment extension )
2- get the list of the case types going to be installed via hrcase extension . (which  already available  via **$caseTypes** variable which is passed by reference to the hook ) .
3- unset the case types from  **$caseTypes** variable in case there are another case type in the database with similar name .