### PR TITLE
PCHR-1139: Change contact tabs order

### DIFF
--- a/com.civicrm.hrjobroles/hrjobroles.php
+++ b/com.civicrm.hrjobroles/hrjobroles.php
@@ -142,7 +142,7 @@ function hrjobroles_civicrm_tabs(&$tabs, $contactID) {
     $tabs[] = array( 'id' => 'hrjobroles',
         'url' => $url,
         'title' => 'Job Roles',
-        'weight' => 300 );
+        'weight' => -180 );
 }
 
 /**

--- a/contactsummary/contactsummary.php
+++ b/contactsummary/contactsummary.php
@@ -157,6 +157,6 @@ function contactsummary_civicrm_tabs(&$tabs) {
     'id'     => 'contactsummary',
     'url'    => CRM_Utils_System::url('civicrm/contact-summary'),
     'title'  => ts('Contact Summary'),
-    'weight' => -1
+    'weight' => -200
   );
 }

--- a/hrabsence/hrabsence.php
+++ b/hrabsence/hrabsence.php
@@ -454,7 +454,7 @@ function hrabsence_civicrm_tabs(&$tabs, $contactID) {
     )),
     'count' => $absenceDuration/(8*60),
     'title' => ts('Absences'),
-    'weight' => 300
+    'weight' => 10
   );
 }
 

--- a/hrjobcontract/hrjobcontract.php
+++ b/hrjobcontract/hrjobcontract.php
@@ -50,9 +50,9 @@ function hrjobcontract_civicrm_install() {
       }
     }
   }
-  
+
   // Add Job Contract top menu
-  
+
   $jobContractNavigation = new CRM_Core_DAO_Navigation();
   $jobContractNavigation->name = 'job_contracts';
   $jobContractNavigationResult = $jobContractNavigation->find();
@@ -85,7 +85,7 @@ function hrjobcontract_civicrm_install() {
       CRM_Core_BAO_Navigation::add($menuItems);
     }
   }
-  
+
   return _hrjobcontract_civix_civicrm_install();
 }
 
@@ -105,7 +105,7 @@ function hrjobcontract_civicrm_uninstall() {
       CRM_Contact_BAO_ContactType::del($id);
     }
   }
-  
+
   $jobContractMenu = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'job_contracts', 'id', 'name');
   if (!empty($jobContractMenu)) {
     CRM_Core_BAO_Navigation::processDelete($jobContractMenu);
@@ -158,7 +158,7 @@ function hrjobcontract_civicrm_enable() {
   $sql = "UPDATE civicrm_navigation SET is_active=1 WHERE name IN ('job_contracts', 'hoursType', 'hours_location', 'pay_scale', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_end_reason')";
   CRM_Core_DAO::executeQuery($sql);
   CRM_Core_BAO_Navigation::resetNavigation();
-    
+
   _hrjobcontract_setActiveFields(1);
   return _hrjobcontract_civix_civicrm_enable();
 }
@@ -173,7 +173,7 @@ function hrjobcontract_civicrm_disable() {
   $sql = "UPDATE civicrm_navigation SET is_active=0 WHERE name IN ('job_contracts', 'hoursType', 'hours_location', 'pay_scale', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_end_reason')";
   CRM_Core_DAO::executeQuery($sql);
   CRM_Core_BAO_Navigation::resetNavigation();
-  
+
   _hrjobcontract_setActiveFields(0);
   return _hrjobcontract_civix_civicrm_disable();
 }
@@ -340,7 +340,7 @@ function hrjobcontract_civicrm_tabs(&$tabs) {
         'id'        => 'hrjobcontract',
         'url'       => CRM_Utils_System::url('civicrm/contact/view/hrjobcontract'),
         'title'     => ts('Job Contract'),
-        'weight'    => 1
+        'weight'    => -190
     );
 
 }

--- a/hrui/hrui.php
+++ b/hrui/hrui.php
@@ -59,7 +59,7 @@ function hrui_civicrm_buildForm($formName, &$form) {
     //HR-358 - Set default values
     //set default value to phone location and type
     $locationId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_LocationType', 'Main', 'id', 'name');
-    // PCHR-1146 : Commenting line ahead to fix the issue, but figuring why it was done at first place coul be useful. 
+    // PCHR-1146 : Commenting line ahead to fix the issue, but figuring why it was done at first place coul be useful.
     //$result = civicrm_api3('LocationType', 'create', array('id'=>$locationId, 'is_default'=> 1, 'is_active'=>1));
     if (($form->elementExists('phone[2][phone_type_id]')) && ($form->elementExists('phone[2][phone_type_id]'))) {
       $phoneType = $form->getElement('phone[2][phone_type_id]');
@@ -418,28 +418,47 @@ function hrui_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
  * Implementation of hook_civicrm_tabs
  */
 function hrui_civicrm_tabs(&$tabs, $contactID) {
-  $newTabs = array();
-
   foreach ($tabs as $i => $tab) {
-    if ($tab['id'] != 'log') {
-      $newTabs[$i] = $tab['title'];
-    }
-    else {
-      $changeLogTabID = $i;
+    switch($tab['title'])  {
+      case 'Assignments':
+        $tabs[$i]['weight'] = 20;
+        break;
+      case 'Identification':
+        $tabs[$i]['weight'] = 50;
+        break;
+      case 'Immigration':
+        $tabs[$i]['weight'] = 60;
+        break;
+      case 'Emergency Contacts':
+        $tabs[$i]['weight'] = 70;
+        break;
+      case 'Relationships':
+        $tabs[$i]['weight'] = 80;
+        $tabs[$i]['title'] = 'Managers';
+        break;
+      case 'Bank Details':
+        $tabs[$i]['weight'] = 90;
+        break;
+      case 'Career History':
+        $tabs[$i]['weight'] = 100;
+        break;
+      case 'Medical & Disability':
+        $tabs[$i]['weight'] = 110;
+        break;
+      case 'Qualifications':
+        $tabs[$i]['weight'] = 120;
+        break;
+      case 'Notes':
+        $tabs[$i]['weight'] = 130;
+        break;
+      case 'Groups':
+        $tabs[$i]['weight'] = 140;
+        break;
+      case 'Change Log':
+        $tabs[$i]['weight'] = 150;
+        break;
     }
   }
-
-  //sort alphabetically
-  asort($newTabs);
-  $weight = 0;
-  //assign the weights based on alphabetic order
-  foreach ($newTabs as $key => $value) {
-    $weight += 10;
-    $tabs[$key]['weight'] = $weight;
-  }
-
-  //Move change log to the end
-  $tabs[$changeLogTabID]['weight'] = $weight + 10;
 }
 
 /**

--- a/uk.co.compucorp.civicrm.appraisals/appraisals.php
+++ b/uk.co.compucorp.civicrm.appraisals/appraisals.php
@@ -149,12 +149,12 @@ function appraisals_civicrm_entityTypes(&$entityTypes) {
 
 function appraisals_civicrm_tabs(&$tabs) {
     CRM_Appraisals_Page_Appraisals::registerScripts();
-    
+
     $tabs[] = Array(
         'id'        => 'appraisals',
         'url'       => CRM_Utils_System::url('civicrm/contact/view/appraisals'),
         'title'     => ts('Appraisals'),
-        'weight'    => 1,
+        'weight'    => 20,
     );
 }
 


### PR DESCRIPTION
Related PR https://github.com/compucorp/civihr-tasks-assignments/pull/63
-------------------------------------------------------------------------------

Changing contact tabs order to make more sense to the user , They are order according to this list :

* Summary
* Job contract
* Job role
* Personal details
* Absences
* Appraisals
* Assignments
* Tasks
* Documents
* Identification
* Immigration
* Emergency contacts
* Relationships ( the title changed to Managers )
* Bank details
* Career History
* Medical and Disability
* Qualifications
* Notes
* Groups
* Change log


Also Relationships tab title changed to "Managers" .


The change of order performed by playing with weight property for each tab and between each tab  and the next in order the weight is increased by 10 to give more space in the future to put other tabs in between without missing with other tabs weights. Also since some of the tabs are from the core and some are created by the extension upgrader instead of hook_civicrm_tab  , the only way was to take advantage of &tabs variable which is passed by reference to hook_civicrm_tab and allow you to change the weight for these tabs their ( these changes done in hrui extension ) .  


### Before

![selection_027](https://cloud.githubusercontent.com/assets/6275540/16089033/1b7cbaf6-3332-11e6-87fd-fa6d7118bfcc.png)

### After

![selection_028](https://cloud.githubusercontent.com/assets/6275540/16089038/20ccaebc-3332-11e6-81ce-50cd017ceace.png)

