### PR TITLE
PCHR-1518: adding a pre-commit hook to run civilint

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,19 @@
+Scripts in this directory :
+
+ * **build-dao**: Used to generate DAO files from XML files
+ due to some problems with GenCode.php script when using it for extensions.
+
+ * **drush-install**: A script that get called via the buildkit to install CiviHR
+ extensions and preparing some configurations on a drupal+CiviCRM site.
+
+ * **git-release**: A script that prepares CiviHR for release by updating extensions
+ info files version and release data.
+
+ * **pre-commit**: Git pre-commit hook script that run civilint on staged files to ensure there
+ is no any code standard valuations before committing the changes. it need to be moved
+ to your *.git/hooks/* directory in order for it to work on your local installation.
+
+ * **civihr-crm-api-tests**: Legacy script to run all CiviHR extensions API tests.(require updating)
+
+ * **civihr-webtests**: Legacy Script to run all CiviHR extensions Web tests.(require updating)
+

--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Run CiviLint to prevent committing the code in case there is any violation
+# for coding standards.
+
+# You need to copy this file to .git/hooks directory to make it work.
+
+civilint

--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -3,6 +3,6 @@
 # Run Civilint on staged files only to prevent committing the code in case there is
 # any violation for coding standards.
 
-# You need to copy this file to .git/hooks directory to make it work.
+# You need to copy this file to .git/hooks/ directory to make it work.
 
 git diff --cached --name-only | civilint

--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-# Run CiviLint to prevent committing the code in case there is any violation
-# for coding standards.
+# Run Civilint on staged files only to prevent committing the code in case there is
+# any violation for coding standards.
 
 # You need to copy this file to .git/hooks directory to make it work.
 
-civilint
+git diff --cached --name-only | civilint

--- a/bin/pre-commit-readme.md
+++ b/bin/pre-commit-readme.md
@@ -1,0 +1,37 @@
+To ensure that your changes adhere to coding standards before committing them you need to run **civilint** on staged files to ensure  that there is no code  violations before committing the changes.
+
+ To make your life easier, This git pre-commit hook will do that for you every time you run (git commit) command.  
+
+### Setup:
+
+- Copy **bin/pre-commit** to civihr repo **.git/hooks/** inside your local civihr site.  
+
+![selection_139](https://cloud.githubusercontent.com/assets/6275540/20575455/3cecb418-b1b1-11e6-93a0-53775439adbe.png)
+
+
+### Usage : 
+
+Suppose you  are working on a branch feature branch called **PCHR-501-sample-data-extension**  and suppose you have one modified and staged file and one modified but not staged file as you can see in the picture below :
+
+![selection_138](https://cloud.githubusercontent.com/assets/6275540/20575411/12df05f4-b1b1-11e6-8201-6f381ac00206.png)
+
+Then If you run :
+
+```bash
+git commit -m "Update something ..."
+```
+
+And in case the staged file contain some code standard violations then the following errors will appear showing you where the violations are and your code will not be committed :
+
+....Add pic here...
+
+Hence that you didn't get any warning from the not staged file because the pre-hook script will only check staged files .
+
+
+Now You can go through these errors one by one and fix them , And after you are done you can commit your work :
+
+```bash
+git commit -m "Update something ..."
+```
+
+....Add pic here...


### PR DESCRIPTION
A pre-commit hook added to bin directory to run civilint to check for any code standards violation for any uncommitted files .

To make this hook work for you locally you need to copy it to **.git/hooks** directory in your local civihr folder.

----------------------------------------------

## More Details 

To ensure that your changes adhere to coding standards before committing them you need to run **civilint** on staged files to ensure  that there is no code  violations before committing the changes.

 To make your life easier, This git pre-commit hook will do that for you every time you run (git commit) command.  

### Setup:

- Copy **bin/pre-commit** to civihr repo **.git/hooks/** inside your local civihr site.  

![selection_139](https://cloud.githubusercontent.com/assets/6275540/20575455/3cecb418-b1b1-11e6-93a0-53775439adbe.png)


### Usage : 

Suppose you  are working on a branch feature branch called **PCHR-501-sample-data-extension**  and suppose you have one modified and staged file and one modified but not staged file as you can see in the picture below :

![selection_138](https://cloud.githubusercontent.com/assets/6275540/20575411/12df05f4-b1b1-11e6-8201-6f381ac00206.png)

Then If you run :

```bash
git commit -m "Update something ..."
```

And in case the staged file contain some code standard violations then the following errors will appear showing you where the violations are and your code will not be committed :

....Add pic here...

Hence that you didn't get any warning from the not staged file because the pre-hook script will only check staged files .


Now You can go through these errors one by one and fix them , And after you are done you can commit your work :

```bash
git commit -m "Update something ..."
```

....Add pic here...