### PR TITLE
PCHR-914: If WorkPattern if the last active one, don't allow it to be disabled

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
@@ -204,6 +204,25 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends PHPUnit_Framework_TestC
         $this->assertEmpty($values);
     }
 
+    /**
+     * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkPatternException
+     * @expectedExceptionMessage You cannot disable a Work Pattern if it's the last one
+     */
+    public function testCannotDisablePatternIfItIsTheLastWorkPatternEnabled() {
+      $workPattern = $this->createBasicWorkPattern(['is_active' => 1]);
+      $this->updateBasicWorkPattern($workPattern->id, ['is_active' => 0]);
+    }
+
+    public function testCanDisablePatternIfItIsNotTheLastWorkPatternEnabled() {
+      $workPattern1 = $this->createBasicWorkPattern(['is_active' => 1]);
+      $this->createBasicWorkPattern(['is_active' => 1]);
+
+      $this->updateBasicWorkPattern($workPattern1->id, ['is_active' => 0]);
+
+      $workPattern1 = $this->findWorkPatternByID($workPattern1->id);
+      $this->assertEquals(0, $workPattern1->is_active);
+    }
+
     private function createBasicWorkPattern($params = [])
     {
         $basicRequiredFields = ['label' => 'Pattern ' . microtime() ];


### PR DESCRIPTION
When disabling a WorkPattern, we now throw a validation error it's it the last one
enabled.

This is how the error message is displayed to the user:
![disable_work_pattern](https://cloud.githubusercontent.com/assets/388373/17105231/b75acde8-525c-11e6-9052-1a9c3f525b82.gif)
