### PR TITLE
PCHR-1086: Add a popup to display the details about the entitlement calculation

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculation.php
@@ -424,4 +424,35 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
 
     return $this->numberOfWorkingDays;
   }
+
+
+  /**
+   * Returns a string representation of the calculation in the format:
+   *
+   * ((CE + PH) * (WDTW / WD)) = (PR) + (BF) = PE
+   *
+   * Where:
+   * CE: Contractual Entitlement (Not including public holidays)
+   * PH: Number of Public Holidays
+   * WDTW: Number of Working days to work
+   * WD: Number of Working days
+   * PR: Pro Rata, rounded to the nearest half day
+   * BF: Number of days Brought Forward
+   * PE: Proposed Entitlement
+   *
+   * @return string
+   */
+  public function __toString()
+  {
+    return sprintf(
+      '((%s + %s) * (%s / %s)) = (%s) + (%s) = %s days',
+      $this->getContractualEntitlement() - $this->getNumberOfPublicHolidaysForPeriod(),
+      $this->getNumberOfPublicHolidaysForPeriod(),
+      $this->getNumberOfWorkingDaysToWork(),
+      $this->period->getNumberOfWorkingDays(),
+      $this->getProRata(),
+      $this->getBroughtForward(),
+      $this->getProposedEntitlement()
+    );
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
@@ -16,6 +16,7 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements = (function($) {
   function ManageEntitlements() {
     this._listElement = $('.entitlement-calculation-list');
     this._instantiateProposedEntitlements();
+    this._addEventListeners();
   }
 
   /**
@@ -26,6 +27,46 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements = (function($) {
   ManageEntitlements.prototype._instantiateProposedEntitlements = function() {
     this._listElement.find('.proposed-entitlement').each(function(i, element) {
       new CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements.ProposedEntitlement($(element));
+    });
+  };
+
+  /**
+   * Add event listeners to events triggered by elements of managed by this class
+   *
+   * @private
+   */
+  ManageEntitlements.prototype._addEventListeners = function() {
+    this._listElement.find('tbody > tr').on('click', this._onListRowClick.bind(this));
+  };
+
+  /**
+   * This is the event handler for when the user clicks on a row of the calculations
+   * list.
+   *
+   * It shows the user a popup with details of the selected calculation. Even if the
+   * proposed entitlement was overridden, we display the original calculation.
+   *
+   * @param event
+   * @private
+   */
+  ManageEntitlements.prototype._onListRowClick = function(event) {
+    var calculationDescription = ts('' +
+      '((Base contractual entitlement + Public Holidays) ' +
+      '* ' +
+      '(No. of working days to work / No. of working days in period)) = ' +
+      '(Period pro rata) + (Brought Forward days) = Period Entitlement'
+    );
+    var calculationDetails = event.currentTarget.dataset.calculationDetails;
+
+    if(!calculationDetails) {
+      return;
+    }
+
+    CRM.confirm({
+      title: ts('Calculation details'),
+      message: calculationDescription + '<br /><br />' + calculationDetails,
+      width: '70%',
+      options: {}
     });
   };
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
@@ -22,7 +22,7 @@
     {assign var=absenceType value=$calculation->getAbsenceType()}
     {assign var=absenceTypeID value=$absenceType->id}
     {assign var=contract value=$calculation->getContract()}
-    <tr>
+    <tr data-calculation-details="{$calculation}">
       <td>{$contract.contact_id}</td>
       <td>{$contract.contact_display_name}</td>
       <td><span class="absence-type" style="background-color: {$absenceType->color};">{$absenceType->title}</span></td>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
@@ -515,6 +515,62 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
     $this->assertEquals($this->contract, $calculation->getContract());
   }
 
+  public function testCalculationCanReturnItsStringRepresentation()
+  {
+    // To simplify the code, we use an Absence where the carried
+    // forward never expires
+    $type = $this->createAbsenceType([
+      'max_number_of_days_to_carry_forward' => 5,
+    ]);
+
+    $previousPeriod = AbsencePeriod::create([
+      'title' => 'Period 1',
+      'start_date' => date('YmdHis', strtotime('2015-01-01')),
+      'end_date' => date('YmdHis', strtotime('2015-12-31')),
+    ]);
+
+    // Set the previous period entitlement as 20 days
+    $this->createEntitlement($previousPeriod, $type, 20);
+
+    // 261 working days - 2 public holidays = 259 working days
+    $currentPeriod = AbsencePeriod::create([
+      'title' => 'Period 2',
+      'start_date' => date('YmdHis', strtotime('2016-01-01')),
+      'end_date' => date('YmdHis', strtotime('2016-12-31')),
+    ]);
+    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    CRM_HRLeaveAndAbsences_BAO_PublicHoliday::create([
+      'title' => 'Holiday 1',
+      'date' => date('YmdHis', strtotime('2016-05-02'))
+    ]);
+    CRM_HRLeaveAndAbsences_BAO_PublicHoliday::create([
+      'title' => 'Holiday 2',
+      'date' => date('YmdHis', strtotime('2016-05-30'))
+    ]);
+
+    // Set the contractual entitlement as 10 days
+    $this->createJobLeaveEntitlement($type, 20, true);
+
+    // 64 days to work
+    $this->setContractDates(
+      date('YmdHis', strtotime('2016-01-01')),
+      date('YmdHis', strtotime('2016-03-30'))
+    );
+
+    $calculation = new EntitlementCalculation($currentPeriod, $this->contract, $type);
+
+    //Contractual Entitlement = 20
+    //Number of Public Holidays = 2
+    //Number of days to work = 64
+    //Number of working days = 259
+    //Pro rata = 5.5
+    //Brought forward = 5
+    //Proposed Entitlement = 10.5
+    $expected = '((20 + 2) * (64 / 259)) = (5.5) + (5) = 10.5 days';
+    $calculationDetails = sprintf('%s', $calculation);
+    $this->assertEquals($expected, $calculationDetails);
+  }
+
   private function findAbsencePeriodByID($id) {
     $currentPeriod     = new AbsencePeriod();
     $currentPeriod->id = $id;


### PR DESCRIPTION
When the user clicks on a row of the entitlement calculation list, a popup should be
displayed containing the description of how the proposed entitlement was calculated:

![calculation_details_popup](https://cloud.githubusercontent.com/assets/388373/16228154/a056584c-378b-11e6-9e05-38c8f865c73a.gif)
