### PR TITLE
PCHR-1238: Fix application details not being stored

### DIFF
--- a/hrrecruitment/CRM/HRRecruitment/Form/Application.php
+++ b/hrrecruitment/CRM/HRRecruitment/Form/Application.php
@@ -238,7 +238,7 @@ class CRM_HRRecruitment_Form_Application extends CRM_Core_Form {
       }
 
       //process Custom data
-      CRM_Core_BAO_CustomValueTable::postprocess($params,CRM_Core_DAO::$_nullArray, 'civicrm_case', $caseObj->id, 'Case');
+      CRM_Core_BAO_CustomValueTable::postProcess($params, 'civicrm_case', $caseObj->id, 'Case');
 
       //Process case to vacancy one-to-one mapping in custom table 'application_case'
       $cgID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', 'application_case', 'id', 'name');

--- a/hrrecruitment/xml/Menu/hrrecruitment.xml
+++ b/hrrecruitment/xml/Menu/hrrecruitment.xml
@@ -24,6 +24,8 @@
     <path>civicrm/vacancy/apply</path>
     <title>Application Form</title>
     <page_callback>CRM_HRRecruitment_Form_Application</page_callback>
+    <access_callback>1</access_callback>
+    <is_public>true</is_public>
   </item>
   <item>
     <path>civicrm/case/pipeline</path>


### PR DESCRIPTION
## Problem

When someone apply for a vacancy , the application details for that applicant are not stored :

![selection_153](https://cloud.githubusercontent.com/assets/6275540/18556485/55da5a40-7b63-11e6-962f-14156685d939.png)
## Solution

The applicantion form fields are actually a custom fields and storing them was handled by calling **CRM_Core_BAO_CustomValueTable::postprocess()** method but in this case it was called with wrong parameters which prevent custom fields from being stored and displayed . so I just fixed that .

![selection_152](https://cloud.githubusercontent.com/assets/6275540/18556502/6067d21c-7b63-11e6-9069-f810cc7b06fa.png)

---

To be more detailed : this method arguments has been changed in civicrm 4.7 https://github.com/civicrm/civicrm-core/commit/5fc3ea244918837ef10e58b172ab84a97f190b86#diff-927e742818deb9c89a00d2528e360bf0R361

( Related PR : https://github.com/civicrm/civihr/pull/1164)
