### PR TITLE
PCHR-1600: Remove link from LeavePeriodEntitlement to LeaveBalanceChange

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -104,7 +104,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
       FROM {$balanceChangeTable}
       WHERE source_id = {$entitlementID} AND
             source_type = '" . self::SOURCE_ENTITLEMENT . "' AND 
-            expired_balance_id IS NULL
+            expired_balance_change_id IS NULL
       ORDER BY id
     ";
 
@@ -211,7 +211,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
   /**
    * This method checks every leave balance change record with an expiry_date in
    * the past and that still don't have a record for the expired days (that is,
-   * a balance change record of this same type and with an expired_balance_id
+   * a balance change record of this same type and with an expired_balance_change_id
    * pointing to the expired record), and creates it.
    *
    * @return int The number of records created
@@ -223,12 +223,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
     $query = "
       SELECT balance_to_expire.*
       FROM {$tableName} balance_to_expire
-      LEFT JOIN {$tableName} expired_balance
-             ON balance_to_expire.id = expired_balance.expired_balance_id
+      LEFT JOIN {$tableName} expired_balance_change
+             ON balance_to_expire.id = expired_balance_change.expired_balance_change_id
       WHERE balance_to_expire.expiry_date IS NOT NULL AND
             balance_to_expire.expiry_date < CURDATE() AND
-            balance_to_expire.expired_balance_id IS NULL AND
-            expired_balance.id IS NULL
+            balance_to_expire.expired_balance_change_id IS NULL AND
+            expired_balance_change.id IS NULL
       ORDER BY balance_to_expire.source_id ASC, balance_to_expire.expiry_date ASC
     ";
 
@@ -255,7 +255,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
         'type_id' => $dao->type_id,
         'amount' => $expiredAmount,
         'expiration_date' => date('YmdHis', strtotime($dao->expiry_date)),
-        'expired_balance_id' => $dao->id
+        'expired_balance_change_id' => $dao->id
       ]);
 
       $numberOfRecordsCreated++;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -5,6 +5,9 @@ use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 
 class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsences_DAO_LeaveBalanceChange {
 
+  const SOURCE_ENTITLEMENT = 'entitlement';
+  const SOURCE_LEAVE_REQUEST_DAY = 'leave_request_day';
+
   /**
    * Create a new LeaveBalanceChange based on array-data
    *
@@ -59,7 +62,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
       FROM {$balanceChangeTable} leave_balance_change
       LEFT JOIN {$leaveRequestDateTable} leave_request_date 
              ON leave_balance_change.source_id = leave_request_date.id AND 
-                leave_balance_change.source_type = 'leave_request_day'
+                leave_balance_change.source_type = '". self::SOURCE_LEAVE_REQUEST_DAY ."'
       LEFT JOIN {$leaveRequestTable} leave_request ON leave_request_date.leave_request_id = leave_request.id
       WHERE (
               leave_request.entitlement_id = {$entitlementID} $whereLeaveRequestStatus
@@ -67,7 +70,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
             OR
             (
               leave_balance_change.source_id = {$entitlementID} AND 
-              leave_balance_change.source_type = 'entitlement'
+              leave_balance_change.source_type = '" . self::SOURCE_ENTITLEMENT . "'
             )
     ";
 
@@ -100,7 +103,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
       SELECT *
       FROM {$balanceChangeTable}
       WHERE source_id = {$entitlementID} AND
-            source_type = 'entitlement' AND 
+            source_type = '" . self::SOURCE_ENTITLEMENT . "' AND 
             expired_balance_id IS NULL
       ORDER BY id
     ";
@@ -180,7 +183,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
       SELECT SUM(leave_balance_change.amount) balance
       FROM {$balanceChangeTable} leave_balance_change
       INNER JOIN {$leaveRequestDateTable} leave_request_date 
-              ON leave_balance_change.source_id = leave_request_date.id AND leave_balance_change.source_type = 'leave_request_day'
+              ON leave_balance_change.source_id = leave_request_date.id AND 
+                 leave_balance_change.source_type = '" . self::SOURCE_LEAVE_REQUEST_DAY . "'
       INNER JOIN {$leaveRequestTable} leave_request ON leave_request_date.leave_request_id = leave_request.id
       WHERE leave_request.entitlement_id = {$entitlementID}
     ";

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
@@ -223,7 +223,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
 
     LeaveBalanceChange::create([
       'type_id' => $balanceChangeTypes['Leave'],
-      'entitlement_id' => $periodEntitlement->id,
+      'source_id' => $periodEntitlement->id,
+      'source_type' => 'entitlement',
       'amount' => $amount
     ]);
   }
@@ -248,7 +249,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
 
       LeaveBalanceChange::create([
         'type_id' => $balanceChangeTypes['Brought Forward'],
-        'entitlement_id' => $periodEntitlement->id,
+        'source_id' => $periodEntitlement->id,
+        'source_type' => 'entitlement',
         'amount' => $broughtForward,
         'expiry_date' => CRM_Utils_Date::processDate($broughtForwardExpirationDate)
       ]);
@@ -285,9 +287,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
 
     if (!empty($publicHolidays)) {
       LeaveBalanceChange::create([
-        'type_id'        => $balanceChangeTypes['Public Holiday'],
-        'entitlement_id' => $periodEntitlement->id,
-        'amount'         => count($publicHolidays)
+        'type_id'     => $balanceChangeTypes['Public Holiday'],
+        'source_id'   => $periodEntitlement->id,
+        'source_type' => 'entitlement',
+        'amount'      => count($publicHolidays)
       ]);
 
       foreach ($publicHolidays as $publicHoliday) {
@@ -302,9 +305,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
 
         LeaveBalanceChange::create([
           'type_id'        => $balanceChangeTypes['Debit'],
-          'entitlement_id' => $periodEntitlement->id,
           'amount'         => -1,
-          'source_id'      => $requestDate->id
+          'source_id'      => $requestDate->id,
+          'source_type'    => 'leave_request_day'
         ]);
       }
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
@@ -224,7 +224,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
     LeaveBalanceChange::create([
       'type_id' => $balanceChangeTypes['Leave'],
       'source_id' => $periodEntitlement->id,
-      'source_type' => 'entitlement',
+      'source_type' => LeaveBalanceChange::SOURCE_ENTITLEMENT,
       'amount' => $amount
     ]);
   }
@@ -250,7 +250,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
       LeaveBalanceChange::create([
         'type_id' => $balanceChangeTypes['Brought Forward'],
         'source_id' => $periodEntitlement->id,
-        'source_type' => 'entitlement',
+        'source_type' => LeaveBalanceChange::SOURCE_ENTITLEMENT,
         'amount' => $broughtForward,
         'expiry_date' => CRM_Utils_Date::processDate($broughtForwardExpirationDate)
       ]);
@@ -289,7 +289,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
       LeaveBalanceChange::create([
         'type_id'     => $balanceChangeTypes['Public Holiday'],
         'source_id'   => $periodEntitlement->id,
-        'source_type' => 'entitlement',
+        'source_type' => LeaveBalanceChange::SOURCE_ENTITLEMENT,
         'amount'      => count($publicHolidays)
       ]);
 
@@ -307,7 +307,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
           'type_id'        => $balanceChangeTypes['Debit'],
           'amount'         => -1,
           'source_id'      => $requestDate->id,
-          'source_type'    => 'leave_request_day'
+          'source_type'    => LeaveBalanceChange::SOURCE_LEAVE_REQUEST_DAY
         ]);
       }
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/LeaveBalanceChange.php
@@ -109,7 +109,7 @@ class CRM_HRLeaveAndAbsences_DAO_LeaveBalanceChange extends CRM_Core_DAO
    *
    * @var int unsigned
    */
-  public $expired_balance_id;
+  public $expired_balance_change_id;
   /**
    * Some balance changes are originated from an specific source (a leave request date, for example) and this field will have the ID of this source.
    *
@@ -142,7 +142,7 @@ class CRM_HRLeaveAndAbsences_DAO_LeaveBalanceChange extends CRM_Core_DAO
   {
     if (!self::$_links) {
       self::$_links = static ::createReferenceColumns(__CLASS__);
-      self::$_links[] = new CRM_Core_Reference_Basic(self::getTableName() , 'expired_balance_id', 'civicrm_hrleaveandabsences_leave_balance_change', 'id');
+      self::$_links[] = new CRM_Core_Reference_Basic(self::getTableName() , 'expired_balance_change_id', 'civicrm_hrleaveandabsences_leave_balance_change', 'id');
     }
     return self::$_links;
   }
@@ -188,8 +188,8 @@ class CRM_HRLeaveAndAbsences_DAO_LeaveBalanceChange extends CRM_Core_DAO
           'title' => ts('Expiry Date') ,
           'description' => 'Some balance changes can expire. This is the date it will expire.',
         ) ,
-        'expired_balance_id' => array(
-          'name' => 'expired_balance_id',
+        'expired_balance_change_id' => array(
+          'name' => 'expired_balance_change_id',
           'type' => CRM_Utils_Type::T_INT,
           'description' => 'FK to LeaveBalanceChange. This is only used for a balance change that represents expired days, and it will be related to the balance change that has expired.',
           'FKClassName' => 'CRM_HRLeaveAndAbsences_DAO_LeaveBalanceChange',
@@ -225,7 +225,7 @@ class CRM_HRLeaveAndAbsences_DAO_LeaveBalanceChange extends CRM_Core_DAO
         'type_id' => 'type_id',
         'amount' => 'amount',
         'expiry_date' => 'expiry_date',
-        'expired_balance_id' => 'expired_balance_id',
+        'expired_balance_change_id' => 'expired_balance_change_id',
         'source_id' => 'source_id',
         'source_type' => 'source_type',
       );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/LeaveBalanceChange.php
@@ -87,12 +87,6 @@ class CRM_HRLeaveAndAbsences_DAO_LeaveBalanceChange extends CRM_Core_DAO
    */
   public $id;
   /**
-   * FK to LeavePeriodEntitlement
-   *
-   * @var int unsigned
-   */
-  public $entitlement_id;
-  /**
    * One of the values of the Leave Balance Type option group
    *
    * @var int unsigned
@@ -123,6 +117,12 @@ class CRM_HRLeaveAndAbsences_DAO_LeaveBalanceChange extends CRM_Core_DAO
    */
   public $source_id;
   /**
+   * Some balance changes are originated from an specific source (a leave request date, for example) and this field will have text string to indicate what is the source.
+   *
+   * @var string
+   */
+  public $source_type;
+  /**
    * class constructor
    *
    * @return civicrm_hrleaveandabsences_leave_balance_change
@@ -142,7 +142,6 @@ class CRM_HRLeaveAndAbsences_DAO_LeaveBalanceChange extends CRM_Core_DAO
   {
     if (!self::$_links) {
       self::$_links = static ::createReferenceColumns(__CLASS__);
-      self::$_links[] = new CRM_Core_Reference_Basic(self::getTableName() , 'entitlement_id', 'civicrm_hrleaveandabsences_leave_period_entitlement', 'id');
       self::$_links[] = new CRM_Core_Reference_Basic(self::getTableName() , 'expired_balance_id', 'civicrm_hrleaveandabsences_leave_balance_change', 'id');
     }
     return self::$_links;
@@ -161,13 +160,6 @@ class CRM_HRLeaveAndAbsences_DAO_LeaveBalanceChange extends CRM_Core_DAO
           'type' => CRM_Utils_Type::T_INT,
           'description' => 'Unique LeaveBalanceChange ID',
           'required' => true,
-        ) ,
-        'entitlement_id' => array(
-          'name' => 'entitlement_id',
-          'type' => CRM_Utils_Type::T_INT,
-          'description' => 'FK to LeavePeriodEntitlement',
-          'required' => true,
-          'FKClassName' => 'CRM_HRLeaveAndAbsences_DAO_LeavePeriodEntitlement',
         ) ,
         'type_id' => array(
           'name' => 'type_id',
@@ -207,6 +199,14 @@ class CRM_HRLeaveAndAbsences_DAO_LeaveBalanceChange extends CRM_Core_DAO
           'type' => CRM_Utils_Type::T_INT,
           'description' => 'Some balance changes are originated from an specific source (a leave request date, for example) and this field will have the ID of this source.',
         ) ,
+        'source_type' => array(
+          'name' => 'source_type',
+          'type' => CRM_Utils_Type::T_STRING,
+          'title' => ts('Source Type') ,
+          'description' => 'Some balance changes are originated from an specific source (a leave request date, for example) and this field will have text string to indicate what is the source.',
+          'maxlength' => 20,
+          'size' => CRM_Utils_Type::MEDIUM,
+        ) ,
       );
     }
     return self::$_fields;
@@ -222,12 +222,12 @@ class CRM_HRLeaveAndAbsences_DAO_LeaveBalanceChange extends CRM_Core_DAO
     if (!(self::$_fieldKeys)) {
       self::$_fieldKeys = array(
         'id' => 'id',
-        'entitlement_id' => 'entitlement_id',
         'type_id' => 'type_id',
         'amount' => 'amount',
         'expiry_date' => 'expiry_date',
         'expired_balance_id' => 'expired_balance_id',
         'source_id' => 'source_id',
+        'source_type' => 'source_type',
       );
     }
     return self::$_fieldKeys;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
@@ -301,13 +301,13 @@ CREATE TABLE `civicrm_hrleaveandabsences_leave_balance_change` (
      `type_id` int unsigned NOT NULL   COMMENT 'One of the values of the Leave Balance Type option group',
      `amount` decimal(20,2) NOT NULL  DEFAULT 0 COMMENT 'The amount of days this change in balance represents to the entitlement',
      `expiry_date` date    COMMENT 'Some balance changes can expire. This is the date it will expire.',
-     `expired_balance_id` int unsigned    COMMENT 'FK to LeaveBalanceChange. This is only used for a balance change that represents expired days, and it will be related to the balance change that has expired.',
+     `expired_balance_change_id` int unsigned    COMMENT 'FK to LeaveBalanceChange. This is only used for a balance change that represents expired days, and it will be related to the balance change that has expired.',
      `source_id` int unsigned    COMMENT 'Some balance changes are originated from an specific source (a leave request date, for example) and this field will have the ID of this source.' ,
      `source_type` varchar(20)    COMMENT 'Some balance changes are originated from an specific source (a leave request date, for example) and this field will have text string to indicate what is the source.' ,
     PRIMARY KEY ( `id` ),
-    UNIQUE INDEX `unique_expiry_record`(expired_balance_id),
+    UNIQUE INDEX `unique_expiry_record`(expired_balance_change_id),
     INDEX `index_source_id`(source_id, source_type),
-    CONSTRAINT FK_civicrm_hrlaa_leave_balance_change_expired_balance_id FOREIGN KEY (`expired_balance_id`) REFERENCES `civicrm_hrleaveandabsences_leave_balance_change`(`id`) ON DELETE CASCADE
+    CONSTRAINT FK_civicrm_hrlaa_leave_balance_change_expired_balance_change_id FOREIGN KEY (`expired_balance_change_id`) REFERENCES `civicrm_hrleaveandabsences_leave_balance_change`(`id`) ON DELETE CASCADE
 )  ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci  ;
 
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
@@ -298,16 +298,15 @@ CREATE TABLE `civicrm_hrleaveandabsences_leave_balance_change` (
 
 
      `id` int unsigned NOT NULL AUTO_INCREMENT  COMMENT 'Unique LeaveBalanceChange ID',
-     `entitlement_id` int unsigned NOT NULL   COMMENT 'FK to LeavePeriodEntitlement',
      `type_id` int unsigned NOT NULL   COMMENT 'One of the values of the Leave Balance Type option group',
      `amount` decimal(20,2) NOT NULL  DEFAULT 0 COMMENT 'The amount of days this change in balance represents to the entitlement',
      `expiry_date` date    COMMENT 'Some balance changes can expire. This is the date it will expire.',
      `expired_balance_id` int unsigned    COMMENT 'FK to LeaveBalanceChange. This is only used for a balance change that represents expired days, and it will be related to the balance change that has expired.',
      `source_id` int unsigned    COMMENT 'Some balance changes are originated from an specific source (a leave request date, for example) and this field will have the ID of this source.' ,
+     `source_type` varchar(20)    COMMENT 'Some balance changes are originated from an specific source (a leave request date, for example) and this field will have text string to indicate what is the source.' ,
     PRIMARY KEY ( `id` ),
     UNIQUE INDEX `unique_expiry_record`(expired_balance_id),
-    INDEX `index_source_id`(source_id),
-    CONSTRAINT FK_civicrm_hrlaa_leave_balance_change_entitlement_id FOREIGN KEY (`entitlement_id`) REFERENCES `civicrm_hrleaveandabsences_leave_period_entitlement`(`id`) ON DELETE CASCADE,
+    INDEX `index_source_id`(source_id, source_type),
     CONSTRAINT FK_civicrm_hrlaa_leave_balance_change_expired_balance_id FOREIGN KEY (`expired_balance_id`) REFERENCES `civicrm_hrleaveandabsences_leave_balance_change`(`id`) ON DELETE CASCADE
 )  ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci  ;
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -57,7 +57,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends PHPUnit_Framewor
       'type_id' => 1,
       'amount' => -3,
       'expiry_date' => CRM_Utils_Date::processDate('2016-01-01'),
-      'expired_balance_id' => $balanceChangeToExpire->id
+      'expired_balance_change_id' => $balanceChangeToExpire->id
     ]);
 
     $this->assertNotEmpty($expiryBalanceChange->id);
@@ -68,7 +68,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends PHPUnit_Framewor
       'type_id' => 1,
       'amount' => -3,
       'expiry_date' => CRM_Utils_Date::processDate('2016-01-01'),
-      'expired_balance_id' => $balanceChangeToExpire->id
+      'expired_balance_change_id' => $balanceChangeToExpire->id
     ]);
   }
 
@@ -597,7 +597,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends PHPUnit_Framewor
 
   private function getExpirationRecordForBalanceChange($balanceChangeID) {
     $record = new LeaveBalanceChange();
-    $record->expired_balance_id = $balanceChangeID;
+    $record->expired_balance_change_id = $balanceChangeID;
     $record->find();
     if($record->N == 1) {
       $record->fetch();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -76,7 +76,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends PHPUnit_Framewor
     $entitlement = $this->createLeavePeriodEntitlement();
 
     LeaveBalanceChange::create([
-      'entitlement_id' => $entitlement->id,
+      'source_id' => $entitlement->id,
+      'source_type' => 'entitlement',
       'type_id' => 1,
       'amount' => 4.3
     ]);
@@ -84,7 +85,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends PHPUnit_Framewor
     $this->assertEquals(4.3, LeaveBalanceChange::getBalanceForEntitlement($entitlement->id));
 
     LeaveBalanceChange::create([
-      'entitlement_id' => $entitlement->id,
+      'source_id' => $entitlement->id,
+      'source_type' => 'entitlement',
       'type_id' => 2,
       'amount' => 2
     ]);
@@ -92,7 +94,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends PHPUnit_Framewor
     $this->assertEquals(6.3, LeaveBalanceChange::getBalanceForEntitlement($entitlement->id));
 
     LeaveBalanceChange::create([
-      'entitlement_id' => $entitlement->id,
+      'source_id' => $entitlement->id,
+      'source_type' => 'entitlement',
       'type_id' => 2,
       'amount' => -3.5
     ]);
@@ -100,7 +103,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends PHPUnit_Framewor
     $this->assertEquals(2.8, LeaveBalanceChange::getBalanceForEntitlement($entitlement->id));
 
     LeaveBalanceChange::create([
-      'entitlement_id' => $entitlement->id,
+      'source_id' => $entitlement->id,
+      'source_type' => 'entitlement',
       'type_id' => 2,
       'amount' => -2
     ]);
@@ -189,7 +193,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends PHPUnit_Framewor
     $this->assertEquals(10, $balanceChanges[0]->amount);
 
     // Even if the days brought forward have expired, they're still
-    // part of the breakdown
+    // part of the breakdown (the expiry record is not returned though)
     $this->createExpiredBroughtForwardBalanceChange($entitlement->id, 4, 2);
     $balanceChanges = LeaveBalanceChange::getBreakdownBalanceChangesForEntitlement($entitlement->id);
     $this->assertCount(2, $balanceChanges);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/LeaveBalanceChangeHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/LeaveBalanceChangeHelpersTrait.php
@@ -137,7 +137,7 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
 
       CRM_Core_DAO::executeQuery("
         INSERT INTO {$balanceChangeTableName}(type_id, amount, source_id, source_type)
-        VALUES({$debitBalanceChangeType}, -1, {$dateId}, 'leave_request_day')
+        VALUES({$debitBalanceChangeType}, -1, {$dateId}, '" . LeaveBalanceChange::SOURCE_LEAVE_REQUEST_DAY . "')
       ");
     }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/LeaveBalanceChangeHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/LeaveBalanceChangeHelpersTrait.php
@@ -70,7 +70,7 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
       'source_id' => $entitlementID,
       'source_type' => 'entitlement',
       'amount' => $expiredAmount * -1, //expired amounts should be negative
-      'expired_balance_id' => $broughtForwardBalanceChangeID
+      'expired_balance_change_id' => $broughtForwardBalanceChangeID
     ]);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/LeaveBalanceChangeHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/LeaveBalanceChangeHelpersTrait.php
@@ -16,10 +16,11 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
     return $this->balanceChangeTypes[$type];
   }
 
-  public function createSourcelessBalanceChange($entitlementID, $amount, $type, $expiryDate = null) {
+  public function createEntitlementBalanceChange($entitlementID, $amount, $type, $expiryDate = null) {
     $params = [
       'type_id' => $type,
-      'entitlement_id' => $entitlementID,
+      'source_id' => $entitlementID,
+      'source_type' => 'entitlement',
       'amount' => $amount
     ];
 
@@ -31,7 +32,7 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
   }
 
   public function createLeaveBalanceChange($entitlementID, $amount) {
-    return $this->createSourcelessBalanceChange(
+    return $this->createEntitlementBalanceChange(
       $entitlementID,
       $amount,
       $this->getBalanceChangeTypeValue('Leave')
@@ -39,7 +40,7 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
   }
 
   public function createBroughtForwardBalanceChange($entitlementID, $amount, $expiryDate = null) {
-    return $this->createSourcelessBalanceChange(
+    return $this->createEntitlementBalanceChange(
       $entitlementID,
       $amount,
       $this->getBalanceChangeTypeValue('Brought Forward'),
@@ -48,7 +49,7 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
   }
 
   public function createPublicHolidayBalanceChange($entitlementID, $amount) {
-    return $this->createSourcelessBalanceChange(
+    return $this->createEntitlementBalanceChange(
       $entitlementID,
       $amount,
       $this->getBalanceChangeTypeValue('Public Holiday')
@@ -56,7 +57,7 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
   }
 
   public function createExpiredBroughtForwardBalanceChange($entitlementID, $amount, $expiredAmount) {
-    $this->createSourcelessBalanceChange(
+    $this->createEntitlementBalanceChange(
       $entitlementID,
       $amount,
       $this->getBalanceChangeTypeValue('Brought Forward')
@@ -66,9 +67,10 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
 
     LeaveBalanceChange::create([
       'type_id' => $this->getBalanceChangeTypeValue('Brought Forward'),
-      'entitlement_id' => $entitlementID,
+      'source_id' => $entitlementID,
+      'source_type' => 'entitlement',
       'amount' => $expiredAmount * -1, //expired amounts should be negative
-      'expired_balance_change_id' => $broughtForwardBalanceChangeID
+      'expired_balance_id' => $broughtForwardBalanceChangeID
     ]);
   }
 
@@ -134,8 +136,8 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
       $dateId = $this->getLastIdInTable($leaveRequestDateTableName);
 
       CRM_Core_DAO::executeQuery("
-        INSERT INTO {$balanceChangeTableName}(entitlement_id, type_id, amount, source_id)
-        VALUES('{$entitlementID}', {$debitBalanceChangeType}, -1, {$dateId})
+        INSERT INTO {$balanceChangeTableName}(type_id, amount, source_id, source_type)
+        VALUES({$debitBalanceChangeType}, -1, {$dateId}, 'leave_request_day')
       ");
     }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/LeaveBalanceChange.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/LeaveBalanceChange.xml
@@ -48,13 +48,13 @@
   </field>
 
   <field>
-    <name>expired_balance_id</name>
+    <name>expired_balance_change_id</name>
     <type>int unsigned</type>
     <comment>FK to LeaveBalanceChange. This is only used for a balance change that represents expired days, and it will be related to the balance change that has expired.</comment>
     <add>4.4</add>
   </field>
   <foreignKey>
-    <name>expired_balance_id</name>
+    <name>expired_balance_change_id</name>
     <table>civicrm_hrleaveandabsences_leave_balance_change</table>
     <key>id</key>
     <add>4.4</add>
@@ -78,7 +78,7 @@
 
   <index>
     <name>unique_expiry_record</name>
-    <fieldName>expired_balance_id</fieldName>
+    <fieldName>expired_balance_change_id</fieldName>
     <unique>true</unique>
     <add>4.4</add>
   </index>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/LeaveBalanceChange.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/LeaveBalanceChange.xml
@@ -21,21 +21,6 @@
   </primaryKey>
 
   <field>
-    <name>entitlement_id</name>
-    <type>int unsigned</type>
-    <required>true</required>
-    <comment>FK to LeavePeriodEntitlement</comment>
-    <add>4.4</add>
-  </field>
-  <foreignKey>
-    <name>entitlement_id</name>
-    <table>civicrm_hrleaveandabsences_leave_period_entitlement</table>
-    <key>id</key>
-    <add>4.4</add>
-    <onDelete>CASCADE</onDelete>
-  </foreignKey>
-
-  <field>
     <name>type_id</name>
     <type>int unsigned</type>
     <required>true</required>
@@ -83,6 +68,14 @@
     <add>4.4</add>
   </field>
 
+  <field>
+    <name>source_type</name>
+    <type>varchar</type>
+    <length>20</length>
+    <comment>Some balance changes are originated from an specific source (a leave request date, for example) and this field will have text string to indicate what is the source.</comment>
+    <add>4.4</add>
+  </field>
+
   <index>
     <name>unique_expiry_record</name>
     <fieldName>expired_balance_id</fieldName>
@@ -90,10 +83,11 @@
     <add>4.4</add>
   </index>
 
-  <!-- Since this is not a real FK, it's important to have an index for this field for a better performance in SQL JOINs -->
+  <!-- Since these are not real FKs, it's important to have an index for these field for a better performance in SQL JOINs -->
   <index>
     <name>index_source_id</name>
     <fieldName>source_id</fieldName>
+    <fieldName>source_type</fieldName>
     <add>4.4</add>
   </index>
 </table>


### PR DESCRIPTION
Instead of using the entitlement_id FK, the LeavePeriodEntitlement will now be linked to LeaveBalanceChange via a polymorphic relationship using the source_id and source_type fields. Every LeaveBalanceChange record linked to a LeavePeriodEntitlement will have the value 'entitlement' on the source_type field and the related period entitlement id on source_id.

Since we had to create the new source_type field on LeaveBalanceChange, we also needed new value for this field for when the LeaveBalanceChange is linked to a LeaveRequestDay. In that case, the source_type is 'leave_request_day'