### PR TITLE
UY-51 - Fixing of fetching Job Contract entities (pay and health).

### DIFF
--- a/hrjobcontract/js/src/job-contract/controllers/contract.js
+++ b/hrjobcontract/js/src/job-contract/controllers/contract.js
@@ -109,20 +109,9 @@ define([
                 details: ContractDetailsService.getOne({ jobcontract_id: contractId }),
                 hour: ContractHourService.getOne({ jobcontract_id: contractId }),
                 leave: ContractLeaveService.get({ jobcontract_id: contractId }),
+                pay: ContractPayService.getOne({ jobcontract_id: contractId}),
+                health: ContractHealthService.getOne({ jobcontract_id: contractId}),
                 pension: ContractPensionService.getOne({ jobcontract_id: contractId })
-            })
-            .then(function (results) {
-                return $q.all({
-                    pay: ContractPayService.getOne({
-                        jobcontract_revision_id: results.details.jobcontract_revision_id
-                    }),
-                    health: ContractHealthService.getOne({
-                        jobcontract_revision_id: results.details.jobcontract_revision_id
-                    })
-                })
-                .then(function (additionalResults) {
-                    return angular.extend(results, additionalResults);
-                });
             })
             .then(function(results){
 


### PR DESCRIPTION
The issue was caused by these two commits in the past:
https://github.com/civicrm/civihr/commit/f5da231fc6486558f97e98e4af6a15fb3937bfe7
and
https://github.com/civicrm/civihr/commit/4210a556cd231ffe5ee0dc9f511cb2492a0bae0d
which seem to move Pay and Health entity fetching below the rest of the entities. The issue was that for both entities there was used Details revision ID instead of particular entities revision.
I've moved Pay and Health fetching into the $q.all() method to get current valid revisions.