### PR TITLE
PCHR-1114: Add the "Manage entitlements" action to the Absence Periods list

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
@@ -42,6 +42,7 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
       $this->exportCSV();
     }
 
+    $this->addButtons($this->getAvailableButtons());
     $this->assign('period', $this->absencePeriod);
     $this->assign('contractsIDs', $this->getContractsIDsFromRequest());
     $this->assign('calculations', $this->calculations);
@@ -322,5 +323,23 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
 
     CRM_Core_Report_Excel::writeCSVFile('entitlement_calculations', $headers, $rows);
     CRM_Utils_System::civiExit();
+  }
+
+  /**
+   * Get the list of action buttons available to this form
+   *
+   * @return array
+   */
+  private function getAvailableButtons() {
+    $buttons = [
+      [
+        'type'      => 'next',
+        'class'     => 'save-new-entitlements-button',
+        'name'      => ts('Save new entitlements'),
+        'isDefault' => TRUE
+      ],
+    ];
+
+    return $buttons;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
@@ -30,6 +30,7 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
    * {@inheritdoc}
    */
   public function buildQuickForm() {
+    $this->setReturnUrl();
     $this->absencePeriod = $this->getAbsencePeriodFromRequest();
     $this->setFormPageTitle($this->absencePeriod);
 
@@ -74,12 +75,18 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
 
     CRM_Core_Session::setStatus(ts('Entitlements successfully updated'), 'Success', 'success');
 
-    $contractsIDs = $this->getContractsIDsFromRequest();
-    $url = CRM_Utils_System::url(
-      'civicrm/admin/leaveandabsences/periods/manage_entitlements',
-      'reset=1&id='.$this->absencePeriod->id . '&' . http_build_query(['cid' => $contractsIDs])
-    );
     $session = CRM_Core_Session::singleton();
+    $url =  $session->get('ManageEntitlementsReturnUrl');
+    //We won't need this value anymore, so let's remove it from the session
+    $session->set('ManageEntitlementsReturnUrl', null);
+
+    if(!$url) {
+      $contractsIDs = $this->getContractsIDsFromRequest();
+      $url = CRM_Utils_System::url(
+        'civicrm/admin/leaveandabsences/periods/manage_entitlements',
+        'reset=1&id='.$this->absencePeriod->id . '&' . http_build_query(['cid' => $contractsIDs])
+      );
+    }
     $session->replaceUserContext($url);
   }
 
@@ -341,5 +348,39 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
     ];
 
     return $buttons;
+  }
+
+  /**
+   * To be able to return to the URL the user was before comming to this form,
+   * we store the Referer in the session.
+   *
+   */
+  private function setReturnUrl() {
+    $session = CRM_Core_Session::singleton();
+    $referer = CRM_Utils_System::refererPath();
+    $vars = [];
+    parse_str(parse_url($referer, PHP_URL_QUERY), $vars);
+    if(!empty($vars['q']) && $this->isValidReturnPath($vars['q'])) {
+      $q = $vars['q'];
+      unset($vars['q']);
+      $url = CRM_Utils_System::url($q, http_build_query($vars));
+      $session->set('ManageEntitlementsReturnUrl', $url);
+    }
+  }
+
+  /**
+   * Checks if the given path is valid to be used as part of the return URL.
+   *
+   * A path is valid to be used as a return URL if it is a CiviCRM path (that
+   * is, the q parameter starts with "civicrm/") and is different from the form
+   * path.
+   *
+   * @param string $path
+   *
+   * @return bool
+   */
+  private function isValidReturnPath($path) {
+    return strpos($path, 'civicrm/') === 0 &&
+           $path != 'civicrm/admin/leaveandabsences/periods/manage_entitlements';
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.php
@@ -47,6 +47,7 @@ class CRM_HRLeaveAndAbsences_Page_AbsencePeriod extends CRM_Core_Page_Basic {
     CRM_Utils_Weight::addOrder($rows, 'CRM_HRLeaveAndAbsences_DAO_AbsencePeriod', 'id', $returnURL);
 
     CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/hrleaveandabsences.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
+    CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/hrleaveandabsences.list.absenceperiod.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
 
     $this->assign('rows', $rows);
   }
@@ -79,6 +80,13 @@ class CRM_HRLeaveAndAbsences_Page_AbsencePeriod extends CRM_Core_Page_Basic {
           'name'  => ts('Delete'),
           'class' => 'civihr-delete',
           'title' => ts('Delete Absence Period'),
+        ],
+        CRM_Core_Action::BASIC => [
+          'name'  => ts('Manage Entitlements'),
+          'url'   => 'civicrm/admin/leaveandabsences/periods/manage_entitlements',
+          'qs'    => 'id=%%id%%&reset=1',
+          'class' => 'civihr-manage-entitlements',
+          'title' => ts('Manage entitlements for this Absence Period'),
         ]
       ];
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
@@ -134,6 +134,6 @@
   padding: 10px;
 }
 
-.save-new-entitlements-button {
-  float: right;
+.crm-container .CRM_HRLeaveAndAbsences_Form_ManageEntitlements .crm-button-type-next  {
+  float: right !important;
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.js
@@ -119,6 +119,7 @@ CRM.HRLeaveAndAbsencesApp.ListPage.Action = (function() {
      * @constructor
      */
     function Action(target, title, confirmationMessage, successMessage) {
+        this._target = target;
         this._listRow = target.closest('.crm-entity');
         this._entity = target.crmEditableEntity();
         this._title = title;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.list.absenceperiod.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.list.absenceperiod.js
@@ -1,0 +1,97 @@
+// Create the namespaces if they don't exist
+CRM.HRLeaveAndAbsencesApp = CRM.HRLeaveAndAbsencesApp || {};
+CRM.HRLeaveAndAbsencesApp.List = CRM.HRLeaveAndAbsencesApp.List || {};
+
+/**
+ * The AbsencePeriod list has a specific action not available on
+ * other list pages of this extension, hence we need this specialized class.
+ *
+ * As the ListPage class cannot be easily extended, we just wrap it and
+ * add the new action needed for this list.
+ */
+CRM.HRLeaveAndAbsencesApp.List.AbsencePeriod = (function($) {
+
+  /**
+   * Creates a new instance of the AbsencePeriod list
+   *
+   * @param {Object} listElement - a jQuery element containing the list of entities
+   * @constructor
+   */
+  function AbsencePeriod(listElement) {
+    this._listElement = listElement;
+    this._listPage = new CRM.HRLeaveAndAbsencesApp.ListPage(listElement);
+    this._addEventListeners();
+  }
+
+  /**
+   * Add event listeners to events triggered by actions specific to this
+   * list
+   *
+   * @private
+   */
+  AbsencePeriod.prototype._addEventListeners = function() {
+    this._listElement.find('.civihr-manage-entitlements')
+      .on('click', this._onManageEntitlementsClick.bind(this));
+  };
+
+  /**
+   * This is the event handler for when the user clicks on the "Manage Entitlements"
+   * action on the Absence Period list
+   *
+   * It instantiates a new ManageEntitlementAction and executes it.
+   *
+   * @param {Object} event
+   * @private
+   */
+  AbsencePeriod.prototype._onManageEntitlementsClick = function(event) {
+    event.preventDefault();
+    var $target = $(event.target);
+    var action = new CRM.HRLeaveAndAbsencesApp.List.AbsencePeriod.ManageEntitlementAction(
+      $target,
+      'The system will now update the staff members leave entitlement.'
+    );
+    action.execute();
+  };
+
+  return AbsencePeriod;
+
+})($);
+
+/**
+ * This is the List Action implementation to the "Manage Entitlement" action.
+ *
+ * It will show a confirmation to the user, saying that all entitlements will be
+ * updated and, if the user confirms, redirects they to the Entitlement Calculation
+ * page.
+ */
+CRM.HRLeaveAndAbsencesApp.List.AbsencePeriod.ManageEntitlementAction = (function() {
+
+  /**
+   * Creates a new action instance
+   *
+   * @param {Object} target - The element that triggered this action
+   * @param {String} confirmationMessage - The confirmation message to be displayed to the user
+   * @constructor
+   */
+  function ManageEntitlementAction(target, confirmationMessage) {
+    CRM.HRLeaveAndAbsencesApp.ListPage.Action.call(
+      this, target, 'Update leave entitlement?', confirmationMessage, ''
+    );
+  }
+
+  ManageEntitlementAction.prototype = Object.create(CRM.HRLeaveAndAbsencesApp.ListPage.Action.prototype);
+
+  /**
+   * Executes this action by redirecting the user to the Entitlement Calculation page
+   *
+   * @private
+   */
+  ManageEntitlementAction.prototype._executeAction = function() {
+    var manageEntitlementsURL = this._target.attr('href');
+    if(manageEntitlementsURL) {
+      window.location = manageEntitlementsURL;
+    }
+  };
+
+  return ManageEntitlementAction;
+})();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
@@ -94,9 +94,9 @@
   {/foreach}
   </tbody>
 </table>
-<div class="action-link">
+<div class="crm-submit-buttons">
   <a href="javascript:history.back()" class="button"><span>{ts}Back{/ts}</span></a>
-  <button class="crm-button save-new-entitlements-button"><i class="fa fa-check"></i>Save new entitlements</button>
+  {include file="CRM/common/formButtons.tpl" location="bottom"}
 </div>
 <div id="add-comment-dialog" title="{ts}Add/Edit comment{/ts}">
   <p>{ts}You can leave a comment as a record of your calculation for the leave entitlement for this period. Comments are then shown as tooltips on the leave entitlement on the contact record for administrators to refer back to.{/ts}</p>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.tpl
@@ -35,7 +35,7 @@
   {literal}
     <script type="text/javascript">
       CRM.$(function () {
-        var listPage = new CRM.HRLeaveAndAbsencesApp.ListPage(CRM.$('.hrleaveandabsences-entity-list'));
+        var list = new CRM.HRLeaveAndAbsencesApp.List.AbsencePeriod(CRM.$('.hrleaveandabsences-entity-list'));
       });
     </script>
   {/literal}


### PR DESCRIPTION
From the Absence Periods list is now possible to go to the Entitlement Calculation page to manage the staff entitlements. To do this, there's a new action available to every period on the list, called "Manage Entitlements". By clicking on it, the user will get a confirmation message and, if they confirm, they will be redirect to the calculations page.

This is the action and the confirmation message:

![manage_entitlements](https://cloud.githubusercontent.com/assets/388373/16505910/b518ddce-3ef5-11e6-8e06-223312ddfe2e.gif)
