### PR TITLE
PCHR-459: Fix a missing semicolon that cause buildkit setup to crash

### DIFF
--- a/hrcase/sql/activities_install.sql
+++ b/hrcase/sql/activities_install.sql
@@ -63,4 +63,4 @@ VALUES
 (@option_group_id_activity_type, 'Complete contract revisions','Complete contract revisions',
   (SELECT @max_val := @max_val+1), NULL, 0,  0, (SELECT @max_val := @max_val+1), '',  0, 0, 1, @compId ),
 (@option_group_id_activity_type, 'Confirm End of Probation Date','Confirm End of Probation Date',
-  (SELECT @max_val := @max_val+1), NULL, 0,  0, (SELECT @max_val := @max_val+1), '',  0, 0, 1, @compId ),
+  (SELECT @max_val := @max_val+1), NULL, 0,  0, (SELECT @max_val := @max_val+1), '',  0, 0, 1, @compId );


### PR DESCRIPTION
Fix a missing semicolon that cause setting up a new civihr instance via the buildkit  to crash