### PR TITLE
PCHR-1535: Fix malformed return URL for the Absence Record form

### DIFF
--- a/hrabsence/CRM/HRAbsence/Form/AbsenceRequest.php
+++ b/hrabsence/CRM/HRAbsence/Form/AbsenceRequest.php
@@ -204,7 +204,7 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
       return _getManagerContacts($employeeID);
     }
   }
-  
+
   public function getPrimaryJobContractId($employeeID)
   {
       $jobContracts = civicrm_api3('HRJobContract', 'get', array(
@@ -212,12 +212,12 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
           'is_primary' => 1,
           'options' => array('limit' => 1),
       ));
-      
+
       if (!empty($jobContracts['values']))
       {
           return $jobContracts['id'];
       }
-      
+
       return null;
   }
 
@@ -660,7 +660,7 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
         }
       }
       self::sendAbsenceMail($mailprm, $sendTemplateParams);
-      $session->pushUserContext(CRM_Utils_System::url('civicrm/absences', "reset=1&cid={$this->_targetContactID}#hrabsence/list"));
+      $session->pushUserContext(CRM_Utils_System::url('civicrm/absences', "reset=1&cid={$this->_targetContactID}", false, 'hrabsence/list'));
     }
     elseif ($this->_mode == 'edit') {
       if (array_key_exists('_qf_AbsenceRequest_done_cancelabsence', $submitValues)) {
@@ -742,7 +742,7 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
         $session->pushUserContext(CRM_Utils_System::url('civicrm/absence/set', "reset=1&action=view&aid={$result['id']}"));
       }
       elseif (array_key_exists('_qf_AbsenceRequest_done_cancel', $submitValues)) {
-        $session->pushUserContext(CRM_Utils_System::url('civicrm/absences', "reset=1&cid={$this->_targetContactID}#hrabsence/list"));
+        $session->pushUserContext(CRM_Utils_System::url('civicrm/absences', "reset=1&cid={$this->_targetContactID}", false, 'hrabsence/list'));
       }
       else {
         $result = civicrm_api3('Activity', 'get', array(
@@ -768,7 +768,7 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
           $this->_aid = $submitValues['source_record_id'];
           $sendTemplateParams['from'] = $mailprm[$this->_targetContactID]['email'];
           $sendTemplateParams['tplParams']['save'] = $sendMail = TRUE;
-          $session->pushUserContext(CRM_Utils_System::url('civicrm/absences', "reset=1&cid={$this->_targetContactID}#hrabsence/list"));
+          $session->pushUserContext(CRM_Utils_System::url('civicrm/absences', "reset=1&cid={$this->_targetContactID}", false, 'hrabsence/list'));
         }
       }
       if (!empty($submitValues['hidden_custom'])) {
@@ -819,7 +819,7 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
         $statusMsg = ts('Absence(s) have been Cancelled');
       }
       elseif (array_key_exists('_qf_AbsenceRequest_done_cancel', $submitValues)) {
-        $session->pushUserContext(CRM_Utils_System::url('civicrm/absences', "reset=1&cid={$this->_targetContactID}#hrabsence/list"));
+        $session->pushUserContext(CRM_Utils_System::url('civicrm/absences', "reset=1&cid={$this->_targetContactID}", false, 'hrabsence/list'));
       }
       civicrm_api3('Activity', 'create', array(
         'id' => $this->_activityId,


### PR DESCRIPTION
After making changes to an Absence Request, the user is redirect to an URL. This URL has a fragment, which is used by the backbone app to select which tab should be displayed. This fragment was added to the end of the URL by passing it to the CRM_Utils_System::url() method as part of the $query paramenter. This commit on the civicrm-core https://github.com/civicrm/civicrm-core/commit/c80e2dbf changed the behavior of how the method handles the $query value if it has a fragment (a string starting with #), turning part of the param value as the path for the URL, which led to a malformed URL.

The CRM_Utils_System::url() have a specific param for URL fragments, so, in order to fix the malformed URLs,  I updated every call to this method to pass the fragment using this param.