### PR TITLE
PCHR-902: Fix the visibility of the "Expire after certain duration" dropdown

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
@@ -126,12 +126,12 @@
                     <div class="label">{ts}Carry forward leave expiry{/ts}</div>
                     <div class="content">
                         {assign var="carry_forward_never_expire" value=false }
-                        {if not $carry_forward_expire_after_duration and not $carry_forward_expire_after_date }
+                        {if $form.carry_forward_expiration_duration.value eq '' and $form.carry_forward_expiration_unit.value.0 eq ''}
                             {assign var="carry_forward_never_expire" value=true }
                         {/if}
                         <label><input type="radio" name="carry_forward_expiration" id="carry_forward_never_expire" {if $carry_forward_never_expire}checked{/if}> {ts}Never expire{/ts}</label>
                         <br/>
-                        <label><input type="radio" name="carry_forward_expiration" id="carry_forward_expire_after_duration"> {ts}Expire after a certain duration{/ts}</label>
+                        <label><input type="radio" name="carry_forward_expiration" id="carry_forward_expire_after_duration" {if not $carry_forward_never_expire}checked{/if}> {ts}Expire after a certain duration{/ts}</label>
                         <br/>
                         <span class="carry-forward-expiration-duration">{$form.carry_forward_expiration_duration.html}{$form.carry_forward_expiration_unit.html}<br/></span>
                     </div>
@@ -198,7 +198,7 @@
                         $('.carry-forward-option').show();
                     }
 
-                    if(carry_forward_expire_after_duration.is(':checked')) {
+                    if(!carry_forward_never_expire.is(':checked')) {
                         $('.carry-forward-expiration-duration').show();
                     }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/WebTest/AbsenceType/FormTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/WebTest/AbsenceType/FormTest.php
@@ -60,6 +60,36 @@ class WebTest_AbsenceType_FormTest extends CiviSeleniumTestCase implements Headl
         $this->assertTrue($this->isVisible('allow_accrue_in_the_past'));
         $this->assertFalse($this->isVisible('accrual_expiration_duration'));
         $this->assertFalse($this->isVisible('s2id_accrual_expiration_unit'));
+
+        // If we submit the form with only the expire duration not empty,
+        // both duration fields should still be visible after the page reloads
+        // (it will reload because the other required fields have not been filled)
+        $this->click('accrual_never_expire');
+        $this->type('accrual_expiration_duration', 10);
+        $this->submitAndWait('AbsenceType');
+        $this->assertTrue($this->isVisible('accrual_expiration_duration'));
+        $this->assertTrue($this->isVisible('s2id_accrual_expiration_unit'));
+        $this->assertFalse($this->isChecked('accrual_never_expire'));
+
+        // If we submit the form with only the expire unit not empty,
+        // both duration fields should still be visible after the page reloads
+        // (it will reload because the other required fields have not been filled)
+        $this->type('accrual_expiration_duration', '');
+        $this->select('accrual_expiration_unit', 'label=Months');
+        $this->submitAndWait('AbsenceType');
+        $this->assertTrue($this->isVisible('accrual_expiration_duration'));
+        $this->assertTrue($this->isVisible('s2id_accrual_expiration_unit'));
+        $this->assertFalse($this->isChecked('accrual_never_expire'));
+
+        // If we submit the form with both the expire duration and unit not empty,
+        // the duration fields should still be visible after the page reloads
+        // (it will reload because the other required fields have not been filled)
+        $this->type('accrual_expiration_duration', 15);
+        $this->select('accrual_expiration_unit', 'label=Months');
+        $this->submitAndWait('AbsenceType');
+        $this->assertTrue($this->isVisible('accrual_expiration_duration'));
+        $this->assertTrue($this->isVisible('s2id_accrual_expiration_unit'));
+        $this->assertFalse($this->isChecked('accrual_never_expire'));
     }
 
     public function testCarryForwardFieldsVisibility()
@@ -97,6 +127,41 @@ class WebTest_AbsenceType_FormTest extends CiviSeleniumTestCase implements Headl
         $this->assertFalse($this->isVisible('s2id_carry_forward_expiration_unit'));
         $this->assertTrue($this->isChecked('carry_forward_never_expire'));
         $this->assertFalse($this->isChecked('carry_forward_expire_after_duration'));
+
+        // If we submit the form with only the expire duration not empty,
+        // both duration fields should still be visible after the page reloads
+        // (it will reload because the other required fields have not been filled)
+        $this->click('carry_forward_expire_after_duration');
+        $this->type('carry_forward_expiration_duration', 10);
+        $this->submitAndWait('AbsenceType');
+        $this->assertTrue($this->isVisible('carry_forward_expiration_duration'));
+        $this->assertTrue($this->isVisible('s2id_carry_forward_expiration_unit'));
+        $this->assertFalse($this->isChecked('carry_forward_never_expire'));
+        $this->assertTrue($this->isChecked('carry_forward_expire_after_duration'));
+
+        // If we submit the form with only the expire unit not empty,
+        // both duration fields should still be visible after the page reloads
+        // (it will reload because the other required fields have not been filled)
+        $this->click('carry_forward_expire_after_duration');
+        $this->type('carry_forward_expiration_duration', '');
+        $this->select('carry_forward_expiration_unit', 'label=Months');
+        $this->submitAndWait('AbsenceType');
+        $this->assertTrue($this->isVisible('carry_forward_expiration_duration'));
+        $this->assertTrue($this->isVisible('s2id_carry_forward_expiration_unit'));
+        $this->assertFalse($this->isChecked('carry_forward_never_expire'));
+        $this->assertTrue($this->isChecked('carry_forward_expire_after_duration'));
+
+        // If we submit the form with both the expire duration and unit not empty,
+        // the duration fields should still be visible after the page reloads
+        // (it will reload because the other required fields have not been filled)
+        $this->click('carry_forward_expire_after_duration');
+        $this->type('carry_forward_expiration_duration', 15);
+        $this->select('carry_forward_expiration_unit', 'label=Months');
+        $this->submitAndWait('AbsenceType');
+        $this->assertTrue($this->isVisible('carry_forward_expiration_duration'));
+        $this->assertTrue($this->isVisible('s2id_carry_forward_expiration_unit'));
+        $this->assertFalse($this->isChecked('carry_forward_never_expire'));
+        $this->assertTrue($this->isChecked('carry_forward_expire_after_duration'));
     }
 
     public function testAddAnEmptyType()


### PR DESCRIPTION
**Problem**
When opening or editing an existing Absence Type which allows carry forward, the "Never expire" option was always selected, even if the Absence Type had an expiry duration set.

**Solution**
 1. Fix the template code which adds a "checked" attribute to the "Never expire" radio ONLY if the Absence Type doesn't have an expiry unit and an expiry duration. It was checking the wrong variables, making the attribute to always be added to the radio.
 2. Fix the template code to add the "checked" attribute to the "Expire after certain duration" radio only if the Absence Type have an expiry unit or expiry duration.
 3. Fix the piece of javascript code which runs after the page load and shows the expiry unit and expiry duration fields if "Never expire" is not checked.

So, when opening/editing an existing Absence Type, the visibility of the carry forward expiry fields should follow these rules:
- If the Absence Type doesn't have an expiry duration
 - "Never expire" should be checked
 - "Expire after certain duration" should not be checked. The respective text and dropdown fields should not be visible

- If the Absence Type have an expiry duration
 - "Never expire" should not be checked
 - "Expire after certain duration" should be checked. The respective text and dropdown fields should be visible

New tests were added to cover these rules.