### PR TITLE
PCHR-1604 - Update extensions to use hook_civicrm_tabset instead of hook_civicrm_tabs

### DIFF
--- a/com.civicrm.hrjobroles/hrjobroles.php
+++ b/com.civicrm.hrjobroles/hrjobroles.php
@@ -131,22 +131,26 @@ function hrjobroles_civicrm_navigationMenu( &$params ) {
 }
 
 /**
- * @param $tabs
- * @param $contactID
- * Create a custom tab for civicrm contact which will implement custom drupal callback function
- * this tab should appear after job contracts tab directly
- * and since contact summary tab weight is
- * -190 we chose this to be -180
- * to give some room for other extensions to place
- * their tabs between these two.
+ * Implementation of hook_civicrm_tabset.
+ *
+ * Create a custom tab for civicrm contact which will implement custom drupal
+ * callback function this tab should appear after job contracts tab directly
+ * and since contact summary tab weight is -190 we chose this to be -180
+ * to give some room for other extensions to place their tabs between these two.
+ *
+ * @param string $tabsetName
+ * @param array &$tabs
+ * @param array $context
  */
-function hrjobroles_civicrm_tabs(&$tabs, $contactID) {
-
-    $url = CRM_Utils_System::url('civicrm/job-roles/' . $contactID);
+function hrjobroles_civicrm_tabset($tabsetName, &$tabs, $context) {
+  if ($tabsetName === 'civicrm/contact/view') {
+    $url = CRM_Utils_System::url('civicrm/job-roles/' . $context['contact_id']);
     $tabs[] = array( 'id' => 'hrjobroles',
-        'url' => $url,
-        'title' => 'Job Roles',
-        'weight' => -180 );
+      'url' => $url,
+      'title' => 'Job Roles',
+      'weight' => -180,
+    );
+  }
 }
 
 /**

--- a/contactsummary/contactsummary.php
+++ b/contactsummary/contactsummary.php
@@ -134,20 +134,25 @@ function contactsummary_civicrm_pageRun($page) {
 }
 
 /**
- * Implementation of hook_civicrm_tabs
- * we set the weight for this tab to -200 since
- * the summary ( personal details ) tab weight is hardcoded
- * to 0 and cannot be changed and this tab has to appear before
- * it , also we chose a large number like 200 to give
- * a large room for other extensions to set its tabs
- * between this tab and ( personal details tab ) without altering
- * other tabs weights.
+ * Implementation of hook_civicrm_tabset.
+ *
+ * We set the weight for this tab to -200 since the summary (personal details)
+ * tab weight is hardcoded to 0 and cannot be changed and this tab has to appear
+ * before it , also we chose a large number like 200 to give a large room for
+ * other extensions to set its tabs between this tab and (personal details tab)
+ * without altering other tabs weights.
+ *
+ * @param string $tabsetName
+ * @param array &$tabs
+ * @param array $context
  */
-function contactsummary_civicrm_tabs(&$tabs) {
-  $tabs[] = Array(
-    'id'     => 'contactsummary',
-    'url'    => CRM_Utils_System::url('civicrm/contact-summary'),
-    'title'  => ts('Contact Summary'),
-    'weight' => -200
-  );
+function contactsummary_civicrm_tabset($tabsetName, &$tabs, $context) {
+  if ($tabsetName === 'civicrm/contact/view') {
+    $tabs[] = Array(
+      'id'     => 'contactsummary',
+      'url'    => CRM_Utils_System::url('civicrm/contact-summary'),
+      'title'  => ts('Contact Summary'),
+      'weight' => -200,
+    );
+  }
 }

--- a/hrabsence/hrabsence.php
+++ b/hrabsence/hrabsence.php
@@ -433,34 +433,41 @@ function hrabsence_civicrm_apiWrappers(&$wrappers, $apiRequest) {
 }
 
 /**
- * Implementation of hook_civicrm_tabs
- * this tab should appear after summary (personal details) tab directly
- * and since personal details tab weight is
- * hardcoded to 0 we chose this to be 10
- * to give some room for other extensions to place
- * their tabs between these two.
+ * Implementation of hook_civicrm_tabset.
+ *
+ * This tab should appear after summary (personal details) tab directly
+ * and since personal details tab weight is hardcoded to 0 we chose this
+ * to be 10 to give some room for other extensions to place their tabs between
+ * these two.
+ *
+ * @param string $tabsetName
+ * @param array &$tabs
+ * @param array $context
  */
-function hrabsence_civicrm_tabs(&$tabs, $contactID) {
-  $contactType = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactID, 'contact_type', 'id');
-  if (!($contactType == 'Individual' && CRM_HRAbsence_Page_EmployeeAbsencePage::checkPermissions($contactID, 'viewWidget'))) {
-    return;
+function hrabsence_civicrm_tabset($tabsetName, &$tabs, $context) {
+  if ($tabsetName === 'civicrm/contact/view') {
+    $contactID = $context['contact_id'];
+    $contactType = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactID, 'contact_type', 'id');
+    if (!($contactType == 'Individual' && CRM_HRAbsence_Page_EmployeeAbsencePage::checkPermissions($contactID, 'viewWidget'))) {
+      return;
+    }
+    $absence = civicrm_api3('Activity', 'getabsences', array('target_contact_id' => $contactID));
+    $absenceDuration = 0;
+    foreach ($absence['values'] as $k => $v) {
+      $absenceDuration += CRM_HRAbsence_BAO_HRAbsenceType::getAbsenceDuration($v['id']);
+    }
+    CRM_HRAbsence_Page_EmployeeAbsencePage::registerResources($contactID);
+    $tabs[] = array(
+      'id'    => 'absenceTab',
+      'url'   =>  CRM_Utils_System::url( 'civicrm/absences', array(
+        'cid' => $contactID,
+        'snippet' => 1,
+      )),
+      'count' => $absenceDuration / (8 * 60),
+      'title' => ts('Absences'),
+      'weight' => 10,
+    );
   }
-  $absence = civicrm_api3('Activity', 'getabsences', array('target_contact_id' => $contactID));
-  $absenceDuration = 0;
-  foreach ($absence['values'] as $k => $v) {
-    $absenceDuration += CRM_HRAbsence_BAO_HRAbsenceType::getAbsenceDuration($v['id']);
-  }
-  CRM_HRAbsence_Page_EmployeeAbsencePage::registerResources($contactID);
-  $tabs[] = array(
-    'id'    => 'absenceTab',
-    'url'   =>  CRM_Utils_System::url( 'civicrm/absences', array(
-      'cid' => $contactID,
-      'snippet' => 1,
-    )),
-    'count' => $absenceDuration/(8*60),
-    'title' => ts('Absences'),
-    'weight' => 10
-  );
 }
 
 /**

--- a/hrident/hrident.php
+++ b/hrident/hrident.php
@@ -121,10 +121,16 @@ function hrident_civicrm_managed(&$entities) {
 }
 
 /**
- * Implementation of hook_civicrm_tabs
+ * Implementation of hook_civicrm_tabset.
+ *
+ * @param string $tabsetName
+ * @param array &$tabs
+ * @param array $context
  */
-function hrident_civicrm_tabs(&$tabs, $contactID) {
-  CRM_Core_Resources::singleton()->addStyleFile('org.civicrm.hrident', 'css/hrident.css');
+function hrident_civicrm_tabset($tabsetName, &$tabs, $context) {
+  if ($tabsetName === 'civicrm/contact/view') {
+    CRM_Core_Resources::singleton()->addStyleFile('org.civicrm.hrident', 'css/hrident.css');
+  }
 }
 
 function hrident_getCustomGroupId() {

--- a/hrjobcontract/hrjobcontract.php
+++ b/hrjobcontract/hrjobcontract.php
@@ -271,20 +271,25 @@ function hrjobcontract_civicrm_buildForm($formName, &$form) {
 
 
 /**
- * Implementation of hook_civicrm_tabs
- * this tab should appear after contact summary tab directly
- * and since contact summary tab weight is
- * -200 we chose this to be -190
- * to give some room for other extensions to place
- * their tabs between these two.
+ * Implementation of hook_civicrm_tabset.
+ *
+ * This tab should appear after contact summary tab directly and since
+ * contact summary tab weight is -200 we chose this to be -190 to give some
+ * room for other extensions to place their tabs between these two.
+ *
+ * @param string $tabsetName
+ * @param array &$tabs
+ * @param array $context
  */
-function hrjobcontract_civicrm_tabs(&$tabs, $contactId) {
-  $tabs[] = Array(
-    'id'        => 'hrjobcontract',
-    'url'       => CRM_Utils_System::url('civicrm/contact/view/hrjobcontract', array('cid' => $contactId)),
-    'title'     => ts('Job Contract'),
-    'weight'    => -190
-  );
+function hrjobcontract_civicrm_tabset($tabsetName, &$tabs, $context) {
+  if ($tabsetName === 'civicrm/contact/view') {
+    $tabs[] = Array(
+      'id'        => 'hrjobcontract',
+      'url'       => CRM_Utils_System::url('civicrm/contact/view/hrjobcontract', array('cid' => $context['contact_id'])),
+      'title'     => ts('Job Contract'),
+      'weight'    => -190,
+    );
+  }
 }
 
 /**

--- a/hrqual/hrqual.php
+++ b/hrqual/hrqual.php
@@ -165,29 +165,34 @@ function hrqual_civicrm_managed(&$entities) {
 }
 
 /**
- * Implementation of hook_civicrm_tabs
+ * Implementation of hook_civicrm_tabset.
+ *
+ * @param string $tabsetName
+ * @param array &$tabs
+ * @param array $context
  */
-function hrqual_civicrm_tabs(&$tabs, $contactID) {
-  $cgid = hrqual_getCustomGroupId();
-  CRM_Core_Resources::singleton()->addStyleFile('org.civicrm.hrqual', 'css/hrqual.css');
-  CRM_Core_Resources::singleton()->addScriptFile('org.civicrm.hrqual', 'js/hrqual.js');
+function hrqual_civicrm_tabset($tabsetName, &$tabs, $context) {
+  if ($tabsetName === 'civicrm/contact/view') {
+    CRM_Core_Resources::singleton()->addStyleFile('org.civicrm.hrqual', 'css/hrqual.css');
+    CRM_Core_Resources::singleton()->addScriptFile('org.civicrm.hrqual', 'js/hrqual.js');
 
-  $optionGroups = CRM_Core_OptionGroup::values('category_of_skill_20130510015438');
-  foreach ($optionGroups as $name => $optionGroup) {
-    $options = array_values(CRM_Core_OptionGroup::values($name));
-    $val[$optionGroup] = $options;
-    unset($options);
+    $optionGroups = CRM_Core_OptionGroup::values('category_of_skill_20130510015438');
+    foreach ($optionGroups as $name => $optionGroup) {
+      $options = array_values(CRM_Core_OptionGroup::values($name));
+      $val[$optionGroup] = $options;
+      unset($options);
+    }
+
+    $cfId1 = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', 'Name_of_Skill', 'id', 'name');
+    $cfId2 = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', 'Category_of_Skill', 'id', 'name');
+    CRM_Core_Resources::singleton()->addSetting(array(
+      'hrqual' => array(
+        'name' => $cfId1,
+        'category' => $cfId2,
+        'optionGroups' => $val,
+      ),
+    ));
   }
-
-  $cfId1 = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', 'Name_of_Skill', 'id', 'name');
-  $cfId2 = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', 'Category_of_Skill', 'id', 'name');
-  CRM_Core_Resources::singleton()->addSetting(array(
-    'hrqual' => array(
-      'name' => $cfId1,
-      'category' => $cfId2,
-      'optionGroups' => $val,
-    ),
-  ));
 }
 
 function hrqual_getCustomGroupId() {

--- a/hrrecruitment/hrrecruitment.php
+++ b/hrrecruitment/hrrecruitment.php
@@ -784,15 +784,19 @@ function hrrecruitment_civicrm_pageRun( &$page ) {
 }
 
 /**
- * Implementation of hook_civicrm_tabs
+ * Implementation of hook_civicrm_tabset.
  *
- * @return void
+ * @param string $tabsetName
+ * @param array &$tabs
+ * @param array $context
  */
-function hrrecruitment_civicrm_tabs( &$tabs, $contactID ) {
-  $cases = CRM_Case_BAO_Case::retrieveCaseIdsByContactId($contactID, FALSE, 'Application');
-  foreach ($tabs as $key=>$val) {
-    if ($val['title'] == 'Assignments') {
-      $tabs[$key]['count'] = $tabs[$key]['count']-count($cases);
+function hrrecruitment_civicrm_tabset($tabsetName, &$tabs, $context) {
+  if ($tabsetName === 'civicrm/contact/view') {
+    $cases = CRM_Case_BAO_Case::retrieveCaseIdsByContactId($context['contact_id'], FALSE, 'Application');
+    foreach ($tabs as $key => $val) {
+      if ($val['title'] == 'Assignments') {
+        $tabs[$key]['count'] = $tabs[$key]['count'] - count($cases);
+      }
     }
   }
 }

--- a/hrvisa/hrvisa.php
+++ b/hrvisa/hrvisa.php
@@ -208,17 +208,22 @@ function hrvisa_civicrm_managed(&$entities) {
 
 
 /**
- * Implementation of hook_civicrm_tabs
+ * Implementation of hook_civicrm_tabset.
+ *
+ * @param string $tabsetName
+ * @param array &$tabs
+ * @param array $context
  */
-function hrvisa_civicrm_tabs(&$tabs, $contactID) {
-  $cgid = hrvisa_getCustomGroupId();
-  CRM_Core_Resources::singleton()->addScriptFile('org.civicrm.hrvisa', 'js/hrvisa.js');
-  CRM_Core_Resources::singleton()->addStyleFile('org.civicrm.hrvisa', 'css/hrvisa.css');
-  CRM_Core_Resources::singleton()->addSetting(array(
-    'hrvisa' => array(
-      'contactID' => $contactID,
-    ),
-  ));
+function hrvisa_civicrm_tabset($tabsetName, &$tabs, $context) {
+  if ($tabsetName === 'civicrm/contact/view') {
+    CRM_Core_Resources::singleton()->addScriptFile('org.civicrm.hrvisa', 'js/hrvisa.js');
+    CRM_Core_Resources::singleton()->addStyleFile('org.civicrm.hrvisa', 'css/hrvisa.css');
+    CRM_Core_Resources::singleton()->addSetting(array(
+      'hrvisa' => array(
+        'contactID' => $context['contact_id'],
+      ),
+    ));
+  }
 }
 
 function hrvisa_getCustomGroupId() {


### PR DESCRIPTION
Implementing 'hook_civicrm_tabset' instead of 'hook_civic…rm_tabs' as it's deprecated in CiviCRM 4.7.
Includes changes for extensions below:
- hrjobroles
- contactsummary
- hrabsence
- hrident
- hrjobcontract
- hrqual
- hrrecruitment
- hrvisa
