### PR TITLE
PCHR-1517: Fix non-compatible declaration of overridden methods in hrreport

### DIFF
--- a/hrreport/CRM/HRReport/Form/Contact/HRDetail.php
+++ b/hrreport/CRM/HRReport/Form/Contact/HRDetail.php
@@ -38,7 +38,7 @@ class CRM_HRReport_Form_Contact_HRDetail extends CRM_Report_Form {
   //FIXME: extend should be a subtype suitable for CiviHR applicants
   protected $_customGroupExtends = array('Individual');
 
-  function __construct() {
+  public function __construct() {
     $this->_exposeContactID = $this->_emailField = FALSE;
     $this->_customGroupJoin = 'LEFT JOIN';
 
@@ -188,7 +188,7 @@ class CRM_HRReport_Form_Contact_HRDetail extends CRM_Report_Form {
           ),
         ),
       ),
-        
+
       'civicrm_hrjobcontract' =>
       array(
         'dao' => 'CRM_Hrjobcontract_DAO_HRJobContract',
@@ -220,7 +220,7 @@ class CRM_HRReport_Form_Contact_HRDetail extends CRM_Report_Form {
         ),
         'grouping' => array('job-fields' => 'Job'),
       ),
-        
+
     'civicrm_hrjobcontract_revision' =>
     array(
       'dao' => 'CRM_Hrjobcontract_DAO_HRJobContractRevision',
@@ -474,7 +474,7 @@ class CRM_HRReport_Form_Contact_HRDetail extends CRM_Report_Form {
     parent::__construct();
   }
 
-  function from() {
+  public function from() {
 
     $this->_from = "
       FROM  civicrm_contact {$this->_aliases['civicrm_contact']} {$this->_aclFrom}
@@ -504,7 +504,7 @@ class CRM_HRReport_Form_Contact_HRDetail extends CRM_Report_Form {
       LEFT JOIN civicrm_contact manager
                ON manager.id = ({$this->_aliases['civicrm_hrjobcontract_role']}.manager_contact_id)
       ";
-    
+
     foreach ($this->_columns as $tableName => $table) {
       if (!empty($table['fields'])) {
         foreach ($table['fields'] as $fieldName => $field) {
@@ -534,7 +534,7 @@ class CRM_HRReport_Form_Contact_HRDetail extends CRM_Report_Form {
     }
   }
 
-  function customDataFrom() {
+  public function customDataFrom($joinsForFiltersOnly = FALSE) {
     parent::customDataFrom();
     $params = array('name'=>'HRJobContract_Summary');
     CRM_Core_DAO::commonRetrieve('CRM_Core_DAO_CustomGroup', $params, $cGrp);
@@ -546,7 +546,7 @@ class CRM_HRReport_Form_Contact_HRDetail extends CRM_Report_Form {
     }
   }
 
-  function where() {
+  public function where() {
     parent::where();
     $params = array('name'=>'HRJobContract_Summary');
     CRM_Core_DAO::commonRetrieve('CRM_Core_DAO_CustomGroup', $params, $cGrp);
@@ -576,14 +576,14 @@ class CRM_HRReport_Form_Contact_HRDetail extends CRM_Report_Form {
     }
   }
 
-  function groupBy() {
+  public function groupBy() {
     if (!empty($this->_params['current_employee_value'])) {
       $this->_groupBy = "GROUP BY {$this->_aliases['civicrm_hrjobcontract']}.id";
       $this->_select = str_replace("manager.sort_name", "GROUP_CONCAT(DISTINCT(manager.sort_name) SEPARATOR ' | ')", $this->_select);
     }
   }
 
-  function alterDisplay(&$rows) {
+  public function alterDisplay(&$rows) {
     $entryFound = FALSE;
     $gender = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id');
     $job_location = CRM_Core_OptionGroup::values('hrjc_location');

--- a/hrreport/CRM/HRReport/Form/Contact/HRSummary.php
+++ b/hrreport/CRM/HRReport/Form/Contact/HRSummary.php
@@ -38,7 +38,7 @@ class CRM_HRReport_Form_Contact_HRSummary extends CRM_Report_Form {
   //FIXME: extend should be a subtype suitable for CiviHR applicants
   protected $_customGroupExtends = array('Individual');
 
-  function __construct() {
+  public function __construct() {
     $this->_emailField = FALSE;
     $this->_customGroupJoin = 'LEFT JOIN';
     $this->_customGroupGroupBy = TRUE;
@@ -136,7 +136,7 @@ class CRM_HRReport_Form_Contact_HRSummary extends CRM_Report_Form {
           ),
         ),
       ),
-        
+
       'civicrm_hrjobcontract' =>
       array(
         'dao' => 'CRM_Hrjobcontract_DAO_HRJobContract',
@@ -168,7 +168,7 @@ class CRM_HRReport_Form_Contact_HRSummary extends CRM_Report_Form {
         ),
         'grouping' => array('job-fields' => 'Job'),
       ),
-        
+
     'civicrm_hrjobcontract_revision' =>
     array(
       'dao' => 'CRM_Hrjobcontract_DAO_HRJobContractRevision',
@@ -418,7 +418,7 @@ class CRM_HRReport_Form_Contact_HRSummary extends CRM_Report_Form {
         ),
         'grouping' => 'job-fields',
       ),
-        
+
       'civicrm_hrjobcontract_leave' =>
       array(
         'dao' => 'CRM_Hrjobcontract_DAO_HRJobLeave',
@@ -493,7 +493,7 @@ class CRM_HRReport_Form_Contact_HRSummary extends CRM_Report_Form {
     }
   }
 
-  function from() {
+  public function from() {
     $this->_from = "
       FROM  civicrm_contact {$this->_aliases['civicrm_contact']} {$this->_aclFrom}
       LEFT JOIN civicrm_hrjobcontract {$this->_aliases['civicrm_hrjobcontract']}
@@ -517,7 +517,7 @@ class CRM_HRReport_Form_Contact_HRSummary extends CRM_Report_Form {
       LEFT JOIN civicrm_hrjobcontract_role {$this->_aliases['civicrm_hrjobcontract_role']}
                ON {$this->_aliases['civicrm_hrjobcontract_revision']}.role_revision_id = {$this->_aliases['civicrm_hrjobcontract_role']}.jobcontract_revision_id
       ";
-    
+
     foreach ($this->_columns as $tableName => $table) {
       if (!empty($table['fields'])) {
         foreach ($table['fields'] as $fieldName => $field) {
@@ -541,7 +541,7 @@ class CRM_HRReport_Form_Contact_HRSummary extends CRM_Report_Form {
     }
   }
 
-  function customDataFrom() {
+  public function customDataFrom($joinsForFiltersOnly = FALSE) {
     parent::customDataFrom();
     $params = array('name'=>'HRJobContract_Summary');
     CRM_Core_DAO::commonRetrieve('CRM_Core_DAO_CustomGroup', $params, $cGrp);
@@ -553,7 +553,7 @@ class CRM_HRReport_Form_Contact_HRSummary extends CRM_Report_Form {
     }
   }
 
-  function where() {
+  public function where() {
     parent::where();
     $params = array('name'=>'HRJobContract_Summary');
     CRM_Core_DAO::commonRetrieve('CRM_Core_DAO_CustomGroup', $params, $cGrp);
@@ -583,7 +583,7 @@ class CRM_HRReport_Form_Contact_HRSummary extends CRM_Report_Form {
     }
   }
 
-  function statistics(&$rows) {
+  public function statistics(&$rows) {
     $statistics = parent::statistics($rows);
     if (!empty($this->_statFields)) {
       if ((array_key_exists("civicrm_hrjobcontract_pay_monthly_cost_eq",$this->_params["fields"]) || array_key_exists("civicrm_hrjobcontract_pay_annual_cost_eq_sum",$this->_params["fields"])) && array_key_exists("civicrm_hrjobcontract_pay_hrjobcontract_pay_pay_currency",$this->_params["fields"])) {
@@ -622,7 +622,7 @@ class CRM_HRReport_Form_Contact_HRSummary extends CRM_Report_Form {
     return $statistics;
   }
 
-  function modifyColumnHeaders() {
+  public function modifyColumnHeaders() {
     // make sure stats columns always appear on right.
     if (!empty($this->_statFields)) {
       $tempHeaders = array();
@@ -634,7 +634,7 @@ class CRM_HRReport_Form_Contact_HRSummary extends CRM_Report_Form {
     }
   }
 
-  function alterDisplay(&$rows) {
+  public function alterDisplay(&$rows) {
     $entryFound = FALSE;
     $gender = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id');
     foreach ($rows as $rowNum => $row) {


### PR DESCRIPTION
## Problem 

The following warning was appearing :

`Strict warning: Declaration of CRM_HRReport_Form_Contact_HRSummary::customDataFrom() should be compatible with CRM_Report_Form::customDataFrom($joinsForFiltersOnly = false) in require_once() (line 37 of civicrm/tools/extensions/civihr/hrreport/CRM/HRReport/Form/Contact/HRSummary.php).`

## Solution

In civicrm 4.7 the signature for **CRM_Report_Form::customDataFrom** method is slightly changed so I've updated the extensions in civihr that override this method to match its signature . I also explicitly delcared all methods in (HRReport/Form/Contact/HRDetail.php) & ( HRReport/Form/Contact/HRSummary.php ) as public.