### PR TITLE
PCHR-1516: modifications to menu items

### DIFF
--- a/bin/drush-install.sh
+++ b/bin/drush-install.sh
@@ -28,9 +28,7 @@ APP_EXTS=\
 org.civicrm.hrreport,\
 org.civicrm.hrui,\
 org.civicrm.hrcase,\
-org.civicrm.hrstaffdir,\
 org.civicrm.hrim,\
-org.civicrm.hrprofile,\
 org.civicrm.hrrecruitment,\
 org.civicrm.reqangular,\
 org.civicrm.contactsummary,\

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
@@ -17,27 +17,6 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
   }
 
   /**
-   * Example: Run an external SQL script when the module is uninstalled
-   *
-  public function uninstall() {
-   $this->executeSqlFile('sql/myuninstall.sql');
-  }
-
-  /**
-   * Example: Run a simple query when a module is enabled
-   *
-  public function enable() {
-    CRM_Core_DAO::executeQuery('UPDATE foo SET is_active = 1 WHERE bar = "whiz"');
-  }
-
-  /**
-   * Example: Run a simple query when a module is disabled
-   *
-  public function disable() {
-    CRM_Core_DAO::executeQuery('UPDATE foo SET is_active = 0 WHERE bar = "whiz"');
-  }
-
-  /**
    * Example: Add start and and date for job roles
    *
    * @return TRUE on success
@@ -63,69 +42,6 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
 
     return TRUE;
   }
-
-
-  /**
-   * Example: Run an external SQL script
-   *
-   * @return TRUE on success
-   * @throws Exception
-  public function upgrade_4201() {
-    $this->ctx->log->info('Applying update 4201');
-    // this path is relative to the extension base dir
-    $this->executeSqlFile('sql/upgrade_4201.sql');
-    return TRUE;
-  } // */
-
-
-  /**
-   * Example: Run a slow upgrade process by breaking it up into smaller chunk
-   *
-   * @return TRUE on success
-   * @throws Exception
-  public function upgrade_4202() {
-    $this->ctx->log->info('Planning update 4202'); // PEAR Log interface
-
-    $this->addTask(ts('Process first step'), 'processPart1', $arg1, $arg2);
-    $this->addTask(ts('Process second step'), 'processPart2', $arg3, $arg4);
-    $this->addTask(ts('Process second step'), 'processPart3', $arg5);
-    return TRUE;
-  }
-  public function processPart1($arg1, $arg2) { sleep(10); return TRUE; }
-  public function processPart2($arg3, $arg4) { sleep(10); return TRUE; }
-  public function processPart3($arg5) { sleep(10); return TRUE; }
-  // */
-
-
-  /**
-   * Example: Run an upgrade with a query that touches many (potentially
-   * millions) of records by breaking it up into smaller chunks.
-   *
-   * @return TRUE on success
-   * @throws Exception
-  public function upgrade_4203() {
-    $this->ctx->log->info('Planning update 4203'); // PEAR Log interface
-
-    $minId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(min(id),0) FROM civicrm_contribution');
-    $maxId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(max(id),0) FROM civicrm_contribution');
-    for ($startId = $minId; $startId <= $maxId; $startId += self::BATCH_SIZE) {
-      $endId = $startId + self::BATCH_SIZE - 1;
-      $title = ts('Upgrade Batch (%1 => %2)', array(
-        1 => $startId,
-        2 => $endId,
-      ));
-      $sql = '
-        UPDATE civicrm_contribution SET foobar = whiz(wonky()+wanker)
-        WHERE id BETWEEN %1 and %2
-      ';
-      $params = array(
-        1 => array($startId, 'Integer'),
-        2 => array($endId, 'Integer'),
-      );
-      $this->addTask($title, 'executeSql', $sql, $params);
-    }
-    return TRUE;
-  } // */
 
   /**
    * Creates new Option Group for Cost Centres

--- a/com.civicrm.hrjobroles/hrjobroles.php
+++ b/com.civicrm.hrjobroles/hrjobroles.php
@@ -111,10 +111,9 @@ function hrjobroles_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
 function hrjobroles_civicrm_navigationMenu( &$params ) {
   // Add sub-menu
   $navId = CRM_Core_DAO::singleValueQuery("SELECT max(id) FROM civicrm_navigation");
-  if (is_integer($navId)) {
-    $navId++;
-  }
-  $topMenuID =  CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'job_contracts', 'id', 'name');
+  $navId++;
+
+  $topMenuID =  CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Contacts', 'id', 'name');
   $parentID =  CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'import_export_job_contracts', 'id', 'name');
   $params[$topMenuID]['child'][$parentID]['child'][$navId] = array(
     'attributes' => array(
@@ -122,8 +121,7 @@ function hrjobroles_civicrm_navigationMenu( &$params ) {
       'name' => "import_job_roles",
       'url' => "civicrm/jobroles/import",
       'permission' => NULL,
-      'operator' => 'OR',
-      'separator' => NULL,
+      'separator' => TRUE,
       'parentID' => $parentID,
       'navID' => $navId,
       'active' => 1

--- a/hrjobcontract/hrjobcontract.php
+++ b/hrjobcontract/hrjobcontract.php
@@ -51,40 +51,6 @@ function hrjobcontract_civicrm_install() {
     }
   }
 
-  // Add Job Contract top menu
-
-  $jobContractNavigation = new CRM_Core_DAO_Navigation();
-  $jobContractNavigation->name = 'job_contracts';
-  $jobContractNavigationResult = $jobContractNavigation->find();
-  if (!$jobContractNavigationResult)
-  {
-    $contactsWeight = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Contacts', 'weight', 'name');
-    $jobContractNavigation = new CRM_Core_DAO_Navigation();
-    $params = array (
-      'domain_id' => CRM_Core_Config::domainID(),
-      'label' => ts('Job Contracts'),
-      'name' => 'job_contracts',
-      'url' => null,
-      'operator' => null,
-      'weight' => $contactsWeight + 1,
-      'is_active' => 1,
-    );
-    $jobContractNavigation->copyValues($params);
-    $jobContractNavigation->save();
-    $jobContractMenuTree = array(
-      array(
-        'label' => ts('Import / Export'),
-        'name' => 'import_export_job_contracts',
-      ),
-    );
-
-    foreach ($jobContractMenuTree as $key => $menuItems) {
-      $menuItems['is_active'] = 1;
-      $menuItems['parent_id'] = $jobContractNavigation->id;
-      $menuItems['weight'] = $key;
-      CRM_Core_BAO_Navigation::add($menuItems);
-    }
-  }
 
   /* on civicrm 4.7.7 this activity type (Contact Deleted by Merge) is not created
  * as a part of civicrm installation but it should be, since it's used in
@@ -137,7 +103,7 @@ function hrjobcontract_civicrm_uninstall() {
   if (!empty($jobContractMenu)) {
     CRM_Core_BAO_Navigation::processDelete($jobContractMenu);
   }
-  CRM_Core_DAO::executeQuery("DELETE FROM civicrm_navigation WHERE name IN ('job_contracts', 'import_export_job_contracts', 'jobImport', 'hoursType', 'pay_scale','hours_location', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_end_reason')");
+  CRM_Core_DAO::executeQuery("DELETE FROM civicrm_navigation WHERE name IN ('import_export_job_contracts', 'import_job_contracts', 'export_job_contracts', 'hoursType', 'pay_scale','hours_location', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_end_reason')");
   CRM_Core_BAO_Navigation::resetNavigation();
 
   //delete custom groups and field
@@ -181,11 +147,6 @@ function hrjobcontract_civicrm_uninstall() {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
  */
 function hrjobcontract_civicrm_enable() {
-  //Enable the Navigation menu and submenus
-  $sql = "UPDATE civicrm_navigation SET is_active=1 WHERE name IN ('job_contracts', 'hoursType', 'hours_location', 'pay_scale', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_end_reason')";
-  CRM_Core_DAO::executeQuery($sql);
-  CRM_Core_BAO_Navigation::resetNavigation();
-
   _hrjobcontract_setActiveFields(1);
   return _hrjobcontract_civix_civicrm_enable();
 }
@@ -196,17 +157,12 @@ function hrjobcontract_civicrm_enable() {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
  */
 function hrjobcontract_civicrm_disable() {
-  //Disable the Navigation menu and submenus
-  $sql = "UPDATE civicrm_navigation SET is_active=0 WHERE name IN ('job_contracts', 'hoursType', 'hours_location', 'pay_scale', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_end_reason')";
-  CRM_Core_DAO::executeQuery($sql);
-  CRM_Core_BAO_Navigation::resetNavigation();
-
   _hrjobcontract_setActiveFields(0);
   return _hrjobcontract_civix_civicrm_disable();
 }
 
 function _hrjobcontract_setActiveFields($setActive) {
-  $sql = "UPDATE civicrm_navigation SET is_active= {$setActive} WHERE name IN ('jobs','jobImport','hoursType', 'job_contracts')";
+  $sql = "UPDATE civicrm_navigation SET is_active= {$setActive} WHERE name IN ('import_export_job_contracts', 'import_job_contracts', 'export_job_contracts', 'hoursType', 'pay_scale','hours_location', 'hrjc_contact_type', 'hrjc_location', 'hrjc_pay_cycle', 'hrjc_benefit_name', 'hrjc_benefit_type', 'hrjc_deduction_name', 'hrjc_deduction_type', 'hrjc_health_provider', 'hrjc_life_provider', 'hrjc_pension_type', 'hrjc_revision_change_reason', 'hrjc_contract_end_reason')";
   CRM_Core_DAO::executeQuery($sql);
   CRM_Core_BAO_Navigation::resetNavigation();
 
@@ -283,43 +239,6 @@ function hrjobcontract_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
     $metaDataFolders[] = $settingsDir;
   }
   $metaDataFolders = array_unique($metaDataFolders);
-}
-
-function hrjobcontract_civicrm_navigationMenu( &$params ) {
-  // Add sub-menu
-  $submenuItems = array();
-  $topMenuID =  CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'job_contracts', 'id', 'name');
-  $parentID =  CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'import_export_job_contracts', 'id', 'name');
-  $submenuItems[] = array(
-      'attributes' => array(
-        'label' => "Import Job Contracts",
-        'name' => "import_job_contracts",
-        'url' => "civicrm/job/import",
-        'permission' => NULL,
-        'operator' => 'OR',
-        'separator' => NULL,
-        'parentID' => $parentID,
-        'navID' => 1,
-        'active' => 1
-      )
-  );
-  $submenuItems[] = array(
-      'attributes' => array(
-        //'label' => "Export Job Contracts",
-        'label' => 'Job Contract Report',
-        'name' => "export_job_contracts",
-        'url' => "civicrm/report/hrjobcontract/summary",
-        'permission' => NULL,
-        'operator' => 'OR',
-        'separator' => NULL,
-        'parentID' => $parentID,
-        'navID' => 2,
-        'active' => 1
-      )
-  );
-  if (!empty($submenuItems)) {
-    $params[$topMenuID]['child'][$parentID]['child'] = $submenuItems;
-  }
 }
 
 /**

--- a/hrui/CRM/HRUI/Upgrader.php
+++ b/hrui/CRM/HRUI/Upgrader.php
@@ -33,173 +33,45 @@ class CRM_HRUI_Upgrader extends CRM_HRUI_Upgrader_Base {
   // By convention, functions that look like "function upgrade_NNNN()" are
   // upgrade tasks. They are executed in order (like Drupal's hook_update_N).
 
-  /**
-   * Example: Run an external SQL script when the module is installed
-   *
   public function install() {
-    $this->executeSqlFile('sql/myinstall.sql');
-  }
+    $revisions = $this->getRevisions();
 
-  /**
-   * Example: Run an external SQL script when the module is uninstalled
-   *
-  public function uninstall() {
-   $this->executeSqlFile('sql/myuninstall.sql');
-  }
+    foreach ($revisions as $revision) {
+      $methodName = 'upgrade_' . $revision;
 
-  /**
-   * Example: Run a simple query when a module is enabled
-   *
-  public function enable() {
-    CRM_Core_DAO::executeQuery('UPDATE foo SET is_active = 1 WHERE bar = "whiz"');
-  }
-
-  /**
-   * Example: Run a simple query when a module is disabled
-   *
-  public function disable() {
-    CRM_Core_DAO::executeQuery('UPDATE foo SET is_active = 0 WHERE bar = "whiz"');
-  }
-   */
-
-  /**
-   * Change the URL of the blog feed on the dashboard
-   *
-   * @return TRUE on success
-   * @throws Exception
-   */
-  public function upgrade_4400() {
-    civicrm_api3('setting', 'create', array(
-      'version' => 3,
-      'blogUrl' => 'https://civicrm.org/taxonomy/term/198/feed',
-    ));
-    return TRUE;
-  }
-
-  /**
-   * Example: Run a couple simple queries
-   *
-   * @return TRUE on success
-   * @throws Exception
-   *
-  public function upgrade_4200() {
-    $this->ctx->log->info('Applying update 4200');
-    CRM_Core_DAO::executeQuery('UPDATE foo SET bar = "whiz"');
-    CRM_Core_DAO::executeQuery('DELETE FROM bang WHERE willy = wonka(2)');
-    return TRUE;
-  } // */
-
-
-  /**
-   * Example: Run an external SQL script
-   *
-   * @return TRUE on success
-   * @throws Exception
-  public function upgrade_4201() {
-    $this->ctx->log->info('Applying update 4201');
-    // this path is relative to the extension base dir
-    $this->executeSqlFile('sql/upgrade_4201.sql');
-    return TRUE;
-  } // */
-
-
-  /**
-   * Example: Run a slow upgrade process by breaking it up into smaller chunk
-   *
-   * @return TRUE on success
-   * @throws Exception
-  public function upgrade_4202() {
-    $this->ctx->log->info('Planning update 4202'); // PEAR Log interface
-
-    $this->addTask(ts('Process first step'), 'processPart1', $arg1, $arg2);
-    $this->addTask(ts('Process second step'), 'processPart2', $arg3, $arg4);
-    $this->addTask(ts('Process second step'), 'processPart3', $arg5);
-    return TRUE;
-  }
-  public function processPart1($arg1, $arg2) { sleep(10); return TRUE; }
-  public function processPart2($arg3, $arg4) { sleep(10); return TRUE; }
-  public function processPart3($arg5) { sleep(10); return TRUE; }
-  // */
-
-
-  /**
-   * Example: Run an upgrade with a query that touches many (potentially
-   * millions) of records by breaking it up into smaller chunks.
-   *
-   * @return TRUE on success
-   * @throws Exception
-  public function upgrade_4203() {
-    $this->ctx->log->info('Planning update 4203'); // PEAR Log interface
-
-    $minId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(min(id),0) FROM civicrm_contribution');
-    $maxId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(max(id),0) FROM civicrm_contribution');
-    for ($startId = $minId; $startId <= $maxId; $startId += self::BATCH_SIZE) {
-      $endId = $startId + self::BATCH_SIZE - 1;
-      $title = ts('Upgrade Batch (%1 => %2)', array(
-        1 => $startId,
-        2 => $endId,
-      ));
-      $sql = '
-        UPDATE civicrm_contribution SET foobar = whiz(wonky()+wanker)
-        WHERE id BETWEEN %1 and %2
-      ';
-      $params = array(
-        1 => array($startId, 'Integer'),
-        2 => array($endId, 'Integer'),
-      );
-      $this->addTask($title, 'executeSql', $sql, $params);
-    }
-    return TRUE;
-  } // */
-
-  public function upgrade_4500() {
-    $this->ctx->log->info('Planning update 1400');
-    //disable individual contact sub types
-    $individualTypeId = civicrm_api3('ContactType', 'getsingle', array('return' => "id",'name' => "Individual"));
-    $subContactId = civicrm_api3('ContactType', 'get', array('parent_id' => $individualTypeId['id']));
-    foreach ($subContactId['values'] as $key) {
-      $paramsSubType = array(
-        'name' => $key['name'],
-        'id' => $key['id'],
-        'is_active' => FALSE,
-      );
-      civicrm_api3('ContactType', 'create', $paramsSubType);
-    }
-
-    $orgTypeId = civicrm_api3('ContactType', 'getsingle', array('return' => "id",'name' => "Organization"));
-    $subOrgId = civicrm_api3('ContactType', 'get', array('parent_id' => $orgTypeId['id']));
-    foreach ($subOrgId['values'] as $key) {
-      if ($key['name'] == 'Team' || $key['name'] == 'Sponsor') {
-	$paramsSubType = array(
-          'name' => $key['name'],
-          'id' => $key['id'],
-          'is_active' => FALSE,
-        );
-	civicrm_api3('ContactType', 'create', $paramsSubType);
+      if (is_callable(array($this, $methodName))) {
+        $this->{$methodName}();
       }
     }
-    CRM_Core_BAO_Navigation::resetNavigation();
-
-    //hide/disable constitution information block
-    $query = "UPDATE civicrm_custom_field JOIN civicrm_custom_group ON civicrm_custom_group.id = civicrm_custom_field.custom_group_id SET civicrm_custom_field.is_active = 0 WHERE civicrm_custom_group.name = 'constituent_information'";
-    CRM_Core_DAO::executeQuery($query);
-    CRM_Core_DAO::executeQuery("UPDATE civicrm_custom_group SET is_active = 0 WHERE name = 'constituent_information'");
-
-    //disable optionGroup and optionValue
-    $query = "UPDATE civicrm_option_value JOIN civicrm_option_group ON civicrm_option_group.id = civicrm_option_value.option_group_id SET civicrm_option_value.is_active = 0 WHERE civicrm_option_group.name IN ('custom_most_important_issue', 'custom_marital_status')";
-    CRM_Core_DAO::executeQuery($query);
-    CRM_Core_DAO::executeQuery("UPDATE civicrm_option_group SET is_active = 0 WHERE name IN ('custom_most_important_issue', 'custom_marital_status')");
-    CRM_Core_DAO::executeQuery("UPDATE civicrm_dashboard SET label = 'CiviHR News' WHERE name = 'blog' ");
-    CRM_Core_DAO::executeQuery("UPDATE civicrm_dashboard SET label = 'Assignments Dashlet' WHERE name = 'casedashboard' ");
-
-    //delete default tag of civicrm
-    CRM_Core_DAO::executeQuery("DELETE FROM civicrm_tag WHERE name IN ('Non-profit', 'Company', 'Government Entity', 'Major Donor', 'Volunteer')");
-    return TRUE;
   }
 
-  public function upgrade_4501() {
-    $this->ctx->log->info('Planning update 1401');
-    CRM_Core_DAO::executeQuery("UPDATE civicrm_relationship_type SET is_active = 1 WHERE name_a_b IN ( 'Case Coordinator is' )");
+  /**
+   * Create (Import Custom Fields) menu items
+   *
+   * @return bool
+   */
+  public function upgrade_4700() {
+    CRM_Core_DAO::executeQuery("DELETE FROM civicrm_navigation WHERE name = 'jobImport'");
+
+    $contactsNavID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Contacts', 'id', 'name');
+    $importContactWeight = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Import Contacts', 'weight', 'name');
+    $params = [
+      'name' => 'import_custom_fields',
+      'label' => ts('Import Custom Fields'),
+      'url' => 'civicrm/import/custom?reset=1',
+      'parent_id' => $contactsNavID,
+      'is_active' => TRUE,
+      'weight' => $importContactWeight,
+      'permission' => 'access CiviCRM',
+      'domain_id' => CRM_Core_Config::domainID(),
+    ];
+
+    $navigation = new CRM_Core_DAO_Navigation();
+    $navigation->copyValues($params);
+    $navigation->save();
+
+    CRM_Core_BAO_Navigation::resetNavigation();
+
     return TRUE;
   }
 }


### PR DESCRIPTION
## Requirements

A set of changes to the navigation menu was required which is :

Remove the following menu items : 
- Search >> Full-text search
- Search >> Search builder
- Search >> Find assignments (Remove when T&A is enabled)
- Search >> Find activities (Remove when T&A is enabled)
- Search >> Custom searches
- Contacts >> Contact reports
- Contacts >> New activity (Remove when T&A is enabled)
- Contacts >> Import activities (Remove when T&A is enabled)
- Contacts >> New tag 
- Contacts >> Manage tags
- Appraisals (and its child menus)
- Reports (and its child menus)
- Administer >> People management >> Redaction rules
- Administer >> CiviReport (and its child menus)
- Job contracts (and move its child menus under "Contacts" below "Import contacts")

Also another menu items need to be created for "Import custom fields" and should be placed under "Contacts" blow "Import contacts".



## Implementation

Inside hrui I removed the core menu items that are required to be removed such as "new tag" , I leveraged  hrui_civicrm_navigation hook which receive menu items by reference in a variable called $params , so I unset all of them their .

 For Appraisals menu items and its child menus , I did nothing since appraisals menu item is created by appraisals extension which is disabled by default when installing a new buildkit instance.

For reports I did nothing too since reports component is already disabled when installing a new buildkit instance .

For "Job contract" menu item , I removed it and moved its sub-menus by adding a new upgrader method ( upgrader  methods are set to run automatically when installing job contract extension ) that remove and then re-create the menu items .

For "Import custom fields" it was already created but with different name "Import Job" via job contract extension and it already had a set of sub-menus work as a shortcut to reach specific custom fields importer pages , 
So I  removed it from job contract and added a code to code to manage it in hrui extension since it does not belong to hrjobcontract.

I also did some general refactoring and removing for unused and commented code .


![anim](https://cloud.githubusercontent.com/assets/6275540/17999704/0bca6e94-6b83-11e6-8fa1-3b231653b77c.gif)

