### PR TITLE
PCHR-1225: fix contact search results page warnings

### DIFF
--- a/hrjobcontract/hrjobcontract.php
+++ b/hrjobcontract/hrjobcontract.php
@@ -588,9 +588,10 @@ function hrjobcontract_civicrm_searchColumns( $objectName, &$headers, &$rows, &$
 
   // replace location options values with label
   foreach($rows as &$row){
-    $location = $row['hrjobcontract_details_location'];
-    if(!empty($location)){
-      $row['hrjobcontract_details_location'] = $options[$location];
+    if(!empty($row['hrjobcontract_details_location']) && isset($options[$row['hrjobcontract_details_location']])){
+      $row['hrjobcontract_details_location'] = $options[$row['hrjobcontract_details_location']];
+    } else {
+      $row['hrjobcontract_details_location'] = '';
     }
   }
 }


### PR DESCRIPTION
After searching for contacts , a list of (undefined index) warnings notices appear in the search page :

![find contacts civihr 1 6 demo](https://cloud.githubusercontent.com/assets/6275540/16516649/c3e81e1e-3f81-11e6-9d5b-6b5cd9c52651.png)

the source of the problem was in hrjobcontract_civicrm_searchColumns Hook implementation in job contract extension where the search result rows are not checked if they contain the location field  (hrjobcontract_details_location) which came from the contact current job contract , so in case some contacts in the search results don't have active job contract the notice will appear for everyone who doesn't have a contract.

I fixed the problem by adding  checks on $row['hrjobcontract_details_location'] so it doesn't through a notice if it is not exist.

![selection_053](https://cloud.githubusercontent.com/assets/6275540/16516824/f273fdba-3f82-11e6-94f5-f31d83b72f54.png)
 