### PR TITLE
PCHR-1443: Create the work pattern get leave days for date method

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkPattern.php
@@ -395,15 +395,21 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPattern extends CRM_HRLeaveAndAbsences_DAO_
     return $date;
   }
 
-  private static function unsetDefaultWorkPatterns()
-  {
+  /**
+   * Unset the is_default flag for the default Work Pattern
+   */
+  private static function unsetDefaultWorkPatterns() {
     $tableName = self::getTableName();
     $query = "UPDATE {$tableName} SET is_default = 0 WHERE is_default = 1";
     CRM_Core_DAO::executeQuery($query);
   }
 
-  public function links()
-  {
+  /**
+   * {@inheritdoc}
+   *
+   * @return array
+   */
+  public function links() {
     $workWeekTable = CRM_HRLeaveAndAbsences_BAO_WorkWeek::getTableName();
     return [
       'id' => "{$workWeekTable}:pattern_id"

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
@@ -1,19 +1,15 @@
 <?php
 
-use Civi\Test\HeadlessInterface;
-use Civi\Test\TransactionalInterface;
+require_once __DIR__."/../BaseTest.php";
+
+use CRM_HRLeaveAndAbsences_BaseTest as BaseTest;
 
 /**
  * Class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest
  *
  * @group headless
  */
-class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends PHPUnit_Framework_TestCase implements
-  HeadlessInterface, TransactionalInterface {
-
-  public function setUpHeadless() {
-    return \Civi\Test::headless()->installMe(__DIR__)->apply();
-  }
+class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseTest {
 
   /**
    * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidAbsencePeriodException

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -1,15 +1,15 @@
 <?php
 
-use Civi\Test\HeadlessInterface;
-use Civi\Test\TransactionalInterface;
+require_once __DIR__."/../BaseTest.php";
+
+use CRM_HRLeaveAndAbsences_BaseTest as BaseTest;
 
 /**
  * Class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest
  *
  * @group headless
  */
-class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends PHPUnit_Framework_TestCase implements
-  HeadlessInterface, TransactionalInterface {
+class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseTest {
 
   private $allColors = [
       '#5A6779', '#E5807F', '#ECA67F', '#8EC68A', '#C096AA', '#9579A8', '#42B0CB',
@@ -17,10 +17,6 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends PHPUnit_Framework_TestC
       '#263345', '#CC4A49', '#D97038', '#4F944A', '#995978', '#5F3D76', '#147E99',
       '#151D2C', '#B32E2E', '#BF561D', '#377A31', '#803D5E', '#47275C', '#056780'
   ];
-
-  public function setUpHeadless() {
-    return \Civi\Test::headless()->installMe(__DIR__)->apply();
-  }
 
   /**
    * @expectedException PEAR_Exception

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -1,9 +1,9 @@
 <?php
 
 require_once __DIR__."/../LeaveBalanceChangeHelpersTrait.php";
+require_once __DIR__."/../BaseTest.php";
 
-use Civi\Test\HeadlessInterface;
-use Civi\Test\TransactionalInterface;
+use CRM_HRLeaveAndAbsences_BaseTest as BaseTest;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement as LeavePeriodEntitlement;
@@ -13,17 +13,9 @@ use CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement as LeavePeriodEntitlement;
  *
  * @group headless
  */
-class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends PHPUnit_Framework_TestCase implements
-  HeadlessInterface, TransactionalInterface {
+class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseTest {
 
   use CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait;
-
-  public function setUpHeadless() {
-    return \Civi\Test::headless()
-                     ->installMe(__DIR__)
-                     ->install('org.civicrm.hrjobcontract')
-                     ->apply();
-  }
 
   public function setUp() {
     // In order to make tests simpler, we disable the foreign key checks,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
@@ -1,9 +1,9 @@
 <?php
 
 require_once __DIR__."/../LeaveBalanceChangeHelpersTrait.php";
+require_once __DIR__."/../BaseTest.php";
 
-use Civi\Test\HeadlessInterface;
-use Civi\Test\TransactionalInterface;
+use CRM_HRLeaveAndAbsences_BaseTest as BaseTest;
 use CRM_HRLeaveAndAbsences_EntitlementCalculation as EntitlementCalculation;
 use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
@@ -17,19 +17,11 @@ use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
  *
  * @group headless
  */
-class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Framework_TestCase implements
-  HeadlessInterface, TransactionalInterface {
+class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseTest {
 
   use CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait;
 
   private $leaveRequestStatuses = [];
-
-  public function setUpHeadless() {
-    return \Civi\Test::headless()
-      ->installMe(__DIR__)
-      ->install('org.civicrm.hrjobcontract')
-      ->apply();
-  }
 
   public function setUp() {
     $this->leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
@@ -480,6 +480,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     $this->assertEquals($contract['id'], $periodEntitlement->contract_id);
     $this->assertEquals(1, $periodEntitlement->overridden);
     $this->assertEquals($overriddenEntitlement, $periodEntitlement->getEntitlement());
+
+    $user = null;
   }
 
   private function createPeriodEntitlement() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestDateTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestDateTest.php
@@ -1,7 +1,8 @@
 <?php
 
-use Civi\Test\HeadlessInterface;
-use Civi\Test\TransactionalInterface;
+require_once __DIR__."/../BaseTest.php";
+
+use CRM_HRLeaveAndAbsences_BaseTest as BaseTest;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
 
 /**
@@ -9,12 +10,7 @@ use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
  *
  * @group headless
  */
-class CRM_HRLeaveAndAbsences_BAO_LeaveRequestDateTest extends PHPUnit_Framework_TestCase implements
-  HeadlessInterface, TransactionalInterface {
-
-  public function setUpHeadless() {
-    return \Civi\Test::headless()->installMe(__DIR__)->apply();
-  }
+class CRM_HRLeaveAndAbsences_BAO_LeaveRequestDateTest extends BaseTest {
 
   public function setUp() {
     // In order to make tests simpler, we disable the foreign key checks,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -1,7 +1,8 @@
 <?php
 
-use Civi\Test\HeadlessInterface;
-use Civi\Test\TransactionalInterface;
+require_once __DIR__."/../BaseTest.php";
+
+use CRM_HRLeaveAndAbsences_BaseTest as BaseTest;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 
 /**
@@ -9,12 +10,7 @@ use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
  *
  * @group headless
  */
-class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends PHPUnit_Framework_TestCase implements
-  HeadlessInterface, TransactionalInterface {
-
-  public function setUpHeadless() {
-    return \Civi\Test::headless()->installMe(__DIR__)->apply();
-  }
+class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseTest {
 
   public function setUp() {
     // In order to make tests simpler, we disable the foreign key checks,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/NotificationReceiverTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/NotificationReceiverTest.php
@@ -1,28 +1,22 @@
 <?php
 
-use Civi\Test\HeadlessInterface;
+require_once __DIR__."/../BaseTest.php";
+
+use CRM_HRLeaveAndAbsences_BaseTest as BaseTest;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 
 /**
  * Class CRM_HRLeaveAndAbsences_BAO_NotificationReceiverTest
  *
  * @group headless
  */
-class CRM_HRLeaveAndAbsences_BAO_NotificationReceiverTest extends CiviUnitTestCase implements HeadlessInterface {
+class CRM_HRLeaveAndAbsences_BAO_NotificationReceiverTest extends BaseTest {
 
   private $absenceType = null;
-
-  protected $_tablesToTruncate = [
-    'civicrm_hrleaveandabsences_notification_receiver'
-  ];
-
-  public function setUpHeadless() {
-    return \Civi\Test::headless()->installMe(__DIR__)->apply();
-  }
 
   public function setUp()
   {
     parent::setUp();
-    $this->loadAllFixtures();
     $this->instantiateAbsenceType();
   }
 
@@ -40,32 +34,31 @@ class CRM_HRLeaveAndAbsences_BAO_NotificationReceiverTest extends CiviUnitTestCa
   {
     $this->addAndRetrieveReceiversForAbsenceType();
 
-    CRM_HRLeaveAndAbsences_BAO_NotificationReceiver::removeReceiversFromAbsenceType($this->absenceType['id']);
+    CRM_HRLeaveAndAbsences_BAO_NotificationReceiver::removeReceiversFromAbsenceType($this->absenceType->id);
 
     $receiversIds = CRM_HRLeaveAndAbsences_BAO_NotificationReceiver::getReceiversIDsForAbsenceType(
-        $this->absenceType['id']
+        $this->absenceType->id
     );
     $this->assertEmpty($receiversIds);
   }
 
   private function instantiateAbsenceType()
   {
-    $result = $this->callAPISuccess('AbsenceType', 'create', [
+    $this->absenceType = AbsenceType::create([
         'title' => 'Type ' . microtime(),
         'color' => '#000000',
         'default_entitlement' => 20,
         'allow_request_cancelation' => 1,
     ]);
-
-    $this->absenceType = reset($result['values']);
   }
 
   private function getContactsIds($limit = 5)
   {
-    $result = $this->callAPISuccess('Contact', 'get', [
+    $result = civicrm_api3('Contact', 'get', [
       'return' => 'id',
       'options' => ['limit' => $limit]
     ]);
+
     if($result['is_error'] == 0) {
       return array_keys($result['values']);
     }
@@ -79,11 +72,11 @@ class CRM_HRLeaveAndAbsences_BAO_NotificationReceiverTest extends CiviUnitTestCa
     $this->assertNotEmpty($receiversIdsToAdd);
 
     CRM_HRLeaveAndAbsences_BAO_NotificationReceiver::addReceiversToAbsenceType(
-        $this->absenceType['id'], $receiversIdsToAdd
+        $this->absenceType->id, $receiversIdsToAdd
     );
 
     $receiversIds = CRM_HRLeaveAndAbsences_BAO_NotificationReceiver::getReceiversIDsForAbsenceType(
-        $this->absenceType['id']
+        $this->absenceType->id
     );
 
     $this->assertEquals(count($receiversIdsToAdd), count($receiversIds));

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/PublicHolidayTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/PublicHolidayTest.php
@@ -1,7 +1,8 @@
 <?php
 
-use Civi\Test\HeadlessInterface;
-use Civi\Test\TransactionalInterface;
+require_once __DIR__."/../BaseTest.php";
+
+use CRM_HRLeaveAndAbsences_BaseTest as BaseTest;
 use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
 
 /**
@@ -9,11 +10,7 @@ use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
  *
  * @group headless
  */
-class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends PHPUnit_Framework_TestCase implements HeadlessInterface, TransactionalInterface {
-
-  public function setUpHeadless() {
-    return \Civi\Test::headless()->installMe(__DIR__)->apply();
-  }
+class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseTest {
 
   /**
    * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidPublicHolidayException

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkDayTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkDayTest.php
@@ -1,18 +1,17 @@
 <?php
 
 use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
+use CRM_HRLeaveAndAbsences_BAO_WorkWeek as WorkWeek;
 
 /**
  * Class CRM_HRLeaveAndAbsences_BAO_WorkDayTest
  *
  * @group headless
  */
-class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends CiviUnitTestCase implements HeadlessInterface {
-
-    protected $_tablesToTruncate = [
-        'civicrm_hrleaveandabsences_work_day',
-        'civicrm_hrleaveandabsences_work_week',
-    ];
+class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends PHPUnit_Framework_TestCase implements
+  HeadlessInterface, TransactionalInterface {
 
     protected $workPattern = null;
     protected $workWeek = null;
@@ -152,10 +151,10 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends CiviUnitTestCase implements
     public function testWorkWeekCannotBeChangedOnUpdate()
     {
         $entity = $this->createBasicWorkDay();
-        $this->assertEquals($this->workWeek['id'], $entity->week_id);
+        $this->assertEquals($this->workWeek->id, $entity->week_id);
 
         $updatedEntity = $this->updateWorkDay($entity->id, ['week_id' => rand(100, 200)]);
-        $this->assertEquals($this->workWeek['id'], $updatedEntity->week_id);
+        $this->assertEquals($this->workWeek->id, $updatedEntity->week_id);
     }
 
     /**
@@ -189,7 +188,7 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends CiviUnitTestCase implements
         $basicDefaultParams = [
             'day_of_the_week' => 1,
             'type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_YES,
-            'week_id' => $this->workWeek['id'],
+            'week_id' => $this->workWeek->id,
             'time_from' => '09:00',
             'time_to' => '18:00',
             'break' => 1,
@@ -221,22 +220,18 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends CiviUnitTestCase implements
         return $entity;
     }
 
-    private function instantiateWorkPatternWithWeek()
-    {
-        $params = ['label' => 'Pattern ' . microtime()];
-        $result = $this->callAPISuccess('WorkPattern', 'create', $params);
+    private function instantiateWorkPatternWithWeek() {
+      $this->workPattern = WorkPattern::create([
+        'label' => 'Pattern ' . microtime()
+      ]);
 
-        $this->workPattern = reset($result['values']);
-
-        $this->instantiateWorkWeek($this->workPattern['id']);
+      $this->instantiateWorkWeek($this->workPattern->id);
     }
 
-    private function instantiateWorkWeek($patternId)
-    {
-        $params['pattern_id'] = $patternId;
-        $result = $this->callAPISuccess('WorkWeek', 'create', $params);
-
-        $this->workWeek = reset($result['values']);
+    private function instantiateWorkWeek($patternId) {
+      $this->workWeek = WorkWeek::create([
+        'pattern_id' => $patternId
+      ]);
     }
 
     public function dayOfTheWeekDataProvider()

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkDayTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkDayTest.php
@@ -199,25 +199,11 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends PHPUnit_Framework_TestCase 
         return CRM_HRLeaveAndAbsences_BAO_WorkDay::create($params);
     }
 
-    private function updateWorkDay($id, $params)
-    {
-        $params['id'] = $id;
-        $this->createBasicWorkDay($params);
+    private function updateWorkDay($id, $params) {
+      $params['id'] = $id;
+      $this->createBasicWorkDay($params);
 
-        return $this->findWorkDayByID($id);
-    }
-
-    private function findWorkDayByID($id)
-    {
-        $entity = new CRM_HRLeaveAndAbsences_BAO_WorkDay();
-        $entity->id = $id;
-        $entity->find(true);
-
-        if($entity->N == 0) {
-            return null;
-        }
-
-        return $entity;
+      return CRM_HRLeaveAndAbsences_BAO_WorkDay::findById($id);
     }
 
     private function instantiateWorkPatternWithWeek() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkDayTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkDayTest.php
@@ -4,6 +4,8 @@ use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
 use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
 use CRM_HRLeaveAndAbsences_BAO_WorkWeek as WorkWeek;
+use CRM_HRLeaveAndAbsences_BAO_WorkDay as WorkDay;
+use CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException as InvalidWorkDayException;
 
 /**
  * Class CRM_HRLeaveAndAbsences_BAO_WorkDayTest
@@ -13,310 +15,291 @@ use CRM_HRLeaveAndAbsences_BAO_WorkWeek as WorkWeek;
 class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends PHPUnit_Framework_TestCase implements
   HeadlessInterface, TransactionalInterface {
 
-    protected $workPattern = null;
-    protected $workWeek = null;
+  protected $workPattern = null;
+  protected $workWeek = null;
 
-    public function setUpHeadless() {
-      return \Civi\Test::headless()->installMe(__DIR__)->apply();
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->installMe(__DIR__)->apply();
+  }
+
+  public function setUp() {
+    parent::setUp();
+    $this->instantiateWorkPatternWithWeek();
+  }
+
+  /**
+   * @dataProvider dayOfTheWeekDataProvider
+   */
+  public function testDayOfTheWeekShouldBeValidAccordingToISO8601($day, $throwsException) {
+    if($throwsException) {
+      $this->setExpectedException(
+        InvalidWorkDayException::class,
+        'Day of the Week should be a number between 1 and 7, according to ISO-8601'
+      );
     }
 
-    public function setUp()
-    {
-        parent::setUp();
-        $this->instantiateWorkPatternWithWeek();
+    $this->createBasicWorkDay(['day_of_the_week' => $day]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException
+   * @expectedExceptionMessage Time From format should be hh:mm
+   *
+   * @dataProvider timeFormatDataProvider
+   */
+  public function testTimeFromFormatShouldBeValid($time) {
+    $this->createBasicWorkDay(['time_from' => $time]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException
+   * @expectedExceptionMessage Time To format should be hh:mm
+   *
+   * @dataProvider timeFormatDataProvider
+   */
+  public function testTimeToFormatShouldBeValid($time) {
+    $this->createBasicWorkDay(['time_to' => $time]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException
+   * @expectedExceptionMessage Time From, Time To and Break are required for Working Days
+   *
+   * @dataProvider timesAndBreakRequiredDataProvider
+   */
+  public function testTimeFromTimeToAndBreakShouldBeRequiredIfItsAWorkingDay($timeTo, $timeFrom, $break) {
+    $params = [
+      'type' => WorkDay::WORK_DAY_OPTION_YES,
+      'time_to' => $timeTo,
+      'time_from' => $timeFrom,
+      'break' => $break
+    ];
+    $this->createBasicWorkDay($params);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException
+   * @expectedExceptionMessage Time From, Time To and Break should be empty for Non Working Days and Weekends
+   *
+   * @dataProvider timesAndBreakEmptyDataProvider
+   */
+  public function testTimeFromTimeToAndBreakShouldBeEmptyIfItsNotAWorkingDay($timeTo, $timeFrom, $break) {
+    $params = [
+      'type' => WorkDay::WORK_DAY_OPTION_NO,
+      'time_to' => $timeTo,
+      'time_from' => $timeFrom,
+      'break' => $break
+    ];
+    $this->createBasicWorkDay($params);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException
+   * @expectedExceptionMessage Time From should be less than Time To
+   *
+   * @dataProvider timeFromGreaterThanTimeToDataProvider
+   */
+  public function testTimeFromShouldNotBeGreaterOrEqualThanTimeTo($timeFrom, $timeTo) {
+    $this->createBasicWorkDay([
+      'time_from' => $timeFrom,
+      'time_to' => $timeTo
+    ]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException
+   * @expectedExceptionMessage Break should be less than the number of hours between Time From and Time To
+   *
+   * @dataProvider breakGreaterThanWorkingHours
+   */
+  public function testBreakShouldNotBeGreaterThenThePeriodBetweenTimeFromAndTimeTo($timeFrom, $timeTo, $break) {
+    $params = [
+      'type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_YES,
+      'time_to' => $timeTo,
+      'time_from' => $timeFrom,
+      'break' => $break
+    ];
+    $this->createBasicWorkDay($params);
+  }
+
+  /**
+   * @dataProvider workDayTypeDataProvider
+   */
+  public function testTypeShouldBeAValidValueInWorkDayTypeOptions($type, $throwsException) {
+    if($throwsException) {
+      $this->setExpectedException(InvalidWorkDayException::class, 'Invalid Work Day Type');
     }
 
-    /**
-     * @dataProvider dayOfTheWeekDataProvider
-     */
-    public function testDayOfTheWeekShouldBeValidAccordingToISO8601($day, $throwsException)
-    {
-        if($throwsException) {
-            $this->setExpectedException(
-                CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException::class,
-                'Day of the Week should be a number between 1 and 7, according to ISO-8601'
-            );
-        }
-
-        $this->createBasicWorkDay(['day_of_the_week' => $day]);
+    // If type is not Working Day, we must set times and break to null,
+    // otherwise we will get another validation error
+    $params = ['type' => $type];
+    if($type != WorkDay::WORK_DAY_OPTION_YES) {
+      $params['time_from'] = null;
+      $params['time_to'] = null;
+      $params['break'] = null;
     }
+    $this->createBasicWorkDay($params);
+  }
 
-    /**
-     * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException
-     * @expectedExceptionMessage Time From format should be hh:mm
-     *
-     * @dataProvider timeFormatDataProvider
-     */
-    public function testTimeFromFormatShouldBeValid($time)
-    {
-        $this->createBasicWorkDay(['time_from' => $time]);
-    }
+  public function testWorkWeekCannotBeChangedOnUpdate() {
+    $entity = $this->createBasicWorkDay();
+    $this->assertEquals($this->workWeek->id, $entity->week_id);
 
-    /**
-     * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException
-     * @expectedExceptionMessage Time To format should be hh:mm
-     *
-     * @dataProvider timeFormatDataProvider
-     */
-    public function testTimeToFormatShouldBeValid($time)
-    {
-        $this->createBasicWorkDay(['time_to' => $time]);
-    }
+    $updatedEntity = $this->updateWorkDay($entity->id, [
+      'week_id' => rand(100, 200)
+    ]);
+    $this->assertEquals($this->workWeek->id, $updatedEntity->week_id);
+  }
 
-    /**
-     * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException
-     * @expectedExceptionMessage Time From, Time To and Break are required for Working Days
-     *
-     * @dataProvider timesAndBreakRequiredDataProvider
-     */
-    public function testTimeFromTimeToAndBreakShouldBeRequiredIfItsAWorkingDay($timeTo, $timeFrom, $break)
-    {
-        $params = [
-            'type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_YES,
-            'time_to' => $timeTo,
-            'time_from' => $timeFrom,
-            'break' => $break
-        ];
-        $this->createBasicWorkDay($params);
-    }
+  /**
+   * @expectedException PEAR_Exception
+   * @expectedExceptionMessage DB Error: already exists
+   */
+  public function testCannotHaveMoreThanOfDayOfTheWeekForEachWeek() {
+    $entity = $this->createBasicWorkDay(['day_of_the_week' => 1]);
+    $this->assertEquals(1, $entity->day_of_the_week);
 
-    /**
-     * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException
-     * @expectedExceptionMessage Time From, Time To and Break should be empty for Non Working Days and Weekends
-     *
-     * @dataProvider timesAndBreakEmptyDataProvider
-     */
-    public function testTimeFromTimeToAndBreakShouldBeEmptyIfItsNotAWorkingDay($timeTo, $timeFrom, $break)
-    {
-        $params = [
-            'type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_NO,
-            'time_to' => $timeTo,
-            'time_from' => $timeFrom,
-            'break' => $break
-        ];
-        $this->createBasicWorkDay($params);
-    }
+    $this->createBasicWorkDay(['day_of_the_week' => 1]);
+  }
 
-    /**
-     * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException
-     * @expectedExceptionMessage Time From should be less than Time To
-     *
-     * @dataProvider timeFromGreaterThanTimeToDataProvider
-     */
-    public function testTimeFromShouldNotBeGreaterOrEqualThanTimeTo($timeFrom, $timeTo)
-    {
-        $this->createBasicWorkDay(['time_from' => $timeFrom, 'time_to' => $timeTo]);
-    }
+  /**
+   * @dataProvider numberOfHoursDataProvider
+   */
+  public function testNumberOfHoursShouldBeCalculatedFromTimesAndBreak($timeFrom, $timeTo, $break, $expectedNumberOfHours) {
+    $entity = $this->createBasicWorkDay([
+      'time_from' => $timeFrom,
+      'time_to' => $timeTo,
+      'break' => $break
+    ]);
 
-    /**
-     * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException
-     * @expectedExceptionMessage Break should be less than the number of hours between Time From and Time To
-     *
-     * @dataProvider breakGreaterThanWorkingHours
-     */
-    public function testBreakShouldNotBeGreaterThenThePeriodBetweenTimeFromAndTimeTo($timeFrom, $timeTo, $break)
-    {
-        $params = [
-            'type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_YES,
-            'time_to' => $timeTo,
-            'time_from' => $timeFrom,
-            'break' => $break
-        ];
-        $this->createBasicWorkDay($params);
-    }
+    $this->assertEquals($expectedNumberOfHours, $entity->number_of_hours);
+  }
 
-    /**
-     * @dataProvider workDayTypeDataProvider
-     */
-    public function testTypeShouldBeAValidValueInWorkDayTypeOptions($type, $throwsException)
-    {
-        if($throwsException) {
-            $this->setExpectedException(
-                CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException::class,
-                'Invalid Work Day Type'
-            );
-        }
+  private function createBasicWorkDay($params = []) {
+    $basicDefaultParams = [
+      'day_of_the_week' => 1,
+      'type' => WorkDay::WORK_DAY_OPTION_YES,
+      'week_id' => $this->workWeek->id,
+      'time_from' => '09:00',
+      'time_to' => '18:00',
+      'break' => 1,
+      'leave_days' => 1
+    ];
 
-        // If type is not Working Day, we must set times and break to null,
-        // otherwise we will get another validation error
-        $params = ['type' => $type];
-        if($type != CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_YES) {
-            $params['time_from'] = null;
-            $params['time_to'] = null;
-            $params['break'] = null;
-        }
-        $this->createBasicWorkDay($params);
-    }
+    $params = array_merge($basicDefaultParams, $params);
+    return WorkDay::create($params);
+  }
 
-    public function testWorkWeekCannotBeChangedOnUpdate()
-    {
-        $entity = $this->createBasicWorkDay();
-        $this->assertEquals($this->workWeek->id, $entity->week_id);
+  private function updateWorkDay($id, $params) {
+    $params['id'] = $id;
+    $this->createBasicWorkDay($params);
 
-        $updatedEntity = $this->updateWorkDay($entity->id, ['week_id' => rand(100, 200)]);
-        $this->assertEquals($this->workWeek->id, $updatedEntity->week_id);
-    }
+    return WorkDay::findById($id);
+  }
 
-    /**
-     * @expectedException PEAR_Exception
-     * @expectedExceptionMessage DB Error: already exists
-     */
-    public function testCannotHaveMoreThanOfDayOfTheWeekForEachWeek()
-    {
-        $entity = $this->createBasicWorkDay(['day_of_the_week' => 1]);
-        $this->assertEquals(1, $entity->day_of_the_week);
+  private function instantiateWorkPatternWithWeek() {
+    $this->workPattern = WorkPattern::create([
+      'label' => 'Pattern ' . microtime()
+    ]);
 
-        $this->createBasicWorkDay(['day_of_the_week' => 1]);
-    }
+    $this->instantiateWorkWeek($this->workPattern->id);
+  }
 
-    /**
-     * @dataProvider numberOfHoursDataProvider
-     */
-    public function testNumberOfHoursShouldBeCalculatedFromTimesAndBreak($timeFrom, $timeTo, $break, $expectedNumberOfHours)
-    {
-        $entity = $this->createBasicWorkDay([
-            'time_from' => $timeFrom,
-            'time_to' => $timeTo,
-            'break' => $break
-        ]);
+  private function instantiateWorkWeek($patternId) {
+    $this->workWeek = WorkWeek::create([
+      'pattern_id' => $patternId
+    ]);
+  }
 
-        $this->assertEquals($expectedNumberOfHours, $entity->number_of_hours);
-    }
+  public function dayOfTheWeekDataProvider() {
+    return [
+      ['a', true],
+      [-10, true],
+      [-1, true],
+      [0, true],
+      [1, false],
+      [2, false],
+      [3, false],
+      [4, false],
+      [5, false],
+      [6, false],
+      [7, false],
+      [8, true],
+      [rand(9, 1000), true],
+      [rand(1001, 2000), true],
+    ];
+  }
 
-    private function createBasicWorkDay($params = [])
-    {
-        $basicDefaultParams = [
-            'day_of_the_week' => 1,
-            'type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_YES,
-            'week_id' => $this->workWeek->id,
-            'time_from' => '09:00',
-            'time_to' => '18:00',
-            'break' => 1,
-            'leave_days' => 1
-        ];
+  public function timeFromGreaterThanTimeToDataProvider() {
+    return [
+      ['19:00', '08:00'],
+      ['19:00', '18:00'],
+      ['19:00', '19:00'],
+      ['01:00', '00:00'],
+      ['17:31', '17:30'],
+    ];
+  }
 
-        $params = array_merge($basicDefaultParams, $params);
-        return CRM_HRLeaveAndAbsences_BAO_WorkDay::create($params);
-    }
+  public function timesAndBreakRequiredDataProvider() {
+    return [
+      [null, null, null],
+      [null, null, 1],
+      [null, '19:00', null],
+      ['17:00', null, null],
+      ['09:00', '17:30', null],
+      [null, '17:30', 2],
+      ['11:30', null, 2],
+    ];
+  }
 
-    private function updateWorkDay($id, $params) {
-      $params['id'] = $id;
-      $this->createBasicWorkDay($params);
+  public function timesAndBreakEmptyDataProvider() {
+    return [
+      [null, null, 1],
+      [null, '19:00', null],
+      ['17:00', null, null],
+      ['09:00', '17:30', null],
+      [null, '17:30', 2],
+      ['11:30', null, 2],
+      ['09:00', '18:00', 1],
+    ];
+  }
 
-      return CRM_HRLeaveAndAbsences_BAO_WorkDay::findById($id);
-    }
+  public function timeFormatDataProvider() {
+    return [
+      ['19'],
+      ['dasdasdas'],
+      [1],
+      ['1:00'],
+    ];
+  }
 
-    private function instantiateWorkPatternWithWeek() {
-      $this->workPattern = WorkPattern::create([
-        'label' => 'Pattern ' . microtime()
-      ]);
+  public function breakGreaterThanWorkingHours() {
+    return [
+      ['10:00', '11:30', 2],
+      ['09:15', '15:15', 7.5],
+      ['12:30', '17:30', 6],
+      ['14:00', '16:00', 2],
+    ];
+  }
 
-      $this->instantiateWorkWeek($this->workPattern->id);
-    }
+  public function workDayTypeDataProvider() {
+    return [
+      [0, true],
+      [WorkDay::WORK_DAY_OPTION_YES, false],
+      [WorkDay::WORK_DAY_OPTION_NO, false],
+      [WorkDay::WORK_DAY_OPTION_WEEKEND, false],
+      ['adasdsa', true],
+      [rand(4, PHP_INT_MAX), true],
+    ];
+  }
 
-    private function instantiateWorkWeek($patternId) {
-      $this->workWeek = WorkWeek::create([
-        'pattern_id' => $patternId
-      ]);
-    }
-
-    public function dayOfTheWeekDataProvider()
-    {
-        return [
-            ['a', true],
-            [-10, true],
-            [-1, true],
-            [0, true],
-            [1, false],
-            [2, false],
-            [3, false],
-            [4, false],
-            [5, false],
-            [6, false],
-            [7, false],
-            [8, true],
-            [rand(9, 1000), true],
-            [rand(1001, 2000), true],
-        ];
-    }
-
-    public function timeFromGreaterThanTimeToDataProvider()
-    {
-        return [
-            ['19:00', '08:00'],
-            ['19:00', '18:00'],
-            ['19:00', '19:00'],
-            ['01:00', '00:00'],
-            ['17:31', '17:30'],
-        ];
-    }
-
-    public function timesAndBreakRequiredDataProvider()
-    {
-        return [
-            [null, null, null],
-            [null, null, 1],
-            [null, '19:00', null],
-            ['17:00', null, null],
-            ['09:00', '17:30', null],
-            [null, '17:30', 2],
-            ['11:30', null, 2],
-        ];
-    }
-
-    public function timesAndBreakEmptyDataProvider()
-    {
-        return [
-            [null, null, 1],
-            [null, '19:00', null],
-            ['17:00', null, null],
-            ['09:00', '17:30', null],
-            [null, '17:30', 2],
-            ['11:30', null, 2],
-            ['09:00', '18:00', 1],
-        ];
-    }
-
-    public function timeFormatDataProvider()
-    {
-        return [
-            ['19'],
-            ['dasdasdas'],
-            [1],
-            ['1:00'],
-        ];
-    }
-
-    public function breakGreaterThanWorkingHours()
-    {
-        return [
-            ['10:00', '11:30', 2],
-            ['09:15', '15:15', 7.5],
-            ['12:30', '17:30', 6],
-            ['14:00', '16:00', 2],
-        ];
-    }
-
-    public function workDayTypeDataProvider()
-    {
-        return [
-            [0, true],
-            [CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_YES, false],
-            [CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_NO, false],
-            [CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_WEEKEND, false],
-            ['adasdsa', true],
-            [rand(4, PHP_INT_MAX), true],
-        ];
-    }
-
-    public function numberOfHoursDataProvider()
-    {
-        return [
-            ['09:00', '18:00', 1, 8],
-            ['07:00', '15:30', 1, 7.5],
-            ['12:00', '18:00', 1, 5],
-            ['12:00', '16:00', 0.25, 3.75],
-            ['10:00', '18:00', 0.75, 7.25],
-        ];
-    }
+  public function numberOfHoursDataProvider() {
+    return [
+      ['09:00', '18:00', 1, 8],
+      ['07:00', '15:30', 1, 7.5],
+      ['12:00', '18:00', 1, 5],
+      ['12:00', '16:00', 0.25, 3.75],
+      ['10:00', '18:00', 0.75, 7.25],
+    ];
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkDayTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkDayTest.php
@@ -1,7 +1,8 @@
 <?php
 
-use Civi\Test\HeadlessInterface;
-use Civi\Test\TransactionalInterface;
+require_once __DIR__."/../BaseTest.php";
+
+use CRM_HRLeaveAndAbsences_BaseTest as BaseTest;
 use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
 use CRM_HRLeaveAndAbsences_BAO_WorkWeek as WorkWeek;
 use CRM_HRLeaveAndAbsences_BAO_WorkDay as WorkDay;
@@ -12,15 +13,10 @@ use CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException as InvalidWorkDayEx
  *
  * @group headless
  */
-class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends PHPUnit_Framework_TestCase implements
-  HeadlessInterface, TransactionalInterface {
+class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends BaseTest {
 
   protected $workPattern = null;
   protected $workWeek = null;
-
-  public function setUpHeadless() {
-    return \Civi\Test::headless()->installMe(__DIR__)->apply();
-  }
 
   public function setUp() {
     parent::setUp();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
@@ -18,6 +18,11 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends PHPUnit_Framework_TestC
       return \Civi\Test::headless()->installMe(__DIR__)->apply();
     }
 
+    public function setUp() {
+      //Deletes the default work pattern so it doesn't interfere with the tests
+      WorkPattern::del(1);
+    }
+
     public function testWeightShouldAlwaysBeMaxWeightPlus1OnCreate()
     {
         $firstEntity = $this->createBasicWorkPattern();
@@ -72,7 +77,6 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends PHPUnit_Framework_TestC
 
     public function testFindWithNumberOfWeeksAndHours()
     {
-
         $this->createWorkPatternWith40HoursWorkWeek('Pattern 1');
         $this->createWorkPatternWithTwoWeeksAnd31AndHalfHours('Pattern 2');
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
@@ -1,7 +1,8 @@
 <?php
 
-use Civi\Test\HeadlessInterface;
-use Civi\Test\TransactionalInterface;
+require_once __DIR__."/../BaseTest.php";
+
+use CRM_HRLeaveAndAbsences_BaseTest as BaseTest;
 use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
 use CRM_HRLeaveAndAbsences_BAO_WorkWeek as WorkWeek;
 use CRM_HRLeaveAndAbsences_BAO_WorkDay as WorkDay;
@@ -11,12 +12,7 @@ use CRM_HRLeaveAndAbsences_BAO_WorkDay as WorkDay;
  *
  * @group headless
  */
-class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends PHPUnit_Framework_TestCase implements
-  HeadlessInterface, TransactionalInterface {
-
-  public function setUpHeadless() {
-    return \Civi\Test::headless()->installMe(__DIR__)->apply();
-  }
+class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends BaseTest {
 
   public function setUp() {
     //Deletes the default work pattern so it doesn't interfere with the tests

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
@@ -12,461 +12,449 @@ use CRM_HRLeaveAndAbsences_BAO_WorkDay as WorkDay;
  * @group headless
  */
 class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends PHPUnit_Framework_TestCase implements
-  HeadlessInterface, TransactionalInterface
-{
-    public function setUpHeadless() {
-      return \Civi\Test::headless()->installMe(__DIR__)->apply();
-    }
+  HeadlessInterface, TransactionalInterface {
 
-    public function setUp() {
-      //Deletes the default work pattern so it doesn't interfere with the tests
-      WorkPattern::del(1);
-    }
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->installMe(__DIR__)->apply();
+  }
 
-    public function testWeightShouldAlwaysBeMaxWeightPlus1OnCreate()
-    {
-        $firstEntity = $this->createBasicWorkPattern();
-        $this->assertNotEmpty($firstEntity->weight);
+  public function setUp() {
+    //Deletes the default work pattern so it doesn't interfere with the tests
+    WorkPattern::del(1);
+  }
 
-        $secondEntity = $this->createBasicWorkPattern();
-        $this->assertNotEmpty($secondEntity->weight);
-        $this->assertEquals($firstEntity->weight + 1, $secondEntity->weight);
-    }
+  public function testWeightShouldAlwaysBeMaxWeightPlus1OnCreate() {
+    $firstEntity = $this->createBasicWorkPattern();
+    $this->assertNotEmpty($firstEntity->weight);
 
-    /**
-     * @expectedException PEAR_Exception
-     * @expectedExceptionMessage DB Error: already exists
-     */
-    public function testWorkPatternLabelsShouldBeUnique() {
-        $this->createBasicWorkPattern(['label' => 'Pattern 1']);
-        $this->createBasicWorkPattern(['label' => 'Pattern 1']);
-    }
+    $secondEntity = $this->createBasicWorkPattern();
+    $this->assertNotEmpty($secondEntity->weight);
+    $this->assertEquals($firstEntity->weight + 1, $secondEntity->weight);
+  }
 
-    public function testThereShouldBeOnlyOneDefaultTypeOnCreate() {
-        $basicEntity = $this->createBasicWorkPattern(['is_default' => true]);
-        $entity1 = $this->findWorkPatternByID($basicEntity->id);
-        $this->assertEquals(1, $entity1->is_default);
+  /**
+   * @expectedException PEAR_Exception
+   * @expectedExceptionMessage DB Error: already exists
+   */
+  public function testWorkPatternLabelsShouldBeUnique() {
+    $this->createBasicWorkPattern(['label' => 'Pattern 1']);
+    $this->createBasicWorkPattern(['label' => 'Pattern 1']);
+  }
 
-        $basicEntity = $this->createBasicWorkPattern(['is_default' => true]);
-        $entity2 = $this->findWorkPatternByID($basicEntity->id);
-        $entity1 = $this->findWorkPatternByID($entity1->id);
-        $this->assertEquals(0,  $entity1->is_default);
-        $this->assertEquals(1, $entity2->is_default);
-    }
+  public function testThereShouldBeOnlyOneDefaultTypeOnCreate() {
+    $basicEntity = $this->createBasicWorkPattern(['is_default' => true]);
+    $entity1 = $this->findWorkPatternByID($basicEntity->id);
+    $this->assertEquals(1, $entity1->is_default);
 
-    public function testThereShouldBeOnlyOneDefaultTypeOnUpdate() {
-        $basicEntity1 = $this->createBasicWorkPattern(['is_default' => false]);
-        $basicEntity2 = $this->createBasicWorkPattern(['is_default' => false]);
-        $entity1 = $this->findWorkPatternByID($basicEntity1->id);
-        $entity2 = $this->findWorkPatternByID($basicEntity2->id);
-        $this->assertEquals(0,  $entity1->is_default);
-        $this->assertEquals(0,  $entity2->is_default);
+    $basicEntity = $this->createBasicWorkPattern(['is_default' => true]);
+    $entity2 = $this->findWorkPatternByID($basicEntity->id);
+    $entity1 = $this->findWorkPatternByID($entity1->id);
+    $this->assertEquals(0,  $entity1->is_default);
+    $this->assertEquals(1, $entity2->is_default);
+  }
 
-        $this->updateBasicWorkPattern($basicEntity1->id, ['is_default' => true]);
-        $entity1 = $this->findWorkPatternByID($basicEntity1->id);
-        $entity2 = $this->findWorkPatternByID($basicEntity2->id);
-        $this->assertEquals(1, $entity1->is_default);
-        $this->assertEquals(0,  $entity2->is_default);
+  public function testThereShouldBeOnlyOneDefaultTypeOnUpdate() {
+    $basicEntity1 = $this->createBasicWorkPattern(['is_default' => false]);
+    $basicEntity2 = $this->createBasicWorkPattern(['is_default' => false]);
+    $entity1 = $this->findWorkPatternByID($basicEntity1->id);
+    $entity2 = $this->findWorkPatternByID($basicEntity2->id);
+    $this->assertEquals(0,  $entity1->is_default);
+    $this->assertEquals(0,  $entity2->is_default);
 
-        $this->updateBasicWorkPattern($basicEntity2->id, ['is_default' => true]);
-        $entity1 = $this->findWorkPatternByID($basicEntity1->id);
-        $entity2 = $this->findWorkPatternByID($basicEntity2->id);
-        $this->assertEquals(0,  $entity1->is_default);
-        $this->assertEquals(1, $entity2->is_default);
-    }
+    $this->updateBasicWorkPattern($basicEntity1->id, ['is_default' => true]);
+    $entity1 = $this->findWorkPatternByID($basicEntity1->id);
+    $entity2 = $this->findWorkPatternByID($basicEntity2->id);
+    $this->assertEquals(1, $entity1->is_default);
+    $this->assertEquals(0,  $entity2->is_default);
 
-    public function testFindWithNumberOfWeeksAndHours()
-    {
-        $this->createWorkPatternWith40HoursWorkWeek('Pattern 1');
-        $this->createWorkPatternWithTwoWeeksAnd31AndHalfHours('Pattern 2');
+    $this->updateBasicWorkPattern($basicEntity2->id, ['is_default' => true]);
+    $entity1 = $this->findWorkPatternByID($basicEntity1->id);
+    $entity2 = $this->findWorkPatternByID($basicEntity2->id);
+    $this->assertEquals(0,  $entity1->is_default);
+    $this->assertEquals(1, $entity2->is_default);
+  }
 
-        $object = new WorkPattern();
-        $object->findWithNumberOfWeeksAndHours();
-        $this->assertEquals(2, $object->N);
+  public function testFindWithNumberOfWeeksAndHours() {
+    $this->createWorkPatternWith40HoursWorkWeek('Pattern 1');
+    $this->createWorkPatternWithTwoWeeksAnd31AndHalfHours('Pattern 2');
 
-        $object->fetch();
-        $this->assertEquals('Pattern 1', $object->label);
-        $this->assertEquals(1, $object->number_of_weeks);
-        $this->assertEquals(40.0, $object->number_of_hours);
+    $object = new WorkPattern();
+    $object->findWithNumberOfWeeksAndHours();
+    $this->assertEquals(2, $object->N);
 
-        $object->fetch();
-        $this->assertEquals('Pattern 2', $object->label);
-        $this->assertEquals(2, $object->number_of_weeks);
-        $this->assertEquals(31.5, $object->number_of_hours);
-    }
+    $object->fetch();
+    $this->assertEquals('Pattern 1', $object->label);
+    $this->assertEquals(1, $object->number_of_weeks);
+    $this->assertEquals(40.0, $object->number_of_hours);
 
-    public function testGetValuesArrayShouldReturnWorkPatternValues()
-    {
-        $params = [
-            'label' => 'Pattern Label',
-            'description' => 'Pattern Description',
-            'is_active' => 1,
-            'is_default' => 1
-        ];
-        $entity = $this->createBasicWorkPattern($params);
-        $values = WorkPattern::getValuesArray($entity->id);
-        $this->assertEquals($params['label'], $values['label']);
-        $this->assertEquals($params['description'], $values['description']);
-        $this->assertEquals($params['is_active'], $values['is_active']);
-        $this->assertEquals($params['is_default'], $values['is_default']);
-        $this->assertEmpty($values['weeks']);
-    }
+    $object->fetch();
+    $this->assertEquals('Pattern 2', $object->label);
+    $this->assertEquals(2, $object->number_of_weeks);
+    $this->assertEquals(31.5, $object->number_of_hours);
+  }
 
-    public function testGetValuesArrayShouldReturnWorkPatternValuesWithWeeksAndDays()
-    {
-      $label = 'Pattern Label ' . microtime();
-      $entity = $this->createWorkPatternWith40HoursWorkWeek($label);
-      $values = WorkPattern::getValuesArray($entity->id);
+  public function testGetValuesArrayShouldReturnWorkPatternValues() {
+    $params = [
+        'label' => 'Pattern Label',
+        'description' => 'Pattern Description',
+        'is_active' => 1,
+        'is_default' => 1
+    ];
+    $entity = $this->createBasicWorkPattern($params);
+    $values = WorkPattern::getValuesArray($entity->id);
+    $this->assertEquals($params['label'], $values['label']);
+    $this->assertEquals($params['description'], $values['description']);
+    $this->assertEquals($params['is_active'], $values['is_active']);
+    $this->assertEquals($params['is_default'], $values['is_default']);
+    $this->assertEmpty($values['weeks']);
+  }
 
-      $this->assertEquals($label, $values['label']);
-      $this->assertCount(1, $values['weeks']);
-      $this->assertCount(7, $values['weeks'][0]['days']);
-    }
+  public function testGetValuesArrayShouldReturnWorkPatternValuesWithWeeksAndDays() {
+    $label = 'Pattern Label ' . microtime();
+    $entity = $this->createWorkPatternWith40HoursWorkWeek($label);
+    $values = WorkPattern::getValuesArray($entity->id);
 
-    public function testCanCreateWorkPatternWithWeeksAndDays()
-    {
-      $params = [
-        'weeks' => [
-          [
-            'days' => [
-              ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 1],
-              ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 2],
-              ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 3],
-              ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 4],
-              ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 5],
-              ['type' => 3, 'day_of_the_week' => 6],
-              ['type' => 3, 'day_of_the_week' => 7],
-            ]
+    $this->assertEquals($label, $values['label']);
+    $this->assertCount(1, $values['weeks']);
+    $this->assertCount(7, $values['weeks'][0]['days']);
+  }
+
+  public function testCanCreateWorkPatternWithWeeksAndDays() {
+    $params = [
+      'weeks' => [
+        [
+          'days' => [
+            ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 1],
+            ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 2],
+            ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 3],
+            ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 4],
+            ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 5],
+            ['type' => 3, 'day_of_the_week' => 6],
+            ['type' => 3, 'day_of_the_week' => 7],
           ]
         ]
-      ];
+      ]
+    ];
 
-      $workPattern = $this->createBasicWorkPattern($params);
-      $this->assertNotEmpty($workPattern->id);
-      $values = WorkPattern::getValuesArray($workPattern->id);
-      $this->assertCount(1, $values['weeks']);
-      $this->assertCount(7, $values['weeks'][0]['days']);
+    $workPattern = $this->createBasicWorkPattern($params);
+    $this->assertNotEmpty($workPattern->id);
+    $values = WorkPattern::getValuesArray($workPattern->id);
+    $this->assertCount(1, $values['weeks']);
+    $this->assertCount(7, $values['weeks'][0]['days']);
 
-      $weekDays = $values['weeks'][0]['days'];
-      foreach($values['weeks'][0]['days'] as $i => $day) {
-        $this->assertEquals($day['type'], $weekDays[$i]['type']);
-        $this->assertEquals($day['day_of_the_week'], $weekDays[$i]['day_of_the_week']);
-        if($day['type'] == 2) {
-          $this->assertEquals($day['time_from'], $weekDays[$i]['time_from']);
-          $this->assertEquals($day['time_to'], $weekDays[$i]['time_to']);
-          $this->assertEquals($day['break'], $weekDays[$i]['break']);
-          $this->assertEquals($day['leave_days'], $weekDays[$i]['leave_days']);
-        }
+    $weekDays = $values['weeks'][0]['days'];
+    foreach($values['weeks'][0]['days'] as $i => $day) {
+      $this->assertEquals($day['type'], $weekDays[$i]['type']);
+      $this->assertEquals($day['day_of_the_week'], $weekDays[$i]['day_of_the_week']);
+      if($day['type'] == 2) {
+        $this->assertEquals($day['time_from'], $weekDays[$i]['time_from']);
+        $this->assertEquals($day['time_to'], $weekDays[$i]['time_to']);
+        $this->assertEquals($day['break'], $weekDays[$i]['break']);
+        $this->assertEquals($day['leave_days'], $weekDays[$i]['leave_days']);
       }
     }
+  }
 
-    public function testCanUpdateWorkPatternWithWeeksAndDays()
-    {
-      $workPattern = $this->createBasicWorkPattern();
-      $this->assertNotEmpty($workPattern->id);
-      $values = WorkPattern::getValuesArray($workPattern->id);
-      $this->assertCount(0, $values['weeks']);
+  public function testCanUpdateWorkPatternWithWeeksAndDays() {
+    $workPattern = $this->createBasicWorkPattern();
+    $this->assertNotEmpty($workPattern->id);
+    $values = WorkPattern::getValuesArray($workPattern->id);
+    $this->assertCount(0, $values['weeks']);
 
-      $params = [
-        'weeks' => [
-          [
-            'days' => [
-              ['type' => 2, 'time_from' => '15:00', 'time_to' => '22:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 1],
-              ['type' => 2, 'time_from' => '13:00', 'time_to' => '23:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 2],
-              ['type' => 2, 'time_from' => '09:00', 'time_to' => '18:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 3],
-              ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 4],
-              ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 5],
-              ['type' => 3, 'day_of_the_week' => 6],
-              ['type' => 3, 'day_of_the_week' => 7],
-            ]
+    $params = [
+      'weeks' => [
+        [
+          'days' => [
+            ['type' => 2, 'time_from' => '15:00', 'time_to' => '22:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 1],
+            ['type' => 2, 'time_from' => '13:00', 'time_to' => '23:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 2],
+            ['type' => 2, 'time_from' => '09:00', 'time_to' => '18:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 3],
+            ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 4],
+            ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 5],
+            ['type' => 3, 'day_of_the_week' => 6],
+            ['type' => 3, 'day_of_the_week' => 7],
           ]
         ]
-      ];
+      ]
+    ];
 
-      $workPattern = $this->updateBasicWorkPattern($workPattern->id, $params);
-      $this->assertNotEmpty($workPattern->id);
-      $values = WorkPattern::getValuesArray($workPattern->id);
-      $this->assertCount(1, $values['weeks']);
-      $this->assertCount(7, $values['weeks'][0]['days']);
+    $workPattern = $this->updateBasicWorkPattern($workPattern->id, $params);
+    $this->assertNotEmpty($workPattern->id);
+    $values = WorkPattern::getValuesArray($workPattern->id);
+    $this->assertCount(1, $values['weeks']);
+    $this->assertCount(7, $values['weeks'][0]['days']);
 
-      $weekDays = $values['weeks'][0]['days'];
-      foreach($values['weeks'][0]['days'] as $i => $day) {
-        $this->assertEquals($day['type'], $weekDays[$i]['type']);
-        $this->assertEquals($day['day_of_the_week'], $weekDays[$i]['day_of_the_week']);
-        if($day['type'] == 2) {
-          $this->assertEquals($day['time_from'], $weekDays[$i]['time_from']);
-          $this->assertEquals($day['time_to'], $weekDays[$i]['time_to']);
-          $this->assertEquals($day['break'], $weekDays[$i]['break']);
-          $this->assertEquals($day['leave_days'], $weekDays[$i]['leave_days']);
-        }
+    $weekDays = $values['weeks'][0]['days'];
+    foreach($values['weeks'][0]['days'] as $i => $day) {
+      $this->assertEquals($day['type'], $weekDays[$i]['type']);
+      $this->assertEquals($day['day_of_the_week'], $weekDays[$i]['day_of_the_week']);
+      if($day['type'] == 2) {
+        $this->assertEquals($day['time_from'], $weekDays[$i]['time_from']);
+        $this->assertEquals($day['time_to'], $weekDays[$i]['time_to']);
+        $this->assertEquals($day['break'], $weekDays[$i]['break']);
+        $this->assertEquals($day['leave_days'], $weekDays[$i]['leave_days']);
       }
     }
+  }
 
-    public function testGetValuesArrayShouldReturnEmptyArrayWhenWorkPatternDoesntExists()
-    {
-        $values = WorkPattern::getValuesArray(1);
-        $this->assertEmpty($values);
+  public function testGetValuesArrayShouldReturnEmptyArrayWhenWorkPatternDoesntExists() {
+    $values = WorkPattern::getValuesArray(1);
+    $this->assertEmpty($values);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkPatternException
+   * @expectedExceptionMessage You cannot disable a Work Pattern if it's the last one
+   */
+  public function testCannotDisablePatternIfItIsTheLastWorkPatternEnabled() {
+    $workPattern = $this->createBasicWorkPattern(['is_active' => 1]);
+    $this->updateBasicWorkPattern($workPattern->id, ['is_active' => 0]);
+  }
+
+  public function testCanDisablePatternIfItIsNotTheLastWorkPatternEnabled() {
+    $workPattern1 = $this->createBasicWorkPattern(['is_active' => 1]);
+    $this->createBasicWorkPattern(['is_active' => 1]);
+
+    $this->updateBasicWorkPattern($workPattern1->id, ['is_active' => 0]);
+
+    $workPattern1 = $this->findWorkPatternByID($workPattern1->id);
+    $this->assertEquals(0, $workPattern1->is_active);
+  }
+
+  private function createBasicWorkPattern($params = []) {
+    $basicRequiredFields = ['label' => 'Pattern ' . microtime() ];
+
+    $params = array_merge($basicRequiredFields, $params);
+    return WorkPattern::create($params);
+  }
+
+  private function updateBasicWorkPattern($id, $params) {
+    $params['id'] = $id;
+    return $this->createBasicWorkPattern($params);
+  }
+
+  private function findWorkPatternByID($id) {
+    $entity = new WorkPattern();
+    $entity->id = $id;
+    $entity->find(true);
+
+    if($entity->N == 0) {
+        return null;
     }
 
-    /**
-     * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkPatternException
-     * @expectedExceptionMessage You cannot disable a Work Pattern if it's the last one
-     */
-    public function testCannotDisablePatternIfItIsTheLastWorkPatternEnabled() {
-      $workPattern = $this->createBasicWorkPattern(['is_active' => 1]);
-      $this->updateBasicWorkPattern($workPattern->id, ['is_active' => 0]);
-    }
+    return $entity;
+  }
 
-    public function testCanDisablePatternIfItIsNotTheLastWorkPatternEnabled() {
-      $workPattern1 = $this->createBasicWorkPattern(['is_active' => 1]);
-      $this->createBasicWorkPattern(['is_active' => 1]);
+  /**
+   * This creates a WorkPattern with a single WorkWeek containing
+   * 7 WorkDays (5 Working Days with 8 working hours each and 2 days
+   * of weekend).
+   *
+   * @param string $label the label of the Work Pattern
+   *
+   * @return \CRM_HRLeaveAndAbsences_DAO_WorkPattern|NULL
+   */
+  private function createWorkPatternWith40HoursWorkWeek($label) {
+    $pattern = $this->createBasicWorkPattern(['label' => $label]);
 
-      $this->updateBasicWorkPattern($workPattern1->id, ['is_active' => 0]);
+    $week = WorkWeek::create([
+      'pattern_id' => $pattern->id,
+      'sequential' => 1
+    ]);
 
-      $workPattern1 = $this->findWorkPatternByID($workPattern1->id);
-      $this->assertEquals(0, $workPattern1->is_active);
-    }
+    WorkDay::create([
+      'week_id'         => $week->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_YES,
+      'day_of_the_week' => 1,
+      'time_from'       => '09:00',
+      'time_to'         => '18:00',
+      'break'           => 1,
+      'leave_days'      => 1
+    ]);
 
-    private function createBasicWorkPattern($params = [])
-    {
-        $basicRequiredFields = ['label' => 'Pattern ' . microtime() ];
+    WorkDay::create([
+      'week_id'         => $week->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_YES,
+      'day_of_the_week' => 2,
+      'time_from'       => '09:00',
+      'time_to'         => '18:00',
+      'break'           => 1,
+      'leave_days'      => 1
+    ]);
 
-        $params = array_merge($basicRequiredFields, $params);
-        return WorkPattern::create($params);
-    }
+    WorkDay::create([
+      'week_id'         => $week->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_YES,
+      'day_of_the_week' => 3,
+      'time_from'       => '09:00',
+      'time_to'         => '18:00',
+      'break'           => 1,
+      'leave_days'      => 1
+    ]);
 
-    private function updateBasicWorkPattern($id, $params)
-    {
-        $params['id'] = $id;
-        return $this->createBasicWorkPattern($params);
-    }
+    WorkDay::create([
+      'week_id'         => $week->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_YES,
+      'day_of_the_week' => 4,
+      'time_from'       => '09:00',
+      'time_to'         => '18:00',
+      'break'           => 1,
+      'leave_days'      => 1
+    ]);
 
-    private function findWorkPatternByID($id)
-    {
-        $entity = new WorkPattern();
-        $entity->id = $id;
-        $entity->find(true);
+    WorkDay::create([
+      'week_id'         => $week->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_YES,
+      'day_of_the_week' => 5,
+      'time_from'       => '09:00',
+      'time_to'         => '18:00',
+      'break'           => 1,
+      'leave_days'      => 1
+    ]);
 
-        if($entity->N == 0) {
-            return null;
-        }
+    WorkDay::create([
+      'week_id'         => $week->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_WEEKEND,
+      'day_of_the_week' => 6
+    ]);
 
-        return $entity;
-    }
+    WorkDay::create([
+      'week_id'         => $week->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_WEEKEND,
+      'day_of_the_week' => 7
+    ]);
 
-    /**
-     * This creates a WorkPattern with a single WorkWeek containing
-     * 7 WorkDays (5 Working Days with 8 working hours each and 2 days
-     * of weekend).
-     *
-     * @param string $label the label of the Work Pattern
-     *
-     * @return \CRM_HRLeaveAndAbsences_DAO_WorkPattern|NULL
-     */
-    private function createWorkPatternWith40HoursWorkWeek($label)
-    {
-      $pattern = $this->createBasicWorkPattern(['label' => $label]);
+    return $pattern;
+  }
 
-      $week = WorkWeek::create([
-        'pattern_id' => $pattern->id,
-        'sequential' => 1
-      ]);
+  /**
+   * This creates a WorkPattern with two WorkWeeks.
+   *
+   * The first WorkWeek contains 3 working days, with 7.5 working hours each,
+   * 2 non working days and 2 days of weekend.
+   *
+   * The second WorkWeek contains 2 working days, with 4.5 working hours each,
+   * 3 non working days and 2 days of weekend.
+   *
+   * @param string $label the label of the Work Pattern
+   *
+   * @return \CRM_HRLeaveAndAbsences_DAO_WorkPattern|NULL
+   */
+  private function createWorkPatternWithTwoWeeksAnd31AndHalfHours($label) {
+    $pattern = $this->createBasicWorkPattern(['label' => $label]);
 
-      WorkDay::create([
-        'week_id'         => $week->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_YES,
-        'day_of_the_week' => 1,
-        'time_from'       => '09:00',
-        'time_to'         => '18:00',
-        'break'           => 1,
-        'leave_days'      => 1
-      ]);
-
-      WorkDay::create([
-        'week_id'         => $week->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_YES,
-        'day_of_the_week' => 2,
-        'time_from'       => '09:00',
-        'time_to'         => '18:00',
-        'break'           => 1,
-        'leave_days'      => 1
-      ]);
-
-      WorkDay::create([
-        'week_id'         => $week->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_YES,
-        'day_of_the_week' => 3,
-        'time_from'       => '09:00',
-        'time_to'         => '18:00',
-        'break'           => 1,
-        'leave_days'      => 1
-      ]);
-
-      WorkDay::create([
-        'week_id'         => $week->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_YES,
-        'day_of_the_week' => 4,
-        'time_from'       => '09:00',
-        'time_to'         => '18:00',
-        'break'           => 1,
-        'leave_days'      => 1
-      ]);
-
-      WorkDay::create([
-        'week_id'         => $week->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_YES,
-        'day_of_the_week' => 5,
-        'time_from'       => '09:00',
-        'time_to'         => '18:00',
-        'break'           => 1,
-        'leave_days'      => 1
-      ]);
-
-      WorkDay::create([
-        'week_id'         => $week->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_WEEKEND,
-        'day_of_the_week' => 6
-      ]);
-
-      WorkDay::create([
-        'week_id'         => $week->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_WEEKEND,
-        'day_of_the_week' => 7
-      ]);
-
-      return $pattern;
-    }
-
-    /**
-     * This creates a WorkPattern with two WorkWeeks.
-     *
-     * The first WorkWeek contains 3 working days, with 7.5 working hours each,
-     * 2 non working days and 2 days of weekend.
-     *
-     * The second WorkWeek contains 2 working days, with 4.5 working hours each,
-     * 3 non working days and 2 days of weekend.
-     *
-     * @param string $label the label of the Work Pattern
-     *
-     * @return \CRM_HRLeaveAndAbsences_DAO_WorkPattern|NULL
-     */
-    private function createWorkPatternWithTwoWeeksAnd31AndHalfHours($label)
-    {
-      $pattern = $this->createBasicWorkPattern(['label' => $label]);
-
-      $week1 = WorkWeek::create([
-        'pattern_id' => $pattern->id,
-        'sequential' => 1
-      ]);
+    $week1 = WorkWeek::create([
+      'pattern_id' => $pattern->id,
+      'sequential' => 1
+    ]);
 
 
-      $week2 = WorkWeek::create([
-        'pattern_id' => $pattern->id,
-        'sequential' => 1
-      ]);
+    $week2 = WorkWeek::create([
+      'pattern_id' => $pattern->id,
+      'sequential' => 1
+    ]);
 
-      WorkDay::create([
-        'week_id'         => $week1->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_YES,
-        'day_of_the_week' => 1,
-        'time_from'       => '07:00',
-        'time_to'         => '15:30',
-        'break'           => 1,
-        'leave_days'      => 1
-      ]);
+    WorkDay::create([
+      'week_id'         => $week1->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_YES,
+      'day_of_the_week' => 1,
+      'time_from'       => '07:00',
+      'time_to'         => '15:30',
+      'break'           => 1,
+      'leave_days'      => 1
+    ]);
 
-      WorkDay::create([
-        'week_id'         => $week1->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_NO,
-        'day_of_the_week' => 2,
-      ]);
+    WorkDay::create([
+      'week_id'         => $week1->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_NO,
+      'day_of_the_week' => 2,
+    ]);
 
-      WorkDay::create([
-        'week_id'         => $week1->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_YES,
-        'day_of_the_week' => 3,
-        'time_from'       => '07:00',
-        'time_to'         => '15:30',
-        'break'           => 1,
-        'leave_days'      => 1
-      ]);
+    WorkDay::create([
+      'week_id'         => $week1->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_YES,
+      'day_of_the_week' => 3,
+      'time_from'       => '07:00',
+      'time_to'         => '15:30',
+      'break'           => 1,
+      'leave_days'      => 1
+    ]);
 
-      WorkDay::create([
-        'week_id'         => $week1->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_NO,
-        'day_of_the_week' => 4,
-      ]);
+    WorkDay::create([
+      'week_id'         => $week1->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_NO,
+      'day_of_the_week' => 4,
+    ]);
 
-      WorkDay::create([
-        'week_id'         => $week1->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_YES,
-        'day_of_the_week' => 5,
-        'time_from'       => '07:00',
-        'time_to'         => '15:30',
-        'break'           => 1,
-        'leave_days'      => 1
-      ]);
+    WorkDay::create([
+      'week_id'         => $week1->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_YES,
+      'day_of_the_week' => 5,
+      'time_from'       => '07:00',
+      'time_to'         => '15:30',
+      'break'           => 1,
+      'leave_days'      => 1
+    ]);
 
-      WorkDay::create([
-        'week_id'         => $week1->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_WEEKEND,
-        'day_of_the_week' => 6,
-      ]);
+    WorkDay::create([
+      'week_id'         => $week1->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_WEEKEND,
+      'day_of_the_week' => 6,
+    ]);
 
-      WorkDay::create([
-        'week_id'         => $week1->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_WEEKEND,
-        'day_of_the_week' => 7,
-      ]);
+    WorkDay::create([
+      'week_id'         => $week1->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_WEEKEND,
+      'day_of_the_week' => 7,
+    ]);
 
-      WorkDay::create([
-        'week_id'         => $week2->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_NO,
-        'day_of_the_week' => 1,
-      ]);
+    WorkDay::create([
+      'week_id'         => $week2->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_NO,
+      'day_of_the_week' => 1,
+    ]);
 
-      WorkDay::create([
-        'week_id'         => $week2->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_YES,
-        'day_of_the_week' => 2,
-        'time_from'       => '07:00',
-        'time_to'         => '12:00',
-        'break'           => 0.5,
-        'leave_days'      => 1
-      ]);
+    WorkDay::create([
+      'week_id'         => $week2->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_YES,
+      'day_of_the_week' => 2,
+      'time_from'       => '07:00',
+      'time_to'         => '12:00',
+      'break'           => 0.5,
+      'leave_days'      => 1
+    ]);
 
-      WorkDay::create([
-        'week_id'         => $week2->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_NO,
-        'day_of_the_week' => 3,
-      ]);
+    WorkDay::create([
+      'week_id'         => $week2->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_NO,
+      'day_of_the_week' => 3,
+    ]);
 
-      WorkDay::create([
-        'week_id'         => $week2->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_YES,
-        'day_of_the_week' => 4,
-        'time_from'       => '07:00',
-        'time_to'         => '12:00',
-        'break'           => 0.5,
-        'leave_days'      => 1
-      ]);
+    WorkDay::create([
+      'week_id'         => $week2->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_YES,
+      'day_of_the_week' => 4,
+      'time_from'       => '07:00',
+      'time_to'         => '12:00',
+      'break'           => 0.5,
+      'leave_days'      => 1
+    ]);
 
-      WorkDay::create([
-        'week_id'         => $week2->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_NO,
-        'day_of_the_week' => 5,
-      ]);
+    WorkDay::create([
+      'week_id'         => $week2->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_NO,
+      'day_of_the_week' => 5,
+    ]);
 
-      WorkDay::create([
-        'week_id'         => $week2->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_WEEKEND,
-        'day_of_the_week' => 6,
-      ]);
+    WorkDay::create([
+      'week_id'         => $week2->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_WEEKEND,
+      'day_of_the_week' => 6,
+    ]);
 
-      WorkDay::create([
-        'week_id'         => $week2->id,
-        'type'            => WorkDay::WORK_DAY_OPTION_WEEKEND,
-        'day_of_the_week' => 7,
-      ]);
-    }
+    WorkDay::create([
+      'week_id'         => $week2->id,
+      'type'            => WorkDay::WORK_DAY_OPTION_WEEKEND,
+      'day_of_the_week' => 7,
+    ]);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkWeekTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkWeekTest.php
@@ -1,7 +1,8 @@
 <?php
 
-use Civi\Test\HeadlessInterface;
-use Civi\Test\TransactionalInterface;
+require_once __DIR__."/../BaseTest.php";
+
+use CRM_HRLeaveAndAbsences_BaseTest as BaseTest;
 use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
 use CRM_HRLeaveAndAbsences_BAO_WorkWeek as WorkWeek;
 use CRM_HRLeaveAndAbsences_BAO_WorkDay as WorkDay;
@@ -11,13 +12,8 @@ use CRM_HRLeaveAndAbsences_BAO_WorkDay as WorkDay;
  *
  * @group headless
  */
-class CRM_HRLeaveAndAbsences_BAO_WorkWeekTest extends PHPUnit_Framework_TestCase implements
-  HeadlessInterface, TransactionalInterface {
+class CRM_HRLeaveAndAbsences_BAO_WorkWeekTest extends BaseTest {
   protected $workPattern = null;
-
-  public function setUpHeadless() {
-    return \Civi\Test::headless()->installMe(__DIR__)->apply();
-  }
 
   public function setUp() {
     $this->instantiateWorkPattern();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkWeekTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkWeekTest.php
@@ -12,193 +12,194 @@ use CRM_HRLeaveAndAbsences_BAO_WorkDay as WorkDay;
  * @group headless
  */
 class CRM_HRLeaveAndAbsences_BAO_WorkWeekTest extends PHPUnit_Framework_TestCase implements
-  HeadlessInterface, TransactionalInterface
-{
-    protected $workPattern = null;
+  HeadlessInterface, TransactionalInterface {
+  protected $workPattern = null;
 
-    public function setUpHeadless() {
-      return \Civi\Test::headless()->installMe(__DIR__)->apply();
-    }
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->installMe(__DIR__)->apply();
+  }
 
-    public function setUp() {
-        $this->instantiateWorkPattern();
-    }
+  public function setUp() {
+    $this->instantiateWorkPattern();
+  }
 
-    public function testNumberShouldAlwaysBeMaxNumberPlus1OnCreate()
-    {
-        $params = ['pattern_id' => $this->workPattern->id];
+  public function testNumberShouldAlwaysBeMaxNumberPlus1OnCreate() {
+    $params = ['pattern_id' => $this->workPattern->id];
 
-        $entity = $this->createWorkWeek($params);
-        $this->assertEquals(1, $entity->number);
+    $entity = $this->createWorkWeek($params);
+    $this->assertEquals(1, $entity->number);
 
-        $entity2 = $this->createWorkWeek($params);
-        $this->assertEquals(2, $entity2->number);
-    }
+    $entity2 = $this->createWorkWeek($params);
+    $this->assertEquals(2, $entity2->number);
+  }
 
-    public function testCannotSetWeekNumberOnCreate()
-    {
-        $params = [
-            'pattern_id' => $this->workPattern->id,
-            'number' => rand(2, 1000)
-        ];
-        $entity = $this->createWorkWeek($params);
-        $this->assertEquals(1, $entity->number);
-    }
-
-    public function testCannotChangeWeekNumberOnUpdate()
-    {
-        $entity = $this->createWorkWeek(['pattern_id' => $this->workPattern->id]);
-        $this->assertEquals(1, $entity->number);
-
-        $updatedEntity = $this->updateWorkWeek($entity->id, ['number' => rand(100, 200)]);
-        $this->assertEquals($entity->number, $updatedEntity->number);
-    }
-
-    public function testCannotChangeWorkPatternId()
-    {
-        $entity = $this->createWorkWeek(['pattern_id' => $this->workPattern->id]);
-        $this->assertEquals($this->workPattern->id, $entity->pattern_id);
-
-        $updatedEntity = $this->updateWorkWeek($entity->id, ['pattern_id' => rand(100, 200)]);
-        $this->assertEquals($this->workPattern->id, $updatedEntity->pattern_id);
-    }
-
-    public function testCanCreateWorkWeekWithDays()
-    {
-      $params = [
+  public function testCannotSetWeekNumberOnCreate() {
+    $params = [
         'pattern_id' => $this->workPattern->id,
-        'days' => [
-          ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 1],
-          ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 2],
-          ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 3],
-          ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 4],
-          ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 5],
-          ['type' => 3, 'day_of_the_week' => 6],
-          ['type' => 3, 'day_of_the_week' => 7],
-        ]
-      ];
+        'number' => rand(2, 1000)
+    ];
+    $entity = $this->createWorkWeek($params);
+    $this->assertEquals(1, $entity->number);
+  }
 
-      $workWeek = $this->createWorkWeek($params);
-      $this->assertNotEmpty($workWeek->id);
-      $weekDays = $this->getWorkDaysForWeek($workWeek->id);
-      $this->assertCount(7, $weekDays);
-      foreach($params['days'] as $i => $day) {
-        $this->assertEquals($day['type'], $weekDays[$i]->type);
-        $this->assertEquals($day['day_of_the_week'], $weekDays[$i]->day_of_the_week);
-        if($day['type'] == 2) {
-          $this->assertEquals($day['time_from'], $weekDays[$i]->time_from);
-          $this->assertEquals($day['time_to'], $weekDays[$i]->time_to);
-          $this->assertEquals($day['break'], $weekDays[$i]->break);
-          $this->assertEquals($day['leave_days'], $weekDays[$i]->leave_days);
-        }
+  public function testCannotChangeWeekNumberOnUpdate() {
+    $entity = $this->createWorkWeek([
+      'pattern_id' => $this->workPattern->id
+    ]);
+    $this->assertEquals(1, $entity->number);
+
+    $updatedEntity = $this->updateWorkWeek($entity->id, [
+      'number' => rand(100, 200)
+    ]);
+    $this->assertEquals($entity->number, $updatedEntity->number);
+  }
+
+  public function testCannotChangeWorkPatternId() {
+    $entity = $this->createWorkWeek([
+      'pattern_id' => $this->workPattern->id
+    ]);
+    $this->assertEquals($this->workPattern->id, $entity->pattern_id);
+
+    $updatedEntity = $this->updateWorkWeek($entity->id, [
+      'pattern_id' => rand(100, 200)
+    ]);
+    $this->assertEquals($this->workPattern->id, $updatedEntity->pattern_id);
+  }
+
+  public function testCanCreateWorkWeekWithDays()
+  {
+    $params = [
+      'pattern_id' => $this->workPattern->id,
+      'days' => [
+        ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 1],
+        ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 2],
+        ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 3],
+        ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 4],
+        ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 5],
+        ['type' => 3, 'day_of_the_week' => 6],
+        ['type' => 3, 'day_of_the_week' => 7],
+      ]
+    ];
+
+    $workWeek = $this->createWorkWeek($params);
+    $this->assertNotEmpty($workWeek->id);
+    $weekDays = $this->getWorkDaysForWeek($workWeek->id);
+    $this->assertCount(7, $weekDays);
+    foreach($params['days'] as $i => $day) {
+      $this->assertEquals($day['type'], $weekDays[$i]->type);
+      $this->assertEquals($day['day_of_the_week'], $weekDays[$i]->day_of_the_week);
+      if($day['type'] == 2) {
+        $this->assertEquals($day['time_from'], $weekDays[$i]->time_from);
+        $this->assertEquals($day['time_to'], $weekDays[$i]->time_to);
+        $this->assertEquals($day['break'], $weekDays[$i]->break);
+        $this->assertEquals($day['leave_days'], $weekDays[$i]->leave_days);
       }
     }
+  }
 
-    public function testCanUpdateWorkWeekWithDays()
-    {
-      $params = ['pattern_id' => $this->workPattern->id];
-      $workWeek = $this->createWorkWeek($params);
-      $this->assertNotEmpty($workWeek->id);
-      $weekDays = $this->getWorkDaysForWeek($workWeek->id);
-      $this->assertCount(0, $weekDays);
+  public function testCanUpdateWorkWeekWithDays()
+  {
+    $params = ['pattern_id' => $this->workPattern->id];
+    $workWeek = $this->createWorkWeek($params);
+    $this->assertNotEmpty($workWeek->id);
+    $weekDays = $this->getWorkDaysForWeek($workWeek->id);
+    $this->assertCount(0, $weekDays);
 
-      $params = [
-        'days' => [
-          ['type' => 2, 'time_from' => '13:00', 'time_to' => '15:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 1],
-          ['type' => 2, 'time_from' => '09:00', 'time_to' => '18:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 2],
-          ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 3],
-          ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 4],
-          ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 5],
-          ['type' => 3, 'day_of_the_week' => 6],
-          ['type' => 3, 'day_of_the_week' => 7],
-        ]
-      ];
+    $params = [
+      'days' => [
+        ['type' => 2, 'time_from' => '13:00', 'time_to' => '15:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 1],
+        ['type' => 2, 'time_from' => '09:00', 'time_to' => '18:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 2],
+        ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 3],
+        ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 4],
+        ['type' => 2, 'time_from' => '10:00', 'time_to' => '19:00', 'break' => 1, 'leave_days' => 1, 'day_of_the_week' => 5],
+        ['type' => 3, 'day_of_the_week' => 6],
+        ['type' => 3, 'day_of_the_week' => 7],
+      ]
+    ];
 
-      $workWeek = $this->updateWorkWeek($workWeek->id, $params);
-      $weekDays = $this->getWorkDaysForWeek($workWeek->id);
-      $this->assertCount(7, $weekDays);
+    $workWeek = $this->updateWorkWeek($workWeek->id, $params);
+    $weekDays = $this->getWorkDaysForWeek($workWeek->id);
+    $this->assertCount(7, $weekDays);
 
-      foreach($params['days'] as $i => $day) {
-        $this->assertEquals($day['type'], $weekDays[$i]->type);
-        $this->assertEquals($day['day_of_the_week'], $weekDays[$i]->day_of_the_week);
-        if($day['type'] == 2) {
-          $this->assertEquals($day['time_from'], $weekDays[$i]->time_from);
-          $this->assertEquals($day['time_to'], $weekDays[$i]->time_to);
-          $this->assertEquals($day['break'], $weekDays[$i]->break);
-          $this->assertEquals($day['leave_days'], $weekDays[$i]->leave_days);
-        }
+    foreach($params['days'] as $i => $day) {
+      $this->assertEquals($day['type'], $weekDays[$i]->type);
+      $this->assertEquals($day['day_of_the_week'], $weekDays[$i]->day_of_the_week);
+      if($day['type'] == 2) {
+        $this->assertEquals($day['time_from'], $weekDays[$i]->time_from);
+        $this->assertEquals($day['time_to'], $weekDays[$i]->time_to);
+        $this->assertEquals($day['break'], $weekDays[$i]->break);
+        $this->assertEquals($day['leave_days'], $weekDays[$i]->leave_days);
       }
     }
+  }
 
-    /**
-     * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkWeekException
-     * @expectedExceptionMessage A Work Week must contain EXACTLY 7 days
-     */
-    public function testCannotCreateWorkWeekWithLessThanSevenDays()
-    {
-      $params = [
-        'pattern_id' => $this->workPattern->id,
-        'days' => [
-          ['type' => 3, 'day_of_the_week' => 1],
-          ['type' => 3, 'day_of_the_week' => 2],
-        ]
-      ];
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkWeekException
+   * @expectedExceptionMessage A Work Week must contain EXACTLY 7 days
+   */
+  public function testCannotCreateWorkWeekWithLessThanSevenDays()
+  {
+    $params = [
+      'pattern_id' => $this->workPattern->id,
+      'days' => [
+        ['type' => 3, 'day_of_the_week' => 1],
+        ['type' => 3, 'day_of_the_week' => 2],
+      ]
+    ];
 
-      $this->createWorkWeek($params);
+    $this->createWorkWeek($params);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkWeekException
+   * @expectedExceptionMessage A Work Week must contain EXACTLY 7 days
+   */
+  public function testCannotCreateWorkWeekWithMoreThanSevenDays() {
+    $params = [
+      'pattern_id' => $this->workPattern->id,
+      'days' => [
+        ['type' => 3, 'day_of_the_week' => 1],
+        ['type' => 3, 'day_of_the_week' => 2],
+        ['type' => 3, 'day_of_the_week' => 3],
+        ['type' => 3, 'day_of_the_week' => 4],
+        ['type' => 3, 'day_of_the_week' => 5],
+        ['type' => 3, 'day_of_the_week' => 6],
+        ['type' => 3, 'day_of_the_week' => 7],
+        ['type' => 3, 'day_of_the_week' => 7],
+      ]
+    ];
+
+    $this->createWorkWeek($params);
+  }
+
+  private function createWorkWeek($params) {
+    return WorkWeek::create($params);
+  }
+
+  private function updateWorkWeek($id, $params) {
+    $params['id'] = $id;
+    CRM_HRLeaveAndAbsences_BAO_WorkWeek::create($params);
+
+    return WorkWeek::findById($id);
+  }
+
+  private function instantiateWorkPattern() {
+    $this->workPattern = WorkPattern::create([
+      'label' => 'Pattern ' . microtime()
+    ]);
+  }
+
+  private function getWorkDaysForWeek($weekId) {
+    $workDays = [];
+
+    $workDay = new WorkDay();
+    $workDay->week_id = $weekId;
+    $workDay->find();
+
+    while($workDay->fetch()) {
+      $workDays[] = clone $workDay;
     }
 
-    /**
-     * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkWeekException
-     * @expectedExceptionMessage A Work Week must contain EXACTLY 7 days
-     */
-    public function testCannotCreateWorkWeekWithMoreThanSevenDays()
-    {
-      $params = [
-        'pattern_id' => $this->workPattern->id,
-        'days' => [
-          ['type' => 3, 'day_of_the_week' => 1],
-          ['type' => 3, 'day_of_the_week' => 2],
-          ['type' => 3, 'day_of_the_week' => 3],
-          ['type' => 3, 'day_of_the_week' => 4],
-          ['type' => 3, 'day_of_the_week' => 5],
-          ['type' => 3, 'day_of_the_week' => 6],
-          ['type' => 3, 'day_of_the_week' => 7],
-          ['type' => 3, 'day_of_the_week' => 7],
-        ]
-      ];
-
-      $this->createWorkWeek($params);
-    }
-
-    private function createWorkWeek($params)
-    {
-        return CRM_HRLeaveAndAbsences_BAO_WorkWeek::create($params);
-    }
-
-    private function updateWorkWeek($id, $params) {
-      $params['id'] = $id;
-      CRM_HRLeaveAndAbsences_BAO_WorkWeek::create($params);
-
-      return WorkWeek::findById($id);
-    }
-
-    private function instantiateWorkPattern() {
-        $this->workPattern = WorkPattern::create([
-          'label' => 'Pattern ' . microtime()
-        ]);
-    }
-
-    private function getWorkDaysForWeek($weekId) {
-      $workDays = [];
-
-      $workDay = new WorkDay();
-      $workDay->week_id = $weekId;
-      $workDay->find();
-
-      while($workDay->fetch()) {
-        $workDays[] = clone $workDay;
-      }
-
-      return $workDays;
-    }
+    return $workDays;
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkWeekTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkWeekTest.php
@@ -175,12 +175,11 @@ class CRM_HRLeaveAndAbsences_BAO_WorkWeekTest extends PHPUnit_Framework_TestCase
         return CRM_HRLeaveAndAbsences_BAO_WorkWeek::create($params);
     }
 
-    private function updateWorkWeek($id, $params)
-    {
-        $params['id'] = $id;
-        CRM_HRLeaveAndAbsences_BAO_WorkWeek::create($params);
+    private function updateWorkWeek($id, $params) {
+      $params['id'] = $id;
+      CRM_HRLeaveAndAbsences_BAO_WorkWeek::create($params);
 
-        return $this->findWorkWeekByID($id);
+      return WorkWeek::findById($id);
     }
 
     private function instantiateWorkPattern() {
@@ -201,18 +200,5 @@ class CRM_HRLeaveAndAbsences_BAO_WorkWeekTest extends PHPUnit_Framework_TestCase
       }
 
       return $workDays;
-    }
-
-    private function findWorkWeekByID($id)
-    {
-        $entity = new CRM_HRLeaveAndAbsences_BAO_WorkWeek();
-        $entity->id = $id;
-        $entity->find(true);
-
-        if($entity->N == 0) {
-            return null;
-        }
-
-        return $entity;
     }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BaseTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BaseTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+abstract class CRM_HRLeaveAndAbsences_BaseTest extends PHPUnit_Framework_TestCase implements
+  HeadlessInterface, TransactionalInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->install('org.civicrm.hrjobcontract')
+      ->apply();
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
@@ -1,8 +1,8 @@
 <?php
 require_once __DIR__."/LeaveBalanceChangeHelpersTrait.php";
+require_once __DIR__."/BaseTest.php";
 
-use Civi\Test\HeadlessInterface;
-use Civi\Test\TransactionalInterface;
+use CRM_HRLeaveAndAbsences_BaseTest as BaseTest;
 use CRM_Hrjobcontract_BAO_HRJobContract as JobContract;
 use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
 use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
@@ -16,21 +16,11 @@ use CRM_HRLeaveAndAbsences_EntitlementCalculation as EntitlementCalculation;
  *
  * @group headless
  */
-class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framework_TestCase implements
- HeadlessInterface, TransactionalInterface {
+class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends BaseTest {
 
   use CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait;
 
   private $contract;
-
-  public function setUpHeadless() {
-    return \Civi\Test::headless()
-      ->installMe(__DIR__)
-      ->install('org.civicrm.hrjobcontract')
-      ->apply();
-    $jobContractUpgrader = CRM_Hrjobcontract_Upgrader::instance();
-    $jobContractUpgrader->install();
-  }
 
   public function setUp()
   {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculatorTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculatorTest.php
@@ -1,7 +1,8 @@
 <?php
 
-use Civi\Test\HeadlessInterface;
-use Civi\Test\TransactionalInterface;
+require_once __DIR__."/BaseTest.php";
+
+use CRM_HRLeaveAndAbsences_BaseTest as BaseTest;
 use CRM_HRLeaveAndAbsences_EntitlementCalculator as EntitlementCalculator;
 use CRM_HRLeaveAndAbsences_EntitlementCalculation as EntitlementCalculation;
 use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
@@ -12,14 +13,7 @@ use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
  *
  * @group headless
  */
-class CRM_HRLeaveAndAbsences_EntitlementCalculatorTest extends PHPUnit_Framework_TestCase implements
-  HeadlessInterface, TransactionalInterface {
-
-  public function setUpHeadless() {
-    return \Civi\Test::headless()
-                     ->installMe(__DIR__)
-                     ->apply();
-  }
+class CRM_HRLeaveAndAbsences_EntitlementCalculatorTest extends BaseTest {
 
   public function testCanReturnCalculationsForMultipleAbsenceTypes()
   {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Validator/DateTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Validator/DateTest.php
@@ -1,17 +1,15 @@
 <?php
 
-use Civi\Test\HeadlessInterface;
+require_once __DIR__."/../BaseTest.php";
+
+use CRM_HRLeaveAndAbsences_BaseTest as BaseTest;
 
 /**
  * Class CRM_HRLeaveAndAbsences_Validator_DateTest
  *
  * @group headless
  */
-class CRM_HRLeaveAndAbsences_BAO_DateTest extends PHPUnit_Framework_TestCase implements HeadlessInterface {
-
-  public function setUpHeadless() {
-    return \Civi\Test::headless()->installMe(__DIR__)->apply();
-  }
+class CRM_HRLeaveAndAbsences_BAO_DateTest extends BaseTest {
 
   /**
    * @dataProvider datesDataProvider


### PR DESCRIPTION
This method will return the leave_days amount for any given date, in a period given by a start and an end date. The main use case for it is to calculate the amount of days to be deducted if a staff member using this work pattern takes a leave on that date.

It will rotate through the pattern's weeks to get the leave_days value. That is, starting from the Start Date, if the date falls on the first week, we get the leave_days amount from the first week of the pattern; if it falls on second week, we get it from the pattern's second week; if it's on the third week, we rotate and get the value from the pattern's first week again and so on.

While doing this, I noticed some of the WorkPattern tests were failing. This PR also includes fixes for them. I also did some overall refactoring to the extension tests to make it easier/faster to run them all at once.