### PR TITLE
PCHR-1039: Entitlement Calculation page

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
@@ -1,7 +1,7 @@
 <?php
 
 class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobContract {
-    
+
     static $_importableFields = array();
 
   /**
@@ -15,30 +15,30 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
     $className = 'CRM_HRJobContract_DAO_HRJobContract';
     $entityName = 'HRJobContract';
     $hook = empty($params['id']) ? 'create' : 'edit';
-    
+
     CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
     $instance = new self();
     $instance->copyValues($params);
     $instance->save();
     CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
-    
+
     if ((is_numeric(CRM_Utils_Array::value('is_primary', $params)) || $hook === 'create') && empty($params['import'])) {
         CRM_Hrjobcontract_DAO_HRJobContract::handlePrimary($instance, $params);
     }
-    
+
     $deleted = isset($params['deleted']) ? $params['deleted'] : 0;
     if ($deleted)
     {
         CRM_Hrjobcontract_JobContractDates::removeDates($instance->id);
     }
-    
+
     if (function_exists('module_exists') && module_exists('rules')) {
         rules_invoke_event('hrjobcontract_after_create', $instance);
     }
 
     return $instance;
   }
-  
+
   /**
    * Delete current HRJobContract based on array-data
    *
@@ -53,7 +53,7 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
           rules_invoke_event('hrjobcontract_after_delete', $id);
       }
   }
-  
+
   /**
    * Get a count of records with the given property
    *
@@ -112,11 +112,11 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
   /**
    * Return 'length_of_service' in days for given Contact ID, and optionally
    * Date and Break (allowed number of days between Contracts).
-   * 
+   *
    * @param int     $contactId  CiviCRM Contact ID
    * @param string  $date       Y-m-d format of a date for which we calculate the result
    * @param int     $break      Allowed number of days between Contracts
-   * 
+   *
    * @throws Exception
    * @return int
    */
@@ -177,9 +177,9 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
 
   /**
    * Return an assotiative array with Contracts dates.
-   * 
+   *
    * @param array $contracts
-   * 
+   *
    * @return array
    */
   protected static function getContractDates($contracts) {
@@ -219,10 +219,10 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
 
   /**
    * Return an array with calculated Service Start Date and Service End Date.
-   * 
+   *
    * @param array   $dates
    * @param int     $break  Number of Break days
-   * 
+   *
    * @return array
    */
   protected static function getServiceDates($dates, $break) {
@@ -255,11 +255,11 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
 
   /**
    * Return a difference of Service dates in days (including break days).
-   * 
+   *
    * @param array   $serviceDates   Array containing 'startDate' and 'endDate' keys
    * @param string   $date          Date in Y-m-d format for which we calculate the result
    * @param int      $break         Allowed number of days between Contracts
-   * 
+   *
    * @return int
    */
   protected static function calculateLength($serviceDates, $date, $break) {
@@ -282,10 +282,10 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
   /**
    * Calculate a new Date which is sum of given Date and number of Break days.
    * Returns null if given date is null.
-   * 
+   *
    * @param string  $date   Date in Y-m-d format
    * @param int     $break  Number of Break days
-   * 
+   *
    * @return string|null
    */
   protected static function sumDateAndBreak($date, $break) {
@@ -296,10 +296,10 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
     $newDate->add(new DateInterval('P' . $break . 'D'));
     return $newDate->format('Y-m-d');
   }
-  
+
   /**
    * Update Length of Service for specific Contact.
-   * 
+   *
    * @return bool
    */
   public static function updateLengthOfService($contactId) {
@@ -326,7 +326,7 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
 
   /**
    * Update Length of Service for all Individual Contacts.
-   * 
+   *
    * @return bool
    */
   public static function updateLengthOfServiceAllContacts() {
@@ -385,14 +385,14 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
     $checkPermission = TRUE,
     $withMultiCustomFields = FALSE
   ) {
-      
+
      $contactType = 'Individual';
-     
+
      $fields = CRM_Hrjobcontract_DAO_HRJobContract::import();
-     
+
       $tmpContactField = $contactFields = array();
       $contactFields = array( );
-      
+
         $contactFields = CRM_Contact_BAO_Contact::importableFields($contactType, NULL);
 
         // Using new Dedupe rule.
@@ -420,7 +420,7 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
             $tmpContactField[trim($value)]['title'] = $title;
           }
         }
-        
+
       $extIdentifier = CRM_Utils_Array::value('external_identifier', $contactFields);
       if ($extIdentifier) {
         $tmpContactField['external_identifier'] = $extIdentifier;
@@ -438,5 +438,88 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
 
       self::$_importableFields = $fields;
     return self::$_importableFields;//$fields;
+  }
+
+  /**
+   * Returns a list of active contracts.
+   *
+   * If no startDate is given, the current date will be used. If no endDate is
+   * given, the startDate will be used for it.
+   *
+   * A contract is active if:
+   * - The effective date of current revision is less or equal the startDate OR
+   *   it is starts someday between the start and end dates
+   * - The contract start date and end dates overlaps with the start and end
+   *   dates passed to the period OR
+   *   it doesn't have an end date and starts before the given start date OR
+   *   it doesn't have an end date and starts between the given start and end
+   *   dates
+   * - The contract is not deleted
+   *
+   * @param null $startDate
+   * @param null $endDate
+   *
+   * @return array
+   */
+  public static function getActiveContracts($startDate = null, $endDate = null)
+  {
+    if($startDate) {
+      $startDate = CRM_Utils_Date::processDate($startDate, null, false, 'Y-m-d');
+    } else {
+      $startDate = date('Y-m-d');
+    }
+
+    if($endDate) {
+      $endDate = CRM_Utils_Date::processDate($endDate, null, false, 'Y-m-d');
+    } else {
+      $endDate = $startDate;
+    }
+
+    $query = "
+      SELECT c.*
+      FROM civicrm_hrjobcontract c
+        INNER JOIN civicrm_hrjobcontract_revision r
+          ON r.id = (SELECT id
+                     FROM civicrm_hrjobcontract_revision r2
+                     WHERE
+                      r2.jobcontract_id = c.id AND
+                      (
+                        r2.effective_date <= '{$startDate}'
+                         OR
+                        ( r2.effective_date >= '{$startDate}' AND
+                          r2.effective_date <= '{$endDate}'
+                        )
+                      )
+                     ORDER BY r2.effective_date DESC, r2.id DESC
+                     LIMIT 1
+        )
+        INNER JOIN civicrm_hrjobcontract_details d ON d.jobcontract_revision_id = r.id
+      WHERE c.deleted = 0 AND
+        (
+          (d.period_end_date IS NOT NULL AND d.period_start_date <= '{$endDate}' AND d.period_end_date >= '{$startDate}')
+            OR
+          (d.period_end_date IS NULL
+            AND
+            (
+              (d.period_start_date >= '{$startDate}' AND d.period_start_date <= '{$endDate}')
+              OR
+              d.period_start_date <= '{$endDate}'
+            )
+          )
+        );
+    ";
+
+    $dao = CRM_Core_DAO::executeQuery($query);
+    $contracts = [];
+    while($dao->fetch()) {
+      $contracts[] = [
+        'id' => $dao->id,
+        'contact_id' => $dao->contact_id,
+        'id_primary' => $dao->is_primary,
+        'deleted' => $dao->deleted
+      ];
+    }
+
+    return $contracts;
   }
 }

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -943,6 +943,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     $this->upgrade_1011();
     $this->upgrade_1012();
     $this->upgrade_1014();
+    $this->upgrade_1015();
   }
 
   function upgrade_1001() {

--- a/hrjobcontract/api/v3/HRJobContract.php
+++ b/hrjobcontract/api/v3/HRJobContract.php
@@ -69,14 +69,14 @@ function civicrm_api3_h_r_job_contract_get($params) {
             }
         }
         $contracts['values'][$key]['is_current'] = (int)$isCurrent;
-        
+
         foreach ($returnFields as $returnField) {
             if (!empty($details[$returnField])) {
                 $contracts['values'][$key][$returnField] = $details[$returnField];
             }
         }
     }
-    
+
     return $contracts;
 }
 
@@ -116,6 +116,32 @@ function civicrm_api3_h_r_job_contract_updatelengthofservice($params) {
   } else {
     $result = CRM_Hrjobcontract_BAO_HRJobContract::updateLengthOfService($params['contact_id']);
   }
+  return civicrm_api3_create_success($result, $params);
+}
+
+/**
+ * HRJobContract.getactivecontracts API
+ *
+ * @param array $params The accepted params are: start_date and end_date
+ * @return array API result descriptor
+ * @throws API_Exception
+ */
+function civicrm_api3_h_r_job_contract_getactivecontracts($params) {
+  $startDate = null;
+  $endDate = null;
+  if(!empty($params['start_date'])) {
+    if(is_array($params['start_date'])) {
+      return civicrm_api3_create_error('The start date parameter can only be used with the = operator');
+    }
+    $startDate = $params['start_date'];
+  }
+  if(!empty($params['end_date'])) {
+    if(is_array($params['end_date'])) {
+      return civicrm_api3_create_error('The end date parameter can only be used with the = operator');
+    }
+    $endDate = $params['end_date'];
+  }
+  $result = CRM_Hrjobcontract_BAO_HRJobContract::getActiveContracts($startDate, $endDate);
   return civicrm_api3_create_success($result, $params);
 }
 

--- a/hrjobcontract/phpunit.xml.dist
+++ b/hrjobcontract/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="tests/phpunit/bootstrap.php"
+>
+  <testsuites>
+    <testsuite name="Job Contracts Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments></arguments>
+    </listener>
+  </listeners>
+</phpunit>

--- a/hrjobcontract/tests/phpunit/CRM/Hrjobcontract/BAO/HRJobContractTest.php
+++ b/hrjobcontract/tests/phpunit/CRM/Hrjobcontract/BAO/HRJobContractTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Class CRM_Hrjobcontract_BAO_HRJobContractTest
+ *
+ * @group headless
+ */
+class CRM_Hrjobcontract_BAO_HRJobContractTest extends PHPUnit_Framework_TestCase implements
+  HeadlessInterface,
+  TransactionalInterface {
+
+  use HRJobContractTestTrait;
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->installMe(__DIR__)->apply();
+  }
+
+  public function testGetActiveContractsDoesntIncludeContractsWithoutDetails() {
+    $this->createContacts(1);
+    $this->createJobContract($this->contacts[0]['id']);
+    $activeContracts = CRM_Hrjobcontract_BAO_HRJobContract::getActiveContracts();
+    $this->assertEmpty($activeContracts);
+  }
+
+  public function testGetActiveContractsDoesntIncludeInactiveContracts() {
+    $this->createContacts(1);
+    $startDate = date('YmdHis', strtotime('-10 days'));
+    $endDate = date('YmdHis', strtotime('-1 day'));
+    $this->createJobContract($this->contacts[0]['id'], $startDate, $endDate);
+    $activeContracts = CRM_Hrjobcontract_BAO_HRJobContract::getActiveContracts();
+    $this->assertEmpty($activeContracts);
+  }
+
+  public function testGetActiveContractsDoesntIncludeDeletedContracts()
+  {
+    $this->createContacts(1);
+    $startDate = date('YmdHis');
+    $endDate = date('YmdHis', strtotime('+10 days'));
+    $contract = $this->createJobContract($this->contacts[0]['id'], $startDate, $endDate);
+
+    $activeContracts = CRM_Hrjobcontract_BAO_HRJobContract::getActiveContracts();
+    $this->assertCount(1, $activeContracts);
+    $this->assertEquals($contract->id, $activeContracts[0]['id']);
+
+    $this->deleteContract($contract->id);
+    $activeContracts = CRM_Hrjobcontract_BAO_HRJobContract::getActiveContracts();
+    $this->assertEmpty($activeContracts);
+  }
+
+  public function testGetActiveContractsShouldIncludeActiveContracts()
+  {
+    $activeContracts = CRM_Hrjobcontract_BAO_HRJobContract::getActiveContracts();
+    $this->assertEmpty($activeContracts);
+
+    $this->createContacts(4);
+    $this->createJobContract($this->contacts[0]['id'], date('Y-m-d'));
+    $this->createJobContract(
+      $this->contacts[1]['id'],
+      date('Y-m-d', strtotime('-1 year'))
+    );
+    $this->createJobContract(
+      $this->contacts[2]['id'],
+      date('Y-m-d', strtotime('-5 months')),
+      date('Y-m-d', strtotime('+5 months'))
+    );
+    $this->createJobContract(
+      $this->contacts[3]['id'],
+      date('Y-m-d', strtotime('-5 months')),
+      date('Y-m-d', strtotime('now'))
+    );
+
+    $activeContracts = CRM_Hrjobcontract_BAO_HRJobContract::getActiveContracts();
+    $this->assertCount(4, $activeContracts);
+  }
+
+  public function testGetActiveContractsCanReturnContractsActiveOnASpecificPeriod()
+  {
+    $activeContracts = CRM_Hrjobcontract_BAO_HRJobContract::getActiveContracts();
+    $this->assertEmpty($activeContracts);
+
+    $this->createContacts(2);
+
+    $startDateInFuture = date('Y-m-d', strtotime('+2 days'));
+    $endDateInFuture = date('Y-m-d', strtotime('+9 days'));
+    $contract1 = $this->createJobContract(
+      $this->contacts[0]['id'],
+      $startDateInFuture,
+      $endDateInFuture
+    );
+    $this->createJobContract(
+      $this->contacts[1]['id'],
+      $endDateInFuture
+    );
+
+    // Since both contracts start in the future,
+    // getActiveContracts without start date should return empty
+    $activeContracts = CRM_Hrjobcontract_BAO_HRJobContract::getActiveContracts();
+    $this->assertEmpty($activeContracts);
+
+    // The contracts overlaps only on the end day,
+    // so, if we getActiveContracts with a maximum end date of end day - 1 day,
+    // only the first contract should be returned
+    $oneDayBeforeEndDateInFuture = date('Y-m-d', strtotime('+8 days'));
+    $activeContracts = CRM_Hrjobcontract_BAO_HRJobContract::getActiveContracts(
+      $startDateInFuture,
+      $oneDayBeforeEndDateInFuture
+    );
+    $this->assertCount(1, $activeContracts);
+    $this->assertEquals($contract1->id, $activeContracts[0]['id']);
+
+    // Now we are searching for active contracts with a start day equals to the
+    // end date in the future (the only date where both contracts overlaps).
+    // Since we are not passing an end date to getActiveContracts, that means
+    // it will return contracts that are active on the exact given date.
+    $activeContracts = CRM_Hrjobcontract_BAO_HRJobContract::getActiveContracts(
+      $endDateInFuture
+    );
+    $this->assertCount(2, $activeContracts);
+  }
+
+}

--- a/hrjobcontract/tests/phpunit/HRJobContractTestTrait.php
+++ b/hrjobcontract/tests/phpunit/HRJobContractTestTrait.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * A trait with helper methods to be reused among this extension's tests
+ */
+trait HRJobContractTestTrait {
+
+  /**
+   * Property used to keep track of the contacts created by the createContacts
+   * method
+   *
+   * @var array
+   */
+  protected $contacts;
+
+  /**
+   * Creates a new Job Contract for the given contact
+   *
+   * If a startDate is given, it will also create a JobDetails instance to save
+   * the contract's start date and end date(if given)
+   *
+   * @param $contactID
+   * @param null $startDate
+   * @param null $endDate
+   *
+   * @return \CRM_HRJob_DAO_HRJobContract|NULL
+   */
+  protected function createJobContract($contactID, $startDate = null, $endDate = null) {
+    $contract = CRM_Hrjobcontract_BAO_HRJobContract::create(['contact_id' => $contactID]);
+    if($startDate) {
+      $params = [
+        'jobcontract_id' => $contract->id,
+        'period_start_date' => CRM_Utils_Date::processDate($startDate),
+        'period_end_date' => null,
+      ];
+
+      if($endDate) {
+        $params['period_end_date'] = CRM_Utils_Date::processDate($endDate);
+      }
+      CRM_Hrjobcontract_BAO_HRJobDetails::create($params);
+    }
+
+    return $contract;
+  }
+
+  /**
+   * Creates as many contacts (Individuals) as the number of contacts given.
+   *
+   * @param int $numberOfContacts
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function createContacts($numberOfContacts = 1) {
+    $numberOfCreatedContacts = count($this->contacts);
+    for($i = $numberOfCreatedContacts; $i < $numberOfCreatedContacts + $numberOfContacts; $i++) {
+      $result = civicrm_api3('Contact', 'create', [
+        'contact_type' => 'Individual',
+        'first_name' => 'Name ',
+        'middle_name' => 'N. ',
+        'last_name' => $i,
+        'email' => 'name_'.$i.'@example.org',
+      ]);
+
+      $this->contacts[] = array_shift($result['values']);
+    }
+  }
+
+  /**
+   * Deletes the contract with the given ID.
+   *
+   * This method uses the delectecontract action of the HRJobContract API, to
+   * make sure all the related entities will also be deleted, and the contract
+   * will be marked as deleted on the database.
+   *
+   * @param $id
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function deleteContract($id) {
+    civicrm_api3('HRJobContract', 'deletecontract', ['id' => $id]);
+  }
+}

--- a/hrjobcontract/tests/phpunit/api/v3/HRJobContractTest.php
+++ b/hrjobcontract/tests/phpunit/api/v3/HRJobContractTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Class api_v3_HRJobContractTest
+ *
+ * @group headless
+ */
+class api_v3_HRJobContractTest extends PHPUnit_Framework_TestCase implements
+  HeadlessInterface,
+  TransactionalInterface {
+
+  use HRJobContractTestTrait;
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->installMe(__DIR__)->apply();
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage The start date parameter can only be used with the = operator
+   *
+   * @dataProvider invalidGetActiveContractsDateOperator
+   */
+  public function testOnGetActiveContractsTheStartDateOnlyAcceptsTheEqualOperator($operator) {
+    civicrm_api3('HRJobContract', 'getactivecontracts', ['start_date' => [$operator => '2016-01-01']]);
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage The end date parameter can only be used with the = operator
+   *
+   * @dataProvider invalidGetActiveContractsDateOperator
+   */
+  public function testOnGetActiveContractsTheEndDateOnlyAcceptsTheEqualOperator($operator) {
+    civicrm_api3('HRJobContract', 'getactivecontracts', ['end_date' => [$operator => '2016-01-01']]);
+  }
+
+  public function testGetActiveContractsReturnsActiveContracts()
+  {
+    $result = civicrm_api3('HRJobContract', 'getactivecontracts');
+    $this->assertEquals(0, $result['count']);
+
+    $this->createContacts(2);
+    $contract1 = $this->createJobContract($this->contacts[0]['id'], date('Y-m-d'));
+    $contract2 = $this->createJobContract($this->contacts[1]['id'], date('Y-m-d', strtotime('-1 day')));
+
+    $result = civicrm_api3('HRJobContract', 'getactivecontracts');
+    $this->assertEquals(2, $result['count']);
+
+    $this->deleteContract($contract1->id);
+    $result = civicrm_api3('HRJobContract', 'getactivecontracts');
+    $this->assertEquals(1, $result['count']);
+
+    $this->deleteContract($contract2->id);
+    $result = civicrm_api3('HRJobContract', 'getactivecontracts');
+    $this->assertEquals(0, $result['count']);
+  }
+
+  public function invalidGetActiveContractsDateOperator()
+  {
+    return [
+      ['>'],
+      ['>='],
+      ['<='],
+      ['<'],
+      ['<>'],
+      ['!='],
+      ['BETWEEN'],
+      ['NOT BETWEEN'],
+      ['LIKE'],
+      ['NOT LIKE'],
+      ['IN'],
+      ['NOT IN'],
+      ['IS NULL'],
+      ['IS NOT NULL'],
+    ];
+  }
+
+}

--- a/hrjobcontract/tests/phpunit/bootstrap.php
+++ b/hrjobcontract/tests/phpunit/bootstrap.php
@@ -1,0 +1,51 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+eval(cv('php:boot --level=full -t', 'phpcode'));
+
+require_once 'HRJobContractTestTrait.php';
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculation.php
@@ -2,7 +2,6 @@
 
 use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
 use CRM_HRLeaveAndAbsences_BAO_Entitlement as Entitlement;
-use CRM_Hrjobcontract_BAO_HRJobContract as JobContract;
 use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
 
@@ -23,9 +22,11 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
   private $period;
 
   /**
-   * The HRJobContract this calculation is based on
+   * The Job Contract this calculation is based on
+   * This is expected to be an array, just like the one returned from an API
+   * call
    *
-   * @var \CRM_Hrjobcontract_BAO_HRJobContract
+   * @var array
    */
   private $contract;
 
@@ -83,10 +84,10 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
    * Creates a new EntitlementCalculation instance
    *
    * @param \CRM_HRLeaveAndAbsences_BAO_AbsencePeriod $period
-   * @param \CRM_Hrjobcontract_BAO_HRJobContract $contract
+   * @param array $contract The contract in array format, like when it's returned by an API call
    * @param \CRM_HRLeaveAndAbsences_BAO_AbsenceType $absenceType
    */
-  public function __construct(AbsencePeriod $period, JobContract $contract, AbsenceType $absenceType) {
+  public function __construct(AbsencePeriod $period, $contract, AbsenceType $absenceType) {
     $this->period = $period;
     $this->contract = $contract;
     $this->absenceType = $absenceType;
@@ -236,7 +237,7 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
 
     if(!$this->previousPeriodEntitlement) {
       $this->previousPeriodEntitlement = Entitlement::getContractEntitlementForPeriod(
-        $this->contract->id,
+        $this->contract['id'],
         $previousPeriod->id,
         $this->absenceType->id
       );
@@ -324,7 +325,7 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
     if(!$this->jobLeave) {
       try {
         $this->jobLeave = civicrm_api3('HRJobLeave', 'getsingle', array(
-          'jobcontract_id' => (int)$this->contract->id,
+          'jobcontract_id' => (int)$this->contract['id'],
           'leave_type' => (int)$this->absenceType->id
         ));
       } catch(CiviCRM_API3_Exception $ex) {
@@ -346,7 +347,7 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
     if(!$this->contractDetails) {
       try {
         $this->contractDetails = civicrm_api3('HRJobDetails', 'getsingle', array(
-          'jobcontract_id' => (int)$this->contract->id,
+          'jobcontract_id' => (int)$this->contract['id'],
         ));
       } catch(CiviCRM_API3_Exception $ex) {
         $this->contractDetails = null;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculation.php
@@ -224,6 +224,26 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
   }
 
   /**
+   * Returns the AbsenceType instance used to create this calculation
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_AbsenceType
+   */
+  public function getAbsenceType()
+  {
+    return $this->absenceType;
+  }
+
+  /**
+   * Returns the Job Contract array used to create this calculation
+   *
+   * @return array
+   */
+  public function getContract()
+  {
+    return $this->contract;
+  }
+
+  /**
    * Returns the calculated Entitlement for the previous period.
    *
    * @return \CRM_HRLeaveAndAbsences_BAO_Entitlement|null

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculator.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculator.php
@@ -1,0 +1,76 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_EntitlementCalculation as EntitlementCalculation;
+use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+
+/**
+ * This class encapsulates the creation of EntitlementCalculations for an
+ * specific AbsencePeriod.
+ */
+class CRM_HRLeaveAndAbsences_EntitlementCalculator {
+
+  /**
+   * The AbsencePeriod to calculate the entitlements for
+   *
+   * @var \CRM_HRLeaveAndAbsences_BAO_AbsencePeriod
+   */
+  private $period;
+
+  /**
+   * An array to cache the loaded enabled AbsenceType instances,
+   * used to calculate the entitlements.
+   *
+   * @var array
+   */
+  private $absenceTypes = [];
+
+  /**
+   * CRM_HRLeaveAndAbsences_EntitlementCalculator constructor.
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_AbsencePeriod $period
+   */
+  public function __construct(AbsencePeriod $period)
+  {
+    $this->period = $period;
+  }
+
+  /**
+   * This method generates EntitlementCalculation instances for the given
+   * contract. One EntitlementCalculation instance is returned for each currently
+   * enabled AbsenceType.
+   *
+   * @param array $contract
+   *  A Job Contract in array format, like when it is returned from an API call
+   *
+   * @return array An array of EntitlementCalculations
+   */
+  public function calculateEntitlementsFor($contract) {
+    $absenceTypes = $this->getEnabledAbsenceTypes();
+    $calculations = [];
+    foreach($absenceTypes as $absenceType) {
+      $calculations[] = new EntitlementCalculation($this->period, $contract, $absenceType);
+    }
+
+    return $calculations;
+  }
+
+  /**
+   * Returns a list of enabled AbsenceTypes.
+   *
+   * @return array
+   */
+  private function getEnabledAbsenceTypes() {
+    if(empty($this->absenceTypes)) {
+      $absenceType = new AbsenceType();
+      $absenceType->is_active = 1;
+      $absenceType->find();
+      while($absenceType->fetch()) {
+        $this->absenceTypes[] = clone $absenceType;
+      }
+    }
+
+    return $this->absenceTypes;
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
@@ -1,0 +1,145 @@
+<?php
+
+require_once 'CRM/Core/Form.php';
+
+use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
+use CRM_HRLeaveAndAbsences_EntitlementCalculator as EntitlementCalculator;
+
+/**
+ * Form controller class
+ *
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC43/QuickForm+Reference
+ */
+class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildQuickForm() {
+    $absencePeriod = $this->getAbsencePeriodFromRequest();
+    $this->setFormPageTitle($absencePeriod);
+
+    $calculations = $this->getEntitlementCalculations($absencePeriod);
+
+    $this->addProposedEntitlementsFields($calculations);
+
+    $this->assign('period', $absencePeriod);
+    $this->assign('calculations', $calculations);
+
+    CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/hrleaveandabsences.css', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
+    CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/hrleaveandabsences.form.manage_entitlements.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
+    parent::buildQuickForm();
+  }
+
+  /**
+   * Retrieves and returns an AbsencePeriod BAO instance for the id parameter
+   * passed through the URL
+   *
+   * @return CRM_HRLeaveAndAbsences_BAO_AbsencePeriod
+   * @throws \Exception
+   */
+  private function getAbsencePeriodFromRequest() {
+    $periodId = CRM_Utils_Request::retrieve('id', 'Integer');
+    return AbsencePeriod::findById((int)$periodId);
+  }
+
+  /**
+   * Sets the page title with the period title and dates
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_AbsencePeriod $absencePeriod
+   */
+  public function setFormPageTitle(AbsencePeriod $absencePeriod) {
+    $pageTitle = ts(
+      'Manage Leave Entitlements for period "%1" - %2 to %3',
+      [
+        1 => $absencePeriod->title,
+        2 => CRM_Utils_Date::customFormat($absencePeriod->start_date),
+        3 => CRM_Utils_Date::customFormat($absencePeriod->end_date),
+      ]
+    );
+    CRM_Utils_System::setTitle($pageTitle);
+  }
+
+  /**
+   * Creates EntitlementCalculation instances for every active contract in
+   * given AbsencePeriod.
+   *
+   * @param CRM_HRLeaveAndAbsences_BAO_AbsencePeriod $absencePeriod
+   *
+   * @return array An array containing all the EntitlementCalculations created
+   */
+  private function getEntitlementCalculations(AbsencePeriod $absencePeriod) {
+    $contracts    = $this->getActiveContractsForPeriod($absencePeriod);
+    $calculator   = new EntitlementCalculator($absencePeriod);
+    $calculations = [];
+    foreach ($contracts as $contract) {
+      $calculations = array_merge($calculations,
+        $calculator->calculateEntitlementsFor($contract));
+    }
+    return $calculations;
+  }
+
+  /**
+   * Returns an array containing all the active contracts for the given
+   * AbsencePeriod.
+   *
+   * This method uses the HRJobContract API to retrieve the contacts, so the
+   * return values will be an array, as this is how they are returned by the
+   * API.
+   *
+   * To help things while displaying the entitlement calculations, the API call
+   * is chained with the Contact API in order to retrieve the staff display
+   * name. Its value is available as 'contact_display_name'.
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_AbsencePeriod $absencePeriod
+   *
+   * @return array
+   */
+  private function getActiveContractsForPeriod(AbsencePeriod $absencePeriod) {
+    try {
+      $result = civicrm_api3('HRJobContract', 'getactivecontracts', [
+        'start_date' => $absencePeriod->start_date,
+        'end_date' => $absencePeriod->end_date,
+        'api.Contact.getvalue' => ['return' => 'display_name']
+      ]);
+
+      array_walk($result['values'], function(&$item) {
+        $item['contact_display_name'] = $item['api.Contact.getvalue'];
+        unset($item['api.Contact.getvalue']);
+      });
+
+      return $result['values'];
+    } catch(\Exception $e) {
+      return [];
+    }
+  }
+
+  /**
+   * Adds the Proposed Entitlements fields to this form.
+   *
+   * These fields are hidden by default, and are visible only if the user chose
+   * to override the calculated proposed entitlement.
+   *
+   * As this is a list of calculations, the field name contains the contract id
+   * and the absence type id, in order to make it possible to related the fields
+   * to the right calculation.
+   *
+   * @param $calculations
+   */
+  private function addProposedEntitlementsFields($calculations) {
+    foreach($calculations as $calculation) {
+      $fieldName = sprintf(
+        'proposed_entitlement[%d][%d]',
+        $calculation->getContract()['id'],
+        $calculation->getAbsenceType()->id
+      );
+
+      $this->add(
+        'text',
+        $fieldName,
+        '',
+        ['class' => 'overridden-proposed-entitlement']
+      );
+    }
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
@@ -67,3 +67,19 @@
   border-top: 1px solid rgba(0, 0, 0, .2);
   border-bottom: 1px solid rgba(0, 0, 0, .2);
 }
+
+.entitlement-calculation-list .absence-type {
+  display: inline-block;
+  color: #fff;
+  padding: 5px;
+}
+
+.entitlement-calculation-list .proposed-entitlement .overridden-proposed-entitlement {
+  display: none;
+  width: 20px;
+}
+
+.entitlement-calculation-list .proposed-entitlement button {
+  border: 0;
+  background-color: transparent;
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
@@ -1,0 +1,130 @@
+// Create the namespaces if they don't exist
+CRM.HRLeaveAndAbsencesApp = CRM.HRLeaveAndAbsencesApp || {};
+CRM.HRLeaveAndAbsencesApp.Form = CRM.HRLeaveAndAbsencesApp.Form || {};
+
+
+/**
+ * This class represents the whole ManageEntitlements form.
+ *
+ */
+CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements = (function($) {
+
+  /**
+   * Creates a new ManageEntitlements form instance
+   * @constructor
+   */
+  function ManageEntitlements() {
+    this._listElement = $('.entitlement-calculation-list');
+    this._instantiateProposedEntitlements();
+  }
+
+  /**
+   * Creates new ProposedEntitlement instances for every calculation on the list
+   *
+   * @private
+   */
+  ManageEntitlements.prototype._instantiateProposedEntitlements = function() {
+    this._listElement.find('.proposed-entitlement').each(function(i, element) {
+      new CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements.ProposedEntitlement($(element));
+    });
+  };
+
+  return ManageEntitlements;
+
+})($);
+
+
+/**
+ * This class wraps the small set of controls that each calculation on the ManageEntitlements
+ * list has to allow the user to edit/override the proposed entitlement.
+ */
+CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements.ProposedEntitlement = (function($) {
+
+  /**
+   * Creates a new ProposedEntitlement instance
+   *
+   * @param {Object} element - The element wrapping all of the proposed entitlement controls
+   * @constructor
+   */
+  function ProposedEntitlement(element) {
+    this._overrideButton = element.find('button');
+    this._overrideCheckbox = element.find('input[type="checkbox"]');
+    this._overrideField = element.find('input[type="text"]');
+    this._proposedValue = element.find('.proposed-value');
+    this._addEventListeners();
+  }
+
+  /**
+   * Add event listeners to the override button and the checkbox
+   *
+   * @private
+   */
+  ProposedEntitlement.prototype._addEventListeners = function() {
+    this._overrideButton.on('click', this._onOverrideButtonClick.bind(this));
+    this._overrideCheckbox.on('click', this._onOverrideCheckboxClick.bind(this));
+  };
+
+  /**
+   * This is the event handler for when the override/edit button is clicked.
+   *
+   * It makes the field to override the proposed entitlement visible;
+   *
+   * @private
+   */
+  ProposedEntitlement.prototype._onOverrideButtonClick = function() {
+    this._makeEntitlementEditable();
+  };
+
+
+  /**
+   * This is the event handle for when the override checkbox is clicked.
+   *
+   * If it's checked, then we make the entitlement editable, by showing the
+   * field to override the proposed entitlement. Otherwise, we hide the field
+   * and display the edit button.
+   *
+   * @param event
+   * @private
+   */
+  ProposedEntitlement.prototype._onOverrideCheckboxClick = function(event) {
+    if(event.target.checked) {
+      this._makeEntitlementEditable();
+    } else {
+      this._displayProposedEntitlementValue();
+    }
+  };
+
+  /**
+   * This make the proposed entitlement editable. That is, the field to override the
+   * proposed value is displayed, the edit field, the edit button and the proposed
+   * value is hidden, and the checkbox gets checked.
+   *
+   * @private
+   */
+  ProposedEntitlement.prototype._makeEntitlementEditable = function() {
+    this._overrideButton.hide();
+    this._proposedValue.hide();
+    this._overrideField
+      .val(this._proposedValue.text())
+      .show()
+      .focus();
+    this._overrideCheckbox.prop('checked', true);
+  };
+
+  /**
+   * This is used to hide the fields to override the entitlement, and display the original
+   * proposed entitlement again.
+   *
+   * @private
+   */
+  ProposedEntitlement.prototype._displayProposedEntitlementValue = function() {
+    this._overrideButton.show();
+    this._proposedValue.show();
+    this._overrideField
+      .val('')
+      .hide();
+    this._overrideCheckbox.prop('checked', false);
+  };
+
+  return ProposedEntitlement;
+})($);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
@@ -1,0 +1,57 @@
+<div class="help">
+  <p>&nbsp;{ts}WARNING: Please note that any currently stored annual entitlement allowance for the selected staff member(s) will be overwritten by this process{/ts}</p>
+</div>
+<table class="entitlement-calculation-list">
+  <thead>
+  <tr>
+    <th>{ts}Employee ID{/ts}</th>
+    <th>{ts}Employee name{/ts}</th>
+    <th>{ts}Leave type{/ts}</th>
+    <th>{ts}Prev. yr entitlement{/ts}</th>
+    <th>{ts}Days taken{/ts}</th>
+    <th>{ts}Remaining{/ts}</th>
+    <th>{ts}Brought Forward from previous period{/ts}</th>
+    <th>{ts}Current Contractual Entitlement{/ts}</th>
+    <th>{ts}New Period Pro rata{/ts}</th>
+    <th>{ts}New Proposed Period Entitlement{/ts}</th>
+    <th>{ts}Comment{/ts}</th>
+  </tr>
+  </thead>
+  <tbody>
+  {foreach from=$calculations item=calculation}
+    {assign var=absenceType value=$calculation->getAbsenceType()}
+    {assign var=absenceTypeID value=$absenceType->id}
+    {assign var=contract value=$calculation->getContract()}
+    <tr>
+      <td>{$contract.contact_id}</td>
+      <td>{$contract.contact_display_name}</td>
+      <td><span class="absence-type" style="background-color: {$absenceType->color};">{$absenceType->title}</span></td>
+      <td>{$calculation->getPreviousPeriodProposedEntitlement()}</td>
+      <td>{$calculation->getNumberOfLeavesTakenOnThePreviousPeriod()}</td>
+      <td>{$calculation->getNumberOfDaysRemainingInThePreviousPeriod()}</td>
+      <td>{$calculation->getBroughtForward()}</td>
+      <td>{$calculation->getContractualEntitlement()}</td>
+      <td>{$calculation->getProRata()}</td>
+      <td>
+        <div class="proposed-entitlement">
+          <span class="proposed-value">{$calculation->getProposedEntitlement()}</span>
+          {$form.proposed_entitlement[$contract.id][$absenceTypeID].html}
+          <button type="button"><i class="fa fa-pencil"></i></button>
+          <label for=""><input type="checkbox"> Override</label>
+        </div>
+      </td>
+      <td></td>
+    </tr>
+  {/foreach}
+  </tbody>
+</table>
+<script type="text/javascript">
+  {literal}
+  CRM.$(function($) {
+    new CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements();
+  });
+  {/literal}
+</script>
+<div class="action-link">
+  <a href="javascript:history.back()" class="button"><span>{ts}Back{/ts}</span></a>
+</div>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
@@ -503,16 +503,18 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   }
 
   private function createContract() {
-    $this->contract = JobContract::create([
+    $result = civicrm_api3('HRJobContract', 'create', [
       'contact_id' => 2, //Existing contact from civicrm_data.mysql,
-      'is_primary' => 1
+      'is_primary' => 1,
+      'sequential' => 1
     ]);
+    $this->contract = $result['values'][0];
   }
 
   private function createEntitlement($period, $type, $proposedEntitlement = 20) {
     Entitlement::create([
       'period_id'            => $period->id,
-      'contract_id'          => $this->contract->id,
+      'contract_id'          => $this->contract['id'],
       'type_id'              => $type->id,
       'proposed_entitlement' => $proposedEntitlement,
     ]);
@@ -533,7 +535,7 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
 
   private function createJobLeaveEntitlement($type, $leaveAmount, $addPublicHolidays = false) {
     CRM_Hrjobcontract_BAO_HRJobLeave::create([
-      'jobcontract_id' => $this->contract->id,
+      'jobcontract_id' => $this->contract['id'],
       'leave_type' => $type->id,
       'leave_amount' => $leaveAmount,
       'add_public_holidays' => $addPublicHolidays ? '1' : '0'
@@ -542,7 +544,7 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
 
   private function setContractDates($startDate, $endDate) {
     CRM_Hrjobcontract_BAO_HRJobDetails::create([
-      'jobcontract_id' => $this->contract->id,
+      'jobcontract_id' => $this->contract['id'],
       'period_start_date' => $startDate,
       'period_end_date' => $endDate,
     ]);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
@@ -495,6 +495,26 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
     $this->assertEquals(10, $calculation->getNumberOfDaysRemainingInThePreviousPeriod());
   }
 
+  public function testGetAbsenceTypeShouldReturnTheAbsenceTypeUsedToCreateTheCalculation()
+  {
+    $type = new AbsenceType();
+    $type->title = 'Absence Type 1';
+
+    $period = new AbsencePeriod();
+
+    $calculation = new EntitlementCalculation($period, [], $type);
+    $this->assertEquals($type, $calculation->getAbsenceType());
+  }
+
+  public function testGetContractShouldReturnTheContractUsedToCreateTheCalculation()
+  {
+    $type = new AbsenceType();
+    $period = new AbsencePeriod();
+
+    $calculation = new EntitlementCalculation($period, $this->contract, $type);
+    $this->assertEquals($this->contract, $calculation->getContract());
+  }
+
   private function findAbsencePeriodByID($id) {
     $currentPeriod     = new AbsencePeriod();
     $currentPeriod->id = $id;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
@@ -23,6 +23,8 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
       ->installMe(__DIR__)
       ->install('org.civicrm.hrjobcontract')
       ->apply();
+    $jobContractUpgrader = CRM_Hrjobcontract_Upgrader::instance();
+    $jobContractUpgrader->install();
   }
 
   public function setUp()

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculatorTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculatorTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+use CRM_HRLeaveAndAbsences_EntitlementCalculator as EntitlementCalculator;
+use CRM_HRLeaveAndAbsences_EntitlementCalculation as EntitlementCalculation;
+use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_EntitlementCalculator
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_EntitlementCalculatorTest extends PHPUnit_Framework_TestCase implements
+  HeadlessInterface, TransactionalInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+                     ->installMe(__DIR__)
+                     ->apply();
+  }
+
+  public function testCanReturnCalculationsForMultipleAbsenceTypes()
+  {
+    $this->createBasicType();
+    $period = new AbsencePeriod();
+
+    // mock the array returned by an API call
+    $contract = [
+      'id' => 1,
+      'is_primary' => 1,
+      'contact_id' => 2,
+    ];
+
+    $calculator = new EntitlementCalculator($period);
+    $calculations = $calculator->calculateEntitlementsFor($contract);
+    // He have 3 reserved absence types that cannot be deleted, and added a
+    // new AbsenceType, so we should get 4 calculations (one for each type)
+    $this->assertCount(4, $calculations);
+    foreach($calculations as $calculation) {
+      $this->assertInstanceOf(EntitlementCalculation::class, $calculation);
+    }
+  }
+
+  public function testCanOnlyReturnCalculationsForEnabledAbsenceTypes()
+  {
+    $this->createBasicType(['is_active' => false]);
+    $period = new AbsencePeriod();
+
+    // mock the array returned by an API call
+    $contract = [
+      'id' => 1,
+      'is_primary' => 1,
+      'contact_id' => 2,
+    ];
+
+    $calculator = new EntitlementCalculator($period);
+    $calculations = $calculator->calculateEntitlementsFor($contract);
+    // He have 3 reserved absence types that cannot be deleted, and added a
+    // new disabled AbsenceType, so we should get only 3 calculations, since
+    // the new one is disabled and should not be included in the calculation
+    $this->assertCount(3, $calculations);
+  }
+
+  private function createBasicType($params = array()) {
+    $basicRequiredFields = [
+      'title' => 'Type ' . microtime(),
+      'color' => '#000000',
+      'default_entitlement' => 20,
+      'allow_request_cancelation' => 1,
+    ];
+
+    $params = array_merge($basicRequiredFields, $params);
+    return AbsenceType::create($params);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/Menu/hrleaveandabsences.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/Menu/hrleaveandabsences.xml
@@ -24,4 +24,10 @@
     <title>Absence Periods</title>
     <access_arguments>administer leave and absences</access_arguments>
   </item>
+  <item>
+    <path>civicrm/admin/leaveandabsences/periods/manage_entitlements</path>
+    <page_callback>CRM_HRLeaveAndAbsences_Form_ManageEntitlements</page_callback>
+    <title>ManageEntitlements</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
This adds the new Entitlement Calculation page. At this point we only have the basic structure for the page, which is a simple list displaying all the calculated entitlements for active contracts on a specific AbsencePeriod.

The page is available at: **civicrm/admin/leaveandabsences/periods/manage_entitlements** and it has a required parameter named **id**, which is the ID of the AbsencePeriod to calculated the entitlements for. It also accepts a **cid** parameter containing Contracts IDs. When this is present, the list will only display calculations for Contracts with the given IDs.

This is how the page looks like:

![captura de tela 2016-06-20 as 16 45 58](https://cloud.githubusercontent.com/assets/388373/16208235/8be10eea-3707-11e6-965d-67bd99b90d6c.png)

Next to each proposed entitlement, there is a small set of controls that allow the user to override that value (for now it only shows/hides the text field, nothing is saved yet). This is how this works:

![untitled5](https://cloud.githubusercontent.com/assets/388373/16208297/d67bbfea-3707-11e6-93f4-68074f90b8dc.gif)

