### PR TITLE
PCHR-1046 - Creating Public Holiday list page

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/PublicHoliday.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/PublicHoliday.php
@@ -27,15 +27,37 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
   }
 
   /**
+   * Delete a PublicHoliday with given ID.
+   * 
+   * @param int $id
+   */
+  public static function del($id) {
+    $publicHoliday = new CRM_HRLeaveAndAbsences_DAO_PublicHoliday();
+    $publicHoliday->id = $id;
+    $publicHoliday->find(true);
+    $publicHoliday->delete();
+  }
+
+  /**
+   * Return an array containing properties of Public Holiday with given ID.
+   * 
+   * @param int $id
+   * @return array|NULL
+   */
+  public static function getDefaultValues($id) {
+    $result = civicrm_api3('PublicHoliday', 'get', array('id' => $id));
+    return !empty($result['values'][$id]) ? $result['values'][$id] : null;
+  }
+
+  /**
    * Validates all the params passed to the create method
    *
    * @param array $params
    *
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidPublicHolidayException
    */
-  private static function validateParams($params)
-  {
-    if(empty($params['title'])) {
+  private static function validateParams($params) {
+    if(empty($params['title']) && empty($params['id'])) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidPublicHolidayException(
         'Title value is required'
       );
@@ -44,26 +66,41 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
   }
 
   /**
-   * Checks if date value in the $params array is valid.
-   *
-   * A date cannot be empty and must be a real date.
+   * If there is no date specified but id exists then we skip the date validation.
+   * Otherwise a date cannot be empty and must be a real date.
    *
    * @param array $params
-   *
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidPublicHolidayException
+   * @return bool
    */
-  private static function validateDate($params)
-  {
-    if(empty($params['date'])) {
+  private static function validateDate($params) {
+    // Skip date validation if we are editing an exsisting record and no new date is specified.
+    if (!isset($params['date']) && !empty($params['id'])) {
+      return true;
+    }
+    if (empty($params['date'])) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidPublicHolidayException(
         'Date value is required'
       );
     }
-
     $dateIsValid = CRM_HRLeaveAndAbsences_Validator_Date::isValid($params['date']);
     if(!$dateIsValid) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidPublicHolidayException(
         'Date value should be valid'
+      );
+    }
+
+    // Check for Public Holiday already existing with given date.
+    $duplicateDateParams = array(
+      'date' => $params['date'],
+    );
+    if (!empty($params['id'])) {
+      $duplicateDateParams['id'] = array('!=' => $params['id']);
+    }
+    $duplicateDate = civicrm_api3('PublicHoliday', 'getcount', $duplicateDateParams);
+    if ($duplicateDate) {
+      throw new CRM_HRLeaveAndAbsences_Exception_InvalidPublicHolidayException(
+        'There is a Public Holiday already existing with given date'
       );
     }
   }
@@ -78,8 +115,7 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
    *
    * @return int The Number of Public Holidays for the given Period
    */
-  public static function getNumberOfPublicHolidaysForPeriod($startDate, $endDate, $excludeWeekends = false)
-  {
+  public static function getNumberOfPublicHolidaysForPeriod($startDate, $endDate, $excludeWeekends = false) {
     $startDate = CRM_Utils_Date::processDate($startDate, null, false, 'Ymd');
     $endDate = CRM_Utils_Date::processDate($endDate, null, false, 'Ymd');
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/PublicHoliday.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/PublicHoliday.php
@@ -44,7 +44,7 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
    * @param int $id
    * @return array|NULL
    */
-  public static function getDefaultValues($id) {
+  public static function getValuesArray($id) {
     $result = civicrm_api3('PublicHoliday', 'get', array('id' => $id));
     return !empty($result['values'][$id]) ? $result['values'][$id] : null;
   }
@@ -63,6 +63,7 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
       );
     }
     self::validateDate($params);
+    self::checkIfDateIsUnique($params);
   }
 
   /**
@@ -89,7 +90,15 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
         'Date value should be valid'
       );
     }
+  }
 
+  /**
+   * Check if there is no Public Holiday already existing with provided date.
+   *
+   * @param array $params
+   * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidPublicHolidayException
+   */
+  private static function checkIfDateIsUnique($params) {
     // Check for Public Holiday already existing with given date.
     $duplicateDateParams = array(
       'date' => $params['date'],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/PublicHoliday.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/PublicHoliday.php
@@ -1,0 +1,11 @@
+<?php
+
+require_once 'CRM/Core/Form.php';
+
+/**
+ * Form controller class
+ *
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC43/QuickForm+Reference
+ */
+class CRM_HRLeaveAndAbsences_Form_PublicHoliday extends CRM_Core_Form {
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/PublicHoliday.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/PublicHoliday.php
@@ -1,0 +1,172 @@
+<?php
+
+class CRM_HRLeaveAndAbsences_Page_PublicHoliday extends CRM_Core_Page_Basic {
+
+  private $links = array();
+
+  /**
+   * Page entry point.
+   */
+  public function run() {
+    CRM_Utils_System::setTitle(ts('Public Holidays'));
+    parent::run();
+  }
+
+  /**
+   * Browse action.
+   */
+  public function browse() {
+    $object = new CRM_HRLeaveAndAbsences_BAO_PublicHoliday();
+    $object->orderBy('date');
+    $object->find();
+    $rows = [];
+    while($object->fetch()) {
+      $rows[$object->id] = array();
+
+      CRM_Core_DAO::storeValues($object, $rows[$object->id]);
+
+      $rows[$object->id]['action'] = CRM_Core_Action::formLink(
+          $this->links(),
+          $this->calculateLinksMask($object),
+          ['id' => $object->id]
+      );
+    }
+
+    $returnURL = CRM_Utils_System::url('civicrm/admin/leaveandabsences/public_holidays', 'reset=1');
+    CRM_Utils_Weight::addOrder($rows, 'CRM_HRLeaveAndAbsences_DAO_PublicHoliday', 'id', $returnURL);
+
+    CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/hrleaveandabsences.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
+
+    $this->assign('rows', $rows);
+  }
+
+  /**
+   * Edit action.
+   * 
+   * @param string $action
+   * @param int $id
+   * @param bool $imageUpload
+   * @param bool $pushUserContext
+   */
+  public function edit($action, $id = NULL, $imageUpload = FALSE, $pushUserContext = TRUE) {
+    if($action & CRM_Core_Action::DELETE) {
+      $this->delete($id);
+    } else {
+      parent::edit($action, $id, $imageUpload, $pushUserContext);
+    }
+  }
+
+  /**
+   * Delete action.
+   * 
+   * @param int $id
+   */
+  public function delete($id) {
+    try {
+      CRM_HRLeaveAndAbsences_BAO_PublicHoliday::del($id);
+      CRM_Core_Session::setStatus(ts('The Public Holiday was deleted'), 'Success', 'success');
+    } catch(Exception $ex) {
+      $message = ts('Error deleting the Public Holiday.') . ' '. $ex->getMessage();
+      CRM_Core_Session::setStatus($message, 'Error', 'error');
+    }
+
+    $url = CRM_Utils_System::url('civicrm/admin/leaveandabsences/public_holidays', 'reset=1&action=browse');
+    CRM_Utils_System::redirect($url);
+  }
+
+  /**
+   * Return a name of the BAO to perform various DB manipulations.
+   *
+   * @return string
+   * @access public
+   */
+  public function getBAOName() {
+    return 'CRM_HRLeaveAndAbsences_BAO_PublicHoliday';
+  }
+
+  /**
+   * Return an array of action links.
+   *
+   * @return array (reference)
+   * @access public
+   */
+  public function &links() {
+    if(empty($this->links)) {
+      $this->links = [
+        CRM_Core_Action::UPDATE  => [
+          'name'  => ts('Edit'),
+          'url'   => 'civicrm/admin/leaveandabsences/public_holidays',
+          'qs'    => 'action=update&id=%%id%%&reset=1',
+          'title' => ts('Edit Public Holiday'),
+        ],
+        CRM_Core_Action::DISABLE => [
+          'name'  => ts('Disable'),
+          'class' => 'crm-enable-disable',
+          'title' => ts('Disable Public Holiday'),
+        ],
+        CRM_Core_Action::ENABLE  => [
+          'name'  => ts('Enable'),
+          'class' => 'crm-enable-disable',
+          'title' => ts('Enable Public Holiday'),
+        ],
+        CRM_Core_Action::DELETE  => [
+          'name'  => ts('Delete'),
+          'class' => 'civihr-delete',
+          'title' => ts('Delete Public Holiday'),
+        ],
+      ];
+    }
+
+    return $this->links;
+  }
+
+  /**
+   * Return a name of the edit form class.
+   *
+   * @return string
+   * @access public
+   */
+  public function editForm() {
+    return 'CRM_HRLeaveAndAbsences_Form_PublicHoliday';
+  }
+
+  /**
+   * Return a name of the form.
+   *
+   * @return string
+   * @access public
+   */
+  public function editName() {
+    return 'Public Holidays';
+  }
+
+  /**
+   * Return userContext to pop back to.
+   *
+   * @param int $mode mode that we are in
+   *
+   * @return string
+   * @access public
+   */
+  public function userContext($mode = null) {
+    return 'civicrm/admin/leaveandabsences/public_holidays';
+  }
+
+  /**
+   * Return Link mask value depending on Public Holiday properties.
+   * 
+   * @param CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
+   * @return int
+   */
+  private function calculateLinksMask($publicHoliday) {
+    $mask = array_sum(array_keys($this->links()));
+
+    if($publicHoliday->is_active) {
+      $mask -= CRM_Core_Action::ENABLE;
+    } else {
+      $mask -= CRM_Core_Action::DISABLE;
+    }
+
+    return $mask;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -74,7 +74,7 @@ function _hrleaveandabsences_create_administer_menu_tree($leaveAndAbsencesAdminN
       array(
           'label'      => ts('Public Holidays'),
           'name'       => 'leave_and_absence_public_holidays',
-          'url'        => 'civicrm/admin/leaveandabsences/public_holidays',
+          'url'        => 'civicrm/admin/leaveandabsences/public_holidays?action=browse&reset=1',
           'permission' => 'administer leave and absences',
       ),
       array(

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/PublicHoliday.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/PublicHoliday.tpl
@@ -1,49 +1,45 @@
-{if $action eq 1 or $action eq 2 or $action eq 8}
-    {include file="CRM/HRLeaveAndAbsences/Form/PublicHoliday.tpl"}
-{else}
-    {if $rows}
-        <div id="ltype">
-            <div class="form-item">
-                {strip}
-                    {* handle enable/disable actions*}
-                    {include file="CRM/common/enableDisableApi.tpl"}
-                    <table cellpadding="0" cellspacing="0" border="0" class="hrleaveandabsences-entity-list">
-                        <thead class="sticky">
-                            <th>{ts}Title{/ts}</th>
-                            <th>{ts}Date{/ts}</th>
-                            <th>{ts}Enabled/Disabled{/ts}</th>
-                            <th></th>
-                        </thead>
-                        {foreach from=$rows item=row}
-                            <tr id="PublicHoliday-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {$row.class}{if NOT $row.is_active} disabled{/if}">
-                                <td data-field="title">{$row.title}</td>
-                                <td>{$row.date}</td>
-                                <td>{if $row.is_active eq 1} {ts}Enabled{/ts} {else} {ts}Disabled{/ts} {/if}</td>
-                                <td>{$row.action|replace:'xx':$row.id}</td>
-                            </tr>
-                        {/foreach}
-                    </table>
-                {/strip}
+{if $rows}
+    <div id="ltype">
+        <div class="form-item">
+            {strip}
+                {* handle enable/disable actions*}
+                {include file="CRM/common/enableDisableApi.tpl"}
+                <table cellpadding="0" cellspacing="0" border="0" class="hrleaveandabsences-entity-list">
+                    <thead class="sticky">
+                        <th>{ts}Title{/ts}</th>
+                        <th>{ts}Date{/ts}</th>
+                        <th>{ts}Enabled/Disabled{/ts}</th>
+                        <th></th>
+                    </thead>
+                    {foreach from=$rows item=row}
+                        <tr id="PublicHoliday-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {$row.class}{if NOT $row.is_active} disabled{/if}">
+                            <td data-field="title">{$row.title}</td>
+                            <td>{$row.date|crmDate}</td>
+                            <td>{if $row.is_active eq 1} {ts}Enabled{/ts} {else} {ts}Disabled{/ts} {/if}</td>
+                            <td>{$row.action|replace:'xx':$row.id}</td>
+                        </tr>
+                    {/foreach}
+                </table>
+            {/strip}
 
-                {if $action ne 1 and $action ne 2}
-                    <div class="action-link">
-                        <a href="{crmURL q="action=add&reset=1"}" class="button"><span><div class="icon add-icon"></div>{ts}Add Public Holiday{/ts}</span></a>
-                    </div>
-                {/if}
-            </div>
+            {if $action ne 1 and $action ne 2}
+                <div class="action-link">
+                    <a href="{crmURL q="action=add&reset=1"}" class="button"><span><div class="icon add-icon"></div>{ts}Add Public Holiday{/ts}</span></a>
+                </div>
+            {/if}
         </div>
-        {literal}
-        <script type="text/javascript">
-            CRM.$(function() {
-                var listPage = new CRM.HRLeaveAndAbsencesApp.ListPage(CRM.$('.hrleaveandabsences-entity-list'));
-            });
-        </script>
-        {/literal}
-    {else}
-        <div class="messages status no-popup">
-            <div class="icon inform-icon"></div>
-            {capture assign=crmURL}{crmURL q="action=add&reset=1"}{/capture}
-            {ts 1=$crmURL}There are no Public Holidays entered. You can <a href='%1'>add one</a>.{/ts}
-        </div>
-    {/if}
+    </div>
+    {literal}
+    <script type="text/javascript">
+        CRM.$(function() {
+            var listPage = new CRM.HRLeaveAndAbsencesApp.ListPage(CRM.$('.hrleaveandabsences-entity-list'));
+        });
+    </script>
+    {/literal}
+{else}
+    <div class="messages status no-popup">
+        <div class="icon inform-icon"></div>
+        {capture assign=crmURL}{crmURL q="action=add&reset=1"}{/capture}
+        {ts 1=$crmURL}There are no Public Holidays entered. You can <a href='%1'>add one</a>.{/ts}
+    </div>
 {/if}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/PublicHoliday.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/PublicHoliday.tpl
@@ -1,0 +1,49 @@
+{if $action eq 1 or $action eq 2 or $action eq 8}
+    {include file="CRM/HRLeaveAndAbsences/Form/PublicHoliday.tpl"}
+{else}
+    {if $rows}
+        <div id="ltype">
+            <div class="form-item">
+                {strip}
+                    {* handle enable/disable actions*}
+                    {include file="CRM/common/enableDisableApi.tpl"}
+                    <table cellpadding="0" cellspacing="0" border="0" class="hrleaveandabsences-entity-list">
+                        <thead class="sticky">
+                            <th>{ts}Title{/ts}</th>
+                            <th>{ts}Date{/ts}</th>
+                            <th>{ts}Enabled/Disabled{/ts}</th>
+                            <th></th>
+                        </thead>
+                        {foreach from=$rows item=row}
+                            <tr id="PublicHoliday-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {$row.class}{if NOT $row.is_active} disabled{/if}">
+                                <td data-field="title">{$row.title}</td>
+                                <td>{$row.date}</td>
+                                <td>{if $row.is_active eq 1} {ts}Enabled{/ts} {else} {ts}Disabled{/ts} {/if}</td>
+                                <td>{$row.action|replace:'xx':$row.id}</td>
+                            </tr>
+                        {/foreach}
+                    </table>
+                {/strip}
+
+                {if $action ne 1 and $action ne 2}
+                    <div class="action-link">
+                        <a href="{crmURL q="action=add&reset=1"}" class="button"><span><div class="icon add-icon"></div>{ts}Add Public Holiday{/ts}</span></a>
+                    </div>
+                {/if}
+            </div>
+        </div>
+        {literal}
+        <script type="text/javascript">
+            CRM.$(function() {
+                var listPage = new CRM.HRLeaveAndAbsencesApp.ListPage(CRM.$('.hrleaveandabsences-entity-list'));
+            });
+        </script>
+        {/literal}
+    {else}
+        <div class="messages status no-popup">
+            <div class="icon inform-icon"></div>
+            {capture assign=crmURL}{crmURL q="action=add&reset=1"}{/capture}
+            {ts 1=$crmURL}There are no Public Holidays entered. You can <a href='%1'>add one</a>.{/ts}
+        </div>
+    {/if}
+{/if}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/PublicHolidayTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/PublicHolidayTest.php
@@ -36,8 +36,8 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends PHPUnit_Framework_Tes
   }
 
   /**
-   * @expectedException PEAR_Exception
-   * @expectedExceptionMessage DB Error: already exists
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidPublicHolidayException
+   * @expectedExceptionMessage There is a Public Holiday already existing with given date
    */
   public function testPublicHolidayDateShouldBeUnique() {
     CRM_HRLeaveAndAbsences_BAO_PublicHoliday::create([

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/Menu/hrleaveandabsences.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/Menu/hrleaveandabsences.xml
@@ -13,6 +13,12 @@
     <access_arguments>administer leave and absences</access_arguments>
   </item>
   <item>
+    <path>civicrm/admin/leaveandabsences/public_holidays</path>
+    <page_callback>CRM_HRLeaveAndAbsences_Page_PublicHoliday</page_callback>
+    <title>Public Holidays</title>
+    <access_arguments>administer leave and absences</access_arguments>
+  </item>
+  <item>
     <path>civicrm/admin/leaveandabsences/periods</path>
     <page_callback>CRM_HRLeaveAndAbsences_Page_AbsencePeriod</page_callback>
     <title>Absence Periods</title>


### PR DESCRIPTION
Creating Public Holidays list page available under civicrm/admin/leaveandabsences/public_holidays?action=browse&reset=1
The page lists all Public Holidays with Title, Date, Enabled/Disabled fields and contains Edit, Enable/Disable and Delete actions. Edit action is not implemented as it's covered by different task.
At the bottom there is a button for creating a new Public Holiday (not implemented, covered by different task).

Public Holiday list page:
![public_holidays_list_page](https://cloud.githubusercontent.com/assets/8986209/15861865/030f87d8-2cce-11e6-9825-968ec2607bf8.png)

Delete action confirmation:
![public_holidays_list_page-delete_action](https://cloud.githubusercontent.com/assets/8986209/15862077/ca1c6940-2cce-11e6-9f6e-4e1c9b3d4e55.png)


Disable action confirmation:
![public_holidays_list_page-disable_action](https://cloud.githubusercontent.com/assets/8986209/15861981/76d62244-2cce-11e6-8524-8382eefc9df2.png)


