### PR TITLE
PCHR-1618: Fix cut-off header for non-admin users

### DIFF
--- a/hrui/css/hrui.css
+++ b/hrui/css/hrui.css
@@ -1,3 +1,11 @@
+/**
+ * Ensures that there is the same top padding regardless whether
+ * the user can see the admin toolbar or not
+ */
+body:not(.toolbar-drawer) {
+  padding-top: 30px;
+}
+
 .crm-tooltip table td {
   width: 50%;
   word-wrap: break-word;


### PR DESCRIPTION
## Problem
Users without the "Use the administration toolbar" permission, would not get the admin toolbar on the top of the page, which among other things would push down the entire page via the `.toolbar-drawer` class (and a javascript-added `padding-top`)

<img width="600" alt="before" src="https://cloud.githubusercontent.com/assets/6400898/19111416/c76cc142-8aff-11e6-953a-08c4e0baeebf.png">

## Solution
By enforcing the `padding-top` in the `hrui` extension, the issue is fixed

<img width="600" alt="after" src="https://cloud.githubusercontent.com/assets/6400898/19111447/e3c6c996-8aff-11e6-8b51-ffcf9e69b12b.png">

```css
body:not(.toolbar-drawer) {
  padding-top: 30px;
}
```