### PR TITLE
PCHR-1602: Change LeavePeriodEntitlement to support multiple contracts for a single period

### DIFF
--- a/hrjobcontract/api/v3/HRJobContract.php
+++ b/hrjobcontract/api/v3/HRJobContract.php
@@ -120,28 +120,65 @@ function civicrm_api3_h_r_job_contract_updatelengthofservice($params) {
 }
 
 /**
+ * HRJobContract.getActiveContractsWithDetails API specification
+ *
+ * @param array $spec description of fields supported by this API call
+ * @return void
+ */
+function _civicrm_api3_h_r_job_contract_getactivecontractswithdetails_spec(&$spec) {
+  $spec['start_date'] = array(
+    'name'         => 'start_date',
+    'title'        => 'Start Date',
+    'type'         => CRM_Utils_Type::T_DATE,
+    'api.required' => 0,
+  );
+
+  $spec['end_date'] = array(
+    'name'         => 'end_date',
+    'title'        => 'End Date',
+    'type'         => CRM_Utils_Type::T_DATE,
+    'api.required' => 0,
+  );
+
+  $spec['contact_id'] = array(
+    'name'         => 'contact_id',
+    'title'        => 'Contact ID',
+    'type'         => CRM_Utils_Type::T_INT,
+    'api.required' => 0,
+  );
+}
+
+/**
  * HRJobContract.getactivecontracts API
  *
  * @param array $params The accepted params are: start_date and end_date
  * @return array API result descriptor
  * @throws API_Exception
  */
-function civicrm_api3_h_r_job_contract_getactivecontracts($params) {
+function civicrm_api3_h_r_job_contract_getactivecontractswithdetails($params) {
   $startDate = null;
   $endDate = null;
+  $contractID = null;
+
   if(!empty($params['start_date'])) {
     if(is_array($params['start_date'])) {
       return civicrm_api3_create_error('The start date parameter can only be used with the = operator');
     }
     $startDate = $params['start_date'];
   }
+
   if(!empty($params['end_date'])) {
     if(is_array($params['end_date'])) {
       return civicrm_api3_create_error('The end date parameter can only be used with the = operator');
     }
     $endDate = $params['end_date'];
   }
-  $result = CRM_Hrjobcontract_BAO_HRJobContract::getActiveContracts($startDate, $endDate);
+
+  if(!empty($params['contact_id'])) {
+    $contractID = (int)$params['contact_id'];
+  }
+
+  $result = CRM_Hrjobcontract_BAO_HRJobContract::getActiveContractsWithDetails($startDate, $endDate, $contractID);
   return civicrm_api3_create_success($result, $params);
 }
 

--- a/hrjobcontract/tests/phpunit/api/v3/HRJobContractTest.php
+++ b/hrjobcontract/tests/phpunit/api/v3/HRJobContractTest.php
@@ -22,23 +22,62 @@ class api_v3_HRJobContractTest extends PHPUnit_Framework_TestCase implements
    * @expectedException CiviCRM_API3_Exception
    * @expectedExceptionMessage The start date parameter can only be used with the = operator
    *
-   * @dataProvider invalidGetActiveContractsDateOperator
+   * @dataProvider invalidGetActiveContractsWithDetailsDateOperator
    */
-  public function testOnGetActiveContractsTheStartDateOnlyAcceptsTheEqualOperator($operator) {
-    civicrm_api3('HRJobContract', 'getactivecontracts', ['start_date' => [$operator => '2016-01-01']]);
+  public function testOnGetActiveContractsWithDetailsTheStartDateOnlyAcceptsTheEqualOperator($operator) {
+    civicrm_api3('HRJobContract', 'getactivecontractswithdetails', ['start_date' => [$operator => '2016-01-01']]);
   }
 
   /**
    * @expectedException CiviCRM_API3_Exception
    * @expectedExceptionMessage The end date parameter can only be used with the = operator
    *
-   * @dataProvider invalidGetActiveContractsDateOperator
+   * @dataProvider invalidGetActiveContractsWithDetailsDateOperator
    */
-  public function testOnGetActiveContractsTheEndDateOnlyAcceptsTheEqualOperator($operator) {
-    civicrm_api3('HRJobContract', 'getactivecontracts', ['end_date' => [$operator => '2016-01-01']]);
+  public function testOnGetActiveContractsWithDetailsTheEndDateOnlyAcceptsTheEqualOperator($operator) {
+    civicrm_api3('HRJobContract', 'getactivecontractswithdetails', ['end_date' => [$operator => '2016-01-01']]);
   }
 
-  public function invalidGetActiveContractsDateOperator()
+  public function testGetActiveContractsWithDetailsCanReturnContractsOnlyForASingleContact() {
+    $this->createContacts(2);
+
+    // Contact 1 has 2 contracts
+    $this->createJobContract(
+      $this->contacts[0]['id'],
+      '2016-01-01',
+      '2016-03-10'
+    );
+
+    $this->createJobContract(
+      $this->contacts[0]['id'],
+      '2016-04-01',
+      '2016-10-17'
+    );
+
+    // Contact 2 has 1 contract
+    $this->createJobContract(
+      $this->contacts[1]['id'],
+      '2016-03-03'
+    );
+
+    $contact1ActiveContracts = civicrm_api3('HRJobContract', 'getactivecontractswithdetails', [
+      'start_date' => '2016-01-01',
+      'end_date' => '2016-12-31',
+      'contact_id' => $this->contacts[0]['id']
+    ]);
+
+    $contact2ActiveContracts = civicrm_api3('HRJobContract', 'getactivecontractswithdetails', [
+      'start_date' => '2016-01-01',
+      'end_date' => '2016-12-31',
+      'contact_id' => $this->contacts[1]['id']
+    ]);
+
+
+    $this->assertCount(2, $contact1ActiveContracts['values']);
+    $this->assertCount(1, $contact2ActiveContracts['values']);
+  }
+
+  public function invalidGetActiveContractsWithDetailsDateOperator()
   {
     return [
       ['>'],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/LeavePeriodEntitlement.php
@@ -99,11 +99,11 @@ class CRM_HRLeaveAndAbsences_DAO_LeavePeriodEntitlement extends CRM_Core_DAO
    */
   public $type_id;
   /**
-   * FK to HRJobContract
+   * FK to Contact (civicrm_contact)
    *
    * @var int unsigned
    */
-  public $contract_id;
+  public $contact_id;
   /**
    * Indicates if the entitlement was overridden
    *
@@ -150,6 +150,7 @@ class CRM_HRLeaveAndAbsences_DAO_LeavePeriodEntitlement extends CRM_Core_DAO
       self::$_links = static ::createReferenceColumns(__CLASS__);
       self::$_links[] = new CRM_Core_Reference_Basic(self::getTableName() , 'period_id', 'civicrm_hrleaveandabsences_absence_period', 'id');
       self::$_links[] = new CRM_Core_Reference_Basic(self::getTableName() , 'type_id', 'civicrm_hrleaveandabsences_absence_type', 'id');
+      self::$_links[] = new CRM_Core_Reference_Basic(self::getTableName() , 'contact_id', 'civicrm_contact', 'id');
       self::$_links[] = new CRM_Core_Reference_Basic(self::getTableName() , 'comment_author_id', 'civicrm_contact', 'id');
     }
     return self::$_links;
@@ -183,11 +184,12 @@ class CRM_HRLeaveAndAbsences_DAO_LeavePeriodEntitlement extends CRM_Core_DAO
           'required' => true,
           'FKClassName' => 'CRM_HRLeaveAndAbsences_DAO_AbsenceType',
         ) ,
-        'contract_id' => array(
-          'name' => 'contract_id',
+        'contact_id' => array(
+          'name' => 'contact_id',
           'type' => CRM_Utils_Type::T_INT,
-          'description' => 'FK to HRJobContract',
+          'description' => 'FK to Contact (civicrm_contact)',
           'required' => true,
+          'FKClassName' => 'CRM_Contact_DAO_Contact',
         ) ,
         'overridden' => array(
           'name' => 'overridden',
@@ -231,7 +233,7 @@ class CRM_HRLeaveAndAbsences_DAO_LeavePeriodEntitlement extends CRM_Core_DAO
         'id' => 'id',
         'period_id' => 'period_id',
         'type_id' => 'type_id',
-        'contract_id' => 'contract_id',
+        'contact_id' => 'contact_id',
         'overridden' => 'overridden',
         'comment' => 'comment',
         'comment_author_id' => 'comment_author_id',

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculation.php
@@ -204,8 +204,8 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
    */
   private function getPeriodEntitlement() {
     if($this->periodEntitlement === false) {
-      $this->periodEntitlement = LeavePeriodEntitlement::getPeriodEntitlementForContract(
-        $this->contract['id'],
+      $this->periodEntitlement = LeavePeriodEntitlement::getPeriodEntitlementForContact(
+        $this->contract['contact_id'],
         $this->period->id,
         $this->absenceType->id
       );
@@ -333,8 +333,8 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
     }
 
     if(!$this->previousPeriodEntitlement) {
-      $this->previousPeriodEntitlement = LeavePeriodEntitlement::getPeriodEntitlementForContract(
-        $this->contract['id'],
+      $this->previousPeriodEntitlement = LeavePeriodEntitlement::getPeriodEntitlementForContact(
+        $this->contract['contact_id'],
         $previousPeriod->id,
         $this->absenceType->id
       );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
@@ -212,7 +212,7 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
    */
   private function getActiveContractsForPeriod(AbsencePeriod $absencePeriod, $filter = []) {
     try {
-      $contracts = CRM_Hrjobcontract_BAO_HRJobContract::getActiveContracts(
+      $contracts = CRM_Hrjobcontract_BAO_HRJobContract::getActiveContractsWithDetails(
         $absencePeriod->start_date,
         $absencePeriod->end_date
       );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
@@ -275,15 +275,16 @@ CREATE TABLE `civicrm_hrleaveandabsences_leave_period_entitlement` (
   `id` int unsigned NOT NULL AUTO_INCREMENT  COMMENT 'Unique Leave Period Entitlement ID',
   `period_id` int unsigned NOT NULL   COMMENT 'FK to AbsencePeriod',
   `type_id` int unsigned NOT NULL   COMMENT 'FK to AbsenceType',
-  `contract_id` int unsigned NOT NULL   COMMENT 'FK to HRJobContract',
+  `contact_id` int unsigned NOT NULL   COMMENT 'FK to Contact (civicrm_contact)',
   `overridden` tinyint   DEFAULT false COMMENT 'Indicates if the entitlement was overridden',
   `comment` text    COMMENT 'The comment added by the user about the calculation for this entitlement',
   `comment_author_id` int unsigned    COMMENT 'FK to Contact. The contact that represents the user who added the comment to this entitlement',
   `comment_date` datetime    COMMENT 'The date and time the comment for this entitlement was added/updated',
   PRIMARY KEY ( `id` ),
-  UNIQUE INDEX `unique_entitlement`(period_id, contract_id, type_id),
+  UNIQUE INDEX `unique_entitlement`(period_id, contact_id, type_id),
   CONSTRAINT FK_civicrm_hrlaa_leave_period_entitlement_period_id FOREIGN KEY (`period_id`) REFERENCES `civicrm_hrleaveandabsences_absence_period`(`id`) ON DELETE CASCADE,
   CONSTRAINT FK_civicrm_hrlaa_leave_period_entitlement_type_id FOREIGN KEY (`type_id`) REFERENCES `civicrm_hrleaveandabsences_absence_type`(`id`) ON DELETE CASCADE,
+  CONSTRAINT FK_civicrm_hrlaa_leave_period_entitlement_contact_id FOREIGN KEY (`contact_id`) REFERENCES `civicrm_contact`(`id`) ON DELETE CASCADE,
   CONSTRAINT FK_civicrm_hrlaa_leave_period_entitlement_comment_author_id FOREIGN KEY (`comment_author_id`) REFERENCES `civicrm_contact`(`id`) ON DELETE CASCADE
 )  ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ;
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -125,42 +125,42 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends PHPUnit_Framewor
 
     $this->createLeaveRequestBalanceChange(
       $entitlement->type_id,
-      $entitlement->getContactIDFromContract(),
+      $entitlement->contact_id,
       $leaveRequestStatuses['Cancelled'],
       date('Y-m-d', strtotime('-10 days'))
     );
 
     $this->createLeaveRequestBalanceChange(
       $entitlement->type_id,
-      $entitlement->getContactIDFromContract(),
+      $entitlement->contact_id,
       $leaveRequestStatuses['Rejected'],
       date('Y-m-d', strtotime('-9 days'))
     );
 
     $this->createLeaveRequestBalanceChange(
       $entitlement->type_id,
-      $entitlement->getContactIDFromContract(),
+      $entitlement->contact_id,
       $leaveRequestStatuses['Approved'],
       date('Y-m-d', strtotime('-8 days'))
     );
 
     $this->createLeaveRequestBalanceChange(
       $entitlement->type_id,
-      $entitlement->getContactIDFromContract(),
+      $entitlement->contact_id,
       $leaveRequestStatuses['Admin Approved'],
       date('Y-m-d', strtotime('-7 days'))
     );
 
     $this->createLeaveRequestBalanceChange(
       $entitlement->type_id,
-      $entitlement->getContactIDFromContract(),
+      $entitlement->contact_id,
       $leaveRequestStatuses['Waiting Approval'],
       date('Y-m-d', strtotime('-6 days'))
     );
 
     $this->createLeaveRequestBalanceChange(
       $entitlement->type_id,
-      $entitlement->getContactIDFromContract(),
+      $entitlement->contact_id,
       $leaveRequestStatuses['More Information Requested'],
       date('Y-m-d', strtotime('-6 days'))
     );
@@ -262,7 +262,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends PHPUnit_Framewor
     // This will deduct 11 days
     $this->createLeaveRequestBalanceChange(
       $entitlement->type_id,
-      $entitlement->getContactIDFromContract(),
+      $entitlement->contact_id,
       $leaveRequestStatuses['Approved'],
       date('Y-m-d'),
       date('Y-m-d', strtotime('+10 days'))
@@ -271,7 +271,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends PHPUnit_Framewor
     // 1 day deducted
     $this->createLeaveRequestBalanceChange(
       $entitlement->type_id,
-      $entitlement->getContactIDFromContract(),
+      $entitlement->contact_id,
       $leaveRequestStatuses['Admin Approved'],
       date('Y-m-d', strtotime('+11 days'))
     );
@@ -279,7 +279,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends PHPUnit_Framewor
     // 1 day deducted
     $this->createLeaveRequestBalanceChange(
       $entitlement->type_id,
-      $entitlement->getContactIDFromContract(),
+      $entitlement->contact_id,
       $leaveRequestStatuses['Cancelled'],
       date('Y-m-d', strtotime('+12 days'))
     );
@@ -287,7 +287,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends PHPUnit_Framewor
     // 1 day deducted
     $this->createLeaveRequestBalanceChange(
       $entitlement->type_id,
-      $entitlement->getContactIDFromContract(),
+      $entitlement->contact_id,
       $leaveRequestStatuses['Rejected'],
       date('Y-m-d', strtotime('+13 days'))
     );
@@ -295,7 +295,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends PHPUnit_Framewor
     // 1 day deducted
     $this->createLeaveRequestBalanceChange(
       $entitlement->type_id,
-      $entitlement->getContactIDFromContract(),
+      $entitlement->contact_id,
       $leaveRequestStatuses['Waiting Approval'],
       date('Y-m-d', strtotime('+14 days'))
     );
@@ -303,7 +303,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends PHPUnit_Framewor
     // 1 day deducted
     $this->createLeaveRequestBalanceChange(
       $entitlement->type_id,
-      $entitlement->getContactIDFromContract(),
+      $entitlement->contact_id,
       $leaveRequestStatuses['More Information Requested'],
       date('Y-m-d', strtotime('+15 days'))
     );
@@ -351,7 +351,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends PHPUnit_Framewor
     // This will deduct 11 days
     $this->createLeaveRequestBalanceChange(
       $entitlement->type_id,
-      $entitlement->getContactIDFromContract(),
+      $entitlement->contact_id,
       $leaveRequestStatuses['Approved'],
       date('Y-m-d'),
       date('Y-m-d', strtotime('+10 days'))
@@ -405,7 +405,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends PHPUnit_Framewor
     // This will deduct 11 days
     $this->createLeaveRequestBalanceChange(
       $entitlement->type_id,
-      $entitlement->getContactIDFromContract(),
+      $entitlement->contact_id,
       $leaveRequestStatuses['Approved'],
       date('Y-m-d'),
       date('Y-m-d', strtotime('+10 days'))
@@ -590,7 +590,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends PHPUnit_Framewor
     return LeavePeriodEntitlement::create([
       'type_id' => 1,
       'period_id' => 1,
-      'contract_id' => 1
+      'contact_id' => 1
     ]);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
@@ -57,17 +57,17 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
    * @expectedException PEAR_Exception
    * @expectedExceptionMessage DB Error: already exists
    */
-  public function testThereCannotBeMoreThanOneEntitlementForTheSameSetOfAbsenceTypeAbsencePeriodAndContract() {
+  public function testThereCannotBeMoreThanOneEntitlementForTheSameSetOfAbsenceTypeAbsencePeriodAndContact() {
     LeavePeriodEntitlement::create([
       'period_id' => 1,
       'type_id' => 1,
-      'contract_id' => 1
+      'contact_id' => 1
     ]);
 
     LeavePeriodEntitlement::create([
       'period_id' => 1,
       'type_id' => 1,
-      'contract_id' => 1
+      'contact_id' => 1
     ]);
   }
 
@@ -122,7 +122,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     // This leave request will deduct 3 days from the entitlement
     $this->createLeaveRequestBalanceChange(
       $periodEntitlement->type_id,
-      $periodEntitlement->getContactIDFromContract(),
+      $periodEntitlement->contact_id,
       $this->leaveRequestStatuses['Approved'],
       date('YmdHis'),
       date('YmdHis', strtotime('+2 day'))
@@ -132,7 +132,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     // it shouldn't be included on the balance
     $this->createLeaveRequestBalanceChange(
       $periodEntitlement->type_id,
-      $periodEntitlement->getContactIDFromContract(),
+      $periodEntitlement->contact_id,
       $this->leaveRequestStatuses['Waiting Approval'],
       date('YmdHis'),
       date('YmdHis', strtotime('+1 day'))
@@ -142,7 +142,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     // it shouldn't be included on the balance
     $this->createLeaveRequestBalanceChange(
       $periodEntitlement->type_id,
-      $periodEntitlement->getContactIDFromContract(),
+      $periodEntitlement->contact_id,
       $this->leaveRequestStatuses['More Information Requested'],
       date('YmdHis')
     );
@@ -159,7 +159,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     // This leave request will deduct 3 days from the entitlement
     $this->createLeaveRequestBalanceChange(
       $periodEntitlement->type_id,
-      $periodEntitlement->getContactIDFromContract(),
+      $periodEntitlement->contact_id,
       $this->leaveRequestStatuses['Approved'],
       date('YmdHis'),
       date('YmdHis', strtotime('+2 day'))
@@ -169,7 +169,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     // it shouldn't be included on the balance
     $this->createLeaveRequestBalanceChange(
       $periodEntitlement->type_id,
-      $periodEntitlement->getContactIDFromContract(),
+      $periodEntitlement->contact_id,
       $this->leaveRequestStatuses['Rejected'],
       date('YmdHis'),
       date('YmdHis', strtotime('+1 day'))
@@ -179,7 +179,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     // it shouldn't be included on the balance
     $this->createLeaveRequestBalanceChange(
       $periodEntitlement->type_id,
-      $periodEntitlement->getContactIDFromContract(),
+      $periodEntitlement->contact_id,
       $this->leaveRequestStatuses['Cancelled'],
       date('YmdHis'),
       date('YmdHis', strtotime('+1 day'))
@@ -197,7 +197,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     // This leave request will deduct 2 days from the entitlement
     $this->createLeaveRequestBalanceChange(
       $periodEntitlement->type_id,
-      $periodEntitlement->getContactIDFromContract(),
+      $periodEntitlement->contact_id,
       $this->leaveRequestStatuses['Approved'],
       date('YmdHis'),
       date('YmdHis', strtotime('+1 day'))
@@ -206,7 +206,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     // This will deduct 1 day
     $this->createLeaveRequestBalanceChange(
       $periodEntitlement->type_id,
-      $periodEntitlement->getContactIDFromContract(),
+      $periodEntitlement->contact_id,
       $this->leaveRequestStatuses['Admin Approved'],
       date('YmdHis')
     );
@@ -214,7 +214,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     // This will deduct 1 more day
     $this->createLeaveRequestBalanceChange(
       $periodEntitlement->type_id,
-      $periodEntitlement->getContactIDFromContract(),
+      $periodEntitlement->contact_id,
       $this->leaveRequestStatuses['Approved'],
       date('YmdHis')
     );
@@ -223,7 +223,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     // it shouldn't be included on the balance
     $this->createLeaveRequestBalanceChange(
       $periodEntitlement->type_id,
-      $periodEntitlement->getContactIDFromContract(),
+      $periodEntitlement->contact_id,
       $this->leaveRequestStatuses['Cancelled'],
       date('YmdHis'),
       date('YmdHis', strtotime('+1 day'))
@@ -251,38 +251,38 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     $this->assertEquals(2.5, $periodEntitlement->getBalance());
   }
 
-  public function testGetContractEntitlementForPeriod() {
+  public function testGetContactEntitlementForPeriod() {
     LeavePeriodEntitlement::create([
       'period_id' => 1,
       'type_id' => 1,
-      'contract_id' => 1,
+      'contact_id' => 1,
     ]);
 
     LeavePeriodEntitlement::create([
       'period_id' => 2,
       'type_id' => 1,
-      'contract_id' => 1
+      'contact_id' => 1
     ]);
 
-    $periodEntitlement1 = LeavePeriodEntitlement::getPeriodEntitlementForContract(1, 1, 1);
+    $periodEntitlement1 = LeavePeriodEntitlement::getPeriodEntitlementForContact(1, 1, 1);
 
     $this->assertEquals(1, $periodEntitlement1->period_id);
-    $this->assertEquals(1, $periodEntitlement1->contract_id);
+    $this->assertEquals(1, $periodEntitlement1->contact_id);
     $this->assertEquals(1, $periodEntitlement1->type_id);
 
-    $periodEntitlement2 = LeavePeriodEntitlement::getPeriodEntitlementForContract(1, 2, 1);
+    $periodEntitlement2 = LeavePeriodEntitlement::getPeriodEntitlementForContact(1, 2, 1);
 
     $this->assertEquals(2, $periodEntitlement2->period_id);
-    $this->assertEquals(1, $periodEntitlement2->contract_id);
+    $this->assertEquals(1, $periodEntitlement2->contact_id);
     $this->assertEquals(1, $periodEntitlement2->type_id);
   }
 
   /**
    * @expectedException InvalidArgumentException
-   * @expectedExceptionMessage You must inform the Contract ID
+   * @expectedExceptionMessage You must inform the Contact ID
    */
-  public function testContractIdIsRequiredForGetContractEntitlementForPeriod() {
-    LeavePeriodEntitlement::getPeriodEntitlementForContract(null, 10, 11);
+  public function testContactIdIsRequiredForGetContactEntitlementForPeriod() {
+    LeavePeriodEntitlement::getPeriodEntitlementForContact(null, 10, 11);
   }
 
   /**
@@ -290,7 +290,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
    * @expectedExceptionMessage You must inform the AbsencePeriod ID
    */
   public function testAbsencePeriodIdIsRequiredForGetContractEntitlementForPeriod() {
-    LeavePeriodEntitlement::getPeriodEntitlementForContract(10, null, 11);
+    LeavePeriodEntitlement::getPeriodEntitlementForContact(10, null, 11);
   }
 
   /**
@@ -298,7 +298,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
    * @expectedExceptionMessage You must inform the AbsenceType ID
    */
   public function testAbsenceTypeIdIsRequiredForGetContractEntitlementForPeriod() {
-    LeavePeriodEntitlement::getPeriodEntitlementForContract(10, 15, NULL);
+    LeavePeriodEntitlement::getPeriodEntitlementForContact(10, 15, NULL);
   }
 
   public function testGetEntitlementShouldIncludeOnlyPositiveLeaveBroughtForwardAndPublicHolidays() {
@@ -329,7 +329,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     // 3 days Leave Request
     $this->createLeaveRequestBalanceChange(
       $periodEntitlement->type_id,
-      $periodEntitlement->getContactIDFromContract(),
+      $periodEntitlement->contact_id,
       $this->leaveRequestStatuses['Approved'],
       date('Y-m-d'),
       date('Y-m-d', strtotime('+2 days'))
@@ -340,7 +340,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     // 6 day Leave Request
     $this->createLeaveRequestBalanceChange(
       $periodEntitlement->type_id,
-      $periodEntitlement->getContactIDFromContract(),
+      $periodEntitlement->contact_id,
       $this->leaveRequestStatuses['Approved'],
       date('Y-m-d', strtotime('+3 days')),
       date('Y-m-d', strtotime('+8 days'))
@@ -355,8 +355,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     $period = $this->createAbsencePeriod('2016-01-01', '2016-12-31');
     $this->setContractDates('2016-01-01', '2016-12-31');
 
-    $periodEntitlement = LeavePeriodEntitlement::getPeriodEntitlementForContract(
-      $this->contract['id'],
+    $periodEntitlement = LeavePeriodEntitlement::getPeriodEntitlementForContact(
+      $this->contract['contact_id'],
       $period->id,
       $type->id
     );
@@ -376,8 +376,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
 
     LeavePeriodEntitlement::saveFromCalculation($calculation);
 
-    $periodEntitlement = LeavePeriodEntitlement::getPeriodEntitlementForContract(
-      $this->contract['id'],
+    $periodEntitlement = LeavePeriodEntitlement::getPeriodEntitlementForContact(
+      $this->contract['contact_id'],
       $period->id,
       $type->id
     );
@@ -385,7 +385,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     $this->assertNotNull($periodEntitlement);
     $this->assertEquals($period->id, $periodEntitlement->period_id);
     $this->assertEquals($type->id, $periodEntitlement->type_id);
-    $this->assertEquals($this->contract['id'], $periodEntitlement->contract_id);
+    $this->assertEquals($this->contract['contact_id'], $periodEntitlement->contact_id);
 
     // 10 + 1 + 3 (Pro Rata + Brought Forward + No. Public Holidays)
     $this->assertEquals(14, $periodEntitlement->getEntitlement());
@@ -429,7 +429,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     $this->setContractDates('2016-01-01', '2016-12-31');
 
     $periodEntitlement1 = LeavePeriodEntitlement::create([
-      'contract_id' => $this->contract['id'],
+      'contact_id' => $this->contract['contact_id'],
       'period_id' => $period->id,
       'type_id' => $type->id
     ]);
@@ -447,8 +447,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
 
     LeavePeriodEntitlement::saveFromCalculation($calculation);
 
-    $periodEntitlement2 = LeavePeriodEntitlement::getPeriodEntitlementForContract(
-      $this->contract['id'],
+    $periodEntitlement2 = LeavePeriodEntitlement::getPeriodEntitlementForContact(
+      $this->contract['contact_id'],
       $period->id,
       $type->id
     );
@@ -467,7 +467,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     $type->id = 1;
     $period = new AbsencePeriod();
     $period->id = 1;
-    $contract = ['id' => 1];
+    $contract = ['contact_id' => 1];
 
     $broughtForward = 1;
     $proRata = 10;
@@ -486,8 +486,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     $comment = 'Lorem ipsum dolor sit amet...';
     LeavePeriodEntitlement::saveFromCalculation($calculation, $overriddenEntitlement, $comment);
 
-    $periodEntitlement = LeavePeriodEntitlement::getPeriodEntitlementForContract(
-      $contract['id'],
+    $periodEntitlement = LeavePeriodEntitlement::getPeriodEntitlementForContact(
+      $contract['contact_id'],
       $period->id,
       $type->id
     );
@@ -495,7 +495,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     $this->assertNotNull($periodEntitlement);
     $this->assertEquals($period->id, $periodEntitlement->period_id);
     $this->assertEquals($type->id, $periodEntitlement->type_id);
-    $this->assertEquals($contract['id'], $periodEntitlement->contract_id);
+    $this->assertEquals($contract['contact_id'], $periodEntitlement->contact_id);
     $this->assertEquals(1, $periodEntitlement->overridden);
     $this->assertEquals($overriddenEntitlement, $periodEntitlement->getEntitlement());
   }
@@ -506,14 +506,14 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     $absenceType = $this->createAbsenceType();
 
     $periodEntitlement = LeavePeriodEntitlement::create([
-      'contract_id' => $this->contract['id'],
+      'contact_id' => $this->contract['contact_id'],
       'type_id'     => $absenceType->id,
       'period_id'   => $absencePeriod->id
     ]);
 
     $dates = $periodEntitlement->getStartAndEndDates();
-    $this->assertEquals('2016-01-01', $dates[0]);
-    $this->assertEquals('2016-12-31', $dates[1]);
+    $this->assertEquals('2016-01-01', $dates[0]['start_date']);
+    $this->assertEquals('2016-12-31', $dates[0]['end_date']);
   }
 
   public function testGetStartAndEndDatesShouldReturnContractDateIfContractStartDateIsGreaterThanThePeriodStartDate() {
@@ -522,14 +522,14 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     $absenceType = $this->createAbsenceType();
 
     $periodEntitlement = LeavePeriodEntitlement::create([
-      'contract_id' => $this->contract['id'],
+      'contact_id' => $this->contract['contact_id'],
       'type_id'     => $absenceType->id,
       'period_id'   => $absencePeriod->id
     ]);
 
     $dates = $periodEntitlement->getStartAndEndDates();
-    $this->assertEquals('2016-03-17', $dates[0]);
-    $this->assertEquals('2016-12-31', $dates[1]);
+    $this->assertEquals('2016-03-17', $dates[0]['start_date']);
+    $this->assertEquals('2016-12-31', $dates[0]['end_date']);
   }
 
   public function testGetStartAndEndDatesShouldReturnAbsencePeriodDateIfContractEndDateIsGreaterThanThePeriodEndDate() {
@@ -538,14 +538,14 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     $absenceType = $this->createAbsenceType();
 
     $periodEntitlement = LeavePeriodEntitlement::create([
-      'contract_id' => $this->contract['id'],
+      'contact_id' => $this->contract['contact_id'],
       'type_id'     => $absenceType->id,
       'period_id'   => $absencePeriod->id
     ]);
 
     $dates = $periodEntitlement->getStartAndEndDates();
-    $this->assertEquals('2016-01-01', $dates[0]);
-    $this->assertEquals('2016-12-31', $dates[1]);
+    $this->assertEquals('2016-01-01', $dates[0]['start_date']);
+    $this->assertEquals('2016-12-31', $dates[0]['end_date']);
   }
 
   public function testGetStartAndEndDatesShouldReturnContractDateIfContractEndDateIsLessThanThePeriodEndDate() {
@@ -554,27 +554,14 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     $absenceType = $this->createAbsenceType();
 
     $periodEntitlement = LeavePeriodEntitlement::create([
-      'contract_id' => $this->contract['id'],
+      'contact_id' => $this->contract['contact_id'],
       'type_id'     => $absenceType->id,
       'period_id'   => $absencePeriod->id
     ]);
 
     $dates = $periodEntitlement->getStartAndEndDates();
-    $this->assertEquals('2016-03-17', $dates[0]);
-    $this->assertEquals('2016-05-23', $dates[1]);
-  }
-
-  public function testGetContactIDFromContract() {
-    $absencePeriod = $this->createAbsencePeriod('2016-01-01', '2016-12-31');
-    $absenceType = $this->createAbsenceType();
-
-    $periodEntitlement = LeavePeriodEntitlement::create([
-      'contract_id' => $this->contract['id'],
-      'type_id'     => $absenceType->id,
-      'period_id'   => $absencePeriod->id
-    ]);
-
-    $this->assertEquals(2, $periodEntitlement->getContactIDFromContract());
+    $this->assertEquals('2016-03-17', $dates[0]['start_date']);
+    $this->assertEquals('2016-05-23', $dates[0]['end_date']);
   }
 
   private function createAbsencePeriod($startDate, $endDate) {
@@ -598,7 +585,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends PHPUnit_Fram
     return LeavePeriodEntitlement::create([
       'type_id'     => 1,
       'period_id'   => 1,
-      'contract_id' => 1
+      'contact_id' => 1
     ]);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
@@ -536,7 +536,7 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
     // Add a 1 day Leave Request to the previous period
     $this->createLeaveRequestBalanceChange(
       $previousPeriodEntitlement->type_id,
-      $previousPeriodEntitlement->getContactIDFromContract(),
+      $previousPeriodEntitlement->contact_id,
       $leaveRequestStatuses['Approved'],
       date('Y-m-d', strtotime('+1 day', $previousPeriodStartDateTimeStamp))
     );
@@ -544,7 +544,7 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
     // Add a 11 days Leave Request to the previous period
     $this->createLeaveRequestBalanceChange(
       $previousPeriodEntitlement->type_id,
-      $previousPeriodEntitlement->getContactIDFromContract(),
+      $previousPeriodEntitlement->contact_id,
       $leaveRequestStatuses['Approved'],
       date('Y-m-d', strtotime('+31 days', $previousPeriodStartDateTimeStamp)),
       date('Y-m-d', strtotime('+41 days', $previousPeriodStartDateTimeStamp))
@@ -937,7 +937,7 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   private function createEntitlement($period, $type, $numberOfDays = 20, $overridden = false, $comment = null) {
     $params = [
       'period_id'            => $period->id,
-      'contract_id'          => $this->contract['id'],
+      'contact_id'           => $this->contract['contact_id'],
       'type_id'              => $type->id,
       'overridden'           => $overridden ? '1' : '0',
     ];

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/LeavePeriodEntitlementHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/LeavePeriodEntitlementHelpersTrait.php
@@ -6,34 +6,26 @@ trait CRM_HRLeaveAndAbsences_LeavePeriodEntitlementHelpersTrait {
    * Creates a mock to be used on tests for the geBalance() method.
    *
    * For these, we mock the getStartAndEndDates() method, so we don't need an
-   * actual AbsencePeriod record on the database and also the
-   * getContactIDFromContract() method so we don't need actual contract and
-   * contact records.
+   * actual AbsencePeriod record on the database.
    *
    * @return CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement
    */
   public function createLeavePeriodEntitlementMockForBalanceTests() {
     $periodEntitlement = $this->getMockBuilder(CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement::class)
-                              ->setMethods([
-                                'getContactIDFromContract',
-                                'getStartAndEndDates'
-                              ])
+                              ->setMethods(['getStartAndEndDates'])
                               ->getMock();
 
     $periodEntitlement->expects($this->any())
-                      ->method('getContactIDFromContract')
-                      ->will($this->returnValue(1));
-
-    $periodEntitlement->expects($this->any())
                       ->method('getStartAndEndDates')
-                      ->will($this->returnValue([
-                        date('Y-01-01'),
-                        date('Y-12-31')
-                      ]));
+                      ->will($this->returnValue([[
+                        'start_date' => date('Y-01-01'),
+                        'end_date' => date('Y-12-31')
+                      ]]));
 
     $periodEntitlement->id = 1;
     $periodEntitlement->type_id = 1;
     $periodEntitlement->period_id = 1;
+    $periodEntitlement->contact_id = 1;
 
     return $periodEntitlement;
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/LeavePeriodEntitlement.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/LeavePeriodEntitlement.xml
@@ -51,12 +51,19 @@
   </foreignKey>
 
   <field>
-    <name>contract_id</name>
+    <name>contact_id</name>
     <type>int unsigned</type>
     <required>true</required>
-    <comment>FK to HRJobContract</comment>
+    <comment>FK to Contact (civicrm_contact)</comment>
     <add>4.4</add>
   </field>
+  <foreignKey>
+    <name>contact_id</name>
+    <table>civicrm_contact</table>
+    <key>id</key>
+    <add>4.4</add>
+    <onDelete>CASCADE</onDelete>
+  </foreignKey>
 
   <field>
     <name>overridden</name>
@@ -98,7 +105,7 @@
   <index>
     <name>unique_entitlement</name>
     <fieldName>period_id</fieldName>
-    <fieldName>contract_id</fieldName>
+    <fieldName>contact_id</fieldName>
     <fieldName>type_id</fieldName>
     <unique>true</unique>
     <add>4.4</add>


### PR DESCRIPTION
An employee can have more than one contract during one Absence Period, meaning that the entitlement for a period is based on the contractual entitlement from each contract. For that reason, it doesn't make sense to have the LeavePeriodEntitlement linked to one specific contract. To fix this, the entity is now linked to the Contact, using the contact_id field, and then we can get the contracts and information related to it using both the contact_id and contract dates.

The main changes caused by this are:

- On LeavePeriodEntitlement, the getStartAndEndDates was updates to return an array with the start and end dates for all of the employee's contracts during that period.

- The getLeaveRequestBalanceForEntitlement and getBalanceForEntitlement methods (on LeaveBalanceChange) where updated to work with the new format of the return value from getStartAndEndDates, which now returns an array of days intead of a single pair of  start and end date.

- The getPeriodEntitlementForContract method was updated and renamed to fetch the same information using the Contact ID instead of the Contract ID.

- The getContactIDFromContract method was removed

- Lots of tests updated to follow the changes on the class
