### PR TITLE
PCHR-1082: Activating missing select2 dropdowns

### DIFF
--- a/org.civicrm.bootstrapcivicrm/bootstrapcivicrm.php
+++ b/org.civicrm.bootstrapcivicrm/bootstrapcivicrm.php
@@ -128,3 +128,12 @@ function bootstrapcivicrm_civicrm_alterSettingsFolders(&$metaDataFolders = NULL)
 function bootstrapcivicrm_civicrm_pageRun($page) {
   CRM_Core_Resources::singleton()->addStyleFile('org.civicrm.bootstrapcivicrm', 'css/bootstrap.css');
 }
+
+/**
+ * This hook is invoked after all the content of a CiviCRM form or page is generated. It allows for direct manipulation of the generated content.
+ */
+function bootstrapcivicrm_civicrm_alterContent( &$content, $context, $tplName, &$object ) {
+  if(strpos($tplName, 'Advanced.tpl') !== false) {
+    $content = '<script src="'.CRM_Extension_System::singleton()->getMapper()->keyToUrl('org.civicrm.bootstrapcivicrm').'/js/enable-select2.js"></script>'. $content;
+  }
+}

--- a/org.civicrm.bootstrapcivicrm/js/enable-select2.js
+++ b/org.civicrm.bootstrapcivicrm/js/enable-select2.js
@@ -1,0 +1,35 @@
+CRM.$(function() {
+  'use strict';
+  /**
+   * The purpose of this script is to activate the "select2" dropdowns on standard select elements.
+   * When the "select2" is enabled, its corresponding select is hidden, so we're
+   * only targeting the visible ones.
+   * Because some select elements are dinamically loaded via AJAX,
+   * we're using the "MutationObserver" to listen to DOM changes
+   */
+
+  /**
+   * We're debouncing the callback to avoid calling the plugin multiple times
+   * during DOM changes
+   */
+  var observer = new MutationObserver(debounce(function() {
+    CRM.$('select:visible').select2();
+  }, 500));
+
+  observer.observe(document.querySelector('body'), {
+    childList: true,
+    subtree: true
+  });
+
+  function debounce(fn, delay) {
+    var timer = null;
+    return function() {
+      var me = this;
+      var args = arguments;
+      clearTimeout(timer);
+      timer = setTimeout(function() {
+        fn.apply(me, args);
+      }, delay);
+    };
+  }
+});


### PR DESCRIPTION
This PR activates the "select2" dropdown plugin on standard select elements which still have the default look and feel.
In order to activate the script and target it only for the "Advanced Search" page, the "civicrm_alterContent" hook was used.

Before:
![before](https://cloud.githubusercontent.com/assets/18520391/17939922/ed44c570-6a2c-11e6-91be-8120f065c5c6.png)

After:
![after](https://cloud.githubusercontent.com/assets/18520391/17939924/f1776d28-6a2c-11e6-86cd-cddd6f1aec31.png)
