### PR TITLE
PCHR-875: Fix contract's start date validation

### DIFF
--- a/com.civicrm.hrjobroles/js/src/job-roles/services/date-validation.js
+++ b/com.civicrm.hrjobroles/js/src/job-roles/services/date-validation.js
@@ -119,6 +119,7 @@ define([
 
                 checkIfValuesAreValid(start, ['start_date']);
                 checkIfStartIsLowerThanContractEnd(start, contractEnd);
+                checkIfStartIsLowerThanContractStart(start, contractStart);
 
                 if (end === 0 || end) {
                   end = formatDate(end, this.dateFormats);
@@ -127,7 +128,6 @@ define([
                   checkIfEndIsEqualOrLowerThanContractEnd(end, contractEnd);
 
                   checkIfStartDateIsLower(start, end);
-                  checkIfStartIsLowerThanContractStart(start, contractStart);
                 }
             }
         };

--- a/com.civicrm.hrjobroles/js/test/controllers/hr-job-roles-controller/hr-job-roles-controller_test.js
+++ b/com.civicrm.hrjobroles/js/test/controllers/hr-job-roles-controller/hr-job-roles-controller_test.js
@@ -142,7 +142,7 @@ define([
                 });
 
                 it('should pass validation dd/mm/yyyy', function(){
-                    form_data.start_date.$viewValue = '31/12/2015';
+                    form_data.start_date.$viewValue = '31/12/2016';
 
                     expect(scope.validateRole(form_data)).toBe(true);
                 });
@@ -154,7 +154,7 @@ define([
                 });
 
                 it('should pass validation new Date()', function(){
-                    form_data.start_date.$viewValue = '2005-05-05';
+                    form_data.start_date.$viewValue = '2016-05-05';
 
                     expect(scope.validateRole(form_data)).toBe(true);
                 });
@@ -163,6 +163,17 @@ define([
                     beforeEach(function () {
                         form_data.start_date.$viewValue = '2016-05-04';
                         form_data.end_date.$viewValue = '2017-05-05';
+                    });
+
+                    it('throws a validation error', function () {
+                        expect(scope.validateRole(form_data)).not.toBe(true);
+                    });
+                });
+
+                describe('when job role start date is lower than contract start date and doesn\'t inform end_date', function () {
+                    beforeEach(function () {
+                        form_data.start_date.$viewValue = '2016-01-01';
+                        form_data.contract.$viewValue = '2';
                     });
 
                     it('throws a validation error', function () {


### PR DESCRIPTION
When wasn't informed the contract's end date it wasn't validated if the start date is lower than the contract's start date, the solution was remove the `checkIfStartIsLowerThanContractStart` method from the end's statement.

**Before**
![pchr-875-before](https://cloud.githubusercontent.com/assets/1280255/16382752/8764a6d2-3c58-11e6-804e-99b0d525bc2e.gif)

**After**
![pchr-875-after](https://cloud.githubusercontent.com/assets/1280255/16382758/8ab5c7b2-3c58-11e6-840b-71aabb138239.gif)