### PR TITLE
PCHR-1066: Allow AbsenceType with add_public_holiday_to_entitlement to be updated

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -197,7 +197,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    */
   private static function validateParams($params) {
     if(!empty($params['add_public_holiday_to_entitlement'])) {
-      self::validateAddPublicHolidayToEntitlement();
+      self::validateAddPublicHolidayToEntitlement($params);
     }
 
     if (!empty($params['allow_request_cancelation']) &&
@@ -219,15 +219,20 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    * method checks if one such type already exists and throws an error if that
    * is the case.
    *
+   * @param array $params The params array received by the create method
+   *
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
-   * @throws \CiviCRM_API3_Exception
    */
-  private static function validateAddPublicHolidayToEntitlement() {
-    $result = civicrm_api3('AbsenceType', 'getcount', array(
-        'sequential' => 1,
-        'add_public_holiday_to_entitlement' => 1,
-    ));
-    if(!isset($result['result']) || $result['result'] > 0) {
+  private static function validateAddPublicHolidayToEntitlement($params) {
+    $dao = new self();
+    $dao->add_public_holiday_to_entitlement = 1;
+
+    $id = empty($params['id']) ? null : intval($params['id']);
+    if($id) {
+      $dao->whereAdd("id <> {$id}");
+    }
+
+    if($dao->count() > 0) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException(
           'There is already one Absence Type where "Must staff take public holiday as leave" is selected'
       );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -22,6 +22,13 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends PHPUnit_Framework_TestC
     return \Civi\Test::headless()->installMe(__DIR__)->apply();
   }
 
+  public function setUp() {
+    // We delete everything two avoid problems with the default absence types
+    // created during the extension installation
+    $tableName = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getTableName();
+    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+  }
+
   /**
    * @expectedException PEAR_Exception
    * @expectedExceptionMessage DB Error: already exists
@@ -89,6 +96,14 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends PHPUnit_Framework_TestC
     $this->assertEquals(0, $entity2->add_public_holiday_to_entitlement);
 
     $this->updateBasicType($basicEntity2->id, ['add_public_holiday_to_entitlement' => true]);
+  }
+
+  public function testUpdatingATypeWithAddPublicHolidayToEntitlementShouldNotTriggerErrorAboutHavingAnotherTypeWithItSelected() {
+    $basicEntity = $this->createBasicType(['add_public_holiday_to_entitlement' => true]);
+    $entity1 = $this->findTypeByID($basicEntity->id);
+    $this->assertEquals(1, $entity1->add_public_holiday_to_entitlement);
+
+    $this->updateBasicType($entity1->id, ['add_public_holiday_to_entitlement' => true]);
   }
 
   /**


### PR DESCRIPTION
#### Problem
Trying to update an existing Absence Type where add_public_holiday_to_entitlement
was checked, was throwing the error: There is already one Absence Type where "Must
staff take public holiday as leave" is selected.

#### Solution
That happened because the validation rule that checks for existing Absence Types
with add_public_holiday_to_entitlement == 1 wasn't taking into account if the existing
type was the one being updated. I fixed this, by adding a "id <> $this->id" condition  
to the validation query, so it won't consider the type being updated as the existing one.

