### PR TITLE
PCHR-1572: Show radiobuttons

### DIFF
--- a/hrjobcontract/views/modalForm.html
+++ b/hrjobcontract/views/modalForm.html
@@ -320,12 +320,10 @@
                         <div class="col-xs-12">
                             <div class="form-group">
                                 <div class="col-sm-5 col-sm-offset-4">
-                                    <label class="radio-inline">
-                                        <input type="radio" id="{{prefix}}paid" value="1" ng-model="entity.pay.is_paid" ng-change="setDefaults()" ng-disabled="isDisabled"> Paid
-                                    </label>
-                                    <label class="radio-inline">
-                                        <input type="radio" id="{{prefix}}unpaid" value="0" ng-model="entity.pay.is_paid" ng-change="resetData()" ng-disabled="isDisabled"> Unpaid
-                                    </label>
+                                    <input type="radio" id="{{prefix}}paid" value="1" ng-model="entity.pay.is_paid" ng-change="setDefaults()" ng-disabled="isDisabled">
+                                    <label class="radio-inline" for="{{prefix}}paid">Paid</label>
+                                    <input type="radio" id="{{prefix}}unpaid" value="0" ng-model="entity.pay.is_paid" ng-change="resetData()" ng-disabled="isDisabled">
+                                    <label class="radio-inline" for="{{prefix}}unpaid">Unpaid</label>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
**Problem**
Radio buttons missing in Job contract Pay page

**Fix**
1. For the custom radiobuttons to work "for" has to be mentioned for the label of the input tag(CSS written that way), which was missing. Adding the same fixes the visibility of radio buttons.
2. Markup modified to show the radio buttons properly.

**Before**
![image](https://cloud.githubusercontent.com/assets/5058867/18482896/980c7f3e-79ff-11e6-9a1b-1497abf83210.png)

**After**
![image](https://cloud.githubusercontent.com/assets/5058867/18482882/8a777450-79ff-11e6-8fc4-e435b709db28.png)
