### PR TITLE
PCHR-1601: Change LeaveRequest to no depend on LeavePeriodEntitlement

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
@@ -1,5 +1,6 @@
 <?php
 use CRM_HRLeaveAndAbsences_EntitlementCalculation as EntitlementCalculation;
+use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
@@ -390,5 +391,53 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
     ];
 
     return LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($this->id, $filterStatuses);
+  }
+
+  /**
+   * This method returns the start and end dates for this LeavePeriodEntitlement.
+   *
+   * The start date is given by this rule: If the Contract start date is less than
+   * the Absence Period start date, then the latter date will be returned. Otherwise,
+   * the former will be used.
+   *
+   * The end date is given by this rule: If the Contract end date is empty or is
+   * greater than the Absence Period end date, then the latter will be returned.
+   * Otherwise, the former will be used.
+   *
+   * @return array
+   *   An array with the start date as the first element and the end date as the second one
+   */
+  public function getStartAndEndDates() {
+    $contractDates = $this->getContractDates();
+    $absencePeriod = AbsencePeriod::findById($this->period_id);
+
+    if(is_null($contractDates['end_date'])) {
+      $contractDates['end_date'] = $absencePeriod->end_date;
+    }
+
+    return $absencePeriod->adjustDatesToMatchPeriodDates($contractDates['start_date'], $contractDates['end_date']);
+  }
+
+  /**
+   * Returns an array containing the Contract's start and end dates.
+   *
+   * @return array|null The array with the dates or null if the contract details could not be found
+   */
+  private function getContractDates() {
+    $result = civicrm_api3('HRJobDetails', 'get', [
+      'jobcontract_id' => $this->contract_id,
+      'sequential' => 1
+    ]);
+
+    if(empty($result['values'][0])) {
+      return null;
+    }
+
+    $contractDetails = $result['values'][0];
+
+    return [
+      'start_date' => $contractDetails['period_start_date'],
+      'end_date' => !empty($contractDetails['period_end_date']) ? $contractDetails['period_end_date'] : null
+    ];
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/LeaveRequest.php
@@ -87,11 +87,17 @@ class CRM_HRLeaveAndAbsences_DAO_LeaveRequest extends CRM_Core_DAO
    */
   public $id;
   /**
-   * FK to LeavePeriodEntitlement
+   * FK to AbsenceType
    *
    * @var int unsigned
    */
-  public $entitlement_id;
+  public $type_id;
+  /**
+   * FK to Contact
+   *
+   * @var int unsigned
+   */
+  public $contact_id;
   /**
    * One of the values of the Leave Request Status option group
    *
@@ -142,7 +148,8 @@ class CRM_HRLeaveAndAbsences_DAO_LeaveRequest extends CRM_Core_DAO
   {
     if (!self::$_links) {
       self::$_links = static ::createReferenceColumns(__CLASS__);
-      self::$_links[] = new CRM_Core_Reference_Basic(self::getTableName() , 'entitlement_id', 'civicrm_hrleaveandabsences_leave_period_entitlement', 'id');
+      self::$_links[] = new CRM_Core_Reference_Basic(self::getTableName() , 'type_id', 'civicrm_hrleaveandabsences_absence_type', 'id');
+      self::$_links[] = new CRM_Core_Reference_Basic(self::getTableName() , 'contact_id', 'civicrm_contact', 'id');
     }
     return self::$_links;
   }
@@ -161,12 +168,19 @@ class CRM_HRLeaveAndAbsences_DAO_LeaveRequest extends CRM_Core_DAO
           'description' => 'Unique LeaveRequest ID',
           'required' => true,
         ) ,
-        'entitlement_id' => array(
-          'name' => 'entitlement_id',
+        'type_id' => array(
+          'name' => 'type_id',
           'type' => CRM_Utils_Type::T_INT,
-          'description' => 'FK to LeavePeriodEntitlement',
+          'description' => 'FK to AbsenceType',
           'required' => true,
-          'FKClassName' => 'CRM_HRLeaveAndAbsences_DAO_LeavePeriodEntitlement',
+          'FKClassName' => 'CRM_HRLeaveAndAbsences_DAO_AbsenceType',
+        ) ,
+        'contact_id' => array(
+          'name' => 'contact_id',
+          'type' => CRM_Utils_Type::T_INT,
+          'description' => 'FK to Contact',
+          'required' => true,
+          'FKClassName' => 'CRM_Contact_DAO_Contact',
         ) ,
         'status_id' => array(
           'name' => 'status_id',
@@ -227,7 +241,8 @@ class CRM_HRLeaveAndAbsences_DAO_LeaveRequest extends CRM_Core_DAO
     if (!(self::$_fieldKeys)) {
       self::$_fieldKeys = array(
         'id' => 'id',
-        'entitlement_id' => 'entitlement_id',
+        'type_id' => 'type_id',
+        'contact_id' => 'contact_id',
         'status_id' => 'status_id',
         'from_date' => 'from_date',
         'from_date_type' => 'from_date_type',

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
@@ -320,16 +320,17 @@ CREATE TABLE `civicrm_hrleaveandabsences_leave_balance_change` (
 -- *******************************************************/
 CREATE TABLE `civicrm_hrleaveandabsences_leave_request` (
 
-
      `id` int unsigned NOT NULL AUTO_INCREMENT  COMMENT 'Unique LeaveRequest ID',
-     `entitlement_id` int unsigned NOT NULL   COMMENT 'FK to LeavePeriodEntitlement',
+     `type_id` int unsigned NOT NULL   COMMENT 'FK to AbsenceType',
+     `contact_id` int unsigned NOT NULL   COMMENT 'FK to Contact',
      `status_id` int unsigned NOT NULL   COMMENT 'One of the values of the Leave Request Status option group',
      `from_date` date NOT NULL   COMMENT 'The date the leave request starts.',
      `from_date_type` int unsigned    COMMENT 'One of the values of the Leave Request Day Type option group',
      `to_date` date    COMMENT 'The date the leave request ends. If null, it means is starts and ends at the same date',
      `to_date_type` int unsigned    COMMENT 'One of the values of the Leave Request Day Type option group',
     PRIMARY KEY ( `id` ),
-    CONSTRAINT FK_civicrm_hrlaa_leave_request_entitlement_id FOREIGN KEY (`entitlement_id`) REFERENCES `civicrm_hrleaveandabsences_leave_period_entitlement`(`id`) ON DELETE CASCADE
+    CONSTRAINT FK_civicrm_hrlaa_leave_request_type_id FOREIGN KEY (`type_id`) REFERENCES `civicrm_hrleaveandabsences_absence_type`(`id`) ON DELETE CASCADE,
+    CONSTRAINT FK_civicrm_hrlaa_leave_request_contact_id FOREIGN KEY (`contact_id`) REFERENCES `civicrm_contact`(`id`) ON DELETE CASCADE
 )  ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci  ;
 
 -- /*******************************************************

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -31,7 +31,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends PHPUnit_Framework_Test
   {
     $fromDate = new DateTime();
     $leaveRequest = LeaveRequest::create([
-      'entitlement_id' => 1,
+      'type_id' => 1,
+      'contact_id' => 1,
       'status_id' => 1, //The status is not important here. We just need a value to be stored in the DB
       'from_date' => $fromDate->format('YmdHis'),
       'from_date_type' => 1 //The type is not important here. We just need a value to be stored in the DB
@@ -47,7 +48,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends PHPUnit_Framework_Test
     $fromDate = new DateTime();
     $toDate = new DateTime('+3 days');
     $leaveRequest = LeaveRequest::create([
-      'entitlement_id' => 1,
+      'type_id' => 1,
+      'contact_id' => 1,
       'status_id' => 1, //The status is not important here. We just need a value to be stored in the DB
       'from_date' => $fromDate->format('YmdHis'),
       'from_date_type' => 1, //The type is not important here. We just need a value to be stored in the DB
@@ -67,7 +69,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends PHPUnit_Framework_Test
   {
     $fromDate = new DateTime();
     $leaveRequest = LeaveRequest::create([
-      'entitlement_id' => 1,
+      'type_id' => 1,
+      'contact_id' => 1,
       'status_id' => 1,
       'from_date' => $fromDate->format('YmdHis'),
       'from_date_type' => 1

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/ContractHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/ContractHelpersTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+trait CRM_HRLeaveAndAbsences_ContractHelpersTrait {
+
+  protected $contract;
+
+  protected function createContract() {
+    $result = civicrm_api3('HRJobContract', 'create', [
+      'contact_id' => 2, //Existing contact from civicrm_data.mysql,
+      'is_primary' => 1,
+      'sequential' => 1
+    ]);
+    $this->contract = $result['values'][0];
+  }
+
+  protected function setContractDates($startDate, $endDate) {
+    civicrm_api3('HRJobDetails', 'create', [
+      'jobcontract_id' => $this->contract['id'],
+      'period_start_date' => $startDate,
+      'period_end_date' => $endDate,
+    ]);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__."/LeaveBalanceChangeHelpersTrait.php";
+require_once __DIR__."/ContractHelpersTrait.php";
 
 use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
@@ -20,8 +21,7 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
  HeadlessInterface, TransactionalInterface {
 
   use CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait;
-
-  private $contract;
+  use CRM_HRLeaveAndAbsences_ContractHelpersTrait;
 
   public function setUpHeadless() {
     return \Civi\Test::headless()
@@ -926,15 +926,6 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
     return $currentPeriod;
   }
 
-  private function createContract() {
-    $result = civicrm_api3('HRJobContract', 'create', [
-      'contact_id' => 2, //Existing contact from civicrm_data.mysql,
-      'is_primary' => 1,
-      'sequential' => 1
-    ]);
-    $this->contract = $result['values'][0];
-  }
-
   private function createEntitlement($period, $type, $numberOfDays = 20, $overridden = false, $comment = null) {
     $params = [
       'period_id'            => $period->id,
@@ -978,11 +969,5 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
     ]);
   }
 
-  private function setContractDates($startDate, $endDate) {
-    CRM_Hrjobcontract_BAO_HRJobDetails::create([
-      'jobcontract_id' => $this->contract['id'],
-      'period_start_date' => $startDate,
-      'period_end_date' => $endDate,
-    ]);
-  }
+
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
@@ -116,6 +116,8 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   }
 
   public function testBroughtForwardShouldNotBeMoreThanTheMaxNumberOfDaysAllowedToBeCarriedForward() {
+    $this->setContractDates(date('YmdHis', strtotime('-2 days')), null);
+
     $type = $this->createAbsenceType([
       'max_number_of_days_to_carry_forward' => 5
     ]);
@@ -145,8 +147,9 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
     $this->assertEquals(5, $calculation->getBroughtForward());
   }
 
-  public function testBroughtForwardShouldNotBeMoreThanTheNumberOfRemainingDaysInPreviousEntitlement()
-  {
+  public function testBroughtForwardShouldNotBeMoreThanTheNumberOfRemainingDaysInPreviousEntitlement() {
+    $this->setContractDates(date('YmdHis', strtotime('-2 days')), null);
+
     $type = $this->createAbsenceType([
       'max_number_of_days_to_carry_forward' => 5
     ]);
@@ -518,6 +521,8 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   public function testNumberOfDaysTakenOnThePreviousPeriodShouldBeTheTotalAmountOfDaysFromAllApprovedLeaveRequestsOnThePeriod() {
     $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
 
+    $this->setContractDates(date('YmdHis', strtotime('2015-01-01')), null);
+
     $type = $this->createAbsenceType();
     $previousPeriod = AbsencePeriod::create([
       'title' => 'Period 1',
@@ -530,14 +535,16 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
     $previousPeriodStartDateTimeStamp = strtotime($previousPeriod->start_date);
     // Add a 1 day Leave Request to the previous period
     $this->createLeaveRequestBalanceChange(
-      $previousPeriodEntitlement->id,
+      $previousPeriodEntitlement->type_id,
+      $previousPeriodEntitlement->getContactIDFromContract(),
       $leaveRequestStatuses['Approved'],
       date('Y-m-d', strtotime('+1 day', $previousPeriodStartDateTimeStamp))
     );
 
     // Add a 11 days Leave Request to the previous period
     $this->createLeaveRequestBalanceChange(
-      $previousPeriodEntitlement->id,
+      $previousPeriodEntitlement->type_id,
+      $previousPeriodEntitlement->getContactIDFromContract(),
       $leaveRequestStatuses['Approved'],
       date('Y-m-d', strtotime('+31 days', $previousPeriodStartDateTimeStamp)),
       date('Y-m-d', strtotime('+41 days', $previousPeriodStartDateTimeStamp))
@@ -568,8 +575,9 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
     $this->assertEquals(0, $calculation->getNumberOfDaysRemainingInThePreviousPeriod());
   }
 
-  public function testNumberOfDaysRemainingInThePreviousPeriodShouldBeEqualsToProposedEntitlementMinusLeavesTaken()
-  {
+  public function testNumberOfDaysRemainingInThePreviousPeriodShouldBeEqualsToProposedEntitlementMinusLeavesTaken() {
+    $this->setContractDates(date('YmdHis', strtotime('2015-01-01')), null);
+
     $type = $this->createAbsenceType();
 
     $previousPeriod = AbsencePeriod::create([

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/LeaveBalanceChangeHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/LeaveBalanceChangeHelpersTrait.php
@@ -83,16 +83,20 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
    * we don't need all that for the tests. Only having the data on the right
    * tables is enough, and that's what this method does.
    *
-   * @param int $entitlementID
-   *    The ID of the entitlement to which the leave request will be added to
+   * @param $typeID
+   *    The ID of the Absence Type this Leave Request will belong to
+   * @param $contactID
+   *    The ID of the Contact (user) this Leave Request will belong to
    * @param int $status
    *    One of the values of the Leave Request Status option list
    * @param $fromDate
    *    The start date of the leave request
    * @param null $toDate
    *    The end date of the leave request. If null, it means it starts and ends at the same date
+   *
+   * @internal param int $entitlementID The ID of the entitlement to which the leave request will be added to*    The ID of the entitlement to which the leave request will be added to
    */
-  public function createLeaveRequestBalanceChange($entitlementID, $status, $fromDate, $toDate = null) {
+  public function createLeaveRequestBalanceChange($typeID, $contactID, $status, $fromDate, $toDate = null) {
     $leaveRequestTable = LeaveRequest::getTableName();
     $startDate = new DateTime($fromDate);
 
@@ -107,8 +111,8 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
     $toDate = $toDate ? "'{$toDate}'" : 'NULL';
 
     $query = "
-      INSERT INTO {$leaveRequestTable}(entitlement_id, status_id, from_date, to_date)
-      VALUES({$entitlementID}, {$status}, {$fromDate}, {$toDate})
+      INSERT INTO {$leaveRequestTable}(type_id, contact_id, status_id, from_date, to_date)
+      VALUES({$typeID}, {$contactID}, {$status}, {$fromDate}, {$toDate})
     ";
 
     CRM_Core_DAO::executeQuery($query);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/LeavePeriodEntitlementHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/LeavePeriodEntitlementHelpersTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+trait CRM_HRLeaveAndAbsences_LeavePeriodEntitlementHelpersTrait {
+
+  /**
+   * Creates a mock to be used on tests for the geBalance() method.
+   *
+   * For these, we mock the getStartAndEndDates() method, so we don't need an
+   * actual AbsencePeriod record on the database and also the
+   * getContactIDFromContract() method so we don't need actual contract and
+   * contact records.
+   *
+   * @return CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement
+   */
+  public function createLeavePeriodEntitlementMockForBalanceTests() {
+    $periodEntitlement = $this->getMockBuilder(CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement::class)
+                              ->setMethods([
+                                'getContactIDFromContract',
+                                'getStartAndEndDates'
+                              ])
+                              ->getMock();
+
+    $periodEntitlement->expects($this->any())
+                      ->method('getContactIDFromContract')
+                      ->will($this->returnValue(1));
+
+    $periodEntitlement->expects($this->any())
+                      ->method('getStartAndEndDates')
+                      ->will($this->returnValue([
+                        date('Y-01-01'),
+                        date('Y-12-31')
+                      ]));
+
+    $periodEntitlement->id = 1;
+    $periodEntitlement->type_id = 1;
+    $periodEntitlement->period_id = 1;
+
+    return $periodEntitlement;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/LeaveRequest.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/LeaveRequest.xml
@@ -21,15 +21,30 @@
   </primaryKey>
 
   <field>
-    <name>entitlement_id</name>
+    <name>type_id</name>
     <type>int unsigned</type>
     <required>true</required>
-    <comment>FK to LeavePeriodEntitlement</comment>
+    <comment>FK to AbsenceType</comment>
     <add>4.4</add>
   </field>
   <foreignKey>
-    <name>entitlement_id</name>
-    <table>civicrm_hrleaveandabsences_leave_period_entitlement</table>
+    <name>type_id</name>
+    <table>civicrm_hrleaveandabsences_absence_type</table>
+    <key>id</key>
+    <add>4.4</add>
+    <onDelete>CASCADE</onDelete>
+  </foreignKey>
+
+  <field>
+    <name>contact_id</name>
+    <type>int unsigned</type>
+    <required>true</required>
+    <comment>FK to Contact</comment>
+    <add>4.4</add>
+  </field>
+  <foreignKey>
+    <name>contact_id</name>
+    <table>civicrm_contact</table>
     <key>id</key>
     <add>4.4</add>
     <onDelete>CASCADE</onDelete>


### PR DESCRIPTION
With this change, the LeaveRequest won't be linked to the LeavePeriodEntitlement anymore. Now, in order to know which LeaveRequest was taken during a period, we just fetch the LeaveRequest between the LeavePeriodEntitlement dates (which are based on the AbsencePeriod and Contract dates). This gives us some flexibility to change the contract or period dates and "move" the LeaveRequest to another period.

Two new fields where added to the LeaveRequest entity: **type_id**, which is a FK to an AbsenceType; and **contact_id**, which is a FK to Contact and represents the use who will be taking the leave. All the methods (and related tests) used to fetch the the leave balance during an leave period were updated to use these new fields. So, basically, to get the number of leaves taken during a period we now do something like: get all leave balance changes from leave requests where the type_id is equal to the leave period entitlement type_id and contact_id is equals to the leave period entitlement contract contact_id and which the dates are in between the leave period entitlement dates.

Note: On LeaveBalanceChangeTest, I commented out a few tests about expiring records. These tests started failing after this change, but there's another ticket to change their logic, so there's no point to spend time fixing something that will change soon.