### PR TITLE
PCHR-1631: Fix absence calendar query error

### DIFF
--- a/hrreport/CRM/HRReport/Form/Activity/HRAbsenceCalendar.php
+++ b/hrreport/CRM/HRReport/Form/Activity/HRAbsenceCalendar.php
@@ -215,9 +215,16 @@ cac.record_type_id = {$targetValue} ";
             continue;
           }
           if (array_key_exists("{$fieldName}_value", $this->_params)) {
-            if ($field['name'] == 'activity_type_id' && count($this->_params["{$fieldName}_value"])) {
+            if ($field['name'] == 'activity_type_id' && !empty($this->_params["{$fieldName}_value"])) {
               $sqlOp = $this->getSQLOperator(CRM_Utils_Array::value("{$fieldName}_op", $this->_params));
-              $clause = "absence.{$fieldName} {$sqlOp} (" . implode(',',$this->_params["{$fieldName}_value"]) . ") ";
+
+              if (is_array($this->_params["{$fieldName}_value"])) {
+                $dataList = implode(',',$this->_params["{$fieldName}_value"]);
+              } else {
+                $dataList = $this->_params["{$fieldName}_value"];
+              }
+
+              $clause = "absence.{$fieldName} {$sqlOp} (" . $dataList . ") ";
             }
 
             if ($field['name'] == 'sort_name' && $this->_params["{$fieldName}_value"]) {


### PR DESCRIPTION
When visiting the absence calendar (civicrm/report/instance/44&reset=1) the following error will appear : 

DB Error: syntax error

```SQL
Database Error Code: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ') AND request.status_id IN (1,2) ORDER BY YEAR(request.activity_date_time), MON' at line 16, 1064
Additional Details:
Array
(
    [callback] => Array
        (
            [0] => CRM_Core_Error
            [1] => handle
        )

    [code] => -2
    [message] => DB Error: syntax error
    [mode] => 16
    [debug_info] => SELECT
YEAR(request.activity_date_time) as year,
MONTH(request.activity_date_time) as month,
DAY(request.activity_date_time) as day,
absence.id as aid,
absence.activity_type_id as ati,
request.status_id status,
cac.contact_id as contact_id,
request.source_record_id,
cc.sort_name as contact_name 
FROM civicrm_activity absence
INNER JOIN civicrm_activity request ON request.source_record_id = absence.id
LEFT JOIN civicrm_activity_contact cac ON cac.activity_id = absence.id
LEFT JOIN civicrm_contact cc ON cac.contact_id = cc.id
 WHERE
cac.record_type_id = 3 AND request.activity_type_id = 56  AND absence.activity_type_id IN ()  AND request.status_id IN (1,2)
ORDER BY YEAR(request.activity_date_time), MONTH(request.activity_date_time), cc.sort_name
 [nativecode=1064 ** You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')  AND request.status_id IN (1,2)
ORDER BY YEAR(request.activity_date_time), MON' at line 16]
    [type] => DB_Error
    [user_info] => SELECT
YEAR(request.activity_date_time) as year,
MONTH(request.activity_date_time) as month,
DAY(request.activity_date_time) as day,
absence.id as aid,
absence.activity_type_id as ati,
request.status_id status,
cac.contact_id as contact_id,
request.source_record_id,
cc.sort_name as contact_name 
FROM civicrm_activity absence
INNER JOIN civicrm_activity request ON request.source_record_id = absence.id
LEFT JOIN civicrm_activity_contact cac ON cac.activity_id = absence.id
LEFT JOIN civicrm_contact cc ON cac.contact_id = cc.id
 WHERE
cac.record_type_id = 3 AND request.activity_type_id = 56  AND absence.activity_type_id IN ()  AND request.status_id IN (1,2)
ORDER BY YEAR(request.activity_date_time), MONTH(request.activity_date_time), cc.sort_name
 [nativecode=1064 ** You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')  AND request.status_id IN (1,2)
ORDER BY YEAR(request.activity_date_time), MON' at line 16]
    [to_string] => [db_error: message="DB Error: syntax error" code=-2 mode=callback callback=CRM_Core_Error::handle prefix="" info="SELECT
YEAR(request.activity_date_time) as year,
MONTH(request.activity_date_time) as month,
DAY(request.activity_date_time) as day,
absence.id as aid,
absence.activity_type_id as ati,
request.status_id status,
cac.contact_id as contact_id,
request.source_record_id,
cc.sort_name as contact_name 
FROM civicrm_activity absence
INNER JOIN civicrm_activity request ON request.source_record_id = absence.id
LEFT JOIN civicrm_activity_contact cac ON cac.activity_id = absence.id
LEFT JOIN civicrm_contact cc ON cac.contact_id = cc.id
 WHERE
cac.record_type_id = 3 AND request.activity_type_id = 56  AND absence.activity_type_id IN ()  AND request.status_id IN (1,2)
ORDER BY YEAR(request.activity_date_time), MONTH(request.activity_date_time), cc.sort_name
 [nativecode=1064 ** You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')  AND request.status_id IN (1,2)
ORDER BY YEAR(request.activity_date_time), MON' at line 16]"]
)
```

the error is specifically in in this part of the query :

```sql
AND absence.activity_type_id IN () 
```
where nothing is passed to IN operator which lead the query to fail .


## Solution

After some invisgiating the issue generated in this part :

```php
              $clause = "absence.{$fieldName} {$sqlOp} (" . implode(',',$this->_params["{$fieldName}_value"]) . ") ";
```

so in case $this->_params["{$fieldName}_value"]) was not an array , then then the output of implode will be NULL so  ending up passing empty values to IN operator , so this is fixed by adding a check to $this->_params["{$fieldName}_value"]) to ensure it is an array otherwise use it as is.