### PR TITLE
PCHR-1081: Staff directory fixes

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/Query.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/Query.php
@@ -51,6 +51,20 @@ class CRM_Hrjobroles_BAO_Query extends CRM_Contact_BAO_Query_Interface {
         return $this->hrjobRoleFields;
     }
 
+    function select(&$query) {
+      if (CRM_Contact_BAO_Query::componentPresent($query->_returnProperties, 'hrjc_')) {
+        $fields = $this->getFields();
+        foreach ($fields as $fldName => $params) {
+          if (!empty($query->_returnProperties[$fldName])) {
+            $query->_select[$fldName]  = "{$params['where']} as $fldName";
+            $query->_element[$fldName] = 1;
+            list($tableName, $dnc) = explode('.', $params['where'], 2);
+            $query->_tables[$tableName]  = $query->_whereTables[$tableName] = 1;
+          }
+        }
+      }
+    }
+
     /**
      * @param $fieldName
      * @param $mode
@@ -62,7 +76,7 @@ class CRM_Hrjobroles_BAO_Query extends CRM_Contact_BAO_Query_Interface {
         $from = '';
         switch ($name) {
             case 'civicrm_contact':
-                $from .= " $side JOIN civicrm_hrjobroles ON hrjobcontract.id = civicrm_hrjobroles.job_contract_id ";
+                $from .= " $side JOIN civicrm_hrjobroles ON rev.jobcontract_id = civicrm_hrjobroles.job_contract_id ";
                 break;
         }
 

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/Query.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/Query.php
@@ -318,10 +318,17 @@ class CRM_Hrjobcontract_BAO_Query extends CRM_Contact_BAO_Query_Interface {
     switch ($name) {
       case 'civicrm_contact':
         $from .= " $side JOIN civicrm_hrjobcontract hrjobcontract ON hrjobcontract.contact_id = contact_a.id AND hrjobcontract.deleted = 0
-            $side JOIN civicrm_hrjobcontract_revision rev ON rev.jobcontract_id = hrjobcontract.id "
-              . " AND ("
-              . "   rev.id = (SELECT id FROM civicrm_hrjobcontract_revision WHERE jobcontract_id = hrjobcontract.id "
-              . "   AND (effective_end_date >= '{$todayDate}' OR effective_end_date IS NULL) AND deleted = 0 AND overrided = 0 ORDER BY effective_date ASC LIMIT 1) "
+            $side JOIN civicrm_hrjobcontract_revision rev ON rev.jobcontract_id = ("
+              . " SELECT hrjc.id
+                                                                        FROM civicrm_hrjobcontract hrjc
+                                                                          LEFT JOIN civicrm_hrjobcontract_revision hrjr
+                                                                            ON hrjr.jobcontract_id = hrjc.id
+                                                                        WHERE hrjc.contact_id = contact_a.id
+                                                                              AND hrjr.effective_date <= '{$todayDate}'
+                                                                              AND hrjc.deleted = 0
+                                                                              AND hrjr.deleted = 0
+                                                                        ORDER BY hrjr.effective_date DESC , created_date DESC
+                                                                        LIMIT 1"
               . " ) ";
       break;
       case 'civicrm_hrjobcontract':

--- a/hrprofile/CRM/HRProfile/BAO/Query.php
+++ b/hrprofile/CRM/HRProfile/BAO/Query.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Class CRM_HRProfile_BAO_Query
+ *
+ * This class is a little bit different from the regular Query classes, as it's
+ * not related to a BAO.
+ *
+ * The query that loads the data for the Staff Directory is the same one that is
+ * used for the AdvancedSearch (with the exception that is uses the Directory
+ * Profile to get the fields to be displayed). So this class injects the JOINS
+ * and fields required to load the information for the "Managers" field of this
+ * profile.
+ */
+class CRM_HRProfile_BAO_Query extends CRM_Contact_BAO_Query_Interface {
+
+  private $fields = [];
+
+  /**
+   * The managers is not a real BAO/DAO field, so we manually add it to the
+   * fields list.
+   *
+   * @return array
+   */
+  public function &getFields() {
+    if(empty($this->fields)) {
+      $this->fields['manager_contact'] = array(
+        'name'  => 'manager_contact',
+        'title' => 'Manager',
+        'type'  => CRM_Utils_Type::T_STRING,
+        'where' => ''
+      );
+    }
+
+    return $this->fields;
+  }
+
+  /**
+   * This method adds the manager_contact field to the query.
+   *
+   * One contact can have multiple managers, so we use GROUP_CONCAT to group all
+   * of them into a single field, separated by commas.
+   *
+   * @param $query
+   */
+  public function select(&$query) {
+    $query->_select['manager_contact']  = "GROUP_CONCAT(DISTINCT manager_contact.sort_name SEPARATOR ', ') AS manager_contact";
+    $query->_element['manager_contact'] = 1;
+    $query->_tables['civicrm_relationship']  = $query->_whereTables['civicrm_relationship'] = 1;
+  }
+
+  /**
+   * This method adds the required statements to fetch the managers of a
+   * contact.
+   *
+   * @param string $name
+   * @param $mode
+   * @param $side
+   *
+   * @return string
+   */
+  public function from($name, $mode, $side) {
+    $currentDate = date('Y-m-d');
+    $from = '';
+
+    switch ($name) {
+      case 'civicrm_contact':
+        $from .= "$side JOIN civicrm_relationship cr
+                    ON cr.contact_id_a = contact_a.id AND
+                       (cr.end_date IS NULL OR cr.end_date >= '{$currentDate}') AND
+                       (cr.start_date IS NULL OR cr.start_date <= '{$currentDate}') AND
+                       cr.is_active = 1 AND
+                       cr.relationship_type_id = (SELECT id FROM civicrm_relationship_type WHERE name_a_b = 'Line Manager Is')
+                  $side JOIN civicrm_contact manager_contact
+                    ON cr.contact_id_b = manager_contact.id AND manager_contact.is_deleted = 0";
+        break;
+    }
+
+    return $from;
+  }
+
+  /**
+   * Even though the CRM_Contact_BAO_Query_Interface doesn't declare this method
+   * on its interface, CRM_Contact_BAO_Query still tries to call it. So this
+   * empty implementation here is just to avoid an undeclared method error.
+   *
+   * @param $panes
+   */
+  public function getPanesMapper(&$panes) {}
+}

--- a/hrprofile/CRM/HRProfile/Page/HRProfile.php
+++ b/hrprofile/CRM/HRProfile/Page/HRProfile.php
@@ -12,19 +12,9 @@ class CRM_HRProfile_Page_HRProfile extends CRM_Profile_Page_Listings {
     $this->_params['contact_type'] = 'Individual';
 
     $selector = new CRM_Profile_Selector_Listings($this->_params, $this->_customFields, $profID, $this->_map, FALSE, 0);
-    $extraWhereClause = NULL;
-    $grpParams = array('name'=>'HRJobContract_Summary');
-    CRM_Core_DAO::commonRetrieve('CRM_Core_DAO_CustomGroup', $grpParams, $cGrp);
-    $fdParams = array('name'=>'Final_Termination_Date', 'custom_group_id' => $cGrp['id']);
-    CRM_Core_DAO::commonRetrieve('CRM_Core_DAO_CustomField', $fdParams, $fdField);
-    $idParams = array('name'=>'Initial_Join_Date', 'custom_group_id' => $cGrp['id']);
-    CRM_Core_DAO::commonRetrieve('CRM_Core_DAO_CustomField', $idParams, $idField);
-
-    $extraWhereClause = " (({$cGrp['table_name']}.{$fdField['column_name']} >= CURDATE() OR {$cGrp['table_name']}.{$fdField['column_name']} IS NULL) AND
-      ({$cGrp['table_name']}.{$idField['column_name']} IS NOT NULL AND {$cGrp['table_name']}.{$idField['column_name']} <= CURDATE()))";
 
     $column = $columnHeaders = $selector->getColumnHeaders();
-    $rows = $selector->getRows(4, 0, 0,NULL, NULL, $extraWhereClause);
+    $rows = $selector->getRows(4, 0, 0, NULL);
 
     CRM_Utils_Hook::searchColumns('profile', $columnHeaders, $rows, $this);
     $this->assign('aaData',json_encode($rows));

--- a/hrprofile/hrprofile.php
+++ b/hrprofile/hrprofile.php
@@ -158,3 +158,12 @@ function hrprofile_updateNavigation($orginalUrl, $updatedUrl) {
   $navigation = CRM_Core_BAO_Navigation::processUpdate($navigationParams,$navigationParamsNew);
   return true;
 }
+
+/**
+ * Implementation of hook_civicrm_queryObjects
+ */
+function hrprofile_civicrm_queryObjects(&$queryObjects, $type) {
+  if ($type == 'Contact') {
+    $queryObjects[] = new CRM_HRProfile_BAO_Query();
+  }
+}

--- a/hrprofile/templates/CRM/HRProfile/Page/HRProfile.tpl
+++ b/hrprofile/templates/CRM/HRProfile/Page/HRProfile.tpl
@@ -66,6 +66,6 @@ CRM.$(function($){
   $( '.crm-profile-name-hrprofile table').css( "table-layout",'fixed');
 });
 </script>
-{/literal} 
+{/literal}
 
 <div class="clear"></div>

--- a/hrstaffdir/CRM/Hrstaffdir/Upgrader.php
+++ b/hrstaffdir/CRM/Hrstaffdir/Upgrader.php
@@ -73,4 +73,26 @@ class CRM_Hrstaffdir_Upgrader extends CRM_Hrstaffdir_Upgrader_Base {
 
     return true;
   }
+
+  public function upgrade_1402() {
+    $ufGroupID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFGroup', 'hrstaffdir_listing', 'id', 'name');
+    $result = civicrm_api3('UFField', 'get', [
+      'sequential' => 1,
+      'uf_group_id' => $ufGroupID,
+      'field_name' => 'hrjobcontract_role_manager_contact'
+    ]);
+
+    // Rename hrjobcontract_role_manager_contact to manager_contact
+    if(!empty($result['values'])) {
+      $params = $result['values'][0];
+      $params['field_name'] = 'manager_contact';
+      try {
+        civicrm_api3('UFField', 'create', $params);
+      } catch(Exception $ex) {
+        return false;
+      }
+    }
+
+    return true;
+  }
 }

--- a/hrstaffdir/CRM/Hrstaffdir/Upgrader.php
+++ b/hrstaffdir/CRM/Hrstaffdir/Upgrader.php
@@ -30,113 +30,6 @@
  */
 class CRM_Hrstaffdir_Upgrader extends CRM_Hrstaffdir_Upgrader_Base {
 
-  // By convention, functions that look like "function upgrade_NNNN()" are
-  // upgrade tasks. They are executed in order (like Drupal's hook_update_N).
-
-  /**
-   * Example: Run an external SQL script when the module is installed
-   *
-  public function install() {
-    $this->executeSqlFile('sql/myinstall.sql');
-  }
-
-  /**
-   * Example: Run an external SQL script when the module is uninstalled
-   *
-  public function uninstall() {
-   $this->executeSqlFile('sql/myuninstall.sql');
-  }
-
-  /**
-   * Example: Run a simple query when a module is enabled
-   *
-  public function enable() {
-    CRM_Core_DAO::executeQuery('UPDATE foo SET is_active = 1 WHERE bar = "whiz"');
-  }
-
-  /**
-   * Example: Run a simple query when a module is disabled
-   *
-  public function disable() {
-    CRM_Core_DAO::executeQuery('UPDATE foo SET is_active = 0 WHERE bar = "whiz"');
-  }
-
-  /**
-   * Example: Run a couple simple queries
-   *
-   * @return TRUE on success
-   * @throws Exception
-   *
-  public function upgrade_4200() {
-    $this->ctx->log->info('Applying update 4200');
-    CRM_Core_DAO::executeQuery('UPDATE foo SET bar = "whiz"');
-    CRM_Core_DAO::executeQuery('DELETE FROM bang WHERE willy = wonka(2)');
-    return TRUE;
-  } // */
-
-
-  /**
-   * Example: Run an external SQL script
-   *
-   * @return TRUE on success
-   * @throws Exception
-  public function upgrade_4201() {
-    $this->ctx->log->info('Applying update 4201');
-    // this path is relative to the extension base dir
-    $this->executeSqlFile('sql/upgrade_4201.sql');
-    return TRUE;
-  } // */
-
-
-  /**
-   * Example: Run a slow upgrade process by breaking it up into smaller chunk
-   *
-   * @return TRUE on success
-   * @throws Exception
-  public function upgrade_4202() {
-    $this->ctx->log->info('Planning update 4202'); // PEAR Log interface
-
-    $this->addTask(ts('Process first step'), 'processPart1', $arg1, $arg2);
-    $this->addTask(ts('Process second step'), 'processPart2', $arg3, $arg4);
-    $this->addTask(ts('Process second step'), 'processPart3', $arg5);
-    return TRUE;
-  }
-  public function processPart1($arg1, $arg2) { sleep(10); return TRUE; }
-  public function processPart2($arg3, $arg4) { sleep(10); return TRUE; }
-  public function processPart3($arg5) { sleep(10); return TRUE; }
-  // */
-
-
-  /**
-   * Example: Run an upgrade with a query that touches many (potentially
-   * millions) of records by breaking it up into smaller chunks.
-   *
-   * @return TRUE on success
-   * @throws Exception
-  public function upgrade_4203() {
-    $this->ctx->log->info('Planning update 4203'); // PEAR Log interface
-
-    $minId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(min(id),0) FROM civicrm_contribution');
-    $maxId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(max(id),0) FROM civicrm_contribution');
-    for ($startId = $minId; $startId <= $maxId; $startId += self::BATCH_SIZE) {
-      $endId = $startId + self::BATCH_SIZE - 1;
-      $title = ts('Upgrade Batch (%1 => %2)', array(
-        1 => $startId,
-        2 => $endId,
-      ));
-      $sql = '
-        UPDATE civicrm_contribution SET foobar = whiz(wonky()+wanker)
-        WHERE id BETWEEN %1 and %2
-      ';
-      $params = array(
-        1 => array($startId, 'Integer'),
-        2 => array($endId, 'Integer'),
-      );
-      $this->addTask($title, 'executeSql', $sql, $params);
-    }
-    return TRUE;
-  } // */
-
   public function upgrade_1400() {
     $this->ctx->log->info('Applying update 1400');
     $finalTermDate = civicrm_api3('CustomField', 'getvalue', array('custom_group_id' => 'HRJobContract_Summary','name' => 'Final_Termination_Date', 'return' => 'id'));
@@ -157,5 +50,27 @@ class CRM_Hrstaffdir_Upgrader extends CRM_Hrstaffdir_Upgrader_Base {
     $result = civicrm_api3('UFField', 'create', $ufFieldParam);
     _hrstaffdir_phone_type($ufGroupID);
     return TRUE;
+  }
+
+  public function upgrade_1401() {
+    $ufGroupID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFGroup', 'hrstaffdir_listing', 'id', 'name');
+    $result = civicrm_api3('UFField', 'get', [
+      'sequential' => 1,
+      'uf_group_id' => $ufGroupID,
+      'field_name' => 'hrjobcontract_role_role_department'
+    ]);
+
+    // Rename hrjobcontract_role_role_department to hrjc_role_department
+    if(!empty($result['values'])) {
+      $params = $result['values'][0];
+      $params['field_name'] = 'hrjc_role_department';
+      try {
+        civicrm_api3('UFField', 'create', $params);
+      } catch(Exception $ex) {
+        return false;
+      }
+    }
+
+    return true;
   }
 }

--- a/hrstaffdir/hrstaffdir.php
+++ b/hrstaffdir/hrstaffdir.php
@@ -70,7 +70,7 @@ function hrstaffdir_civicrm_searchColumns($objectName, &$headers, &$values, &$se
             'id'
           );
           $imageCol[] = ($imageUrl) ? '<a href="' . $imageUrl . '" class="crm-image-popup"><img src="' . $imageUrl . '" height = "56" width="100"></a>' : "";
-          $value[1] = "<a href='" . CRM_Utils_System::url('civicrm/profile/view', "reset=1&id={$matches[1]}&gid={$profileId }") . "'>{$value[1]}</a>";
+          $value[1] = "<a href='" . CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid={$matches[1]}") . "'>{$value[1]}</a>";
           $value = array_merge($imageCol, $value);
         }
       }

--- a/hrstaffdir/xml/auto_install.xml
+++ b/hrstaffdir/xml/auto_install.xml
@@ -163,7 +163,7 @@
       <profile_group_name>Directory</profile_group_name>
     </ProfileField>
     <ProfileField>
-      <field_name>hrjobcontract_role_role_department</field_name>
+      <field_name>hrjc_role_department</field_name>
       <is_active>1</is_active>
       <is_view>0</is_view>
       <is_required>0</is_required>

--- a/hrstaffdir/xml/auto_install.xml
+++ b/hrstaffdir/xml/auto_install.xml
@@ -131,7 +131,7 @@
       <profile_group_name>Directory</profile_group_name>
     </ProfileField>
     <ProfileField>
-      <field_name>hrjobcontract_role_manager_contact</field_name>
+      <field_name>manager_contact</field_name>
       <is_active>1</is_active>
       <is_view>0</is_view>
       <is_required>0</is_required>


### PR DESCRIPTION
The Staff Directory (accessible on index.php?q=civicrm/profile/table&reset=1&gid=19&force=1) were presenting a number of problems:
- Trying to access the page resulted in a DB error
- Clicking on name does not take you back to Contact page
- The Title was coming from a past contract
- Department was not coming through
- The manager was not coming though

This required a number of approaches to fix the problems:
- The DB error was caused by a misconstructed query. A method on CRM_HRProfile_Page_HRProfile was trying to add the Final_Termination_Date and Initial_Join_Date fields to the query, but those have been removed a long time ago, on PCHR-774. To fix the error, I removed the piece of code that was doing this.
- To fix the link on the contact name, I updated the hrstaffdir_civicrm_searchColumns hook which was the one who was setting the link pointing to the profile page instead of the contact one
- To show the correct contract Title, I updated the JOIN on CRM_Hrjobcontract_BAO_Query::from to properly join with the latest contract revision
- To be able to show the department, I needed to:
  - Fix the JOIN clause from the job role to the contract, to get the roles
    for the active contract
  - Add the job roles to the list of fields of the select statement. This
    was achieved by implementing the select() method on the CRM_Hrjobroles_BAO_Query
    class
  - Update the Profile configuration to use the job roles field instead of the
    old/deprecated jobcontract_role
- To show the manager, I created a new Query Object to the hrprofile extension that injects all the necessary joins and fields to fetch the managers for a contract. Since we have multiple managers from a single contact and we need to return this information in a single field, I used the GROUP_CONCAT function to group all the managers into a single field, separated by commas.
