### PR TITLE
PCHR-1065: Add the "Manage leave entitlement" task to the Advanced Search

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/Task/ManageEntitlements.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/Task/ManageEntitlements.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * This class provides the functionality to manage the leave entitlements for the
+ * selected contacts.
+ */
+class CRM_HRLeaveAndAbsences_Form_Task_ManageEntitlements extends CRM_Contact_Form_Task {
+
+  /**
+   * Build all the data structures needed to build the form.
+   */
+  public function preProcess() {
+    // initialize the task and row fields
+    parent::preProcess();
+    CRM_Utils_System::setTitle('Manage leave entitlements');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildQuickForm() {
+    $this->add(
+      'select',
+      'absence_period',
+      ts('Select Period'),
+      $this->getAbsencePeriods(),
+      true,
+      ['placeholder' => true]
+    );
+
+    $this->addDefaultButtons(ts('Next'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function postProcess()
+  {
+    $absencePeriodId = $this->exportValue('absence_period');
+
+    $url = CRM_Utils_System::url(
+      'civicrm/admin/leaveandabsences/periods/manage_entitlements',
+      http_build_query([
+        'id'    => $absencePeriodId,
+        'cid'   => $this->_contactIds,
+        'reset' => 1
+      ])
+    );
+
+    CRM_Utils_System::redirect($url);
+  }
+
+  /**
+   * Returns a list of Absence Periods to be listed in the "Select Period"
+   * dropdown. The returned list is an array in the ['id' => 'title'] format.
+   *
+   * @return array
+   */
+  private function getAbsencePeriods() {
+    $object = new CRM_HRLeaveAndAbsences_BAO_AbsencePeriod();
+    $object->orderBy('weight');
+    $object->find();
+
+    $rows = [];
+    while($object->fetch()) {
+      $rows[$object->id] = $object->title;
+    }
+
+    return $rows;
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -320,6 +320,18 @@ function hrleaveandabsences_civicrm_entityTypes(&$entityTypes) {
 }
 
 /**
+ * Implementation of hook_civicrm_searchTasks
+ */
+function hrleaveandabsences_civicrm_searchTasks($objectType, &$tasks) {
+  if($objectType == 'contact' && CRM_Core_Permission::check('administer leave and absences')) {
+    $tasks[] = [
+      'title' => ts('Manage leave entitlements'),
+      'class' => 'CRM_HRLeaveAndAbsences_Form_Task_ManageEntitlements'
+    ];
+  }
+}
+
+/**
  * Functions below this ship commented out. Uncomment as required.
  *
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/Task/ManageEntitlements.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/Task/ManageEntitlements.tpl
@@ -1,0 +1,12 @@
+<div class="crm-block crm-form-block crm-absence-period-form-block crm-leave-and-absences-form-block">
+  {if $single eq false}
+    <div class="messages status no-popup">{include file="CRM/Contact/Form/Task.tpl"}</div>
+  {/if}
+  <table class="form-layout">
+    <tr>
+      <td class="label">{$form.absence_period.label}</td>
+      <td class="html-adjust">{$form.absence_period.html}</td>
+    </tr>
+  </table>
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+</div>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/WebTest/ManageEntitlements/AdvancedSearchTaskTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/WebTest/ManageEntitlements/AdvancedSearchTaskTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+
+/**
+ * Class WebTest_AbsenceType_FormTest
+ *
+ * @group headless
+ */
+class WebTest_ManageEntitlements_AdvanceSearchTaskTest extends CiviSeleniumTestCase implements HeadlessInterface {
+
+  private $advancedSearchUrl = 'contact/search/advanced';
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->installMe(__DIR__)->apply();
+  }
+
+  private function loginAsAdmin() {
+    if(is_null($this->loggedInAs)) {
+      $this->webtestLogin('admin');
+    }
+  }
+
+  public function testManageLeaveEntitlementsTaskExists() {
+    $this->loginAsAdmin();
+    $this->openAdvancedSearch();
+    $this->searchForIndividuals();
+    $this->selectAllRecords();
+    $this->selectAndWait('task', 'Manage leave entitlements');
+    //Checks if the absence period dropdown is visible
+    $this->assertTrue($this->isVisible('absence_period'));
+  }
+
+  private function openAdvancedSearch() {
+    $this->openCiviPage($this->advancedSearchUrl, 'reset=1');
+  }
+
+  private function searchForIndividuals() {
+    $this->select('contact_type', "value=Individual");
+    $this->submitAndWait('Advanced');
+  }
+
+  private function selectAllRecords() {
+    $this->click('CIVICRM_QFID_ts_all_10');
+    sleep(1);
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/Menu/hrleaveandabsences.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/Menu/hrleaveandabsences.xml
@@ -28,6 +28,6 @@
     <path>civicrm/admin/leaveandabsences/periods/manage_entitlements</path>
     <page_callback>CRM_HRLeaveAndAbsences_Form_ManageEntitlements</page_callback>
     <title>ManageEntitlements</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>administer leave and absences</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION

This commit adds a new "Manage leave entitlement" to the Advanced Search. When
the user selects this action, they're redirected to a form containing a dropdown
listing all Absence Period, so they can select to which one they want to manage
the entitlements to. After selecting the period, we should redirect to the Manage
Entitlements page (with the selected Period ID and the ID of the contacts on the
search form).

Here you can see the new Task in action:
![manage_leave_entitlements](https://cloud.githubusercontent.com/assets/388373/16928414/db530d7c-4d08-11e6-82cf-2b33aed5fe68.gif)
