### PR TITLE
PCHR-1088: Add the "Export to CSV" action to the Entitlement Calculations page

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
@@ -78,7 +78,12 @@
 }
 
 .entitlement-calculation-filters .absence-type-filter {
-  float: right;
+  display: inline;
+  margin-right: 10px;
+}
+
+.entitlement-calculation-filters .col-sm-4:last-child {
+  text-align: right;
 }
 
 .entitlement-calculation-list tr.hidden {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
@@ -16,6 +16,7 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements = (function($) {
   function ManageEntitlements() {
     this._filtersElement = $('.entitlement-calculation-filters');
     this._listElement = $('.entitlement-calculation-list');
+    this._formElement = $('.CRM_HRLeaveAndAbsences_Form_ManageEntitlements');
     this._overrideFilter = this.OVERRIDE_FILTER_BOTH;
     this._absenceTypeFilter = [];
     this._setUpOverrideFilters();
@@ -56,6 +57,7 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements = (function($) {
   ManageEntitlements.prototype._addEventListeners = function() {
     this._filtersElement.find('.override-filter').on('change', this._onOverrideFilterChange.bind(this));
     this._filtersElement.find('.absence-type-filter select').on('change', this._onAbsenceTypeFilterChange.bind(this));
+    this._filtersElement.find('.export-csv-action').on('click', this._onExportCSVClick.bind(this));
     this._listElement.find('tbody > tr').on('click', this._onListRowClick.bind(this));
   };
 
@@ -203,6 +205,27 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements = (function($) {
       width: '70%',
       options: {}
     });
+  };
+
+  /**
+   * This is the event handler for when the user clicks on the "Export to CSV"
+   * link.
+   *
+   * The CSV is basically the entitlement calculation page in a CSV format, so
+   * we get it by submitting the form with a "export_csv" flag set. Another
+   * reason for getting the CSV by submitting the form is that, this way, we
+   * can get any entitlement that was overridden and include it in the exported
+   * file.
+   *
+   * @param event
+   * @private
+   */
+  ManageEntitlements.prototype._onExportCSVClick = function(event) {
+    event.preventDefault();
+
+    this._formElement.find('#export_csv').val(1); //set the export csv flag
+    this._formElement.submit();
+    this._formElement.find('#export_csv').val(''); //resets the export csv flag
   };
 
   return ManageEntitlements;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
@@ -1,6 +1,16 @@
 <div class="help">
   <p>&nbsp;{ts}WARNING: Please note that any currently stored annual entitlement allowance for the selected staff member(s) will be overwritten by this process{/ts}</p>
 </div>
+
+{* These hidden fields are used when we submit the form to export the CSV file *}
+{* The id is used so we know from which period we are exporting the CSV *}
+{* The cid is used so can export calculations only for the specified contracts *}
+<input type="hidden" name="export_csv" id="export_csv" value="0">
+<input type="hidden" name="id" id="period_id" value="{$period->id}">
+{foreach from=$contractsIDs item=id}
+  <input type="hidden" name="cid[]" value="{$id}">
+{/foreach}
+
 <div class="entitlement-calculation-filters row">
   <div class="col-sm-4">
   </div>
@@ -24,6 +34,7 @@
         {/foreach}
       </select>
     </div>
+    <a href="{crmURL q="id=`$period->id`&csv=1&reset=1"}" class="export-csv-action">{ts}Export to CSV{/ts}</a>
   </div>
 </div>
 <table class="entitlement-calculation-list">


### PR DESCRIPTION
This is a link at the top right side of the entitlement calculations list and, when clicked,
exports a CSV file with exactly the same information displayed on the screen.

As we need to export the data on the screen, even if the user has overridden some of
the entitlements, the file is generated by submitting the form so we can include the proper
values in the file.

This is where the link is located:
![captura_de_tela_2016-06-23_as_16_17_45](https://cloud.githubusercontent.com/assets/388373/16316734/321e7ce0-395e-11e6-805e-e5ceffb5b6c9.png)

And this is how the CSV file looks like:
![captura de tela 2016-06-23 as 16 21 01](https://cloud.githubusercontent.com/assets/388373/16316813/83552276-395e-11e6-99a7-7a7b50202cec.png)


