### PR TITLE
PCHR-1650: Show SSP link always

### DIFF
--- a/hrui/CRM/Core/BAO/Navigation.php
+++ b/hrui/CRM/Core/BAO/Navigation.php
@@ -604,21 +604,8 @@ ORDER BY parent_id, weight";
         $homeURL = CRM_Utils_System::url('civicrm/dashboard', 'reset=1');
         $homeLabel = ts('CiviCRM Home');
       }
-      // Link to hide the menubar
-      if (
-        ($config->userSystem->is_drupal) &&
-        ((module_exists('toolbar') && user_access('access toolbar')) ||
-          module_exists('admin_menu') && user_access('access administration menu')
-        )
-      ) {
-        $hideLabel = ts('Self Service Portal');//ts('Drupal Menu');
-      }
-      elseif ($config->userSystem->is_wordpress) {
-        $hideLabel = ts('WordPress Menu');
-      }
-      else {
-        $hideLabel = ts('Hide Menu');
-      }
+
+      $hideLabel = ts('Self Service Portal');//ts('Drupal Menu');
 
       $prepandString = "
         <li class='menumain crm-link-home'>$homeIcon


### PR DESCRIPTION
**Requirement**
When you are not admin or civi admin role, the logo drop down in CiviCRM, shows "Hide menu" instead of the "Self Service Portal" - fix it to say Self Service Portal for any role.

**Fix**
Showing "Self Service Portal" always.