### PR TITLE
PCHR-1210: Remove the carry forward expiration date from Absence Type

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -228,15 +228,6 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
       );
     }
 
-    $has_carry_forward_expiration_day = !empty($params['carry_forward_expiration_day']);
-    $has_carry_forward_expiration_month = !empty($params['carry_forward_expiration_month']);
-    $has_carry_forward_expiration_date = $has_carry_forward_expiration_day && $has_carry_forward_expiration_month;
-    if($has_carry_forward_expiration_date && !$allow_carry_forward) {
-      throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException(
-          'To set the Carry Forward Expiration Date you must allow Carry Forward'
-      );
-    }
-
     $has_carry_forward_expiration_duration = !empty($params['carry_forward_expiration_duration']);
     $has_carry_forward_expiration_unit = !empty($params['carry_forward_expiration_unit']);
     if($has_carry_forward_expiration_duration && $has_carry_forward_expiration_unit && !$allow_carry_forward) {
@@ -245,24 +236,9 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
       );
     }
 
-    $has_carry_forward_expiration_duration_or_unit = $has_carry_forward_expiration_unit || $has_carry_forward_expiration_duration;
-    if($has_carry_forward_expiration_date && $has_carry_forward_expiration_duration_or_unit) {
-      throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException(
-          "You can't set both the Carry Forward Expiration Date and Period"
-      );
-    }
-
     if($has_carry_forward_expiration_unit xor $has_carry_forward_expiration_duration) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException(
           'Invalid Carry Forward Expiration. It should have both Unit and Duration'
-      );
-    }
-
-    if ($has_carry_forward_expiration_date &&
-        !self::isValidDateAndMonth($params['carry_forward_expiration_day'], $params['carry_forward_expiration_month'])
-    ) {
-      throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException(
-          'Invalid Carry Forward Expiration Date'
       );
     }
 
@@ -273,28 +249,6 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
           'Invalid Carry Forward Expiration Unit'
       );
     }
-  }
-
-  /**
-   * Checks if a date in dd-mm format is valid.
-   *
-   * @TODO Find a better place to put this method.
-   *
-   */
-  private static function isValidDateAndMonth($day, $month) {
-    if($month < 1 || $month > 12) {
-      return false;
-    }
-
-    if($month == 2 && $day > 29) {
-      return false;
-    }
-
-    if(in_array($month, [4, 6, 9, 11]) && $day > 30) {
-      return false;
-    }
-
-    return true;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/AbsenceType.php
@@ -205,18 +205,6 @@ class CRM_HRLeaveAndAbsences_DAO_AbsenceType extends CRM_Core_DAO
    */
   public $carry_forward_expiration_unit;
   /**
-   * If expiration_unit + expiration_duration is not informed, the expiration day and month should be
-   *
-   * @var int
-   */
-  public $carry_forward_expiration_day;
-  /**
-   * If expiration_unit + expiration_duration is not informed, the expiration day and month should be
-   *
-   * @var int
-   */
-  public $carry_forward_expiration_month;
-  /**
    * class constructor
    *
    * @return civicrm_hrleaveandabsences_absence_type
@@ -369,18 +357,6 @@ class CRM_HRLeaveAndAbsences_DAO_AbsenceType extends CRM_Core_DAO
           'title' => ts('Carry Forward Expiration Unit') ,
           'description' => 'The unit (year, month, etc) of carry_forward_expiration_duration of this type default expiry',
         ) ,
-        'carry_forward_expiration_day' => array(
-          'name' => 'carry_forward_expiration_day',
-          'type' => CRM_Utils_Type::T_INT,
-          'title' => ts('Carry Forward Expiration Day') ,
-          'description' => 'If expiration_unit + expiration_duration is not informed, the expiration day and month should be',
-        ) ,
-        'carry_forward_expiration_month' => array(
-          'name' => 'carry_forward_expiration_month',
-          'type' => CRM_Utils_Type::T_INT,
-          'title' => ts('Carry Forward Expiration Month') ,
-          'description' => 'If expiration_unit + expiration_duration is not informed, the expiration day and month should be',
-        ) ,
       );
     }
     return self::$_fields;
@@ -417,8 +393,6 @@ class CRM_HRLeaveAndAbsences_DAO_AbsenceType extends CRM_Core_DAO
         'max_number_of_days_to_carry_forward' => 'max_number_of_days_to_carry_forward',
         'carry_forward_expiration_duration' => 'carry_forward_expiration_duration',
         'carry_forward_expiration_unit' => 'carry_forward_expiration_unit',
-        'carry_forward_expiration_day' => 'carry_forward_expiration_day',
-        'carry_forward_expiration_month' => 'carry_forward_expiration_month',
       );
     }
     return self::$_fieldKeys;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
@@ -95,24 +95,6 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form
       return 'AbsenceType';
     }
 
-    private function getMonthsOptions()
-    {
-        return [
-            1 => ts('Jan'),
-            2 => ts('Feb'),
-            3 => ts('Mar'),
-            4 => ts('Apr'),
-            5 => ts('May'),
-            6 => ts('Jun'),
-            7 => ts('Jul'),
-            8 => ts('Ago'),
-            9 => ts('Sep'),
-            10 => ts('Oct'),
-            11 => ts('Nov'),
-            12 => ts('Dec'),
-        ];
-    }
-
     private function addBasicDetailsFields()
     {
         $this->add(
@@ -242,16 +224,6 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form
             'carry_forward_expiration_unit',
             ['options' => CRM_HRLeaveAndAbsences_BAO_AbsenceType::getExpirationUnitOptions()]
         );
-        $this->add(
-            'text',
-            'carry_forward_expiration_day',
-            '',
-            $this->getDAOFieldAttributes('carry_forward_expiration_day')
-        );
-        $this->addSelect(
-            'carry_forward_expiration_month',
-            ['options' => $this->getMonthsOptions()]
-        );
     }
 
     private function getDAOFieldAttributes($field)
@@ -269,7 +241,6 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form
         $this->addRule('accrual_expiration_duration', $positiveNumberMessage, 'positiveInteger');
         $this->addRule('max_number_of_days_to_carry_forward', $positiveNumberMessage, 'positiveInteger');
         $this->addRule('carry_forward_expiration_duration', $positiveNumberMessage, 'positiveInteger');
-        $this->addRule('carry_forward_expiration_day', $positiveNumberMessage, 'positiveInteger');
         $this->addFormRule([$this, 'formRules']);
     }
 
@@ -300,8 +271,6 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form
     {
         $expiration_unit = CRM_Utils_Array::value('carry_forward_expiration_unit', $values);
         $expiration_duration = CRM_Utils_Array::value('carry_forward_expiration_duration', $values);
-        $expiration_day = CRM_Utils_Array::value('carry_forward_expiration_day', $values);
-        $expiration_month = CRM_Utils_Array::value('carry_forward_expiration_month', $values);
 
         if($expiration_unit && !$expiration_duration) {
             $errors['carry_forward_expiration_duration'] = ts('You must also set the expiration duration');
@@ -309,14 +278,6 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form
 
         if($expiration_duration && !$expiration_unit) {
             $errors['carry_forward_expiration_unit'] = ts('You must also set the expiration unit');
-        }
-
-        if($expiration_day && !$expiration_month) {
-            $errors['carry_forward_expiration_month'] = ts('You must also set the expiration month');
-        }
-
-        if($expiration_month && !$expiration_day) {
-            $errors['carry_forward_expiration_day'] = ts('You must also set the expiration day');
         }
     }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
@@ -15,7 +15,7 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form
     public function setDefaultValues() {
         if(empty($this->defaultValues)) {
             if ($this->_id) {
-                $this->defaultValues = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getDefaultValues($this->_id);
+                $this->defaultValues = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getValuesArray($this->_id);
             } else {
                 $this->defaultValues = [
                     'allow_request_cancelation' => CRM_HRLeaveAndAbsences_BAO_AbsenceType::REQUEST_CANCELATION_IN_ADVANCE_OF_START_DATE,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
@@ -28,8 +28,6 @@ CREATE TABLE `civicrm_hrleaveandabsences_absence_type` (
      `max_number_of_days_to_carry_forward` int unsigned    ,
      `carry_forward_expiration_duration` int unsigned    COMMENT 'An amount of carry_forward_expiration_unit',
      `carry_forward_expiration_unit` int unsigned    COMMENT 'The unit (year, month, etc) of carry_forward_expiration_duration of this type default expiry',
-     `carry_forward_expiration_day` int    COMMENT 'If expiration_unit + expiration_duration is not informed, the expiration day and month should be',
-     `carry_forward_expiration_month` int    COMMENT 'If expiration_unit + expiration_duration is not informed, the expiration day and month should be',
     PRIMARY KEY ( `id` ),
     UNIQUE INDEX `hrleaveandabsences_absence_type_title`(title)
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
@@ -125,26 +125,15 @@
                 <div class="crm-section carry-forward-option">
                     <div class="label">{ts}Carry forward leave expiry{/ts}</div>
                     <div class="content">
-                        {assign var="carry_forward_expire_after_duration" value=false }
-                        {assign var="carry_forward_expire_after_date" value=false }
                         {assign var="carry_forward_never_expire" value=false }
-                        {if $form.carry_forward_expiration_duration.value neq '' or $form.carry_forward_expiration_unit.value.0 neq '' }
-                            {assign var="carry_forward_expire_after_duration" value=true }
-                        {/if}
-                        {if $form.carry_forward_expiration_day.value neq '' or $form.carry_forward_expiration_month.value.0 neq '' }
-                            {assign var="carry_forward_expire_after_date" value=true }
-                        {/if}
                         {if not $carry_forward_expire_after_duration and not $carry_forward_expire_after_date }
                             {assign var="carry_forward_never_expire" value=true }
                         {/if}
                         <label><input type="radio" name="carry_forward_expiration" id="carry_forward_never_expire" {if $carry_forward_never_expire}checked{/if}> {ts}Never expire{/ts}</label>
                         <br/>
-                        <label><input type="radio" name="carry_forward_expiration" id="carry_forward_expire_after_duration" {if $carry_forward_expire_after_duration}checked{/if}> {ts}Expire after a certain duration{/ts}</label>
+                        <label><input type="radio" name="carry_forward_expiration" id="carry_forward_expire_after_duration"> {ts}Expire after a certain duration{/ts}</label>
                         <br/>
                         <span class="carry-forward-expiration-duration">{$form.carry_forward_expiration_duration.html}{$form.carry_forward_expiration_unit.html}<br/></span>
-                        <label><input type="radio" name="carry_forward_expiration" id="carry_forward_expire_after_date" {if $carry_forward_expire_after_date}checked{/if}> {ts}Expire on a particular date{/ts}</label>
-                        <br/>
-                        <span class="carry-forward-expiration-date">{$form.carry_forward_expiration_day.html}{$form.carry_forward_expiration_month.html}</span>
                     </div>
                     <div class="clear"></div>
                 </div>
@@ -204,7 +193,6 @@
                     var allow_carry_forward = $('#allow_carry_forward');
                     var carry_forward_never_expire = $('#carry_forward_never_expire');
                     var carry_forward_expire_after_duration = $('#carry_forward_expire_after_duration');
-                    var carry_forward_expire_after_date = $('#carry_forward_expire_after_date');
 
                     if(allow_carry_forward.is(':checked')) {
                         $('.carry-forward-option').show();
@@ -212,10 +200,6 @@
 
                     if(carry_forward_expire_after_duration.is(':checked')) {
                         $('.carry-forward-expiration-duration').show();
-                    }
-
-                    if(carry_forward_expire_after_date.is(':checked')) {
-                        $('.carry-forward-expiration-date').show();
                     }
 
                     allow_carry_forward.on('click', function() {
@@ -229,21 +213,12 @@
                     carry_forward_never_expire.on('click', function() {
                         if(this.checked) {
                             hideCarryForwardExpirationDuration();
-                            hideCarryForwardExpirationDate();
-                        }
-                    })
-
-                    carry_forward_expire_after_duration.on('click', function() {
-                        if(this.checked) {
-                            hideCarryForwardExpirationDate();
-                            $('.carry-forward-expiration-duration').show();
                         }
                     });
 
-                    carry_forward_expire_after_date.on('click', function() {
+                    carry_forward_expire_after_duration.on('click', function() {
                         if(this.checked) {
-                            hideCarryForwardExpirationDuration();
-                            $('.carry-forward-expiration-date').show();
+                            $('.carry-forward-expiration-duration').show();
                         }
                     });
                 }
@@ -256,7 +231,6 @@
                     }
                     carry_forward_expiration_radios.item(0).checked = true;
                     hideCarryForwardExpirationDuration();
-                    hideCarryForwardExpirationDate();
                     $('.carry-forward-option').hide();
                 }
 
@@ -264,12 +238,6 @@
                     document.getElementById('carry_forward_expiration_duration').value = '';
                     $('#carry_forward_expiration_unit').select2('val', '');
                     $('.carry-forward-expiration-duration').hide();
-                }
-
-                function hideCarryForwardExpirationDate() {
-                    document.getElementById('carry_forward_expiration_day').value = '';
-                    $('#carry_forward_expiration_month').select2('val', '');
-                    $('.carry-forward-expiration-date').hide();
                 }
 
                 function initColorPicker() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -1,13 +1,15 @@
 <?php
 
 use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
 
 /**
  * Class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest
  *
  * @group headless
  */
-class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends CiviUnitTestCase implements HeadlessInterface {
+class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends PHPUnit_Framework_TestCase implements
+  HeadlessInterface, TransactionalInterface {
 
   private $allColors = [
       '#5A6779', '#E5807F', '#ECA67F', '#8EC68A', '#C096AA', '#9579A8', '#42B0CB',
@@ -16,21 +18,8 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends CiviUnitTestCase implem
       '#151D2C', '#B32E2E', '#BF561D', '#377A31', '#803D5E', '#47275C', '#056780'
   ];
 
-  protected $_tablesToTruncate = [
-    'civicrm_hrleaveandabsences_notification_receiver',
-    'civicrm_hrleaveandabsences_absence_type',
-  ];
-
   public function setUpHeadless() {
     return \Civi\Test::headless()->installMe(__DIR__)->apply();
-  }
-
-  public function setUp() {
-    parent::setUp();
-  }
-
-  public function tearDown() {
-    parent::tearDown();
   }
 
   /**
@@ -383,15 +372,19 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends CiviUnitTestCase implem
    */
   private function createReservedType()
   {
-    $connection = $this->getConnection()->getConnection();
     $title = 'Title ' . microtime();
     $query = "
       INSERT INTO
         civicrm_hrleaveandabsences_absence_type(title, color, default_entitlement, allow_request_cancelation, is_reserved, weight)
         VALUES('{$title}', '#000000', 0, 1, 1, 1)
     ";
-    if($connection->query($query)) {
-      return $connection->lastInsertId();
+    CRM_Core_DAO::executeQuery($query);
+
+    $query = "SELECT id FROM civicrm_hrleaveandabsences_absence_type WHERE title = '{$title}'";
+    $dao = CRM_Core_DAO::executeQuery($query);
+    if($dao->N == 1) {
+      $dao->fetch();
+      return $dao->id;
     }
 
     return null;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -185,18 +185,6 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends CiviUnitTestCase implem
 
   /**
    * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
-   * @expectedExceptionMessage To set the Carry Forward Expiration Date you must allow Carry Forward
-   */
-  public function testAllowCarryForwardShouldBeTrueIfCarryForwardExpirationDayAndMonthAreNotEmpty() {
-    $this->createBasicType([
-        'allow_carry_forward'   => false,
-        'carry_forward_expiration_day' => 10,
-        'carry_forward_expiration_month' => 4,
-    ]);
-  }
-
-  /**
-   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
    * @expectedExceptionMessage To set the carry forward expiry duration you must allow Carry Forward
    */
   public function testAllowCarryForwardShouldBeTrueIfCarryForwardExpirationDurationAndUnitAreNotEmpty() {
@@ -204,20 +192,6 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends CiviUnitTestCase implem
         'allow_carry_forward' => false,
         'carry_forward_expiration_duration' => 1,
         'carry_forward_expiration_unit' => CRM_HRLeaveAndAbsences_BAO_AbsenceType::EXPIRATION_UNIT_DAYS
-    ]);
-  }
-
-  /**
-   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
-   * @expectedExceptionMessage You can't set both the Carry Forward Expiration Date and Period
-   */
-  public function testCarryForwardExpirationDateAndPeriodCannotBothBeNotEmpty() {
-    $this->createBasicType([
-      'allow_carry_forward' => true,
-      'carry_forward_expiration_duration' => 1,
-      'carry_forward_expiration_unit' => CRM_HRLeaveAndAbsences_BAO_AbsenceType::EXPIRATION_UNIT_YEARS,
-      'carry_forward_expiration_day' => 15,
-      'carry_forward_expiration_month' => 4,
     ]);
   }
 
@@ -236,24 +210,6 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends CiviUnitTestCase implem
         'allow_carry_forward' => true,
         'carry_forward_expiration_unit' => $unit,
         'carry_forward_expiration_duration' => $duration,
-    ]);
-  }
-
-  /**
-   * @dataProvider carryForwardExpirationDateDataProvider
-   */
-  public function testCarryForwardExpirationDateIsValid($day, $month, $throwsException) {
-    if($throwsException) {
-      $this->setExpectedException(
-          CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException::class,
-          'Invalid Carry Forward Expiration Date'
-      );
-    }
-
-    $this->createBasicType([
-        'allow_carry_forward' => true,
-        'carry_forward_expiration_day' => $day,
-        'carry_forward_expiration_month' => $month
     ]);
   }
 
@@ -358,7 +314,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends CiviUnitTestCase implem
     $this->assertNull($entity);
 
   }
-  
+
   private function createBasicType($params = array()) {
     $basicRequiredFields = [
         'title' => 'Type ' . microtime(),
@@ -418,18 +374,6 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends CiviUnitTestCase implem
       $data[] = [$option, false];
     }
     return $data;
-  }
-
-  public function carryForwardExpirationDateDataProvider() {
-    return [
-      [12, 12, false],
-      [1, 2, false],
-      [31, 1, false],
-      [30, 2, true],
-      [31, 4, true],
-      [77, 9, true],
-      [12, 31, true],
-    ];
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -304,6 +304,25 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends PHPUnit_Framework_TestC
 
   }
 
+  public function testGetValuesArrayShouldReturnAbsenceTypeValues()
+  {
+    $params = [
+      'title' => 'Title 1',
+      'color' => '#000101',
+      'default_entitlement' => 21,
+      'allow_request_cancelation' => 1,
+      'is_active' => 1,
+      'is_default' => 1,
+      'allow_carry_forward' => 1,
+      'max_number_of_days_to_carry_forward' => 10,
+    ];
+    $entity = $this->createBasicType($params);
+    $values = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getValuesArray($entity->id);
+    foreach($params as $field => $value) {
+      $this->assertEquals($value, $values[$field]);
+    }
+  }
+
   private function createBasicType($params = array()) {
     $basicRequiredFields = [
         'title' => 'Type ' . microtime(),

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/WebTest/AbsenceType/FormTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/WebTest/AbsenceType/FormTest.php
@@ -73,52 +73,30 @@ class WebTest_AbsenceType_FormTest extends CiviSeleniumTestCase implements Headl
         $this->assertFalse($this->isVisible('max_number_of_days_to_carry_forward'));
         $this->assertFalse($this->isVisible('carry_forward_expiration_duration'));
         $this->assertFalse($this->isVisible('s2id_carry_forward_expiration_unit'));
-        $this->assertFalse($this->isVisible('carry_forward_expiration_day'));
-        $this->assertFalse($this->isVisible('s2id_carry_forward_expiration_month'));
 
-        // When carry forward is checked, shome fields become visible
+        // When carry forward is checked, some fields become visible
         $this->click('allow_carry_forward');
         $this->assertTrue($this->isVisible('max_number_of_days_to_carry_forward'));
         $this->assertFalse($this->isVisible('carry_forward_expiration_duration'));
         $this->assertFalse($this->isVisible('s2id_carry_forward_expiration_unit'));
-        $this->assertFalse($this->isVisible('carry_forward_expiration_day'));
-        $this->assertFalse($this->isVisible('s2id_carry_forward_expiration_month'));
         $this->assertTrue($this->isChecked('carry_forward_never_expire'));
         $this->assertFalse($this->isChecked('carry_forward_expire_after_duration'));
-        $this->assertFalse($this->isChecked('carry_forward_expire_after_date'));
 
         // When expire after a certain duration is checked, the duration fields become visible
         $this->click('carry_forward_expire_after_duration');
         $this->assertTrue($this->isVisible('max_number_of_days_to_carry_forward'));
         $this->assertTrue($this->isVisible('carry_forward_expiration_duration'));
         $this->assertTrue($this->isVisible('s2id_carry_forward_expiration_unit'));
-        $this->assertFalse($this->isVisible('carry_forward_expiration_day'));
-        $this->assertFalse($this->isVisible('s2id_carry_forward_expiration_month'));
         $this->assertFalse($this->isChecked('carry_forward_never_expire'));
         $this->assertTrue($this->isChecked('carry_forward_expire_after_duration'));
-        $this->assertFalse($this->isChecked('carry_forward_expire_after_date'));
 
-        // When expire after date is checked, the date fields become visible
-        $this->click('carry_forward_expire_after_date');
-        $this->assertTrue($this->isVisible('max_number_of_days_to_carry_forward'));
-        $this->assertFalse($this->isVisible('carry_forward_expiration_duration'));
-        $this->assertFalse($this->isVisible('s2id_carry_forward_expiration_unit'));
-        $this->assertTrue($this->isVisible('carry_forward_expiration_day'));
-        $this->assertTrue($this->isVisible('s2id_carry_forward_expiration_month'));
-        $this->assertFalse($this->isChecked('carry_forward_never_expire'));
-        $this->assertFalse($this->isChecked('carry_forward_expire_after_duration'));
-        $this->assertTrue($this->isChecked('carry_forward_expire_after_date'));
-
-        // When Never expire is checked, the duration and date fields become hidden
+        // When Never expire is checked, the duration fields become hidden
         $this->click('carry_forward_never_expire');
         $this->assertTrue($this->isVisible('max_number_of_days_to_carry_forward'));
         $this->assertFalse($this->isVisible('carry_forward_expiration_duration'));
         $this->assertFalse($this->isVisible('s2id_carry_forward_expiration_unit'));
-        $this->assertFalse($this->isVisible('carry_forward_expiration_day'));
-        $this->assertFalse($this->isVisible('s2id_carry_forward_expiration_month'));
         $this->assertTrue($this->isChecked('carry_forward_never_expire'));
         $this->assertFalse($this->isChecked('carry_forward_expire_after_duration'));
-        $this->assertFalse($this->isChecked('carry_forward_expire_after_date'));
     }
 
     public function testAddAnEmptyType()
@@ -228,27 +206,6 @@ class WebTest_AbsenceType_FormTest extends CiviSeleniumTestCase implements Headl
         $this->assertElementContainsText($expirationUnitError, 'You must also set the expiration duration');
     }
 
-    public function testCannotSetIncompleteCarryForwardExpirationDate()
-    {
-        $this->loginAsAdmin();
-        $this->openAddForm();
-        $this->click('allow_carry_forward');
-        $this->click('carry_forward_expire_after_date');
-
-        // First we try it without informing the expiration month
-        $this->type('carry_forward_expiration_day', 10);
-        $this->submitAndWait('AbsenceType');
-        $expirationUnitError = "xpath=//select[@id='carry_forward_expiration_month']/following-sibling::span";
-        $this->assertElementContainsText($expirationUnitError, 'You must also set the expiration month');
-
-        // Now we try without informing the expiration day
-        $this->type('carry_forward_expiration_day', '');
-        $this->select('carry_forward_expiration_month', 'label=Ago');
-        $this->submitAndWait('AbsenceType');
-        $expirationUnitError = "xpath=//input[@id='carry_forward_expiration_day']/following-sibling::span";
-        $this->assertElementContainsText($expirationUnitError, 'You must also set the expiration day');
-    }
-
     public function testNumericFieldsShouldOnlyAllowPositiveNumbers()
     {
         $numericFields = [
@@ -277,14 +234,6 @@ class WebTest_AbsenceType_FormTest extends CiviSeleniumTestCase implements Headl
             $elementError = "xpath=//input[@id='$field']/following-sibling::span";
             $this->assertElementContainsText($elementError, 'The value should be a positive number');
         }
-
-        // We must test carry forward expiration date separately
-        // Because we can't have both expiration duration and date
-        $this->click('carry_forward_expire_after_date');
-        $this->type('carry_forward_expiration_day', CRM_Utils_String::createRandom(5, 'abcdefghijklmnopqrstuvwxyz'));
-        $this->submitAndWait('AbsenceType');
-        $elementError = "xpath=//input[@id='carry_forward_expiration_day']/following-sibling::span";
-        $this->assertElementContainsText($elementError, 'The value should be a positive number');
     }
 
     private function openAddForm()

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/AbsenceType.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/AbsenceType.xml
@@ -154,15 +154,5 @@
     <type>int unsigned</type>
     <comment>The unit (year, month, etc) of carry_forward_expiration_duration of this type default expiry</comment>
   </field>
-  <field>
-    <name>carry_forward_expiration_day</name>
-    <type>int</type>
-    <comment>If expiration_unit + expiration_duration is not informed, the expiration day and month should be</comment>
-  </field>
-  <field>
-    <name>carry_forward_expiration_month</name>
-    <type>int</type>
-    <comment>If expiration_unit + expiration_duration is not informed, the expiration day and month should be</comment>
-  </field>
 
 </table>


### PR DESCRIPTION
To make things simpler on the entitlement calculation, it was decided to remove
these fields from the AbsenceType. Now, the expiration of carry forward days will
only be calculated in terms of duration.

This is how the Absence Type form was before the change:
![captura de tela 2016-06-16 as 14 33 18](https://cloud.githubusercontent.com/assets/388373/16126613/4b51d804-33cf-11e6-8a1e-5637969eea83.png)

And this is how it looks like after the change:
![captura de tela 2016-06-16 as 14 30 20](https://cloud.githubusercontent.com/assets/388373/16126617/542f0640-33cf-11e6-92a9-f88fbc5910fd.png)
