### PR TITLE
PCHR-1089: Add the "Copy to All" and "Add 1 Day" buttons

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
@@ -34,6 +34,8 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
     $this->assign('enabledAbsenceTypes', $this->getEnabledAbsenceTypes());
 
     CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/hrleaveandabsences.css', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
+    CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/inputmask.min.js');
+    CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/inputmask.numeric.extensions.min.js');
     CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/hrleaveandabsences.form.manage_entitlements.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
     parent::buildQuickForm();
   }
@@ -172,7 +174,10 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
         'text',
         $fieldName,
         '',
-        ['class' => 'overridden-proposed-entitlement']
+        [
+          'class' => 'overridden-proposed-entitlement',
+          'maxlength' => 4
+        ]
       );
     }
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
@@ -86,6 +86,15 @@
   text-align: right;
 }
 
+.entitlement-calculation-list .proposed-entitlement-header .title {
+  width: 65%;
+  float: left;
+}
+
+.entitlement-calculation-list .proposed-entitlement-header .actions {
+  float: right;
+}
+
 .entitlement-calculation-list tr.hidden {
   display: none;
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
@@ -107,7 +107,7 @@
 
 .entitlement-calculation-list .proposed-entitlement .overridden-proposed-entitlement {
   display: none;
-  width: 20px;
+  width: 24px;
 }
 
 .entitlement-calculation-list .proposed-entitlement button {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
@@ -287,6 +287,7 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements.ProposedEntitlement = (functio
     this._overrideCheckbox = element.find('input[type="checkbox"]');
     this._overrideField = element.find('input[type="text"]');
     this._proposedValue = element.find('.proposed-value');
+    this._setupOverrideFieldMask();
     this._addEventListeners();
   }
 
@@ -343,6 +344,15 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements.ProposedEntitlement = (functio
     }
 
     return currentValue;
+  };
+
+  ProposedEntitlement.prototype._setupOverrideFieldMask = function() {
+    var mask = Inputmask({
+      'alias': 'decimal',
+      'rightAlign': false
+    });
+
+    mask.mask(this._overrideField);
   };
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
@@ -19,6 +19,7 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements = (function($) {
     this._formElement = $('.CRM_HRLeaveAndAbsences_Form_ManageEntitlements');
     this._overrideFilter = this.OVERRIDE_FILTER_BOTH;
     this._absenceTypeFilter = [];
+    this._proposedEntitlements = [];
     this._setUpOverrideFilters();
     this._instantiateProposedEntitlements();
     this._addEventListeners();
@@ -44,8 +45,11 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements = (function($) {
    * @private
    */
   ManageEntitlements.prototype._instantiateProposedEntitlements = function() {
+    var that = this;
     this._listElement.find('.proposed-entitlement').each(function(i, element) {
-      new CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements.ProposedEntitlement($(element));
+      that._proposedEntitlements.push(
+        new CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements.ProposedEntitlement($(element))
+      );
     });
   };
 
@@ -58,6 +62,8 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements = (function($) {
     this._filtersElement.find('.override-filter').on('change', this._onOverrideFilterChange.bind(this));
     this._filtersElement.find('.absence-type-filter select').on('change', this._onAbsenceTypeFilterChange.bind(this));
     this._filtersElement.find('.export-csv-action').on('click', this._onExportCSVClick.bind(this));
+    this._listElement.find('thead .proposed-entitlement-header .add-one-day').on('click', this._onAddOneDayClick.bind(this));
+    this._listElement.find('thead .proposed-entitlement-header .copy-to-all').on('click', this._onCopyToAllClick.bind(this));
     this._listElement.find('tbody > tr').on('click', this._onListRowClick.bind(this));
   };
 
@@ -228,6 +234,37 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements = (function($) {
     this._formElement.find('#export_csv').val(''); //resets the export csv flag
   };
 
+  /**
+   * This is the event handler for when the user clicks on the "Add one day" button,
+   * on the "New Proposed Entitlement" header.
+   *
+   * It loops through all the Proposed Entitlements, and overrides them adding one
+   * more day to its current value.
+   *
+   * @private
+   */
+  ManageEntitlements.prototype._onAddOneDayClick = function() {
+    this._proposedEntitlements.forEach(function(proposedEntitlement) {
+      proposedEntitlement.addOneDay();
+    });
+  };
+
+  /**
+   * This is the event handler for when the user clicks on the "Copy to All" button,
+   * on the "New Proposed Entitlement" header.
+   *
+   * It gets the value of the proposed entitlement on the first row and then loops
+   * through all the Proposed Entitlements setting them to this value.
+   *
+   * @private
+   */
+  ManageEntitlements.prototype._onCopyToAllClick = function() {
+    var firsEntitlementValue = this._proposedEntitlements[0].getCurrentValue();
+    this._proposedEntitlements.forEach(function(proposedEntitlement) {
+      proposedEntitlement.setValue(firsEntitlementValue);
+    });
+  };
+
   return ManageEntitlements;
 
 })($);
@@ -252,6 +289,61 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements.ProposedEntitlement = (functio
     this._proposedValue = element.find('.proposed-value');
     this._addEventListeners();
   }
+
+  /**
+   * Sets the proposed entitlement value to the one given.
+   *
+   * If this proposed entitlement is not overridden, it will be
+   * marked as so.
+   *
+   * @param {float} newValue
+   */
+  ProposedEntitlement.prototype.setValue = function(newValue) {
+    if(!this._isOverridden) {
+      this._makeEntitlementEditable();
+    }
+
+    this._overrideField.val(newValue);
+  };
+
+  /**
+   * Adds one day to the current Proposed Entitlement value.
+   *
+   * If this proposed entitlement is not overridden, it will be
+   * marked as so.
+   */
+  ProposedEntitlement.prototype.addOneDay = function() {
+    var currentEntitlement = this.getCurrentValue();
+    this.setValue(currentEntitlement + 1);
+  };
+
+  /**
+   * Returns the current value of this Proposed Entitlement.
+   *
+   * If it has been overridden, the overridden value will be returned,
+   * otherwise the original value will be returned.
+   *
+   * If the overridden value is an invalid number, 0 will be returned.
+   *
+   * @returns {float}
+   */
+  ProposedEntitlement.prototype.getCurrentValue = function() {
+    var currentValue;
+
+    if(this._isOverridden) {
+      currentValue = this._overrideField.val();
+    } else {
+      currentValue = this._proposedValue.text();
+    }
+
+    currentValue = parseFloat(currentValue);
+
+    if(isNaN(currentValue)) {
+      currentValue = 0;
+    }
+
+    return currentValue;
+  };
 
   /**
    * Add event listeners to the override button and the checkbox
@@ -308,6 +400,7 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements.ProposedEntitlement = (functio
       .show()
       .focus();
     this._overrideCheckbox.prop('checked', true);
+    this._isOverridden = true;
   };
 
   /**
@@ -323,6 +416,7 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements.ProposedEntitlement = (functio
       .val('')
       .hide();
     this._overrideCheckbox.prop('checked', false);
+    this._isOverridden = false;
   };
 
   return ProposedEntitlement;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
@@ -49,7 +49,17 @@
     <th>{ts}Brought Forward from previous period{/ts}</th>
     <th>{ts}Current Contractual Entitlement{/ts}</th>
     <th>{ts}New Period Pro rata{/ts}</th>
-    <th>{ts}New Proposed Period Entitlement{/ts}</th>
+    <th class="proposed-entitlement-header">
+      <div class="title">{ts}New Proposed Period Entitlement{/ts}</div>
+      <div class="actions">
+        <button type="button" class="add-one-day" title="{ts}Add an extra day to all contacts listed{/ts}">
+          <i class="fa fa-plus-square"></i>
+        </button>
+        <button type="button" class="copy-to-all" title="{ts}Copy the new proposed entitlement from top row to all others{/ts}">
+          <i class="fa fa-copy"></i>
+        </button>
+      </div>
+    </th>
     <th>{ts}Comment{/ts}</th>
   </tr>
   </thead>


### PR DESCRIPTION
These buttons are inside the "New Proposed Entitlement" header, and work as follow:

**Add 1 Day button**: Adds an extra day to every entitlement on the list and marks the
entitlement as overridden.

![add_1_day](https://cloud.githubusercontent.com/assets/388373/16345930/eab1b724-3a1a-11e6-9f6d-629a10c70eec.gif)

**Copy to All**: Copy the value of the first proposed entitlement on the list to all others and
marks the entitlements as overriden.

![copy_to_all](https://cloud.githubusercontent.com/assets/388373/16345932/f1904baa-3a1a-11e6-92df-0cf6ed432070.gif)
