### PR TITLE
PCHR-1294: Add the scheduled job to expire leave balance changes

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveBalanceChange.php
@@ -44,3 +44,13 @@ function civicrm_api3_leave_balance_change_delete($params) {
 function civicrm_api3_leave_balance_change_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
+
+/**
+ * LeaveBalanceChange.createexpirationrecords API
+ *
+ * @return int The number of records created
+ * @throws API_Exception
+ */
+function civicrm_api3_leave_balance_change_createexpirationrecords() {
+  return CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange::createExpirationRecords();
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/LeaveBalanceChangeHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/LeaveBalanceChangeHelpersTrait.php
@@ -16,32 +16,39 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
     return $this->balanceChangeTypes[$type];
   }
 
-  public function createSourcelessBalanceChange($entitlementID, $amount, $type) {
-    LeaveBalanceChange::create([
+  public function createSourcelessBalanceChange($entitlementID, $amount, $type, $expiryDate = null) {
+    $params = [
       'type_id' => $type,
       'entitlement_id' => $entitlementID,
       'amount' => $amount
-    ]);
+    ];
+
+    if($expiryDate) {
+      $params['expiry_date'] = $expiryDate;
+    }
+
+    return LeaveBalanceChange::create($params);
   }
 
   public function createLeaveBalanceChange($entitlementID, $amount) {
-    $this->createSourcelessBalanceChange(
+    return $this->createSourcelessBalanceChange(
       $entitlementID,
       $amount,
       $this->getBalanceChangeTypeValue('Leave')
     );
   }
 
-  public function createBroughtForwardBalanceChange($entitlementID, $amount) {
-    $this->createSourcelessBalanceChange(
+  public function createBroughtForwardBalanceChange($entitlementID, $amount, $expiryDate = null) {
+    return $this->createSourcelessBalanceChange(
       $entitlementID,
       $amount,
-      $this->getBalanceChangeTypeValue('Brought Forward')
+      $this->getBalanceChangeTypeValue('Brought Forward'),
+      $expiryDate
     );
   }
 
   public function createPublicHolidayBalanceChange($entitlementID, $amount) {
-    $this->createSourcelessBalanceChange(
+    return $this->createSourcelessBalanceChange(
       $entitlementID,
       $amount,
       $this->getBalanceChangeTypeValue('Public Holiday')

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveBalanceChangeTest.php
@@ -1,0 +1,47 @@
+<?php
+
+require_once __DIR__.'/../../CRM/HRLeaveAndAbsences/LeaveBalanceChangeHelpersTrait.php';
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Class api_v3_LeaveBalanceChangeTest
+ *
+ * @group headless
+ */
+class api_v3_LeaveBalanceChangeTest extends PHPUnit_Framework_TestCase implements
+  HeadlessInterface,
+  TransactionalInterface {
+
+  use CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait;
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->installMe(__DIR__)->apply();
+  }
+
+  public function setUp() {
+    // In order to make tests simpler, we disable the foreign key checks,
+    // as a way to allow the creation of brought forward records related
+    // to a non-existing entitlement
+    CRM_Core_DAO::executeQuery("SET foreign_key_checks = 0;");
+  }
+
+  public function tearDown() {
+    CRM_Core_DAO::executeQuery("SET foreign_key_checks = 1;");
+  }
+
+  public function testCreateExpirationRecords() {
+    $result = civicrm_api3('LeaveBalanceChange', 'createexpirationrecords');
+    $this->assertEquals(0, $result);
+
+    $this->createBroughtForwardBalanceChange(1, 2, date('YmdHis', strtotime('-1 day')));
+    $this->createBroughtForwardBalanceChange(2, 5, date('YmdHis'));
+    $this->createBroughtForwardBalanceChange(3, 3.5, date('YmdHis', strtotime('-2 days')));
+
+    // Should create two records: one for the entitlement 1 and another one
+    // for entitlement 3. The brought forward for entitlement 2 has not expired
+    $result = civicrm_api3('LeaveBalanceChange', 'createexpirationrecords');
+    $this->assertEquals(2, $result);
+  }
+}


### PR DESCRIPTION
This scheduled job will run daily, checking for balance changes with an
expiry date in the past and creating the respective expiration record.

Example:
Imagine you have 3 days Brought Forward that will expire on 2016-04-01. This is how the balance change table will look like:

| id | amount | expiry_date | expired_balance_id |
|----|--------|-------------|--------------------|
| 1 | 3 | 2016-04-01 | NULL |

Now, after running the scheduled job, a new record will be created with the amount of days expired as a negative number. On this example, since no leave was taken, all the 3 days will expire:


| id | amount | expiry_date | expired_balance_id |
|----|--------|-------------|--------------------|
| 1 | 3 | 2016-04-01 | NULL |
| 2 | -3 | 2016-04-01 | 1 |