### PR TITLE
PCHR-1236: Blank start and end dates  input boxes when editing vacancies 

### DIFF
--- a/hrrecruitment/CRM/HRRecruitment/Form/HRVacancy.php
+++ b/hrrecruitment/CRM/HRRecruitment/Form/HRVacancy.php
@@ -97,13 +97,6 @@ class CRM_HRRecruitment_Form_HRVacancy extends CRM_Core_Form {
 
     if (!empty($params['id'])) {
       CRM_HRRecruitment_BAO_HRVacancy::retrieve($params, $defaults);
-      //format vacancy start/end date
-      if (!empty($defaults['start_date'])) {
-        list($defaults['start_date'], $defaults['start_date_time']) = CRM_Utils_Date::setDateDefaults($defaults['start_date'], 'activityDateTime');
-      }
-      if (!empty($defaults['end_date'])) {
-        list($defaults['end_date'], $defaults['end_date_time']) = CRM_Utils_Date::setDateDefaults($defaults['end_date'], 'activityDateTime');
-      }
 
       //show that only number of permission row(s) which have defaults if any
       if (!empty($defaults['permission']) && count($defaults['permission'])) {
@@ -140,8 +133,8 @@ class CRM_HRRecruitment_Form_HRVacancy extends CRM_Core_Form {
     $this->add('wysiwyg', 'benefits', ts('Benefits'), array('rows' => 2, 'cols' => 40));
     $this->add('wysiwyg', 'requirements', ts('Requirements'), array('rows' => 2, 'cols' => 40));
 
-    $this->add('datepicker', 'start_date', ts('Start Date'), FALSE, array('formatType' => 'activityDateTime'));
-    $this->add('datepicker', 'end_date', ts('End Date'), FALSE, array('formatType' => 'activityDateTime'));
+    $this->add('datepicker', 'start_date', ts('Start Date'), NULL, TRUE, array('minDate' => time()));
+    $this->add('datepicker', 'end_date', ts('End Date'), NULL, TRUE, array('minDate' => time()));
 
     $include = & $this->addElement('advmultiselect', 'stages',
       '', CRM_Core_OptionGroup::values('case_status', FALSE, FALSE, FALSE, " AND grouping = 'Vacancy'"),
@@ -244,7 +237,11 @@ class CRM_HRRecruitment_Form_HRVacancy extends CRM_Core_Form {
       $errors['stages'] = ts('Please select at least one Vacancy stage');
     }
 
-    if ((strtotime($fields['start_date_display'])) > (strtotime($fields['end_date_display']))) {
+    if ((strtotime($fields['start_date'])) < time()) {
+      $errors['start_date'] = ts('Start date should be greater or equal the current date.');
+    }
+
+    if ((strtotime($fields['start_date'])) > (strtotime($fields['end_date']))) {
       $errors['end_date'] = ts('End date should be greater than start date.');
     }
 


### PR DESCRIPTION
## Problem

When Trying to edit a vacancy the start and end dates input boxes are shown empty 

![before](https://cloud.githubusercontent.com/assets/6275540/18269825/ce8fdf4e-7421-11e6-8f16-d7c8c94cfdfb.gif)

The issue is inside quick form **setDefaultValues** method , the start and end dates are converted to a format not recognized by the used JavaScript date picker plugin.

another problem is after submitting the form , the following notices will appear in vacancy listing page :

![selection_121](https://cloud.githubusercontent.com/assets/6275540/18269846/e4b1d1e2-7421-11e6-8eae-5e902d078532.png)

which is because inside quick form **formRule** method , **start_date_display** and **end_date_display** where used instead of **start_date** and **end_date**.

## Solution

Actually the date picker plugin appear to accept MySQL DateTime format so I just removed the date converting inside **setDefaultValues** method .

![after](https://cloud.githubusercontent.com/assets/6275540/18269830/d423a1fc-7421-11e6-92b3-26a94a94b5e2.gif)


for the notices , i corrected the field names inside **formRule** method .