### PR TITLE
PCHR-1496: Add the "add_public_holiday" field during the extension in…

### DIFF
--- a/hrjobcontract/hrjobcontract.php
+++ b/hrjobcontract/hrjobcontract.php
@@ -113,6 +113,9 @@ function hrjobcontract_civicrm_install() {
     ));
   }
 
+  // Adding 'add_public_holidays' field to 'civicrm_hrjobcontract_leave' table
+  CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_hrjobcontract_leave` ADD `add_public_holidays` TINYINT NOT NULL DEFAULT 0");
+
   return _hrjobcontract_civix_civicrm_install();
 }
 


### PR DESCRIPTION
**Problem**

The piece of code that adds the field was in an upgrade method, which is not called during the extension installation, causing the field to not be available right after a new install.

**Solution**

The code that adds the field was also added to the extension's hook_civicrm_install implementation.