### PR TITLE
PCHR-1090: Add a dialog box to allow the user to add/edit an entitlement comment

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
@@ -21,7 +21,7 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
 
     $calculations = $this->getEntitlementCalculations($absencePeriod);
 
-    $this->addProposedEntitlementsFields($calculations);
+    $this->addProposedEntitlementAndCommentFields($calculations);
 
     $exportCSV = CRM_Utils_Request::retrieve('export_csv', 'Integer');
     if($exportCSV) {
@@ -151,20 +151,21 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
   }
 
   /**
-   * Adds the Proposed Entitlements fields to this form.
+   * Adds the Proposed Entitlements and the Comments fields to this form.
    *
-   * These fields are hidden by default, and are visible only if the user chose
-   * to override the calculated proposed entitlement.
+   * These fields are hidden by default. The Proposed Entitlement field is
+   * visible only if the user chose to override the calculated proposed
+   * entitlement.
    *
-   * As this is a list of calculations, the field name contains the contract id
+   * As this is a list of calculations, the field names contains the contract id
    * and the absence type id, in order to make it possible to related the fields
    * to the right calculation.
    *
    * @param $calculations
    */
-  private function addProposedEntitlementsFields($calculations) {
+  private function addProposedEntitlementAndCommentFields($calculations) {
     foreach($calculations as $calculation) {
-      $fieldName = sprintf(
+      $proposedEntitlementFieldName = sprintf(
         'proposed_entitlement[%d][%d]',
         $calculation->getContract()['id'],
         $calculation->getAbsenceType()->id
@@ -172,12 +173,24 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
 
       $this->add(
         'text',
-        $fieldName,
+        $proposedEntitlementFieldName,
         '',
         [
           'class' => 'overridden-proposed-entitlement',
           'maxlength' => 4
         ]
+      );
+
+      $commentFieldName = sprintf(
+        'comment[%d][%d]',
+        $calculation->getContract()['id'],
+        $calculation->getAbsenceType()->id
+      );
+      $this->add(
+        'textarea',
+        $commentFieldName,
+        '',
+        ['class' => 'comment-text']
       );
     }
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
@@ -110,7 +110,26 @@
   width: 24px;
 }
 
-.entitlement-calculation-list .proposed-entitlement button {
+.entitlement-calculation-list .borderless-button {
   border: 0;
   background-color: transparent;
+  cursor: pointer;
+}
+
+.entitlement-calculation-list .add-comment {
+  font-size: 1.1em;
+}
+
+.entitlement-calculation-list .comment-text {
+  display: none;
+}
+
+#add-comment-dialog {
+  display: none;
+}
+
+#add-comment-dialog .calculation_comment {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 10px;
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
@@ -22,6 +22,7 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements = (function($) {
     this._proposedEntitlements = [];
     this._setUpOverrideFilters();
     this._instantiateProposedEntitlements();
+    this._instantiateComments();
     this._addEventListeners();
   }
 
@@ -54,6 +55,17 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements = (function($) {
   };
 
   /**
+   * Creates new Comment instances for every calculation on the list
+   *
+   * @private
+   */
+  ManageEntitlements.prototype._instantiateComments = function() {
+    this._listElement.find('td.comment').each(function(i, element) {
+      new CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements.Comment($(element))
+    });
+  };
+
+  /**
    * Add event listeners to events triggered by elements of managed by this class
    *
    * @private
@@ -64,7 +76,7 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements = (function($) {
     this._filtersElement.find('.export-csv-action').on('click', this._onExportCSVClick.bind(this));
     this._listElement.find('thead .proposed-entitlement-header .add-one-day').on('click', this._onAddOneDayClick.bind(this));
     this._listElement.find('thead .proposed-entitlement-header .copy-to-all').on('click', this._onCopyToAllClick.bind(this));
-    this._listElement.find('tbody > tr').on('click', this._onListRowClick.bind(this));
+    this._listElement.find('tbody tr td').on('click', this._onListRowClick.bind(this));
   };
 
   /**
@@ -187,9 +199,10 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements = (function($) {
    * @private
    */
   ManageEntitlements.prototype._onListRowClick = function(event) {
-    // If the user clicked on one of the override proposed entitlement
-    // controls, we don't show the calculationDescription
-    if($(event.target).parents('.proposed-entitlement').length > 0) {
+    // If the user clicked to override and entitlement or to add a comment,
+    // we don't show the calculationDescription
+    if($(event.currentTarget).hasClass('proposed-entitlement') ||
+      $(event.currentTarget).hasClass('comment')) {
       return;
     }
 
@@ -199,7 +212,7 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements = (function($) {
       '(No. of working days to work / No. of working days in period)) = ' +
       '(Period pro rata) + (Brought Forward days) = Period Entitlement'
     );
-    var calculationDetails = event.currentTarget.dataset.calculationDetails;
+    var calculationDetails = event.currentTarget.parentNode.dataset.calculationDetails;
 
     if(!calculationDetails) {
       return;
@@ -430,4 +443,169 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements.ProposedEntitlement = (functio
   };
 
   return ProposedEntitlement;
+})($);
+
+/**
+ * This class encapsulates all the logic to add/edit comments to an entitlement.
+ *
+ * It displays the "Add/Edit comment" dialog when the user clicks on the comment action
+ * button and updates the entitlement comment in case the user add or edit it.
+ *
+ */
+CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements.Comment = (function($) {
+
+  /**
+   * Creates a new Comment instance
+   * @param {Object} commentElement - A jQuery object of the TD wrapping the comment field and button
+   * @constructor
+   */
+  function Comment(commentElement) {
+    this._commentElement = commentElement;
+    this._addCommentButton = this._commentElement.find('.add-comment');
+    this._commentTextarea = this._commentElement.find('.comment-text');
+    this._addEventListeners();
+  }
+
+  /**
+   * Attach handlers to events listened by this object
+   *
+   * @private
+   */
+  Comment.prototype._addEventListeners = function() {
+    this._addCommentButton.on('click', this._onAddCommentClick.bind(this));
+  };
+
+  /**
+   * This is the event handler for when the add comment button is clicked.
+   *
+   * It will display the dialog box and updates the entitlement's comment if
+   * the user saved the changes made.
+   *
+   * @private
+   */
+  Comment.prototype._onAddCommentClick = function() {
+    CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements.CommentDialog.show(
+      this._getCurrentValue(),
+      function(comment) {
+        this._setCurrentValue(comment);
+      }.bind(this)
+    );
+  };
+
+  /**
+   * Returns this comment current value
+   *
+   * @returns {String}
+   * @private
+   */
+  Comment.prototype._getCurrentValue = function() {
+    return this._commentTextarea.val();
+  };
+
+  /**
+   * Sets the current value for this comment
+   *
+   * @param comment
+   * @private
+   */
+  Comment.prototype._setCurrentValue = function(comment) {
+    this._commentTextarea.val(comment);
+  };
+
+  return Comment;
+})($);
+
+/**
+ * This Object wraps the logic to create and display the "Add Comment" dialog.
+ *
+ * As there's a single dialog that can be used to add/edit comments for every
+ * entitlement, we don't have a constructor function here. We only return a
+ * plain object with a single method name "show", that can be used to show the
+ * dialog to user, with the given comment.
+ */
+CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements.CommentDialog = (function($) {
+
+  var dialogSelector = '#add-comment-dialog';
+  var textAreaSelector = dialogSelector + ' .calculation_comment';
+
+  /**
+   * Erases the value of the dialog's textarea
+   */
+  function eraseCommentInDialog() {
+    $(textAreaSelector).val('');
+  }
+
+  /**
+   * Closes the dialog
+   */
+  function closeDialog() {
+    $(dialogSelector).dialog("close");
+  }
+
+  /**
+   * Returns the comment entered in the dialog's textarea
+   *
+   * @returns {String}
+   */
+  function getCommentInDialog() {
+    return $(textAreaSelector).val();
+  }
+
+  /**
+   * Sets the given comment as the value of the dialog's textarea
+   *
+   * @param {String} comment
+   */
+  function setCommentInDialog(comment) {
+    $(textAreaSelector).val(comment)
+  }
+
+  /**
+   * Shows the dialog to the user.
+   *
+   * The given callback will be called if the user closes the dialog
+   * by clicking on the "Save" button. The current comment in the
+   * dialog textarea will be passed as an argument to the callback.
+   *
+   * @param {Function} callback
+   */
+  function showDialog(callback) {
+    $('#add-comment-dialog').dialog({
+      'width': '500px',
+      'close': eraseCommentInDialog,
+      buttons: [
+        {
+          text: ts('Cancel'),
+          click: closeDialog
+        },
+        {
+          text: ts('Save'),
+          click: function () {
+            callback(getCommentInDialog());
+            closeDialog();
+          }
+        }
+      ]
+    });
+  }
+
+  return {
+    /**
+     * Shows the dialog to the user.
+     *
+     * The given comment will be displayed in the dialog's textarea.
+     *
+     * The given callback will be called if the user closes the dialog
+     * by clicking on the "Save" button. The current comment in the
+     * dialog textarea will be passed as an argument to the callback.
+     *
+     * @param {String} comment
+     * @param {Function} callback
+     */
+    show: function(comment, callback) {
+      setCommentInDialog(comment);
+      showDialog(callback);
+    }
+  };
+
 })($);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
@@ -78,21 +78,26 @@
       <td>{$calculation->getBroughtForward()}</td>
       <td>{$calculation->getContractualEntitlement()}</td>
       <td>{$calculation->getProRata()}</td>
-      <td>
-        <div class="proposed-entitlement">
+      <td class="proposed-entitlement">
           <span class="proposed-value">{$calculation->getProposedEntitlement()}</span>
           {$form.proposed_entitlement[$contract.id][$absenceTypeID].html}
-          <button type="button"><i class="fa fa-pencil"></i></button>
+          <button type="button" class="borderless-button"><i class="fa fa-pencil"></i></button>
           <label for="override_checkbox_{$contract.id}_{$absenceTypeID}">
             <input id="override_checkbox_{$contract.id}_{$absenceTypeID}" type="checkbox" class="override-checkbox"> Override
           </label>
-        </div>
       </td>
-      <td></td>
+      <td class="comment">
+        {$form.comment[$contract.id][$absenceTypeID].html}
+        <button type="button" class="borderless-button add-comment"><i class="fa fa-share-square-o"></i></button>
+      </td>
     </tr>
   {/foreach}
   </tbody>
 </table>
+<div id="add-comment-dialog" title="{ts}Add/Edit comment{/ts}">
+  <p>{ts}You can leave a comment as a record of your calculation for the leave entitlement for this period. Comments are then shown as tooltips on the leave entitlement on the contact record for administrators to refer back to.{/ts}</p>
+  <textarea name="calculation_comment" class="calculation_comment" cols="30" rows="10"></textarea>
+</div>
 <script type="text/javascript">
   {literal}
   CRM.$(function($) {


### PR DESCRIPTION
There's a new action available on the "Comment" column of the entitlement
calculations list. By clicking it, the user is presented with a dialog box where they
can add/edit a comment to describe the the how that entitlement calculation was made.

Here is how it works:
![comment_dialog](https://cloud.githubusercontent.com/assets/388373/16393886/e6f0f378-3c88-11e6-9c0c-67c892c22207.gif)
