### PR TITLE
PCHR-1576: Change style of CiviCRM menu

### DIFF
--- a/hrui/css/hrui.css
+++ b/hrui/css/hrui.css
@@ -15,3 +15,8 @@
   height: 26px !important;
   line-height: 26px;
 }
+
+#civicrm-menu #crm-qsearch {
+  line-height: 28px;
+  height: 30px !important;
+}

--- a/hrui/css/hrui.css
+++ b/hrui/css/hrui.css
@@ -5,3 +5,13 @@
 #crm-main-content-wrapper #contactDetails #govID span {
   margin-right: 1%;
 }
+
+/*CiviCRM Menu Buttons*/
+#civicrm-menu {
+  height: 32px;
+}
+
+#civicrm-menu > li.menumain {
+  height: 26px !important;
+  line-height: 26px;
+}


### PR DESCRIPTION
# Requirement
1. Fix menu height, make menu item hover state and delimiter take full height of the menu, so red area on the screenshot, instead of how it is right now.
![image-2016-09-16-10-13-03-633](https://cloud.githubusercontent.com/assets/5058867/18658478/228dde3e-7f21-11e6-9f2b-5e9f7767d0ac.png)

# After
![image](https://cloud.githubusercontent.com/assets/5058867/18665183/9b414b6e-7f43-11e6-987f-27098c41747f.png)

