### PR TITLE
PCHR-1087: Add entitlement calculation list filters

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -404,4 +404,21 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
   {
     return $this->carry_forward_expiration_duration && $this->carry_forward_expiration_unit;
   }
+
+  /**
+   * Returns a list of all enabled Absence Types, ordered by weight
+   */
+  public static function getEnabledAbsenceTypes()
+  {
+    $absenceTypes = [];
+    $absenceType = new self();
+    $absenceType->is_active = 1;
+    $absenceType->orderBy('weight');
+    $absenceType->find();
+    while($absenceType->fetch()) {
+      $absenceTypes[] = clone $absenceType;
+    }
+
+    return $absenceTypes;
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculator.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculator.php
@@ -62,12 +62,7 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculator {
    */
   private function getEnabledAbsenceTypes() {
     if(empty($this->absenceTypes)) {
-      $absenceType = new AbsenceType();
-      $absenceType->is_active = 1;
-      $absenceType->find();
-      while($absenceType->fetch()) {
-        $this->absenceTypes[] = clone $absenceType;
-      }
+      $this->absenceTypes = AbsenceType::getEnabledAbsenceTypes();
     }
 
     return $this->absenceTypes;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
@@ -25,6 +25,7 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
 
     $this->assign('period', $absencePeriod);
     $this->assign('calculations', $calculations);
+    $this->assign('enabledAbsenceTypes', $this->getEnabledAbsenceTypes());
 
     CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/hrleaveandabsences.css', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
     CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/hrleaveandabsences.form.manage_entitlements.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
@@ -171,5 +172,14 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
         ['class' => 'overridden-proposed-entitlement']
       );
     }
+  }
+
+  /**
+   * Returns a list of enabled Absence Types
+   *
+   * @return array
+   */
+  private function getEnabledAbsenceTypes() {
+    return CRM_HRLeaveAndAbsences_BAO_AbsenceType::getEnabledAbsenceTypes();
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
@@ -68,6 +68,15 @@
   border-bottom: 1px solid rgba(0, 0, 0, .2);
 }
 
+.entitlement-calculation-filters {
+  text-align: center;
+  padding: 15px 0;
+}
+
+.entitlement-calculation-filters .override-filters label {
+  display: inline-block;
+}
+
 .entitlement-calculation-list .absence-type {
   display: inline-block;
   color: #fff;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
@@ -77,6 +77,14 @@
   display: inline-block;
 }
 
+.entitlement-calculation-filters .absence-type-filter {
+  float: right;
+}
+
+.entitlement-calculation-list tr.hidden {
+  display: none;
+}
+
 .entitlement-calculation-list .absence-type {
   display: inline-block;
   color: #fff;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
@@ -14,10 +14,27 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements = (function($) {
    * @constructor
    */
   function ManageEntitlements() {
+    this._filtersElement = $('.entitlement-calculation-filters');
     this._listElement = $('.entitlement-calculation-list');
+    this._overrideFilter = this.OVERRIDE_FILTER_BOTH;
+    this._setUpOverrideFilters();
     this._instantiateProposedEntitlements();
     this._addEventListeners();
   }
+
+  //Constants for the Override Filter values
+  ManageEntitlements.prototype.OVERRIDE_FILTER_OVERRIDDEN = 1;
+  ManageEntitlements.prototype.OVERRIDE_FILTER_NON_OVERRIDDEN = 2;
+  ManageEntitlements.prototype.OVERRIDE_FILTER_BOTH = 3;
+
+  /**
+   * Transforms the radios of the Override Filter into a jQuery UI button set
+   *
+   * @private
+   */
+  ManageEntitlements.prototype._setUpOverrideFilters = function() {
+    this._filtersElement.find('.override-filters').buttonset();
+  };
 
   /**
    * Creates new ProposedEntitlement instances for every calculation on the list
@@ -36,7 +53,73 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements = (function($) {
    * @private
    */
   ManageEntitlements.prototype._addEventListeners = function() {
+    this._filtersElement.find('.override-filter').on('change', this._onOverrideFilterChange.bind(this));
     this._listElement.find('tbody > tr').on('click', this._onListRowClick.bind(this));
+  };
+
+  /**
+   * This is the event listener for when the value of the Override Filter changes.
+   *
+   * If the new value is different from the previous one, the list is updated to
+   * reflect the option selected.
+   *
+   * @param {Object} event
+   * @private
+   */
+  ManageEntitlements.prototype._onOverrideFilterChange = function(event) {
+    var newOverrideFilterValue = parseInt(event.target.value);
+    if(newOverrideFilterValue != this._overrideFilter) {
+      this._overrideFilter = newOverrideFilterValue;
+      this._updateList();
+    }
+  };
+
+  /**
+   * Updates the entitlements list to reflect the actual filter selection
+   *
+   * @private
+   */
+  ManageEntitlements.prototype._updateList = function() {
+    switch(this._overrideFilter) {
+      case this.OVERRIDE_FILTER_OVERRIDDEN:
+        this._showOnlyOverridden();
+        break;
+      case this.OVERRIDE_FILTER_NON_OVERRIDDEN:
+        this._showOnlyNonOverridden();
+        break;
+      default:
+        this._showOverriddenAndNonOverridden();
+        break;
+    }
+  };
+
+  /**
+   * Makes all the entitlements visible
+   *
+   * @private
+   */
+  ManageEntitlements.prototype._showOverriddenAndNonOverridden = function() {
+    this._listElement.find('tr').show();
+  };
+
+  /**
+   * Makes visible only the entitlements where the proposed entitlement was not overridden
+   *
+   * @private
+   */
+  ManageEntitlements.prototype._showOnlyOverridden = function() {
+    this._showOverriddenAndNonOverridden();
+    this._listElement.find('.proposed-entitlement .override-checkbox:not(:checked)').parents('tr').hide();
+  };
+
+  /**
+   * Makes visible only the entitlements where the proposed entitlement was overridden
+   *
+   * @private
+   */
+  ManageEntitlements.prototype._showOnlyNonOverridden = function() {
+    this._showOverriddenAndNonOverridden();
+    this._listElement.find('.proposed-entitlement .override-checkbox:checked').parents('tr').hide();
   };
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
@@ -1,6 +1,18 @@
 <div class="help">
   <p>&nbsp;{ts}WARNING: Please note that any currently stored annual entitlement allowance for the selected staff member(s) will be overwritten by this process{/ts}</p>
 </div>
+<div class="entitlement-calculation-filters">
+  <div class="override-filters">
+    <input type="radio" id="override-filter-overridden" name="override-filter" class="override-filter" value="1">
+    <label for="override-filter-overridden">Overridden</label>
+
+    <input type="radio" id="override-filter-not-overridden" name="override-filter" class="override-filter" value="2">
+    <label for="override-filter-not-overridden">Not Overridden</label>
+
+    <input type="radio" id="override-filter-both" name="override-filter" class="override-filter" value="3" checked="checked">
+    <label for="override-filter-both">Both</label>
+  </div>
+</div>
 <table class="entitlement-calculation-list">
   <thead>
   <tr>
@@ -37,7 +49,9 @@
           <span class="proposed-value">{$calculation->getProposedEntitlement()}</span>
           {$form.proposed_entitlement[$contract.id][$absenceTypeID].html}
           <button type="button"><i class="fa fa-pencil"></i></button>
-          <label for=""><input type="checkbox"> Override</label>
+          <label for="override_checkbox_{$contract.id}_{$absenceTypeID}">
+            <input id="override_checkbox_{$contract.id}_{$absenceTypeID}" type="checkbox" class="override-checkbox"> Override
+          </label>
         </div>
       </td>
       <td></td>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
@@ -1,16 +1,29 @@
 <div class="help">
   <p>&nbsp;{ts}WARNING: Please note that any currently stored annual entitlement allowance for the selected staff member(s) will be overwritten by this process{/ts}</p>
 </div>
-<div class="entitlement-calculation-filters">
-  <div class="override-filters">
-    <input type="radio" id="override-filter-overridden" name="override-filter" class="override-filter" value="1">
-    <label for="override-filter-overridden">Overridden</label>
+<div class="entitlement-calculation-filters row">
+  <div class="col-sm-4">
+  </div>
+  <div class="col-sm-4">
+    <div class="override-filters">
+      <input type="radio" id="override_filter_overridden" name="override-filter" class="override-filter" value="1">
+      <label for="override_filter_overridden">Overridden</label>
 
-    <input type="radio" id="override-filter-not-overridden" name="override-filter" class="override-filter" value="2">
-    <label for="override-filter-not-overridden">Not Overridden</label>
+      <input type="radio" id="override_filter_not_overridden" name="override-filter" class="override-filter" value="2">
+      <label for="override_filter_not_overridden">Not Overridden</label>
 
-    <input type="radio" id="override-filter-both" name="override-filter" class="override-filter" value="3" checked="checked">
-    <label for="override-filter-both">Both</label>
+      <input type="radio" id="override_filter_both" name="override-filter" class="override-filter" value="3" checked="checked">
+      <label for="override_filter_both">Both</label>
+    </div>
+  </div>
+  <div class="col-sm-4">
+    <div class="absence-type-filter">
+      <select name="absence-type-filter" id="absence_type_filter" class="crm-select2" multiple="multiple" data-placeholder="{ts}Leave Type{/ts}">
+        {foreach from=$enabledAbsenceTypes item=absenceType}
+          <option value="{$absenceType->id}">{$absenceType->title}</option>
+        {/foreach}
+      </select>
+    </div>
   </div>
 </div>
 <table class="entitlement-calculation-list">
@@ -34,7 +47,7 @@
     {assign var=absenceType value=$calculation->getAbsenceType()}
     {assign var=absenceTypeID value=$absenceType->id}
     {assign var=contract value=$calculation->getContract()}
-    <tr data-calculation-details="{$calculation}">
+    <tr data-calculation-details="{$calculation}" data-absence-type="{$absenceTypeID}">
       <td>{$contract.contact_id}</td>
       <td>{$contract.contact_display_name}</td>
       <td><span class="absence-type" style="background-color: {$absenceType->color};">{$absenceType->title}</span></td>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -245,6 +245,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends PHPUnit_Framework_TestC
   }
 
   public function testShouldHaveAllTheColorsAvailableIfTheresNotTypeCreated() {
+    $this->deleteAllAbsenceTypes();
     $availableColors = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getAvailableColors();
     foreach($this->allColors as $color) {
       $this->assertContains($color, $availableColors);
@@ -252,6 +253,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends PHPUnit_Framework_TestC
   }
 
   public function testShouldNotAllowColorToBeReusedUntilAllColorsHaveBeenUsed() {
+    $this->deleteAllAbsenceTypes();
     $usedColors = [];
     $numberOfColors = count($this->allColors);
     for($i = 0; $i < $numberOfColors; $i++) {
@@ -455,5 +457,9 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends PHPUnit_Framework_TestC
     }
 
     return null;
+  }
+
+  private function deleteAllAbsenceTypes() {
+    CRM_Core_DAO::executeQuery('DELETE FROM civicrm_hrleaveandabsences_absence_type');
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -361,6 +361,40 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends PHPUnit_Framework_TestC
     $this->assertNull($absenceType->carryForwardNeverExpires());
   }
 
+  public function testGetEnabledAbsenceTypesShouldReturnAListOfEnabledAbsenceTypesOrderedByWeight()
+  {
+    $this->deleteAllAbsenceTypes();
+    $absenceType1 = $this->createBasicType();
+    $absenceType2 = $this->createBasicType();
+    $absenceType3 = $this->createBasicType();
+
+    // Let's change the types order
+    $absenceType2 = $this->updateBasicType($absenceType2->id, ['weight' => 1]);
+    $absenceType3 = $this->updateBasicType($absenceType3->id, ['weight' => 2]);
+    $absenceType1 = $this->updateBasicType($absenceType1->id, ['weight' => 3]);
+
+    $absenceTypes = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getEnabledAbsenceTypes();
+    $this->assertCount(3, $absenceTypes);
+
+    $this->assertEquals($absenceType2->id, $absenceTypes[0]->id);
+    $this->assertEquals($absenceType2->title, $absenceTypes[0]->title);
+
+    $this->assertEquals($absenceType3->id, $absenceTypes[1]->id);
+    $this->assertEquals($absenceType3->title, $absenceTypes[1]->title);
+
+    $this->assertEquals($absenceType1->id, $absenceTypes[2]->id);
+    $this->assertEquals($absenceType1->title, $absenceTypes[2]->title);
+  }
+
+  public function testGetEnabledAbsenceTypesShouldNotIncludeDisabledTypes() {
+    $this->deleteAllAbsenceTypes();
+    $this->createBasicType(['is_active' => 1]);
+    $this->createBasicType(['is_active' => 0]);
+
+    $absenceTypes = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getEnabledAbsenceTypes();
+    $this->assertCount(1, $absenceTypes);
+  }
+
   private function createBasicType($params = array()) {
     $basicRequiredFields = [
         'title' => 'Type ' . microtime(),


### PR DESCRIPTION
Two filters were added to the entitlement calculation list:

### Override filter
This filter allows the user to select if they want to see only overridden entitlements, only non overridden or both:
![override_filter](https://cloud.githubusercontent.com/assets/388373/16271549/d1b6aab4-3870-11e6-9389-d1a217d5c5db.gif)

### Absence Type filter
This filter allows the user to select which absence types they want to see the entitlements for:
![absence_type_filter](https://cloud.githubusercontent.com/assets/388373/16271618/1d364e68-3871-11e6-95b0-a8d7f9f651aa.gif)
