### PR TITLE
PCHR-1146: Set the default phone location type when creating/editing a contact

### DIFF
--- a/hrui/hrui.php
+++ b/hrui/hrui.php
@@ -57,18 +57,11 @@ function hrui_civicrm_buildForm($formName, &$form) {
   if ($form instanceof CRM_Contact_Form_Contact) {
     CRM_Core_Resources::singleton()
       ->addSetting(array('formName' => 'contactForm'));
-    //HR-358 - Set default values
-    //set default value to phone location and type
-    $locationId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_LocationType', 'Main', 'id', 'name');
-    // PCHR-1146 : Commenting line ahead to fix the issue, but figuring why it was done at first place coul be useful.
-    //$result = civicrm_api3('LocationType', 'create', array('id'=>$locationId, 'is_default'=> 1, 'is_active'=>1));
-    if (($form->elementExists('phone[2][phone_type_id]')) && ($form->elementExists('phone[2][phone_type_id]'))) {
-      $phoneType = $form->getElement('phone[2][phone_type_id]');
-      $phoneValue = CRM_Core_OptionGroup::values('phone_type');
-      $phoneKey = CRM_Utils_Array::key('Mobile', $phoneValue);
-      $phoneType->setSelected($phoneKey);
-      $phoneLocation = $form->getElement('phone[2][location_type_id]');
-      $phoneLocation->setSelected($locationId);
+
+    $phoneIndex = 2;
+    if (_hrui_phone_is_empty($phoneIndex, $form)) {
+      _hrui_set_phone_type_as_mobile($phoneIndex, $form);
+      _hrui_set_phone_location_to_the_default_location($phoneIndex, $form);
     }
   }
 
@@ -95,6 +88,78 @@ function hrui_civicrm_buildForm($formName, &$form) {
     }
     $form->setDefaults($default);
   }
+}
+
+/**
+ * Sets the location type of the phone with the given index to the default
+ * location type.
+ *
+ * @param int $phoneIndex
+ *  The index of phone in the contact form
+ * @param CRM_Core_Form $form
+ *  The Contact Form instance
+ */
+function _hrui_set_phone_location_to_the_default_location($phoneIndex, $form) {
+  $locationId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_LocationType', 1, 'id', 'is_default');
+
+  if($locationId) {
+    $form->setDefaults([
+      "phone[{$phoneIndex}][location_type_id]" => $locationId
+    ]);
+  }
+}
+
+/**
+ * Sets the phone type of the phone with the given index as 'Mobile'.
+ *
+ * @param $phoneIndex
+ *  The index of phone in the contact form
+ * @param CRM_Core_Form $form
+ *  The Contact Form instance
+ */
+function _hrui_set_phone_type_as_mobile($phoneIndex, $form) {
+  _hrui_set_phone_type($phoneIndex, $form, 'Mobile');
+}
+
+/**
+ * Sets the phone type of the phone with the given index to the type given by
+ * $type.
+ *
+ * @param int $phoneIndex
+ *   The index of phone in the contact form
+ * @param CRM_Core_Form $form
+ *   The Contact Form instance
+ * @param string $type
+ *   The new phone type. Valid values are those from the phone_type option list
+ */
+function _hrui_set_phone_type($phoneIndex, $form, $type) {
+  $elementName = "phone[{$phoneIndex}][phone_type_id]";
+
+  if(!$form->elementExists($elementName)) {
+    return;
+  }
+
+  $phoneType  = $form->getElement($elementName);
+  $phoneValue = CRM_Core_OptionGroup::values('phone_type');
+  $phoneKey   = CRM_Utils_Array::key($type, $phoneValue);
+  if($phoneKey) {
+    $phoneType->setSelected($phoneKey);
+  }
+}
+
+/**
+ * Returns if the contact form has a phone with the given index and it's empty
+ *
+ * @param int $phoneIndex
+ *  The index of phone in the contact form
+ * @param CRM_Core_Form $form
+ *  The Contact Form instance
+ *
+ * @return bool
+ */
+function _hrui_phone_is_empty($phoneIndex, $form) {
+  return $form->elementExists("phone[{$phoneIndex}][phone]") &&
+         empty($form->getElementValue("phone[{$phoneIndex}][phone]"));
 }
 
 /**


### PR DESCRIPTION
When creating a new contact, the location type of the first phone number 
is automatically set to the default location type, but this doesn't happen to
the second number (Mobile), which end up with another location type by default.

We use the buildForm hook to alter the form in order to change the default
value of the location type field to the default location type. This is done only
if the phone number empty, so to avoid overwrite any previously selected
value.

Having "Work" set as the default Location type, this is how the field value was set before this change:

![captura_de_tela_2016-07-21_as_07_53_10](https://cloud.githubusercontent.com/assets/388373/17020576/c3079258-4f18-11e6-8493-0fbbc77c54e6.png)

Now, this is the location type field showing the default location type for both phones after this change:

![captura_de_tela_2016-07-21_as_07_53_36](https://cloud.githubusercontent.com/assets/388373/17020630/1962df5e-4f19-11e6-9a11-d7a9f77f34d5.png)

It still uses the default location type as long as the phone is empty:

![captura de tela 2016-07-21 as 08 01 39](https://cloud.githubusercontent.com/assets/388373/17020702/769c0efc-4f19-11e6-8219-1425a2855575.png)

If the phone is not empty, the saved location type is displayed:

![captura de tela 2016-07-21 as 08 03 01](https://cloud.githubusercontent.com/assets/388373/17020753/b8c6a238-4f19-11e6-8b20-af39b813fa46.png)

