### PR TITLE
PCHR-1070: Fix contact merge on civicrm 4.7.7

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1238,6 +1238,36 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     return true;
   }
 
+  function upgrade_1016() {
+    /* on civicrm 4.7.7 this activity type (Contact Deleted by Merge) is not created
+   * as a part of civicrm installation but it should be, since it's used in
+   * contact merge code in core civicrm files. So here we just insure that it will
+   * be created for existing installations.
+   */
+    try {
+      $result = civicrm_api3('OptionValue', 'getsingle', array(
+        'sequential' => 1,
+        'name' => "Contact Deleted by Merge",
+      ));
+      $is_error = $result['is_error'];
+    } catch (CiviCRM_API3_Exception $e) {
+      $is_error = true;
+    }
+
+    if ($is_error)  {
+      civicrm_api3('OptionValue', 'create', array(
+        'sequential' => 1,
+        'option_group_id' => "activity_type",
+        'name' => "Contact Deleted by Merge",
+        'label' => "Contact Deleted by Merge",
+        'filter' => 1,
+        'description' => "Contact was merged into another contact",
+        'is_reserved' => 1,
+      ));
+    }
+    return true;
+  }
+
   function decToFraction($fte) {
     $fteDecimalPart = explode('.', $fte);
     $array = array();

--- a/hrjobcontract/hrjobcontract.php
+++ b/hrjobcontract/hrjobcontract.php
@@ -86,6 +86,33 @@ function hrjobcontract_civicrm_install() {
     }
   }
 
+  /* on civicrm 4.7.7 this activity type (Contact Deleted by Merge) is not created
+ * as a part of civicrm installation but it should be, since it's used in
+ * contact merge code in core civicrm files. So here we just insure that it will
+ * be created .
+ */
+  try {
+    $result = civicrm_api3('OptionValue', 'getsingle', array(
+      'sequential' => 1,
+      'name' => "Contact Deleted by Merge",
+    ));
+    $is_error = $result['is_error'];
+  } catch (CiviCRM_API3_Exception $e) {
+    $is_error = true;
+  }
+
+  if ($is_error)  {
+    civicrm_api3('OptionValue', 'create', array(
+      'sequential' => 1,
+      'option_group_id' => "activity_type",
+      'name' => "Contact Deleted by Merge",
+      'label' => "Contact Deleted by Merge",
+      'filter' => 1,
+      'description' => "Contact was merged into another contact",
+      'is_reserved' => 1,
+    ));
+  }
+
   return _hrjobcontract_civix_civicrm_install();
 }
 


### PR DESCRIPTION
## Problem

When trying to merge contacts on civihr 1.6 ( with civicrm 4.7.7 ) this error appear :
<img width="365" alt="screen shot 2016-06-24 at 11 25 20" src="https://cloud.githubusercontent.com/assets/6275540/16554815/13b63018-41c9-11e6-998a-7d2e48e0f076.png">

This is a civicrm 4.7.7 problem and not related to civihr that it doesn't create "**Contact Deleted by Merge**" activity type automatically when installed via the buildkit which is used in the core files to create an new activity after the merge get complete .

## Solution

I added a new code to hrjobcontract_civicrm_install hook to check for existence of "**Contact Deleted by Merge** activity type and in case it doesn't exists it will be created. and for existing installations I've added an upgrader method to do the same thing. 

Note : this problem is solved in civicrm 4.7.8+ and "**Contact Deleted by Merge**" is created automatically.
