### PR TITLE
PCHR-1105: Fix $compile "non-assignable expression" errors for calendars

### DIFF
--- a/com.civicrm.hrjobroles/views/include/job_role_panel.html
+++ b/com.civicrm.hrjobroles/views/include/job_role_panel.html
@@ -106,7 +106,7 @@
                                                         <input type="text" class="form-control" id="{{prefix}}start_date"
                                                           placeholder="{{format}}"
                                                           name="start_date"
-                                                          is-open="!!(CalendarShow.start_date)"
+                                                          is-open="CalendarShow.start_date"
                                                           uib-datepicker-popup
                                                           ng-model="edit_data[job_roles_data.id]['start_date']"
                                                           ng-change="select('start_date')"
@@ -135,7 +135,7 @@
                                                         <input type="text" class="form-control" id="{{prefix}}end_date"
                                                           placeholder="{{format}}"
                                                           name="end_date"
-                                                          is-open="!!(CalendarShow.end_date)"
+                                                          is-open="CalendarShow.end_date"
                                                           uib-datepicker-popup
                                                           ng-model="edit_data[job_roles_data.id]['end_date']"
                                                           ng-change="select('end_date')"


### PR DESCRIPTION
### Problem
The is-open attribute on the calendar directives of the "edit role" panel had a value set to an expression (`is-open="!!(CalendarShow.start_date)"`), that caused a [non-assignable expression](https://docs.angularjs.org/error/$compile/nonassign?p0=isOpen(%27start_date%27)&p1=isOpen&p2=uibDatepickerPopup) error.

### Solution
Simply assigning the value of the `CalendarShow.{x}` property  instead of the "force to bool" expression solved the problem