### PR TITLE
PCHR-1489: Change how overridden entitlements are stored

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/option_groups/leave_balance_change_types_install.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/option_groups/leave_balance_change_types_install.xml
@@ -71,5 +71,17 @@
       <is_active>1</is_active>
       <option_group_name>hrleaveandabsences_leave_balance_change_type</option_group_name>
     </OptionValue>
+
+    <OptionValue>
+      <label>Overridden</label>
+      <value>6</value>
+      <name>overridden</name>
+      <is_default>0</is_default>
+      <weight>5</weight>
+      <is_optgroup>0</is_optgroup>
+      <is_reserved>1</is_reserved>
+      <is_active>1</is_active>
+      <option_group_name>hrleaveandabsences_leave_balance_change_type</option_group_name>
+    </OptionValue>
   </OptionValues>
 </CustomData>


### PR DESCRIPTION
Now, overridden entitlements are stored as the difference between proposed entitlement and the overridden value. For example, if the proposed entitlement was 20 and it was overridden to 50, we should store two balance changes. One of "Leave" type, with 20 as the amount and another one of "Overridden" type and 30 (50 - 20) as the value. This way, if we sum all the balance changes we'll get the right value, but we'll still have access to the original proposed value.

The tests were updated to reflect this and a new test was added, to cover the case when the overridden value is less than the proposed value.

A new "Overridden" type was added to the hrleaveandabsences_leave_balance_change_type option group

