### PR TITLE
PCHR-1229: Fix hrrecruitment extenstion momentjs script location

### DIFF
--- a/hrrecruitment/CRM/HRRecruitment/Page/Dashboard.php
+++ b/hrrecruitment/CRM/HRRecruitment/Page/Dashboard.php
@@ -36,7 +36,7 @@ class CRM_HRRecruitment_Page_Dashboard extends CRM_Core_Page {
     CRM_Core_Resources::singleton()
       ->addStyleFile('org.civicrm.hrrecruitment', 'css/dashboard.css')
       ->addScriptFile('org.civicrm.hrrecruitment', 'templates/CRM/HRRecruitment/Page/Dashboard.js')
-      ->addScriptFile('civicrm', 'packages/momentjs/moment.min.js');
+      ->addScriptFile('org.civicrm.reqangular', 'src/common/vendor/moment.min.js');
     $vacancies = CRM_HRRecruitment_BAO_HRVacancy::getVacanciesByStatus();
     $recentActivities = CRM_HRRecruitment_BAO_HRVacancy::recentApplicationActivities();
     $this->assign('vacanciesByStatus', $vacancies);


### PR DESCRIPTION
## Problem

- Open Vacancies/Dashboard
- Then try to click on Absences, Mailing, Search, etc.
- The drop down menus don't appear, and nothing happens when clicking on these menus.

![before](https://cloud.githubusercontent.com/assets/6275540/18069251/7e19f564-6e4e-11e6-894f-3f0ee1f94207.gif)

The reason behinde this is that  momentjs is used in hrrecruitment extension but it  points to wrong location ( momentjs was shipped with civicrm previously but not anymore in 4.7 and that's where it was pointing ).

## Solution

since momentjs library is available in org.civicrm.reqangular extension i just changed hrrecruitment to use it.

![after](https://cloud.githubusercontent.com/assets/6275540/18069303/f835b176-6e4e-11e6-81e0-fb52bc68d72a.gif)
