### PR TITLE
PCHR-898:  Remove "Years" from toil and carry forward expiry dropdown

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
@@ -438,9 +438,6 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
       case AbsenceType::EXPIRATION_UNIT_MONTHS:
         $unit = 'M';
         break;
-      case AbsenceType::EXPIRATION_UNIT_YEARS:
-        $unit = 'Y';
-        break;
       default:
         return null;
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -4,7 +4,6 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
 
   const EXPIRATION_UNIT_DAYS = 1;
   const EXPIRATION_UNIT_MONTHS = 2;
-  const EXPIRATION_UNIT_YEARS = 3;
 
   const REQUEST_CANCELATION_NO = 1;
   const REQUEST_CANCELATION_ALWAYS = 2;
@@ -131,7 +130,6 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
     return [
         self::EXPIRATION_UNIT_DAYS   => ts('Days'),
         self::EXPIRATION_UNIT_MONTHS => ts('Months'),
-        self::EXPIRATION_UNIT_YEARS  => ts('Years')
     ];
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/AbsenceType.php
@@ -177,7 +177,7 @@ class CRM_HRLeaveAndAbsences_DAO_AbsenceType extends CRM_Core_DAO
    */
   public $accrual_expiration_duration;
   /**
-   * The unit (year, month, etc) of accrual_expiration_duration of this type default expiry
+   * The unit (months or days) of accrual_expiration_duration of this type default expiry
    *
    * @var int unsigned
    */
@@ -199,7 +199,7 @@ class CRM_HRLeaveAndAbsences_DAO_AbsenceType extends CRM_Core_DAO
    */
   public $carry_forward_expiration_duration;
   /**
-   * The unit (year, month, etc) of carry_forward_expiration_duration of this type default expiry
+   * The unit (months or days) of carry_forward_expiration_duration of this type default expiry
    *
    * @var int unsigned
    */
@@ -333,7 +333,7 @@ class CRM_HRLeaveAndAbsences_DAO_AbsenceType extends CRM_Core_DAO
           'name' => 'accrual_expiration_unit',
           'type' => CRM_Utils_Type::T_INT,
           'title' => ts('Accrual Expiration Unit') ,
-          'description' => 'The unit (year, month, etc) of accrual_expiration_duration of this type default expiry',
+          'description' => 'The unit (months or days) of accrual_expiration_duration of this type default expiry',
         ) ,
         'allow_carry_forward' => array(
           'name' => 'allow_carry_forward',
@@ -355,7 +355,7 @@ class CRM_HRLeaveAndAbsences_DAO_AbsenceType extends CRM_Core_DAO
           'name' => 'carry_forward_expiration_unit',
           'type' => CRM_Utils_Type::T_INT,
           'title' => ts('Carry Forward Expiration Unit') ,
-          'description' => 'The unit (year, month, etc) of carry_forward_expiration_duration of this type default expiry',
+          'description' => 'The unit (months or days) of carry_forward_expiration_duration of this type default expiry',
         ) ,
       );
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
@@ -23,11 +23,11 @@ CREATE TABLE `civicrm_hrleaveandabsences_absence_type` (
      `max_leave_accrual` int unsigned    COMMENT 'Value is the number of days that can be accrued. Null means unlimited',
      `allow_accrue_in_the_past` tinyint   DEFAULT 0 ,
      `accrual_expiration_duration` int unsigned    COMMENT 'An amount of accrual_expiration_unit',
-     `accrual_expiration_unit` int unsigned    COMMENT 'The unit (year, month, etc) of accrual_expiration_duration of this type default expiry',
+     `accrual_expiration_unit` int unsigned    COMMENT 'The unit (months or days) of accrual_expiration_duration of this type default expiry',
      `allow_carry_forward` tinyint   DEFAULT 0 ,
      `max_number_of_days_to_carry_forward` int unsigned    ,
      `carry_forward_expiration_duration` int unsigned    COMMENT 'An amount of carry_forward_expiration_unit',
-     `carry_forward_expiration_unit` int unsigned    COMMENT 'The unit (year, month, etc) of carry_forward_expiration_duration of this type default expiry',
+     `carry_forward_expiration_unit` int unsigned    COMMENT 'The unit (months or days) of carry_forward_expiration_duration of this type default expiry',
     PRIMARY KEY ( `id` ),
     UNIQUE INDEX `hrleaveandabsences_absence_type_title`(title)
 
@@ -67,8 +67,8 @@ INSERT INTO `civicrm_hrleaveandabsences_absence_type`(
   0,
   1,
   5,
-  1,
-  3, -- Years
+  12,
+  2, -- Months
   1,
   1,
   1

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
@@ -459,7 +459,14 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends PHPUnit_Framework_Tes
     $expectedDate = $startDate->add(new DateInterval('P5D'));
     $this->assertEquals($expectedDate->format('Y-m-d'), $expirationDate);
 
+    //485 days duration
+    $absenceType->carry_forward_expiration_duration = 485;
+    $expirationDate = $period->getExpirationDateForAbsenceType($absenceType);
+    $expectedDate = $startDate->add(new DateInterval('P485D'));
+    $this->assertEquals($expectedDate->format('Y-m-d'), $expirationDate);
+
     //5 months duration
+    $absenceType->carry_forward_expiration_duration = 5;
     $absenceType->carry_forward_expiration_unit = CRM_HRLeaveAndAbsences_BAO_AbsenceType::EXPIRATION_UNIT_MONTHS;
     $expirationDate = $period->getExpirationDateForAbsenceType($absenceType);
     $expectedDate = $startDate->add(new DateInterval('P5M'));
@@ -471,16 +478,16 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends PHPUnit_Framework_Tes
     $expectedDate = $startDate->add(new DateInterval('P10M'));
     $this->assertEquals($expectedDate->format('Y-m-d'), $expirationDate);
 
-    //10 years duration
-    $absenceType->carry_forward_expiration_unit = CRM_HRLeaveAndAbsences_BAO_AbsenceType::EXPIRATION_UNIT_YEARS;
-    $expirationDate = $period->getExpirationDateForAbsenceType($absenceType);
-    $expectedDate = $startDate->add(new DateInterval('P10Y'));
-    $this->assertEquals($expectedDate->format('Y-m-d'), $expirationDate);//10 years
-
-    //1 year duration
-    $absenceType->carry_forward_expiration_duration = 1;
+    //12 months duration
+    $absenceType->carry_forward_expiration_duration = 12;
     $expirationDate = $period->getExpirationDateForAbsenceType($absenceType);
     $expectedDate = $startDate->add(new DateInterval('P1Y'));
+    $this->assertEquals($expectedDate->format('Y-m-d'), $expirationDate);
+
+    //27 months duration
+    $absenceType->carry_forward_expiration_duration = 27;
+    $expirationDate = $period->getExpirationDateForAbsenceType($absenceType);
+    $expectedDate = $startDate->add(new DateInterval('P27M'));
     $this->assertEquals($expectedDate->format('Y-m-d'), $expirationDate);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -350,7 +350,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends PHPUnit_Framework_TestC
     $absenceType = $this->createBasicType([
       'allow_carry_forward' => true,
       'carry_forward_expiration_duration' => 4,
-      'carry_forward_expiration_unit' => CRM_HRLeaveAndAbsences_BAO_AbsenceType::EXPIRATION_UNIT_YEARS
+      'carry_forward_expiration_unit' => CRM_HRLeaveAndAbsences_BAO_AbsenceType::EXPIRATION_UNIT_MONTHS
     ]);
     $this->assertFalse($absenceType->carryForwardNeverExpires());
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/AbsenceType.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/AbsenceType.xml
@@ -129,7 +129,7 @@
   <field>
     <name>accrual_expiration_unit</name>
     <type>int unsigned</type>
-    <comment>The unit (year, month, etc) of accrual_expiration_duration of this type default expiry</comment>
+    <comment>The unit (months or days) of accrual_expiration_duration of this type default expiry</comment>
   </field>
   <field>
     <name>allow_carry_forward</name>
@@ -152,7 +152,7 @@
   <field>
     <name>carry_forward_expiration_unit</name>
     <type>int unsigned</type>
-    <comment>The unit (year, month, etc) of carry_forward_expiration_duration of this type default expiry</comment>
+    <comment>The unit (months or days) of carry_forward_expiration_duration of this type default expiry</comment>
   </field>
 
 </table>


### PR DESCRIPTION
- Tests that used the "Year" were updated to use "Months" or "Days".
- The expiry date for the "Vacation" absence type was change to 12 months instead of 1 year

| Before | After |
|--------|-------|
|![captura de tela 2016-07-25 as 15 32 57](https://cloud.githubusercontent.com/assets/388373/17112606/194dadfc-527d-11e6-80be-b0f347c14587.png)|![captura de tela 2016-07-25 as 15 32 30](https://cloud.githubusercontent.com/assets/388373/17112614/212c0f3c-527d-11e6-8588-a11e85eb3842.png)| 