### PR TITLE
PCHR-1580: Set default localisation settings

### DIFF
--- a/bin/drush-install.sh
+++ b/bin/drush-install.sh
@@ -48,13 +48,21 @@ function set_default_localisation_settings() {
 
   UKID=$(drush cvapi Country.getsingle return="id" iso_code="GB" | grep -oh '[0-9]*')
 
-  drush cvapi Setting.create sequential=1 defaultCurrency="GBP" \
+  drush cvapi Setting.create defaultCurrency="GBP" \
   dateformatDatetime="%d/%m/%Y %l:%M %P" dateformatFull="%d/%m/%Y" \
   dateformatFinancialBatch="%d/%m/%Y" dateInputFormat="dd/mm/yy" \
   lcMessages=${LOC_FILE} defaultContactCountry=${UKID}
 
-  drush cvapi OptionValue.create sequential=1 option_group_id="currencies_enabled" \
+  drush cvapi OptionValue.create option_group_id="currencies_enabled" \
   label="GBP (£)" value="GBP" is_default=1 is_active=1
+}
+
+##
+# Set Any needed Resource URLs
+function set_resource_urls() {
+  # Set Custom CSS URL
+  drush cvapi Setting.create \
+  customCSSURL="[civicrm.root]/tools/extensions/civihr/org.civicrm.bootstrapcivicrm/css/custom-civicrm.css"
 }
 
 ##################################
@@ -78,3 +86,5 @@ if [ -n "$WITHSAMPLE" ]; then
 fi
 
 set_default_localisation_settings $1
+set_resource_urls
+

--- a/bin/drush-install.sh
+++ b/bin/drush-install.sh
@@ -35,6 +35,28 @@ org.civicrm.contactsummary,\
 org.civicrm.bootstrapcivicrm,\
 org.civicrm.bootstrapcivihr
 
+##
+# Set Default localisation settings
+# It expect one parameter ($1) which points to civicrm absolute path
+function set_default_localisation_settings() {
+  LOC_FILE="en_US"
+  if wget -q "https://download.civicrm.org/civicrm-l10n-core/mo/en_GB/civicrm.mo" > /dev/null; then
+    mkdir -p $1/l10n/en_GB/LC_MESSAGES/
+    mv civicrm.mo $1/l10n/en_GB/LC_MESSAGES/civicrm.mo
+    LOC_FILE="en_GB"
+  fi
+
+  UKID=$(drush cvapi Country.getsingle return="id" iso_code="GB" | grep -oh '[0-9]*')
+
+  drush cvapi Setting.create sequential=1 defaultCurrency="GBP" \
+  dateformatDatetime="%d/%m/%Y %l:%M %P" dateformatFull="%d/%m/%Y" \
+  dateformatFinancialBatch="%d/%m/%Y" dateInputFormat="dd/mm/yy" \
+  lcMessages=${LOC_FILE} defaultContactCountry=${UKID}
+
+  drush cvapi OptionValue.create sequential=1 option_group_id="currencies_enabled" \
+  label="GBP (£)" value="GBP" is_default=1 is_active=1
+}
+
 ##################################
 ## Main
 
@@ -54,3 +76,5 @@ if [ -n "$WITHSAMPLE" ]; then
   drush "$@" cvapi extension.install keys=org.civicrm.hrsampledata
   set +ex
 fi
+
+set_default_localisation_settings $1


### PR DESCRIPTION
1- Set Default Language to (English - United Kingdom).
2- Set Default Currency to (GBP).
3- Add (GBP) to current list of enabled currencies.
4- Set Default Country to (United Kingdom).
5- Set Date formats (input and output formats) to "dd/mm/yy".
6- Set the Cusom CSS URL to point to the new theme which is available at "[civicrm.root]/tools/extensions/civihr/org.civicrm.bootstrapcivicrm/css/custom-civicrm.css"