### PR TITLE
PCHR-1139: Change contact tabs order

### DIFF
--- a/com.civicrm.hrjobroles/hrjobroles.php
+++ b/com.civicrm.hrjobroles/hrjobroles.php
@@ -135,6 +135,11 @@ function hrjobroles_civicrm_navigationMenu( &$params ) {
  * @param $tabs
  * @param $contactID
  * Create a custom tab for civicrm contact which will implement custom drupal callback function
+ * this tab should appear after job contracts tab directly
+ * and since contact summary tab weight is
+ * -190 we chose this to be -180
+ * to give some room for other extensions to place
+ * their tabs between these two.
  */
 function hrjobroles_civicrm_tabs(&$tabs, $contactID) {
 
@@ -142,7 +147,7 @@ function hrjobroles_civicrm_tabs(&$tabs, $contactID) {
     $tabs[] = array( 'id' => 'hrjobroles',
         'url' => $url,
         'title' => 'Job Roles',
-        'weight' => 300 );
+        'weight' => -180 );
 }
 
 /**

--- a/contactsummary/contactsummary.php
+++ b/contactsummary/contactsummary.php
@@ -151,12 +151,19 @@ EOT;
 
 /**
  * Implementation of hook_civicrm_tabs
+ * we set the weight for this tab to -200 since
+ * the summary ( personal details ) tab weight is hardcoded
+ * to 0 and cannot be changed and this tab has to appear before
+ * it , also we chose a large number like 200 to give
+ * a large room for other extensions to set its tabs
+ * between this tab and ( personal details tab ) without altering
+ * other tabs weights.
  */
 function contactsummary_civicrm_tabs(&$tabs) {
   $tabs[] = Array(
     'id'     => 'contactsummary',
     'url'    => CRM_Utils_System::url('civicrm/contact-summary'),
     'title'  => ts('Contact Summary'),
-    'weight' => -1
+    'weight' => -200
   );
 }

--- a/hrabsence/hrabsence.php
+++ b/hrabsence/hrabsence.php
@@ -434,6 +434,11 @@ function hrabsence_civicrm_apiWrappers(&$wrappers, $apiRequest) {
 
 /**
  * Implementation of hook_civicrm_tabs
+ * this tab should appear after summary (personal details) tab directly
+ * and since personal details tab weight is
+ * hardcoded to 0 we chose this to be 10
+ * to give some room for other extensions to place
+ * their tabs between these two.
  */
 function hrabsence_civicrm_tabs(&$tabs, $contactID) {
   $contactType = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactID, 'contact_type', 'id');
@@ -454,7 +459,7 @@ function hrabsence_civicrm_tabs(&$tabs, $contactID) {
     )),
     'count' => $absenceDuration/(8*60),
     'title' => ts('Absences'),
-    'weight' => 300
+    'weight' => 10
   );
 }
 

--- a/hrjobcontract/hrjobcontract.php
+++ b/hrjobcontract/hrjobcontract.php
@@ -50,9 +50,9 @@ function hrjobcontract_civicrm_install() {
       }
     }
   }
-  
+
   // Add Job Contract top menu
-  
+
   $jobContractNavigation = new CRM_Core_DAO_Navigation();
   $jobContractNavigation->name = 'job_contracts';
   $jobContractNavigationResult = $jobContractNavigation->find();
@@ -85,7 +85,7 @@ function hrjobcontract_civicrm_install() {
       CRM_Core_BAO_Navigation::add($menuItems);
     }
   }
-  
+
   return _hrjobcontract_civix_civicrm_install();
 }
 
@@ -105,7 +105,7 @@ function hrjobcontract_civicrm_uninstall() {
       CRM_Contact_BAO_ContactType::del($id);
     }
   }
-  
+
   $jobContractMenu = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'job_contracts', 'id', 'name');
   if (!empty($jobContractMenu)) {
     CRM_Core_BAO_Navigation::processDelete($jobContractMenu);
@@ -158,7 +158,7 @@ function hrjobcontract_civicrm_enable() {
   $sql = "UPDATE civicrm_navigation SET is_active=1 WHERE name IN ('job_contracts', 'hoursType', 'hours_location', 'pay_scale', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_end_reason')";
   CRM_Core_DAO::executeQuery($sql);
   CRM_Core_BAO_Navigation::resetNavigation();
-    
+
   _hrjobcontract_setActiveFields(1);
   return _hrjobcontract_civix_civicrm_enable();
 }
@@ -173,7 +173,7 @@ function hrjobcontract_civicrm_disable() {
   $sql = "UPDATE civicrm_navigation SET is_active=0 WHERE name IN ('job_contracts', 'hoursType', 'hours_location', 'pay_scale', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_end_reason')";
   CRM_Core_DAO::executeQuery($sql);
   CRM_Core_BAO_Navigation::resetNavigation();
-  
+
   _hrjobcontract_setActiveFields(0);
   return _hrjobcontract_civix_civicrm_disable();
 }
@@ -333,6 +333,11 @@ function hrjobcontract_civicrm_buildForm($formName, &$form) {
 
 /**
  * Implementation of hook_civicrm_tabs
+ * this tab should appear after contact summary tab directly
+ * and since contact summary tab weight is
+ * -200 we chose this to be -190
+ * to give some room for other extensions to place
+ * their tabs between these two.
  */
 function hrjobcontract_civicrm_tabs(&$tabs) {
     CRM_Hrjobcontract_Page_JobContractTab::registerScripts();
@@ -340,7 +345,7 @@ function hrjobcontract_civicrm_tabs(&$tabs) {
         'id'        => 'hrjobcontract',
         'url'       => CRM_Utils_System::url('civicrm/contact/view/hrjobcontract'),
         'title'     => ts('Job Contract'),
-        'weight'    => 1
+        'weight'    => -190
     );
 
 }

--- a/hrui/hrui.php
+++ b/hrui/hrui.php
@@ -418,27 +418,60 @@ function hrui_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
  */
 function hrui_civicrm_tabs(&$tabs, $contactID) {
   $newTabs = array();
-
+  /*
+   * 1) we alter the weights for these tabs here
+   * since these tabs are not created by hook_civicrm_tab
+   * and the only way to alter their weights is here
+   * by taking advantage of &$tabs variable.
+   * 2) we set assignments tab to 30 since it should appear
+   * after appraisals tab directly which have the weight of 20.
+   * 3) we jump to weight of 60 in identifications tab since 40 & 50
+   * are occupied by tasks & assignments extension tabs .
+   * 4) the weight increased by 10 between every tab
+   * to give a large space for other tabs to be inserted
+   * between any two without altering other tabs weights.
+   */
   foreach ($tabs as $i => $tab) {
-    if ($tab['id'] != 'log') {
-      $newTabs[$i] = $tab['title'];
-    }
-    else {
-      $changeLogTabID = $i;
+    switch($tab['title'])  {
+      case 'Assignments':
+        $tabs[$i]['weight'] = 30;
+        break;
+      case 'Identification':
+        $tabs[$i]['weight'] = 60;
+        break;
+      case 'Immigration':
+        $tabs[$i]['weight'] = 70;
+        break;
+      case 'Emergency Contacts':
+        $tabs[$i]['weight'] = 80;
+        break;
+      case 'Relationships':
+        $tabs[$i]['weight'] = 90;
+        $tabs[$i]['title'] = 'Managers';
+        break;
+      case 'Bank Details':
+        $tabs[$i]['weight'] = 100;
+        break;
+      case 'Career History':
+        $tabs[$i]['weight'] = 110;
+        break;
+      case 'Medical & Disability':
+        $tabs[$i]['weight'] = 120;
+        break;
+      case 'Qualifications':
+        $tabs[$i]['weight'] = 130;
+        break;
+      case 'Notes':
+        $tabs[$i]['weight'] = 140;
+        break;
+      case 'Groups':
+        $tabs[$i]['weight'] = 150;
+        break;
+      case 'Change Log':
+        $tabs[$i]['weight'] = 160;
+        break;
     }
   }
-
-  //sort alphabetically
-  asort($newTabs);
-  $weight = 0;
-  //assign the weights based on alphabetic order
-  foreach ($newTabs as $key => $value) {
-    $weight += 10;
-    $tabs[$key]['weight'] = $weight;
-  }
-
-  //Move change log to the end
-  $tabs[$changeLogTabID]['weight'] = $weight + 10;
 }
 
 /**

--- a/uk.co.compucorp.civicrm.appraisals/appraisals.php
+++ b/uk.co.compucorp.civicrm.appraisals/appraisals.php
@@ -145,16 +145,21 @@ function appraisals_civicrm_entityTypes(&$entityTypes) {
 
 /**
  * Implementation of hook_civicrm_tabs
+ * this tab should appear after absences tab directly
+ * and since absences tab weight is
+ * set to 10 we chose this to be 20
+ * to give some room for other extensions to place
+ * their tabs between these two.
  */
 
 function appraisals_civicrm_tabs(&$tabs) {
     CRM_Appraisals_Page_Appraisals::registerScripts();
-    
+
     $tabs[] = Array(
         'id'        => 'appraisals',
         'url'       => CRM_Utils_System::url('civicrm/contact/view/appraisals'),
         'title'     => ts('Appraisals'),
-        'weight'    => 1,
+        'weight'    => 20,
     );
 }
 


### PR DESCRIPTION
Related PR https://github.com/compucorp/civihr-tasks-assignments/pull/63
-------------------------------------------------------------------------------

Changing contact tabs order to make more sense to the user , They are order according to this list :

* Summary
* Job contract
* Job role
* Personal details
* Absences
* Appraisals
* Assignments
* Tasks
* Documents
* Identification
* Immigration
* Emergency contacts
* Relationships ( the title changed to Managers )
* Bank details
* Career History
* Medical and Disability
* Qualifications
* Notes
* Groups
* Change log


Also Relationships tab title changed to "Managers" .


The change of order performed by playing with weight property for each tab and between each tab  and the next in order the weight is increased by 10 to give more space in the future to put other tabs in between without missing with other tabs weights. Also since some of the tabs are from the core and some are created by the extension upgrader instead of hook_civicrm_tab  , the only way was to take advantage of &tabs variable which is passed by reference to hook_civicrm_tab and allow you to change the weight for these tabs their ( these changes done in hrui extension ) .  


### Before

![selection_027](https://cloud.githubusercontent.com/assets/6275540/16089033/1b7cbaf6-3332-11e6-87fd-fa6d7118bfcc.png)

### After

![selection_028](https://cloud.githubusercontent.com/assets/6275540/16089038/20ccaebc-3332-11e6-81ce-50cd017ceace.png)
