### PR TITLE
PCHR-1193: fetch needed data for new summary page UI

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/HrJobRoles.php
@@ -80,10 +80,30 @@ class CRM_Hrjobroles_BAO_HrJobRoles extends CRM_Hrjobroles_DAO_HrJobRoles {
     return $result->fetch() ? $result->id : 0;
   }
 
+  /**
+   * Returns an array containing the list of departments
+   * for specific contact based on the current contract ID
+   *
+   * @param int $contractID contract ID
+   * @return array
+   */
+  public static function getDepartmentsList($contractID)  {
+    $queryParam = array(1 => array($contractID, 'Integer'));
+    $query = "SELECT cov.id, cov.label
+            FROM civicrm_hrjobroles hrjr
+            LEFT JOIN civicrm_option_value cov
+            ON hrjr.department = cov.id
+            WHERE hrjr.job_contract_id = %1";
+    $response = CRM_Core_DAO::executeQuery($query, $queryParam);
+    $result = array();
+    while($response->fetch())  {
+      $result[$response->id] = $response->label;
+    }
+    return  $result;
+  }
+
   public static function importableFields() {
     $fields = array('' => array('title' => ts('- do not import -')));
     return array_merge($fields, static::import());
   }
-
-
 }

--- a/com.civicrm.hrjobroles/phpunit.xml.dist
+++ b/com.civicrm.hrjobroles/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/phpunit/bootstrap.php">
+  <testsuites>
+    <testsuite name="Job Roles Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/com.civicrm.hrjobroles/tests/phpunit/CRM/Hrjobroles/BAO/HrJobRolesTest.php
+++ b/com.civicrm.hrjobroles/tests/phpunit/CRM/Hrjobroles/BAO/HrJobRolesTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Class CRM_Hrjobroles_BAO_HrJobRolesTest
+ *
+ * @group headless
+ */
+class CRM_Hrjobroles_BAO_HrJobRolesTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface, TransactionalInterface {
+
+  use HrJobRolesTestTrait;
+
+  public function setUpHeadless() {
+    // job contract is installed before job roles since job roles is depend on it
+    // otherwise the installation of job roles will fail.
+    return \Civi\Test::headless()
+      ->install('org.civicrm.hrjobcontract')
+      ->installMe(__DIR__)
+      ->apply();
+    $jobContractUpgrader = CRM_Hrjobcontract_Upgrader::instance();
+    $jobContractUpgrader->install();
+  }
+
+  public function testGetDepartmentsList() {
+    $contactParams = array("first_name" => "chrollo", "last_name" => "lucilfer");
+    $contactID =  $this->createContact($contactParams);
+    $contract =  $this->createJobContract($contactID);
+
+    $departmentID1 =  $this->createDepartment('special_investigation', 'Special Investigation');
+
+    $params = array('job_contract_id' => $contract->id, 'department' => $departmentID1);
+    $this->createJobRole($params);
+
+    $departments = CRM_Hrjobroles_BAO_HrJobRoles::getDepartmentsList($contract->id);
+    $this->assertContains('Special Investigation', $departments);
+    $this->assertCount(1, $departments);
+  }
+
+}

--- a/com.civicrm.hrjobroles/tests/phpunit/HrJobRolesTestTrait.php
+++ b/com.civicrm.hrjobroles/tests/phpunit/HrJobRolesTestTrait.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * A trait with helper methods to be reused among this extension's tests
+ */
+trait HrJobRolesTestTrait {
+
+  /**
+   * Creates a new Job role from the given data
+   *
+   * @param array $params
+   */
+  protected function createJobRole($params = array()) {
+    CRM_Hrjobroles_BAO_HrJobRoles::create($params);
+  }
+
+  /**
+   * Creates single (Individuals) contact from the provided data.
+   *
+   * @param array $params should contain first_name and last_name
+   * @return int return the contact ID
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function createContact($params) {
+    $result = civicrm_api3('Contact', 'create', array(
+      'contact_type' => "Individual",
+      'first_name' => $params['first_name'],
+      'last_name' => $params['last_name'],
+      'display_name' => $params['first_name'] . ' ' . $params['last_name'],
+    ));
+    return $result['id'];
+  }
+
+  /**
+   * Creates a new Job Contract for the given contact
+   *
+   * If a startDate is given, it will also create a JobDetails instance to save
+   * the contract's start date and end date(if given)
+   *
+   * @param $contactID
+   * @param null $startDate
+   * @param null $endDate
+   * @param array $extraParams
+   *
+   * @return \CRM_HRJob_DAO_HRJobContract|NULL
+   */
+  protected function createJobContract($contactID, $startDate = null, $endDate = null, $extraParams = array()) {
+    $contract = CRM_Hrjobcontract_BAO_HRJobContract::create(['contact_id' => $contactID]);
+    if($startDate) {
+      $params = [
+        'jobcontract_id' => $contract->id,
+        'period_start_date' => CRM_Utils_Date::processDate($startDate),
+        'period_end_date' => null,
+      ];
+
+      if($endDate) {
+        $params['period_end_date'] = CRM_Utils_Date::processDate($endDate);
+      }
+      $params = array_merge($params, $extraParams);
+      CRM_Hrjobcontract_BAO_HRJobDetails::create($params);
+    }
+
+    return $contract;
+  }
+
+  /**
+   * Creates a new department option value
+   *
+   * @param string $name
+   * @param string $label
+   * @return int $newDepartment
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function createDepartment($name, $label) {
+    $newDepartment = civicrm_api3('OptionValue', 'create', array(
+      'option_group_id' => 'hrjc_department',
+      'name' => $name,
+      'label'=> $label,
+    ));
+
+    return $newDepartment['id'];
+  }
+
+}

--- a/com.civicrm.hrjobroles/tests/phpunit/bootstrap.php
+++ b/com.civicrm.hrjobroles/tests/phpunit/bootstrap.php
@@ -1,0 +1,51 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+eval(cv('php:boot --level=classloader', 'phpcode'));
+
+require_once 'HrJobRolesTestTrait.php';
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
@@ -522,4 +522,34 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
 
     return $contracts;
   }
+
+  /**
+   * Return the current contract for the contact if exist.
+   *
+   * @param int $contactID
+   * @return array|null
+   */
+  public static function getCurrentContract($contactID)  {
+    try  {
+      $queryParam = array(1 => array($contactID, 'Integer'));
+      $query = "SELECT hrjc.id as contract_id , hrjd.*
+                FROM civicrm_hrjobcontract hrjc
+                LEFT JOIN civicrm_hrjobcontract_revision hrjr
+                ON hrjr.jobcontract_id = hrjc.id
+                LEFT JOIN civicrm_hrjobcontract_details hrjd
+                ON hrjr.details_revision_id = hrjd.jobcontract_revision_id
+                WHERE hrjc.contact_id = %1
+                AND hrjr.effective_date <= CURDATE()
+                AND ( hrjr.effective_end_date > CURDATE() OR hrjr.effective_end_date IS NULL)
+                AND ( hrjd.period_end_date > CURDATE() OR hrjd.period_end_date IS NULL)
+                AND hrjc.deleted = 0
+                AND hrjr.deleted = 0
+                LIMIT 1";
+      $response = CRM_Core_DAO::executeQuery($query, $queryParam);
+      $result =  $response->fetch() ? $response : null;
+    } catch(CiviCRM_API3_Exception $ex)  {
+      $result =  null;
+    }
+    return $result;
+  }
 }

--- a/hrjobcontract/tests/phpunit/CRM/Hrjobcontract/BAO/HRJobContractTest.php
+++ b/hrjobcontract/tests/phpunit/CRM/Hrjobcontract/BAO/HRJobContractTest.php
@@ -121,4 +121,28 @@ class CRM_Hrjobcontract_BAO_HRJobContractTest extends PHPUnit_Framework_TestCase
     $this->assertCount(2, $activeContracts);
   }
 
+
+  public function testGetCurrentContract() {
+    $contactParams = array("first_name" => "chrollo", "last_name" => "lucilfer");
+    $contactID =  $this->createContact($contactParams);
+
+    $params = array(
+      'position' => 'spiders boss',
+      'title' => 'spiders boss');
+    $this->createJobContract($contactID, '2015-06-01', '2015-10-01', $params);
+
+    $params = array(
+      'position' => 'spiders boss2',
+      'title' => 'spiders boss2');
+    $this->createJobContract($contactID, '2016-06-01', null, $params);
+
+    $params = array(
+      'position' => 'spiders boss3',
+      'title' => 'spiders boss3');
+    $this->createJobContract($contactID, '2014-06-01', '2014-10-01', $params);
+
+    $currentContract = CRM_Hrjobcontract_BAO_HRJobContract::getCurrentContract($contactID);
+    $this->assertEquals('spiders boss2', $currentContract->title);
+  }
+
 }

--- a/hrjobcontract/tests/phpunit/HRJobContractTestTrait.php
+++ b/hrjobcontract/tests/phpunit/HRJobContractTestTrait.php
@@ -22,10 +22,11 @@ trait HRJobContractTestTrait {
    * @param $contactID
    * @param null $startDate
    * @param null $endDate
+   * @param array $extraParams
    *
    * @return \CRM_HRJob_DAO_HRJobContract|NULL
    */
-  protected function createJobContract($contactID, $startDate = null, $endDate = null) {
+  protected function createJobContract($contactID, $startDate = null, $endDate = null, $extraParams = array()) {
     $contract = CRM_Hrjobcontract_BAO_HRJobContract::create(['contact_id' => $contactID]);
     if($startDate) {
       $params = [
@@ -37,10 +38,28 @@ trait HRJobContractTestTrait {
       if($endDate) {
         $params['period_end_date'] = CRM_Utils_Date::processDate($endDate);
       }
+      $params = array_merge($params, $extraParams);
       CRM_Hrjobcontract_BAO_HRJobDetails::create($params);
     }
 
     return $contract;
+  }
+
+  /**
+   * Creates single (Individuals) contact from the provided data.
+   *
+   * @param array $params should contain first_name and last_name
+   * @return int return the contact ID
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function createContact($params) {
+    $result = civicrm_api3('Contact', 'create', array(
+      'contact_type' => "Individual",
+      'first_name' => $params['first_name'],
+      'last_name' => $params['last_name'],
+      'display_name' => $params['first_name'] . ' ' . $params['last_name'],
+    ));
+    return $result['id'];
   }
 
   /**
@@ -65,6 +84,7 @@ trait HRJobContractTestTrait {
     }
   }
 
+
   /**
    * Deletes the contract with the given ID.
    *
@@ -79,4 +99,5 @@ trait HRJobContractTestTrait {
   protected function deleteContract($id) {
     civicrm_api3('HRJobContract', 'deletecontract', ['id' => $id]);
   }
+
 }

--- a/hrui/CRM/HRUI/Helper.php
+++ b/hrui/CRM/HRUI/Helper.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Collection of methods to be used in this extension
+ */
+class CRM_HRUI_Helper {
+
+  /**
+   * return an array containing the list of line managers
+   * for specific contact
+   *
+   * @param int $contactID contact ID
+   * @return array
+   */
+  public static function getLineManagersList($contactID)  {
+    try {
+      $result = civicrm_api3('RelationshipType', 'getsingle', array(
+        'sequential' => 1,
+        'return' => array("id"),
+        'name_a_b' => "Line Manager is",
+      ));
+      $relationshipTypeID = $result['id'];
+      $queryParam =
+        array(
+          1 => array($contactID, 'Integer'),
+          2 => array($relationshipTypeID, 'Integer')
+        );
+      $query = "SELECT cc.id, cc.display_name
+            FROM civicrm_relationship cr
+            LEFT JOIN civicrm_contact cc
+            ON cr.contact_id_b = cc.id
+            WHERE cr.contact_id_a = %1
+            AND cr.relationship_type_id = %2
+            AND (cr.end_date IS NULL OR cr.end_date >= CURDATE())
+            AND (cr.start_date IS NULL OR cr.start_date <= CURDATE())
+            AND cr.is_active = 1
+            AND cc.is_deleted = 0";
+      $response = CRM_Core_DAO::executeQuery($query, $queryParam);
+      $result = array();
+      while($response->fetch())  {
+        $result[$response->id] = $response->display_name;
+      }
+      return $result;
+    }
+    catch (CiviCRM_API3_Exception $ex){
+      return array();
+    }
+  }
+}

--- a/hrui/hrui.php
+++ b/hrui/hrui.php
@@ -59,7 +59,7 @@ function hrui_civicrm_buildForm($formName, &$form) {
     //HR-358 - Set default values
     //set default value to phone location and type
     $locationId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_LocationType', 'Main', 'id', 'name');
-    // PCHR-1146 : Commenting line ahead to fix the issue, but figuring why it was done at first place coul be useful. 
+    // PCHR-1146 : Commenting line ahead to fix the issue, but figuring why it was done at first place coul be useful.
     //$result = civicrm_api3('LocationType', 'create', array('id'=>$locationId, 'is_default'=> 1, 'is_active'=>1));
     if (($form->elementExists('phone[2][phone_type_id]')) && ($form->elementExists('phone[2][phone_type_id]'))) {
       $phoneType = $form->getElement('phone[2][phone_type_id]');
@@ -506,6 +506,29 @@ function hrui_civicrm_navigationMenu( &$params ) {
  */
 function hrui_civicrm_alterContent( &$content, $context, $tplName, &$object ) {
   $smarty = CRM_Core_Smarty::singleton();
+
+  // fetch data to the new summary page UI
+  if($context == 'page' && $tplName == "CRM/Contact/Page/View/Summary.tpl" ) {
+    $contact_id = CRM_Utils_Request::retrieve( 'cid', 'Positive');
+    /* $currentContractDetails contain current contact data including
+     * Current ( Position = $currentContractDetails->position ) and
+     * ( Normal Place of work =  $currentContractDetails->location )
+    */
+    $currentContractDetails = CRM_Hrjobcontract_BAO_HRJobContract::getCurrentContract($contact_id);
+    // $departmentsList contain current roles departments list separated by comma
+    $departmentsList = null;
+    if ($currentContractDetails)  {
+      $departmentsArray = CRM_Hrjobroles_BAO_HrJobRoles::getDepartmentsList($currentContractDetails->contract_id);
+      $departmentsList = implode(', ', $departmentsArray);
+    }
+    // $managersList contain current line managers list separated by comma
+    $managersList = null;
+    if ($currentContractDetails)  {
+      $managersArray = CRM_HRUI_Helper::getLineManagersList($contact_id);
+      $managersList = implode(', ', $managersArray);
+    }
+  }
+
   if ($context == "form" && $tplName == "CRM/Contact/Import/Form/MapField.tpl" ) {
     $columnToHide = array(
       'formal_title',
@@ -594,3 +617,4 @@ function hrui_civicrm_alterContent( &$content, $context, $tplName, &$object ) {
    </script>";
   }
 }
+

--- a/hrui/phpunit.xml.dist
+++ b/hrui/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/phpunit/bootstrap.php">
+  <testsuites>
+    <testsuite name="HRUI Extension Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/hrui/tests/phpunit/CRM/HRUI/HelperTest.php
+++ b/hrui/tests/phpunit/CRM/HRUI/HelperTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Class CRM_HRUI_HelperTest
+ *
+ * @group headless
+ */
+class CRM_HRUI_HelperTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface, TransactionalInterface {
+
+  use HRUITrait;
+
+  public function setUpHeadless() {
+    // hrcase create ( Line Manager is ) relationship type which is need for the tests
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->install('org.civicrm.hrcase')
+      ->apply();
+  }
+
+  public function testGetLineManagersList() {
+    $contactParamsA = array("first_name" => "chrollo", "last_name" => "lucilfer");
+    $contactParamsB = array("first_name" => "hisoka", "last_name" => "morou");
+    $contactA = $this->createContact($contactParamsA);
+    $contactB = $this->createContact($contactParamsB)
+    ;
+    $this->createRelationship($contactA, $contactB, 'Line Manager is');
+
+    $managers = CRM_HRUI_Helper::getLineManagersList($contactA);
+    $this->assertContains('hisoka morou', $managers);
+    $this->assertEquals(1, count($managers));
+
+    // add another line manager
+    $contactParamsC = array("first_name" => "illumi", "last_name" => "zoldyck");
+    $contactC = $this->createContact($contactParamsC);
+
+    $this->createRelationship($contactA, $contactC, 'Line Manager is');
+
+    $managers = CRM_HRUI_Helper::getLineManagersList($contactA);
+    $this->assertContains('illumi zoldyck', $managers);
+    $this->assertContains('hisoka morou', $managers);
+    $this->assertCount(2, $managers);
+  }
+
+}

--- a/hrui/tests/phpunit/HRUITrait.php
+++ b/hrui/tests/phpunit/HRUITrait.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * A trait with helper methods to be reused among this extension's tests
+ */
+trait HrUITrait {
+
+  /**
+   * Creates a single (Individuals) contact from the provided data.
+   *
+   * @param array $params should contain first_name and last_name
+   * @return int return the contact ID
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function createContact($params) {
+    $result = civicrm_api3('Contact', 'create', array(
+      'contact_type' => "Individual",
+      'first_name' => $params['first_name'],
+      'last_name' => $params['last_name'],
+      'display_name' => $params['first_name'] . ' ' . $params['last_name'],
+    ));
+    return $result['id'];
+  }
+
+  /**
+   * Creates a relationship between two contacts
+   *
+   * @param int $contactA contact A ID
+   * @param int $contactB contact B ID
+   * @param string $relationship_type relationship type label
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function createRelationship($contactA, $contactB, $relationship_type) {
+    $relationshipType = civicrm_api3('RelationshipType', 'getsingle', array(
+      'return' => array("id"),
+      'name_a_b' => $relationship_type,
+    ));
+    civicrm_api3('Relationship', 'create', array(
+      'contact_id_a' => $contactA,
+      'contact_id_b' => $contactB,
+      'relationship_type_id' => $relationshipType['id'],
+    ));
+  }
+
+}

--- a/hrui/tests/phpunit/bootstrap.php
+++ b/hrui/tests/phpunit/bootstrap.php
@@ -1,0 +1,51 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+eval(cv('php:boot --level=classloader', 'phpcode'));
+
+require_once 'HRUITrait.php';
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}


### PR DESCRIPTION
For the New summary page UI , The following information have to be viewed on the page :
1- Position and Normal Place of Work comes from Contract (people should have only 1 active contract) .
2- Department comes from Role. Could be multiple, so in that case separate by comma. (e.g. Finance, Marketing) .
3- Manager should come from Relationships > Line Manager is .

![selection_033](https://cloud.githubusercontent.com/assets/6275540/16264195/09c2ddde-3870-11e6-9ea0-3cdd53056aeb.png)


So I fetched them inside hrui_civicrm_alterContent so they are available to the front end developer to display them on the page and style them.