### PR TITLE
PCHR-1107: Add the getCountForCurrentPeriod action to the PublicHoliday API

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
@@ -258,6 +258,25 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
   }
 
   /**
+   * Returns the current AbsencePeriod. That is, the period that contains the
+   * current date. If no such period is found, null will be returned.
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_AbsencePeriod|null
+   */
+  public static function getCurrentPeriod()
+  {
+    $period = new self();
+    $period->whereAdd("start_date <= CURDATE()");
+    $period->whereAdd("end_date >= CURDATE()");
+    $period->limit(1);
+    if($period->find(true)) {
+      return $period;
+    }
+
+    return null;
+  }
+
+  /**
    * Returns the number of working days for this Absence Period.
    *
    * The number is given by "number of ways in period" - "weekends" - "public holidays".

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/PublicHoliday.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/PublicHoliday.php
@@ -152,4 +152,26 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
 
     return (int)$dao->public_holidays;
   }
+
+  /**
+   * Returns the number of Public Holidays in the Current Period
+   *
+   * @param bool $excludeWeekends
+   *  If true, public holidays that falls on a weekend won't be counted. Default is false
+   *
+   * @return int
+   */
+  public static function getNumberOfPublicHolidaysForCurrentPeriod($excludeWeekends = false) {
+    $currentPeriod = CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::getCurrentPeriod();
+
+    if(!$currentPeriod) {
+      return 0;
+    }
+
+    return self::getNumberOfPublicHolidaysForPeriod(
+      $currentPeriod->start_date,
+      $currentPeriod->end_date,
+      $excludeWeekends
+    );
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/PublicHoliday.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/PublicHoliday.php
@@ -43,3 +43,26 @@ function civicrm_api3_public_holiday_delete($params) {
 function civicrm_api3_public_holiday_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
+
+/**
+ * PublicHoliday.getcountforcurrentperiod API specification
+ *
+ * @param array $spec description of fields supported by this API call
+ * @return void
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ */
+function _civicrm_api3_public_holiday_getcountforcurrentperiod_spec(&$spec) {
+  $spec['exclude_weekends']['api.default'] = 0;
+}
+
+/**
+ * PublicHoliday.getcountforcurrentperiod API
+ *
+ * @param $params
+ * @param array $params
+ * @return array API result descriptor
+ */
+function civicrm_api3_public_holiday_getcountforcurrentperiod($params) {
+  $excludeWeekends = empty($params['exclude_weekends']) ? false : true;
+  return CRM_HRLeaveAndAbsences_BAO_PublicHoliday::getNumberOfPublicHolidaysForCurrentPeriod($excludeWeekends);
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
@@ -484,6 +484,52 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends PHPUnit_Framework_Tes
     $this->assertEquals($expectedDate->format('Y-m-d'), $expirationDate);
   }
 
+  public function testGetCurrentPeriodShouldReturnTheCurrentPeriod()
+  {
+    $currentPeriod = $this->createBasicPeriod([
+      'start_date' => date('YmdHis', strtotime('-2 days')),
+      'end_date' => date('YmdHis', strtotime('+2 days')),
+    ]);
+    // Load the period from the database to make sure it was stored and
+    // to get the dates in the Y-m-d format
+    $currentPeriod = $this->findPeriodByID($currentPeriod->id);
+
+    $this->createBasicPeriod([
+      'start_date' => date('YmdHis', strtotime('-5 days')),
+      'end_date' => date('YmdHis', strtotime('-3 days')),
+    ]);
+
+    $this->createBasicPeriod([
+      'start_date' => date('YmdHis', strtotime('+3 days')),
+      'end_date' => date('YmdHis', strtotime('+5 days')),
+    ]);
+
+    $returnedPeriod = CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::getCurrentPeriod();
+    $this->assertEquals($currentPeriod->id, $returnedPeriod->id);
+    $this->assertEquals($currentPeriod->title, $returnedPeriod->title);
+    $this->assertEquals($currentPeriod->start_date, $returnedPeriod->start_date);
+    $this->assertEquals($currentPeriod->end_date, $returnedPeriod->end_date);
+  }
+
+  public function testGetCurrentPeriodShouldReturnNullIfThereIsNoPeriod()
+  {
+    $this->createBasicPeriod([
+      'start_date' => date('YmdHis', strtotime('-5 days')),
+      'end_date' => date('YmdHis', strtotime('-3 days')),
+    ]);
+
+    $this->createBasicPeriod([
+      'start_date' => date('YmdHis', strtotime('+3 days')),
+      'end_date' => date('YmdHis', strtotime('+5 days')),
+    ]);
+    $this->assertNull(CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::getCurrentPeriod());
+  }
+
+  public function testGetCurrentPeriodShouldReturnNullIfThereIsNoCurrentPeriod()
+  {
+    $this->assertNull(CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::getCurrentPeriod());
+  }
+
   private function createBasicPeriod($params = array()) {
     $basicRequiredFields = [
         'title' => 'Type ' . microtime(),

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/PublicHolidayTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/PublicHolidayTest.php
@@ -142,6 +142,62 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends PHPUnit_Framework_Tes
     );
   }
 
+  public function testGetNumberOfPublicHolidaysForCurrentPeriod()
+  {
+    CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::create([
+      'title' => 'Current Period',
+      'start_date' => date('YmdHis', strtotime('first day of January')),
+      'end_date' => date('YmdHis', strtotime('last day of December')),
+    ]);
+
+    $this->createBasicPublicHoliday([
+      'date' => date('YmdHis', strtotime('2015-01-01'))
+    ]);
+
+    $this->createBasicPublicHoliday([
+      'date' => date('YmdHis', strtotime('first monday of January'))
+    ]);
+    $this->createBasicPublicHoliday([
+      'date' => date('YmdHis', strtotime('first tuesday of February'))
+    ]);
+    $this->createBasicPublicHoliday([
+      'date' => date('YmdHis', strtotime('last thursday of May'))
+    ]);
+    $this->createBasicPublicHoliday([
+      'date' => date('YmdHis', strtotime('last monday of May'))
+    ]);
+    $this->createBasicPublicHoliday([
+      'date' => date('YmdHis', strtotime('last friday of December'))
+    ]);
+
+    $this->assertEquals(
+      5,
+      CRM_HRLeaveAndAbsences_BAO_PublicHoliday::getNumberOfPublicHolidaysForCurrentPeriod()
+    );
+  }
+
+  public function testGetNumberOfPublicHolidaysForCurrentPeriodCanExcludeWeekendsFromCount()
+  {
+    CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::create([
+      'title' => 'Current Period',
+      'start_date' => date('YmdHis', strtotime('first day of January')),
+      'end_date' => date('YmdHis', strtotime('last day of December')),
+    ]);
+
+    $this->createBasicPublicHoliday([
+      'date' => date('YmdHis', strtotime('first monday of January'))
+    ]);
+    $this->createBasicPublicHoliday([
+      'date' => date('YmdHis', strtotime('first sunday of February'))
+    ]);
+
+    $excludeWeekends = true;
+    $this->assertEquals(
+      1,
+      CRM_HRLeaveAndAbsences_BAO_PublicHoliday::getNumberOfPublicHolidaysForCurrentPeriod($excludeWeekends)
+    );
+  }
+
   private function createBasicPublicHoliday($params)
   {
     $basicRequiredFields = [

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/PublicHolidayTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/PublicHolidayTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
+use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
+
+/**
+ * Class api_v3_PublicHolidayTest
+ *
+ * @group headless
+ */
+class api_v3_PublicHolidayTest extends PHPUnit_Framework_TestCase implements
+  HeadlessInterface,
+  TransactionalInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->installMe(__DIR__)->apply();
+  }
+
+  public function testGetCountForCurrentPeriod() {
+    AbsencePeriod::create([
+      'title' => 'Current Period',
+      'start_date' => date('YmdHis', strtotime('first day of January')),
+      'end_date' => date('YmdHis', strtotime('last day of December')),
+    ]);
+
+    $result = civicrm_api3('PublicHoliday', 'getcountforcurrentperiod');
+    $this->assertEquals(0, $result);
+
+    PublicHoliday::create([
+      'title' => 'Public Holiday 1',
+      'date' => date('YmdHis', strtotime('first monday of January'))
+    ]);
+
+    $result = civicrm_api3('PublicHoliday', 'getcountforcurrentperiod');
+    $this->assertEquals(1, $result);
+
+    PublicHoliday::create([
+      'title' => 'Public Holiday 2',
+      'date' => date('YmdHis', strtotime('first tuesday of February'))
+    ]);
+
+    $result = civicrm_api3('PublicHoliday', 'getcountforcurrentperiod');
+    $this->assertEquals(2, $result);
+  }
+
+  public function testGetCountForCurrentPeriodCanExcludeWeekends() {
+    AbsencePeriod::create([
+      'title' => 'Current Period',
+      'start_date' => date('YmdHis', strtotime('first day of January')),
+      'end_date' => date('YmdHis', strtotime('last day of December')),
+    ]);
+
+    PublicHoliday::create([
+      'title' => 'Public Holiday Weekday',
+      'date' => date('YmdHis', strtotime('first monday of January'))
+    ]);
+
+    PublicHoliday::create([
+      'title' => 'Public Holiday Weekend',
+      'date' => date('YmdHis', strtotime('first sunday of February'))
+    ]);
+
+    $result = civicrm_api3('PublicHoliday', 'getcountforcurrentperiod', [
+      'exclude_weekends' => 1
+    ]);
+    $this->assertEquals(1, $result);
+  }
+}


### PR DESCRIPTION
This new API action basically returns the value of the (also new)
PublicHoliday.getNumberOfPublicHolidaysForCurrentPeriod method. The API can
accept a single paramenter, named "exclude_weekends" that, when true, will not
count Public Holidays that falls on a weekend.

#### Usage examples for the new API action
Returning the number of public holidays including those that fall on a weekend
```php
$result = civicrm_api3('PublicHoliday', 'getcountforcurrentperiod');
```

Returning the number of public holidays excluding those that fall on a weekend:
```php
$result = civicrm_api3('PublicHoliday', 'getcountforcurrentperiod', [
    'exclude_weekends' => 1
]);
```

As the default **getcount** action of the CiviCRM API, this action returns an integer.