### PR TITLE
PCHR-1047 - Creating Public Holiday Form, templates and Web test.

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/PublicHoliday.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/PublicHoliday.php
@@ -99,6 +99,10 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidPublicHolidayException
    */
   private static function checkIfDateIsUnique($params) {
+    // Skip date validation if we are editing an exsisting record and no new date is specified.
+    if (!isset($params['date']) && !empty($params['id'])) {
+      return true;
+    }
     // Check for Public Holiday already existing with given date.
     $duplicateDateParams = array(
       'date' => $params['date'],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/PublicHoliday.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/PublicHoliday.php
@@ -44,8 +44,6 @@ class CRM_HRLeaveAndAbsences_Form_PublicHoliday extends CRM_Core_Form {
     $this->assign('deleteUrl', $this->getDeleteUrl());
 
     CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/hrleaveandabsences.css');
-    CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/spectrum.css');
-    CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/spectrum-min.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
     parent::buildQuickForm();
   }
 
@@ -179,8 +177,10 @@ class CRM_HRLeaveAndAbsences_Form_PublicHoliday extends CRM_Core_Form {
     $buttons = [
       [ 'type' => 'next', 'name' => ts('Save'), 'isDefault' => true ],
       [ 'type' => 'cancel', 'name' => ts('Cancel') ],
-      [ 'type' => 'delete', 'name' => ts('Delete') ],
     ];
+    if ($this->_action & CRM_Core_Action::UPDATE) {
+        $buttons[] = [ 'type' => 'delete', 'name' => ts('Delete') ];
+    }
     return $buttons;
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/PublicHoliday.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/PublicHoliday.php
@@ -8,4 +8,189 @@ require_once 'CRM/Core/Form.php';
  * @see http://wiki.civicrm.org/confluence/display/CRMDOC43/QuickForm+Reference
  */
 class CRM_HRLeaveAndAbsences_Form_PublicHoliday extends CRM_Core_Form {
+
+  private $defaultValues = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setDefaultValues() {
+    if(empty($this->defaultValues)) {
+      if ($this->_id) {
+        $this->defaultValues = CRM_HRLeaveAndAbsences_BAO_PublicHoliday::getValuesArray($this->_id);
+      } else {
+        $this->defaultValues = [
+          'id' => null,
+          'title' => '',
+          'date' => '',
+          'is_active' => 1,
+        ];
+      }
+    }
+
+    return $this->defaultValues;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildQuickForm() {
+    $this->_id = CRM_Utils_Request::retrieve('id' , 'Positive', $this);
+
+    $this->addFields();
+    $this->addFieldsRules();
+
+    $this->addButtons($this->getAvailableButtons());
+    $this->assign('deleteUrl', $this->getDeleteUrl());
+
+    CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/hrleaveandabsences.css');
+    CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/spectrum.css');
+    CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/spectrum-min.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
+    parent::buildQuickForm();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function postProcess() {
+    if ($this->_action & (CRM_Core_Action::ADD | CRM_Core_Action::UPDATE)) {
+        // store the submitted values in an array
+        $params = $this->exportValues();
+        $params['date'] = !empty($params['date']) ? CRM_Utils_Date::processDate($params['date']) : NULL;
+
+        if ($this->_action & CRM_Core_Action::UPDATE) {
+            $params['id'] = $this->_id;
+        }
+
+        //when a checkbox is not checked, it is not sent on the request
+        //so we check if it wasn't sent and set the param value to 0
+        $checkboxFields = ['is_active'];
+        foreach ($checkboxFields as $field) {
+            if(!array_key_exists($field, $params)) {
+                $params[$field] = 0;
+            }
+        }
+
+        $actionDescription = ($this->_action & CRM_Core_Action::UPDATE) ? 'updated' : 'created';
+        try {
+            $publicHoliday = CRM_HRLeaveAndAbsences_BAO_PublicHoliday::create($params);
+            CRM_Core_Session::setStatus(ts("The Public Holiday '%1' has been $actionDescription.", array( 1 => $publicHoliday->title)), 'Success', 'success');
+        } catch(CRM_HRLeaveAndAbsences_Exception_InvalidPublicHolidayException $ex) {
+            $message = ts("The Public Holiday could not be $actionDescription.");
+            $message .= ' ' . $ex->getMessage();
+            CRM_Core_Session::setStatus($message, 'Error', 'error');
+        }
+
+        $url = CRM_Utils_System::url('civicrm/admin/leaveandabsences/public_holidays', 'reset=1&action=browse');
+        $session = CRM_Core_Session::singleton();
+        $session->replaceUserContext($url);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefaultEntity() {
+    return 'PublicHoliday';
+  }
+
+  /**
+   * Adds fields to the Form.
+   */
+  private function addFields() {
+    $this->add(
+      'text',
+      'title',
+      ts('Title'),
+      $this->getDAOFieldAttributes('title'),
+      true
+    );
+    $this->add(
+      'datepicker',
+      'date',
+      ts('Date'),
+      $this->getDAOFieldAttributes('date'),
+      true,
+      ['time' => false]
+    );
+    $this->add(
+      'checkbox',
+      'is_active',
+      ts('Enabled')
+    );
+  }
+
+  /**
+   * Return an array containing attributes of given field.
+   * 
+   * @param string $field
+   * @return array|null
+   */
+  private function getDAOFieldAttributes($field) {
+    $dao = 'CRM_HRLeaveAndAbsences_DAO_PublicHoliday';
+    return CRM_Core_DAO::getAttribute($dao, $field);
+  }
+
+  /**
+   * Add validation rules for the fields on this form.
+   */
+  private function addFieldsRules() {
+    $this->addFormRule([$this, 'formRules']);
+  }
+
+  /**
+   * Execute validations concerning all the form fields.
+   *
+   * Different from regular field rules, Form Rules can be used for validations
+   * that depends on multiple fields,(for example, if field X is not empty,
+   * then Y is required). Here, we use it to validate the dates, because start
+   * date can't be greater or equal to end date.
+   *
+   * @param array $values An array containing all the form's fields values
+   *
+   * @return array|bool Returns true if form is valid. Otherwise, an
+   *                    array containing all the validation errors is returned.
+   */
+  public function formRules($values) {
+    $errors = [];
+    $this->validateDate($values, $errors);
+    return empty($errors) ? true : $errors;
+  }
+
+  /**
+   * Validates date.
+   *
+   * @param array $values An array containing all the form's fields values
+   * @param array $errors A reference to the errors array where errors will be
+   *                      added if dates are invalid
+   */
+  private function validateDate($values, &$errors) {
+    if (empty($values['date'])) {
+      return;
+    }
+
+    $dateIsValid = CRM_HRLeaveAndAbsences_Validator_Date::isValid($values['date'], 'Y-m-d');
+    if(!$dateIsValid) {
+      $errors['date'] = ts('Date should be a valid date');
+    }
+  }
+
+  private function getAvailableButtons() {
+    $buttons = [
+      [ 'type' => 'next', 'name' => ts('Save'), 'isDefault' => true ],
+      [ 'type' => 'cancel', 'name' => ts('Cancel') ],
+      [ 'type' => 'delete', 'name' => ts('Delete') ],
+    ];
+    return $buttons;
+  }
+
+  private function getDeleteUrl() {
+    return CRM_Utils_System::url(
+      'civicrm/admin/leaveandabsences/public_holidays',
+      "action=delete&id={$this->_id}&reset=1",
+      false,
+      null,
+      false
+    );
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/PublicHoliday.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/PublicHoliday.tpl
@@ -1,0 +1,59 @@
+<h1 class="title">{if $action eq 1}{ts}New Public Holiday{/ts}{elseif $action eq 2}{ts}Edit Public Holiday{/ts}{/if}</h1>
+
+<div class="crm-block crm-form-block crm-public_holiday-form-block crm-leave-and-absences-form-block">
+    {if $action neq 8}
+        <div class="row">
+            <div class="col-sm-6">
+                <h3>{ts}Basic Details{/ts}</h3>
+                <div class="crm-section">
+                    <div class="label">{$form.title.label}</div>
+                    <div class="content">{$form.title.html}</div>
+                    <div class="clear"></div>
+                </div>
+                <div class="crm-section">
+                    <div class="label">{$form.date.label}</div>
+                    <div class="content">{$form.date.html}</div>
+                    <div class="clear"></div>
+                </div>
+                <div class="crm-section">
+                    <div class="label">{$form.is_active.label}</div>
+                    <div class="content">{$form.is_active.html}</div>
+                    <div class="clear"></div>
+                </div>
+            </div>
+        </div>
+        <div class="clear"></div>
+    {literal}
+        <script type="text/javascript">
+            CRM.$(function($) {
+                function initDeleteButton() {
+                    $('.crm-button-type-delete').on('click', function(e) {
+                        e.preventDefault();
+                        CRM.confirm({
+                            title: ts('Delete Public Holiday'),
+                            message: ts('Are you sure you want to delete this Public Holiday?'),
+                            options: {
+                                yes: ts('Yes'),
+                                no: ts('No')
+                            }
+                        })
+                        .on('crmConfirm:yes', deleteCallback);
+                    });
+                }
+
+                function deleteCallback() {
+                    {/literal}
+                    window.location = "{$deleteUrl}";
+                    {literal}
+                }
+
+                $(document).ready(function() {
+                    initDeleteButton();
+                });
+
+            });
+        </script>
+    {/literal}
+    {/if}
+    <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+</div>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/PublicHoliday.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/PublicHoliday.tpl
@@ -1,45 +1,49 @@
-{if $rows}
-    <div id="ltype">
-        <div class="form-item">
-            {strip}
-                {* handle enable/disable actions*}
-                {include file="CRM/common/enableDisableApi.tpl"}
-                <table cellpadding="0" cellspacing="0" border="0" class="hrleaveandabsences-entity-list">
-                    <thead class="sticky">
-                        <th>{ts}Title{/ts}</th>
-                        <th>{ts}Date{/ts}</th>
-                        <th>{ts}Enabled/Disabled{/ts}</th>
-                        <th></th>
-                    </thead>
-                    {foreach from=$rows item=row}
-                        <tr id="PublicHoliday-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {$row.class}{if NOT $row.is_active} disabled{/if}">
-                            <td data-field="title">{$row.title}</td>
-                            <td>{$row.date|crmDate}</td>
-                            <td>{if $row.is_active eq 1} {ts}Enabled{/ts} {else} {ts}Disabled{/ts} {/if}</td>
-                            <td>{$row.action|replace:'xx':$row.id}</td>
-                        </tr>
-                    {/foreach}
-                </table>
-            {/strip}
-
-            {if $action ne 1 and $action ne 2}
-                <div class="action-link">
-                    <a href="{crmURL q="action=add&reset=1"}" class="button"><span><div class="icon add-icon"></div>{ts}Add Public Holiday{/ts}</span></a>
-                </div>
-            {/if}
-        </div>
-    </div>
-    {literal}
-    <script type="text/javascript">
-        CRM.$(function() {
-            var listPage = new CRM.HRLeaveAndAbsencesApp.ListPage(CRM.$('.hrleaveandabsences-entity-list'));
-        });
-    </script>
-    {/literal}
+{if $action eq 1 or $action eq 2 or $action eq 8}
+    {include file="CRM/HRLeaveAndAbsences/Form/PublicHoliday.tpl"}
 {else}
-    <div class="messages status no-popup">
-        <div class="icon inform-icon"></div>
-        {capture assign=crmURL}{crmURL q="action=add&reset=1"}{/capture}
-        {ts 1=$crmURL}There are no Public Holidays entered. You can <a href='%1'>add one</a>.{/ts}
-    </div>
+    {if $rows}
+        <div id="ltype">
+            <div class="form-item">
+                {strip}
+                    {* handle enable/disable actions*}
+                    {include file="CRM/common/enableDisableApi.tpl"}
+                    <table cellpadding="0" cellspacing="0" border="0" class="hrleaveandabsences-entity-list">
+                        <thead class="sticky">
+                            <th>{ts}Title{/ts}</th>
+                            <th>{ts}Date{/ts}</th>
+                            <th>{ts}Enabled/Disabled{/ts}</th>
+                            <th></th>
+                        </thead>
+                        {foreach from=$rows item=row}
+                            <tr id="PublicHoliday-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {$row.class}{if NOT $row.is_active} disabled{/if}">
+                                <td data-field="title">{$row.title}</td>
+                                <td>{$row.date|crmDate}</td>
+                                <td>{if $row.is_active eq 1} {ts}Enabled{/ts} {else} {ts}Disabled{/ts} {/if}</td>
+                                <td>{$row.action|replace:'xx':$row.id}</td>
+                            </tr>
+                        {/foreach}
+                    </table>
+                {/strip}
+
+                {if $action ne 1 and $action ne 2}
+                    <div class="action-link">
+                        <a href="{crmURL q="action=add&reset=1"}" class="button"><span><div class="icon add-icon"></div>{ts}Add Public Holiday{/ts}</span></a>
+                    </div>
+                {/if}
+            </div>
+        </div>
+        {literal}
+        <script type="text/javascript">
+            CRM.$(function() {
+                var listPage = new CRM.HRLeaveAndAbsencesApp.ListPage(CRM.$('.hrleaveandabsences-entity-list'));
+            });
+        </script>
+        {/literal}
+    {else}
+        <div class="messages status no-popup">
+            <div class="icon inform-icon"></div>
+            {capture assign=crmURL}{crmURL q="action=add&reset=1"}{/capture}
+            {ts 1=$crmURL}There are no Public Holidays entered. You can <a href='%1'>add one</a>.{/ts}
+        </div>
+    {/if}
 {/if}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/WebTest/PublicHoliday/FormTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/WebTest/PublicHoliday/FormTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Class WebTest_PublicHoliday_FormTest
+ *
+ * @group headless
+ */
+class WebTest_PublicHoliday_FormTest extends CiviSeleniumTestCase implements HeadlessInterface, TransactionalInterface {
+
+  private $formUrl = 'admin/leaveandabsences/public_holidays';
+  private $addUrlParams = 'action=add&reset=1';
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->installMe(__DIR__)->apply();
+  }
+
+  private function loginAsAdmin() {
+    if (is_null($this->loggedInAs)) {
+      $this->webtestLogin('admin');
+    }
+  }
+
+  public function testCreateWithEmptyFields() {
+    $this->loginAsAdmin();
+    $this->openAddForm();
+    $this->type('title', '');
+    $this->type('date', '');
+    $this->submitAndWait('PublicHoliday');
+    $this->assertTrue($this->isTextPresent('Title is a required field.'));
+    $this->assertTrue($this->isTextPresent('Date is a required field.'));
+  }
+
+  public function testCreateWithCurrentlyExistingDate() {
+    $this->loginAsAdmin();
+    $this->openAddForm();
+    $this->type('title', 'Title 1');
+    $this->type('date', '2016-06-01');
+    $this->submitAndWait('PublicHoliday');
+    $this->openAddForm();
+    $this->type('title', 'Title 2');
+    $this->type('date', '2016-06-01');
+    $this->submitAndWait('PublicHoliday');
+    $this->assertTrue($this->isTextPresent('There is a Public Holiday already existing with given date'));
+  }
+
+  public function testCreateValidPublicHoliday() {
+    $this->loginAsAdmin();
+    $this->openAddForm();
+    $this->type('title', 'Valid Public Holiday');
+    $this->type('date', '2020-01-01');
+    $this->submitAndWait('PublicHoliday');
+    $firstTdOfLastRow = 'xpath=//div[@class="form-item"]/table/tbody/tr[last()]/td[1]';
+    $this->assertElementContainsText($firstTdOfLastRow, 'Valid Public Holiday');
+  }
+
+  private function openAddForm() {
+    $this->openCiviPage($this->formUrl, $this->addUrlParams);
+  }
+}


### PR DESCRIPTION
Creating Public Holiday Form which allows to create / edit Public Holidays. It contains 'title', 'date' (with datepicker) and 'is_active' fields. Title and date are required fields. The form also allows to delete the Public Holiday which we are editing.
Creating Web tests for the Form.

Public Holiday Form
![public_holiday_form](https://cloud.githubusercontent.com/assets/8986209/15865608/bb060f9e-2cdb-11e6-8c16-4f8c37cad4d5.png)

Public Holiday Form validation
![public_holiday_form_validation](https://cloud.githubusercontent.com/assets/8986209/15865622/c8865ea8-2cdb-11e6-8dc6-e92c36259b94.png)
