### PR TITLE
PCHR-1607: Make manage entitlements page able to handle multiple periods

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
@@ -16,8 +16,10 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
   /**
    * Create a new AbsencePeriod based on array-data
    *
-   * @param array $params key-value pairs
-   * @return CRM_HRLeaveAndAbsences_DAO_AbsencePeriod|NULL
+   * @param array $params
+   *  An array of field => value pairs
+   *
+   * @return \CRM_HRLeaveAndAbsences_DAO_AbsencePeriod|NULL
    */
   public static function create($params) {
     $entityName = 'AbsencePeriod';
@@ -53,8 +55,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    *
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidAbsencePeriodException
    */
-  private static function validateParams($params)
-  {
+  private static function validateParams($params) {
     self::validateDates($params);
 
     if(self::overlapsWithAnotherPeriod($params)) {
@@ -74,8 +75,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    *
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidAbsencePeriodException
    */
-  private static function validateDates($params)
-  {
+  private static function validateDates($params) {
     if(empty($params['start_date']) || empty($params['end_date'])) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsencePeriodException(
         'Both the start and end dates are required'
@@ -103,12 +103,12 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    * Checks if there's an existing Absence Period that overlaps with the
    * start and end dates on the given params array.
    *
-   * @param array $params - The params array passed to the create method
+   * @param array $params
+   *  The params array passed to the create method
    *
    * @return bool
    */
-  private static function overlapsWithAnotherPeriod($params)
-  {
+  private static function overlapsWithAnotherPeriod($params) {
     $tableName = self::getTableName();
     $query = "
       SELECT COUNT(*) as overlaping_periods
@@ -137,10 +137,10 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    * It checks if there's another period with the same weight and, if positive,
    * increase the weight of every period that has an equal or greater weight.
    *
-   * @param CRM_HRLeaveAndAbsences_BAO_AbsencePeriod $instance - The just saved AbsencePeriod
+   * @param \CRM_HRLeaveAndAbsences_BAO_AbsencePeriod $instance
+   *  The just saved AbsencePeriod
    */
-  private static function updatePeriodsOrder($instance)
-  {
+  private static function updatePeriodsOrder($instance) {
     if(self::theresAnotherPeriodWithTheSameWeight($instance)) {
       self::increaseWeightsEqualOrGreaterTo($instance);
     }
@@ -149,12 +149,11 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
   /**
    * Checks if there's another period with the same weight of the given AbsencePeriod
    *
-   * @param CRM_HRLeaveAndAbsences_BAO_AbsencePeriod $instance - An AbsencePeriod
+   * @param \CRM_HRLeaveAndAbsences_BAO_AbsencePeriod $instance
    *
    * @return bool
    */
-  private static function theresAnotherPeriodWithTheSameWeight($instance)
-  {
+  private static function theresAnotherPeriodWithTheSameWeight($instance) {
     $tableName = self::getTableName();
     $query = "
       SELECT COUNT(*) as periods
@@ -175,10 +174,9 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    * Increases the weight of every existing period with a weight equal to or
    * greater than the weight of the given AbsencePeriod
    *
-   * @param CRM_HRLeaveAndAbsences_BAO_AbsencePeriod $instance - An AbsencePeriod
+   * @param \CRM_HRLeaveAndAbsences_BAO_AbsencePeriod $instance
    */
-  private static function increaseWeightsEqualOrGreaterTo($instance)
-  {
+  private static function increaseWeightsEqualOrGreaterTo($instance) {
     $tableName = self::getTableName();
     $query = "
       UPDATE {$tableName}
@@ -198,7 +196,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    *
    * Returns 0 if there's no Period available
    *
-   * @return int the maximum weight
+   * @return int
    */
   public static function getMaxWeight() {
     $tableName = self::getTableName();
@@ -221,7 +219,8 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    * An empty array is returned if it is not possible to load
    * the data.
    *
-   * @param int $id The id of the AbsencePeriod to retrieve the values
+   * @param int $id
+   *  The id of the AbsencePeriod to retrieve the values
    *
    * @return array An array containing the values
    */
@@ -241,10 +240,10 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    *
    * If there's no existing Absence Period, the current date is returned
    *
-   * @return string The most recent start date available in Y-m-d format
+   * @return string
+   *  The most recent start date available in Y-m-d format
    */
-  public static function getMostRecentStartDateAvailable()
-  {
+  public static function getMostRecentStartDateAvailable() {
     $tableName = self::getTableName();
     $query = "SELECT MAX(end_date) as latest_end_date FROM {$tableName}";
     $dao = CRM_Core_DAO::executeQuery($query);
@@ -263,8 +262,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    *
    * @return \CRM_HRLeaveAndAbsences_BAO_AbsencePeriod|null
    */
-  public static function getCurrentPeriod()
-  {
+  public static function getCurrentPeriod() {
     $period = new self();
     $period->whereAdd("start_date <= CURDATE()");
     $period->whereAdd("end_date >= CURDATE()");
@@ -285,8 +283,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    *
    * @return int
    */
-  public function getNumberOfWorkingDays()
-  {
+  public function getNumberOfWorkingDays() {
     if(!$this->numberOfWorkingDays) {
       if(!CRM_HRLeaveAndAbsences_Validator_Date::isValid($this->start_date, 'Y-m-d')) {
         throw new UnexpectedValueException('You can only get the number of working days for an AbsencePeriod with a valid start date');
@@ -336,8 +333,10 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    * greater than AbsencePeriod end date, then the AbsencePeriod's end date
    * will be used.
    *
-   * @param string $startDate A date in the Y-m-d format
-   * @param string $endDate A date in the Y-m-d format
+   * @param string $startDate
+   *  A date in the Y-m-d format
+   * @param string $endDate
+   *  A date in the Y-m-d format
    *
    * @return int
    */
@@ -363,7 +362,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    * Returns the Absence Period previous to this one. That is, the Absence
    * Period where weight is equal to this Period weight - 1.
    *
-   * @return null|CRM_HRLeaveAndAbsences_BAO_AbsencePeriod
+   * @return null|\CRM_HRLeaveAndAbsences_BAO_AbsencePeriod
    *  The previous Absence Period or null if there's none
    */
   public function getPreviousPeriod() {
@@ -374,7 +373,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    * Returns the Absence Period next to this one. That is, the Absence
    * Period where weight is equal to this Period weight + 1.
    *
-   * @return null|CRM_HRLeaveAndAbsences_BAO_AbsencePeriod
+   * @return null|\CRM_HRLeaveAndAbsences_BAO_AbsencePeriod
    *  The next Absence Period or null if there's none
    */
   public function getNextPeriod() {
@@ -411,12 +410,12 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    *
    * @param \CRM_HRLeaveAndAbsences_BAO_AbsenceType $absenceType
    *
-   * @return null|string A date in Y-m-d or null if it can not be calculated
+   * @return null|string
+   *  A date in Y-m-d or null if it can not be calculated
    *
    * @throws \UnexpectedValueException
    */
-  public function getExpirationDateForAbsenceType(AbsenceType $absenceType)
-  {
+  public function getExpirationDateForAbsenceType(AbsenceType $absenceType) {
     if(!$this->hasValidDates()) {
       throw new UnexpectedValueException(
         'You can only calculate the expiration date for an AbsenceType from an AbsencePeriod with start and end dates'
@@ -441,10 +440,10 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    *
    * @param \CRM_HRLeaveAndAbsences_BAO_AbsenceType $absenceType
    *
-   * @return null|string A date in Y-m-d or null if it can not be calculated
+   * @return null|string
+   *  A date in Y-m-d or null if it can not be calculated
    */
-  private function getExpirationDurationDate(AbsenceType $absenceType)
-  {
+  private function getExpirationDurationDate(AbsenceType $absenceType) {
     if(!$absenceType->allow_carry_forward || !$absenceType->hasExpirationDuration()) {
       return null;
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
@@ -363,15 +363,39 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    * Returns the Absence Period previous to this one. That is, the Absence
    * Period where weight is equal to this Period weight - 1.
    *
-   * @return null|CRM_HRLeaveAndAbsences_BAO_AbsencePeriod - The previous Absence Period or null if there's none
+   * @return null|CRM_HRLeaveAndAbsences_BAO_AbsencePeriod
+   *  The previous Absence Period or null if there's none
    */
-  public function getPreviousPeriod()
-  {
-    $previousPeriod = new self();
-    $previousPeriod->weight = $this->weight - 1;
-    $previousPeriod->find(true);
-    if($previousPeriod->id) {
-      return $previousPeriod;
+  public function getPreviousPeriod() {
+    return $this->getAbsencePeriodByWeight($this->weight - 1);
+  }
+
+  /**
+   * Returns the Absence Period next to this one. That is, the Absence
+   * Period where weight is equal to this Period weight + 1.
+   *
+   * @return null|CRM_HRLeaveAndAbsences_BAO_AbsencePeriod
+   *  The next Absence Period or null if there's none
+   */
+  public function getNextPeriod() {
+    return $this->getAbsencePeriodByWeight($this->weight + 1);
+  }
+
+  /**
+   * Returns the Absence Period with the given $weight.
+   *
+   * If there is no Absence Period with the given value, null will be returned.
+   *
+   * @param int $weight
+   *
+   * @return null|\CRM_HRLeaveAndAbsences_BAO_AbsencePeriod
+   */
+  private function getAbsencePeriodByWeight($weight) {
+    $nextPeriod = new self();
+    $nextPeriod->weight = (int)$weight;
+    $nextPeriod->find(true);
+    if($nextPeriod->id) {
+      return $nextPeriod;
     }
 
     return null;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -173,7 +173,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
    *    When given, will make the method count only days taken as leave starting from this date
    *
    * @return float
-   * @internal param int $entitlementID The ID of the entitlement to get the balance*    The ID of the entitlement to get the balance
    */
   public static function getLeaveRequestBalanceForEntitlement(
     LeavePeriodEntitlement $periodEntitlement,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/ContractEntitlementCalculation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/ContractEntitlementCalculation.php
@@ -1,0 +1,181 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_ContractEntitlementCalculation
+ */
+class CRM_HRLeaveAndAbsences_ContractEntitlementCalculation {
+
+  private $contract;
+  private $period;
+  private $absenceType;
+  private $jobLeave = false;
+
+  /**
+   * Creates a new Contract Entitlement Calculation based on the give Absence
+   * Period, Contract and AbsenceType
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_AbsencePeriod $period
+   * @param array $contract
+   *  An array representing the contract. The contract must have the
+   *  period_start_date and period_end_date
+   * @param \CRM_HRLeaveAndAbsences_BAO_AbsenceType $type
+   */
+  public function __construct(AbsencePeriod $period, array $contract, AbsenceType $type) {
+    $this->contract = $contract;
+    $this->period = $period;
+    $this->absenceType = $type;
+  }
+
+  /**
+   * Calculates the Pro Rata for the contract, which is given by:
+   *
+   * CE * (WDTW / WD)
+   *
+   * Where:
+   * CE: Contractual Entitlement
+   * WDTW: No. Working Days to Work
+   * WD: No. Working Days
+   *
+   * @return float
+   */
+  public function getProRata() {
+    $numberOfWorkingDaysToWork = $this->getNumberOfWorkingDaysToWork();
+    $numberOfWorkingDays = $this->getNumberOfWorkingDays();
+
+    $contractualEntitlement = $this->getContractualEntitlement();
+
+    $proRata = ($numberOfWorkingDaysToWork / $numberOfWorkingDays) * $contractualEntitlement;
+
+    return $proRata;
+  }
+
+  /**
+   * Returns the number of working days for this contract in this calculation's
+   * period
+   *
+   * @return int
+   */
+  public function getNumberOfWorkingDaysToWork() {
+    return $this->period->getNumberOfWorkingDaysToWork(
+      $this->contract['period_start_date'],
+      $this->contract['period_end_date']
+    );
+  }
+
+  /**
+   * Returns the number of working days for this calculation's period
+   *
+   * @return int
+   */
+  public function getNumberOfWorkingDays() {
+    return $this->period->getNumberOfWorkingDays();
+  }
+
+  /**
+   * Returns the contractual entitlement for this calculation's contract,
+   * based on the Job Leave settings
+   *
+   * @return float
+   */
+  public function getContractualEntitlement() {
+    $jobLeave = $this->getJobLeave();
+
+    if(!$jobLeave) {
+      return 0;
+    }
+
+    return (float)$jobLeave['leave_amount'];
+  }
+
+  /**
+   * Returns the number of Public Holidays added to the entitlement because of
+   * contract with "Add Public Holiday?" set.
+   *
+   * @return int
+   */
+  public function getNumberOfPublicHolidaysInEntitlement() {
+    $jobLeave = $this->getJobLeave();
+
+    if(!empty($jobLeave['add_public_holidays'])) {
+      return PublicHoliday::getNumberOfPublicHolidaysForPeriod(
+        $this->contract['period_start_date'],
+        $this->contract['period_end_date']
+      );
+    }
+
+    return 0;
+  }
+
+  /**
+   * Returns a list of PublicHolidays instances representing the Public Holidays
+   * added to the entitlement.
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_PublicHoliday[]
+   */
+  public function getPublicHolidaysInEntitlement() {
+    $jobLeave = $this->getJobLeave();
+
+    if(!empty($jobLeave['add_public_holidays'])) {
+      return PublicHoliday::getPublicHolidaysForPeriod(
+        $this->contract['period_start_date'],
+        $this->contract['period_end_date']
+      );
+    }
+
+    return [];
+  }
+
+  /**
+   * Returns the calculated Total Entitlement for this contract, which is given
+   * by Pro Rata + Number Of Public Holidays
+   *
+   * @return float
+   */
+  public function getTotalEntitlement() {
+    return $this->getProRata() + $this->getNumberOfPublicHolidaysInEntitlement();
+  }
+
+  /**
+   * Returns the start date of this calculation's contract
+   *
+   * @return string
+   */
+  public function getContractStartDate() {
+    return $this->contract['period_start_date'];
+  }
+
+  /**
+   * Returns the end date of this calculation's contract
+   *
+   * @return string
+   */
+  public function getContractEndDate() {
+    return $this->contract['period_end_date'];
+  }
+
+  /**
+   * Returns an array with the values of the JobLeave for the given contract and
+   * the calculation's  absence type.
+   *
+   * @return array|null
+   *   An array with the JobLeave fields or null if there's no JobLeave for this AbsenceType
+   */
+  private function getJobLeave() {
+    if($this->jobLeave === false) {
+      try {
+        $this->jobLeave = civicrm_api3('HRJobLeave', 'getsingle', array(
+          'jobcontract_id' => (int)$this->contract['id'],
+          'leave_type' => (int)$this->absenceType->id
+        ));
+      } catch(CiviCRM_API3_Exception $ex) {
+        $this->jobLeave = null;
+      }
+    }
+
+    return $this->jobLeave;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculation.php
@@ -270,7 +270,7 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
       return 0.0;
     }
 
-    return $entitlement->getLeaveRequestBalance() * -1.0;
+    return abs($entitlement->getLeaveRequestBalance());
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculation.php
@@ -384,7 +384,8 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
    */
   private function shouldCalculateBroughtForward() {
     return $this->absenceType->allow_carry_forward &&
-           !$this->broughtForwardHasExpired();
+           !$this->broughtForwardHasExpired() &&
+           $this->previousPeriodIsOver();
   }
 
   /**
@@ -516,5 +517,22 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
     }
 
     return $numberOfPublicHolidays;
+  }
+
+  /**
+   * Checks if the Previous Period is Over. That is, if its end date is in the
+   * past.
+   *
+   * If there is no previous period, this method returns true.
+   *
+   * @return bool
+   */
+  private function previousPeriodIsOver() {
+    $previousPeriod = $this->getPreviousPeriod();
+    if($previousPeriod) {
+      return strtotime($previousPeriod->end_date) < strtotime('now');
+    }
+
+    return true;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculation.php
@@ -470,7 +470,7 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
    *
    * @return int
    */
-  private function getNumberOfPublicHolidaysInEntitlement() {
+  public function getNumberOfPublicHolidaysInEntitlement() {
     $numberOfPublicHolidays = 0;
 
     $calculations = $this->getContractEntitlementCalculations();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculation.php
@@ -172,18 +172,27 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
    * This is basically the Pro Rata + the number of days brought forward + any
    * public holidays added for contracts with "Add public holiday?"
    *
-   * @return float|int
+   * @return float
    */
   public function getProposedEntitlement() {
-    $periodEntitlement = $this->getPeriodEntitlement();
-
-    if($periodEntitlement && $periodEntitlement->overridden) {
-      return $periodEntitlement->getEntitlement();
-    }
-
     return $this->getProRata() +
            $this->getBroughtForward() +
            $this->getNumberOfPublicHolidaysInEntitlement();
+  }
+
+  /**
+   * If there's a Leave Period Entitlement for this Calculation's Absence Period,
+   * and it has been overridden, this method will return the overridden value.
+   * Otherwise, it will return 0;
+   *
+   * @return float
+   */
+  public function getOverriddenEntitlement() {
+    if($this->isCurrentPeriodEntitlementOverridden()) {
+      return $this->getPeriodEntitlement()->getEntitlement();
+    }
+
+    return 0;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/EntitlementCalculation.php
@@ -1,9 +1,9 @@
 <?php
 
+use CRM_HRLeaveAndAbsences_ContractEntitlementCalculation as ContractEntitlementCalculation;
 use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
 use CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement as LeavePeriodEntitlement;
 use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
-use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
 
 /**
  * This class encapsulates all of the entitlement calculation logic.
@@ -52,7 +52,7 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
   private $previousPeriodEntitlement;
 
   /**
-   * Variable to cache the return from the getContractsInPeriod method
+   * Variable to cache the return from the getContractsInPeriodWithAdjustedDates method
    *
    * @var array
    */
@@ -67,6 +67,14 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
    * @var bool|null
    */
   private $periodEntitlement = FALSE;
+
+  /**
+   * Variable to cache the return from the getContractEntitlementCalculations()
+   * method.
+   *
+   * @var \CRM_HRLeaveAndAbsences_ContractEntitlementCalculation[]
+   */
+  private $contractsEntitlementCalculations = null;
 
   /**
    * Creates a new EntitlementCalculation instance
@@ -106,6 +114,30 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
   }
 
   /**
+   * Returns an array of ContractEntitlementCalculation instances for all the
+   * contracts of this calculation's contact during the Absence Period
+   *
+   * @return \CRM_HRLeaveAndAbsences_ContractEntitlementCalculation[]
+   */
+  public function getContractEntitlementCalculations() {
+    if($this->contractsEntitlementCalculations === null) {
+      $this->contractsEntitlementCalculations = [];
+
+      $contracts = $this->getContractsInPeriodWithAdjustedDates();
+      foreach($contracts as $contract) {
+        $this->contractsEntitlementCalculations[] = new ContractEntitlementCalculation(
+          $this->period,
+          $contract,
+          $this->absenceType
+        );
+      }
+    }
+
+
+    return $this->contractsEntitlementCalculations;
+  }
+
+  /**
    * Returns the Pro Rata for all of the contracts included in this calculation.
    *
    * For each contract, we calculate the Pro Rata as:
@@ -123,47 +155,14 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
    * @return float
    */
   public function getProRata() {
-    $contracts = $this->getContractsInPeriodWithAdjustedDates();
-    $proRata = array_reduce($contracts, function($proRata, $contract) {
-      $proRata += $this->getContractProRata($contract);
+    $calculations = $this->getContractEntitlementCalculations();
+    $proRata = array_reduce($calculations, function($proRata, $calculation) {
+      $proRata += $calculation->getProRata();
 
       return $proRata;
     });
 
     return ceil($proRata * 2) / 2;
-  }
-
-  /**
-   * Calculates the Pro Rata for a single contract, which is given by:
-   *
-   * CE * (WDTW / WD)
-   *
-   * Where:
-   * CE: Contractual Entitlement
-   * WDTW: No. Working Days to Work
-   * WD: No. Working Days
-   *
-   * @param array $contract
-   *   An array representing a HRJobContract
-   *
-   * @return float
-   */
-  private function getContractProRata($contract) {
-    $numberOfWorkingDaysToWork = $this->period->getNumberOfWorkingDaysToWork(
-      $contract['period_start_date'],
-      $contract['period_end_date']
-    );
-    $numberOfWorkingDays = $this->period->getNumberOfWorkingDays();
-    $contractualEntitlement = 0;
-
-    $jobLeave = $this->getJobLeaveForAbsenceType($contract['id']);
-    if($jobLeave) {
-      $contractualEntitlement = (float)$jobLeave['leave_amount'];
-    }
-
-    $proRata = ($numberOfWorkingDaysToWork / $numberOfWorkingDays) * $contractualEntitlement;
-
-    return $proRata;
   }
 
   /**
@@ -389,31 +388,26 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
   }
 
   /**
-   * Returns an array with the values of the JobLeave for the given contract and
-   * the calculation's  absence type.
-   *
-   * @param int $contractID
-   *
-   * @return array|null
-   *   An array with the JobLeave fields or null if there's no JobLeave for this AbsenceType
-   */
-  private function getJobLeaveForAbsenceType($contractID) {
-    try {
-      return civicrm_api3('HRJobLeave', 'getsingle', array(
-        'jobcontract_id' => (int)$contractID,
-        'leave_type' => (int)$this->absenceType->id
-      ));
-    } catch(CiviCRM_API3_Exception $ex) {
-      return null;
-    }
-  }
-
-  /**
    * Returns an array with all the of the contracts for the calculation's contact
    * during the calculation's Absence Period.
    *
-   * The contract dates are adjusted to match the calculation's Absence Period
-   * dates.
+   * @return array
+   *  An array with the output of the HRJobContract.getContractsWithDetailsInPeriod
+   *  API endpoint
+   */
+  private function getContractsInPeriod() {
+    $result = civicrm_api3('HRJobContract', 'getcontractswithdetailsinperiod', [
+      'contact_id' => $this->contact['id'],
+      'start_date' => $this->period->start_date,
+      'end_date'   => $this->period->end_date
+    ]);
+
+    return $result['values'];
+  }
+
+  /**
+   * This is basically the same as getContractsInPeriod(), but with the contract
+   * dates ajusted to match the calculation's Absence Period
    *
    * @return array
    *  An array with the output of the HRJobContract.getContractsWithDetailsInPeriod
@@ -421,13 +415,7 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
    */
   private function getContractsInPeriodWithAdjustedDates() {
     if(is_null($this->contractsInPeriod)) {
-      $result = civicrm_api3('HRJobContract', 'getcontractswithdetailsinperiod', [
-        'contact_id' => $this->contact['id'],
-        'start_date' => $this->period->start_date,
-        'end_date'   => $this->period->end_date
-      ]);
-
-      $this->contractsInPeriod = $result['values'];
+      $this->contractsInPeriod = $this->getContractsInPeriod();
 
       foreach($this->contractsInPeriod as $i => $contract) {
         if(empty($contract['period_end_date'])) {
@@ -450,18 +438,6 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
   }
 
   /**
-   * Returns the string representation for this calculation
-   *
-   * @TODO return an actual representation instead of an empty string
-   *
-   * @return string
-   */
-  public function __toString()
-  {
-    return "";
-  }
-
-  /**
    * Returns the expiration date for a brought forward, based on the
    * AbsencePeriod start date and the AbsenceType carry forward rules
    *
@@ -480,16 +456,9 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
   public function getPublicHolidaysInEntitlement() {
     $publicHolidays = [];
 
-    $contracts = $this->getContractsInPeriodWithAdjustedDates();
-    foreach($contracts as $contract) {
-      $jobLeave = $this->getJobLeaveForAbsenceType($contract['id']);
-
-      if(!empty($jobLeave['add_public_holidays'])) {
-        $publicHolidays += PublicHoliday::getPublicHolidaysForPeriod(
-          $contract['period_start_date'],
-          $contract['period_end_date']
-        );
-      }
+    $calculations = $this->getContractEntitlementCalculations();
+    foreach($calculations as $calculation) {
+      $publicHolidays += $calculation->getPublicHolidaysInEntitlement();
     }
 
     return $publicHolidays;
@@ -504,16 +473,9 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculation {
   private function getNumberOfPublicHolidaysInEntitlement() {
     $numberOfPublicHolidays = 0;
 
-    $contracts = $this->getContractsInPeriodWithAdjustedDates();
-    foreach($contracts as $contract) {
-      $jobLeave = $this->getJobLeaveForAbsenceType($contract['id']);
-
-      if(!empty($jobLeave['add_public_holidays'])) {
-        $numberOfPublicHolidays += PublicHoliday::getNumberOfPublicHolidaysForPeriod(
-          $contract['period_start_date'],
-          $contract['period_end_date']
-        );
-      }
+    $calculations = $this->getContractEntitlementCalculations();
+    foreach($calculations as $calculation) {
+      $numberOfPublicHolidays += $calculation->getNumberOfPublicHolidaysInEntitlement();
     }
 
     return $numberOfPublicHolidays;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
@@ -355,11 +355,15 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
    * @return array
    */
   private function getAvailableButtons() {
+    $buttonName = ts('Save new entitlements');
+    if($this->hasMorePeriodsToCalculate()) {
+      $buttonName = ts('Save and go to the next period');
+    }
     $buttons = [
       [
         'type'      => 'next',
         'class'     => 'save-new-entitlements-button',
-        'name'      => ts('Save new entitlements'),
+        'name'      => $buttonName,
         'isDefault' => TRUE
       ],
     ];
@@ -417,5 +421,15 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
       'reset=1&id=' . $period->id . '&' . http_build_query(['cid' => $contactsIDs])
     );
     return $url;
+  }
+
+  /**
+   * Returns true is there are more Absence Periods available to calculate the
+   * entitlements
+   *
+   * @return bool
+   */
+  private function hasMorePeriodsToCalculate() {
+    return $this->absencePeriod->getNextPeriod() != null;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
@@ -46,10 +46,14 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
     if(!empty($this->calculations) && empty($this->defaultValues)) {
       $this->defaultValues = [];
       foreach($this->calculations as $calculation) {
+        $contactID = $calculation->getContact()['id'];
+        $absenceTypeID = $calculation->getAbsenceType()->id;
         if($calculation->getCurrentPeriodEntitlementComment()) {
-          $contactID = $calculation->getContact()['id'];
-          $absenceTypeID = $calculation->getAbsenceType()->id;
           $this->defaultValues['comment'][$contactID][$absenceTypeID] = $calculation->getCurrentPeriodEntitlementComment();
+        }
+
+        if($calculation->isCurrentPeriodEntitlementOverridden()) {
+          $this->defaultValues['overridden_entitlement'][$contactID][$absenceTypeID] = $calculation->getOverriddenEntitlement();
         }
       }
     }
@@ -97,7 +101,7 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
 
       LeavePeriodEntitlement::saveFromCalculation(
         $calculation,
-        $values['proposed_entitlement'][$contactID][$absenceTypeID],
+        $values['overridden_entitlement'][$contactID][$absenceTypeID],
         $values['comment'][$contactID][$absenceTypeID]
       );
     }
@@ -241,7 +245,7 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
   private function addProposedEntitlementAndCommentFields() {
     foreach($this->calculations as $calculation) {
       $proposedEntitlementFieldName = sprintf(
-        'proposed_entitlement[%d][%d]',
+        'overridden_entitlement[%d][%d]',
         $calculation->getContact()['id'],
         $calculation->getAbsenceType()->id
       );
@@ -333,8 +337,8 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
         'overridden' => 0
       ];
 
-      if(!empty($formValues['proposed_entitlement'][$contactID][$absenceTypeID])) {
-        $row['proposed_entitlement'] = $formValues['proposed_entitlement'][$contactID][$absenceTypeID];
+      if(!empty($formValues['overridden_entitlement'][$contactID][$absenceTypeID])) {
+        $row['proposed_entitlement'] = $formValues['overridden_entitlement'][$contactID][$absenceTypeID];
         $row['overridden'] = 1;
       }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/EntitlementCalculationDetails.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/EntitlementCalculationDetails.php
@@ -1,0 +1,61 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_EntitlementCalculation as EntitlementCalculation;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Page_EntitlementCalculationDetails
+ */
+class CRM_HRLeaveAndAbsences_Page_EntitlementCalculationDetails extends CRM_Core_Page {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function run() {
+    $typeID = CRM_Utils_Request::retrieve('type_id', 'Integer');
+    $contactID = CRM_Utils_Request::retrieve('contact_id', 'Integer');
+    $periodID = CRM_Utils_Request::retrieve('period_id', 'Integer');
+
+    if(empty($typeID) || empty($contactID) || empty($periodID)) {
+      return;
+    }
+
+    $type = CRM_HRLeaveAndAbsences_BAO_AbsenceType::findById($typeID);
+    $contact = civicrm_api3('Contact', 'getsingle', ['id' => $contactID, 'sequential' => 1]);
+    $period = CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::findById($periodID);
+
+    $calculation = new EntitlementCalculation($period, $contact, $type);
+
+    $this->assign('calculation', $calculation);
+    $this->assign('proRataCalculationDescription', $this->buildProRataCalculationDescription($calculation));
+
+    CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/hrleaveandabsences.css', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
+
+    parent::run();
+  }
+
+  /**
+   * A helper method that builds the period pro rata description, which is a sum
+   * of all pro ratas for every contract in this calculation.
+   *
+   * This was created basically to remove all this logic from the template
+   *
+   * @param CRM_HRLeaveAndAbsences_EntitlementCalculation $entitlementCalculation
+   *
+   * @return string
+   */
+  private function buildProRataCalculationDescription(EntitlementCalculation $entitlementCalculation) {
+    $contractsCalculation = $entitlementCalculation->getContractEntitlementCalculations();
+    $contractsProRatas = [];
+    $i = 1;
+    foreach($contractsCalculation as $calculation) {
+      $proRata = number_format($calculation->getProRata(), 2);
+      $contractsProRatas[] = '<span class="contract-'.$i.'-pro-rata">' . $proRata . '</span>';
+      $i++;
+    }
+
+    $proRataCalculation = implode(' + ', $contractsProRatas);
+    $proRataSum = '<span class="calculation-pro-rata">' . $entitlementCalculation->getProRata().'</span>';
+
+    return "{$proRataCalculation} = {$proRataSum}";
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/AbsencePeriod.php
@@ -1,0 +1,31 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
+
+class CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod extends
+  CRM_HRLeaveAndAbsences_Test_Fabricator_SequentialTitle {
+
+  public static function fabricate($params = [], $loadAfterSave = false) {
+    $params = array_merge(static::getDefaultParams(), $params);
+
+    if(empty($params['title'])) {
+      $params['title'] = static::nextSequentialTitle();
+    }
+
+    $absencePeriod = AbsencePeriod::create($params);
+
+    if($loadAfterSave) {
+      $absencePeriod = AbsencePeriod::findById($absencePeriod->id);
+    }
+
+    return $absencePeriod;
+  }
+
+  private static function getDefaultParams() {
+    return [
+      'start_date' => date('YmdHis'),
+      'end_date' => date('YmdHis', strtotime('+1 day'))
+    ];
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/AbsenceType.php
@@ -1,0 +1,25 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+
+class CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType extends
+  CRM_HRLeaveAndAbsences_Test_Fabricator_SequentialTitle {
+
+  private static $defaultParams = [
+    'color'                     => '#000000',
+    'default_entitlement'       => 20,
+    'allow_request_cancelation' => 1,
+    'allow_carry_forward'       => 1,
+  ];
+
+  public static function fabricate($params = []) {
+    $params = array_merge(static::$defaultParams, $params);
+
+    if(empty($params['title'])) {
+      $params['title'] = static::nextSequentialTitle();
+    }
+
+    return AbsenceType::create($params);
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/PublicHoliday.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/PublicHoliday.php
@@ -1,0 +1,15 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
+
+class CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHoliday extends
+  CRM_HRLeaveAndAbsences_Test_Fabricator_SequentialTitle {
+
+  public static function fabricate($params = []) {
+    if(empty($params['title'])) {
+      $params['title'] = static::nextSequentialTitle();
+    }
+
+    return PublicHoliday::create($params);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/SequentialTitle.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/SequentialTitle.php
@@ -1,0 +1,18 @@
+<?php
+
+abstract class CRM_HRLeaveAndAbsences_Test_Fabricator_SequentialTitle {
+
+  protected static $sequenceNumber = 1;
+
+  protected static function nextSequentialTitle() {
+    $title = static::getEntityTitle() . ' ' . static::$sequenceNumber;
+    static::$sequenceNumber++;
+
+    return $title;
+  }
+
+  protected static function getEntityTitle() {
+    $namespaceParts = explode('_', static::class);
+    return end($namespaceParts);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
@@ -77,6 +77,10 @@
   display: inline-block;
 }
 
+.entitlement-calculation-filters .override-filters label:before {
+  display: none;
+}
+
 .entitlement-calculation-filters .absence-type-filter {
   display: inline;
   margin-right: 10px;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/css/hrleaveandabsences.css
@@ -141,3 +141,18 @@
 .crm-container .CRM_HRLeaveAndAbsences_Form_ManageEntitlements .crm-button-type-next  {
   float: right !important;
 }
+
+#calculation-details .base-contractual-entitlement { color: #42afcb; }
+#calculation-details .working-days-to-work { color: #8EC68A; }
+#calculation-details .working-days-in-period { color: #ECA67F; }
+/*
+  It's unlikely that an employee will have more than 5 contracts
+  during a single period, but if that is the case, more
+  .contract-n-pro-rata classes will need to be added here
+ */
+#calculation-details .contract-1-pro-rata { color: #E6807F; }
+#calculation-details .contract-2-pro-rata { color: #797300; }
+#calculation-details .contract-3-pro-rata { color: #904E1E; }
+#calculation-details .contract-4-pro-rata { color: #0511B1; }
+#calculation-details .contract-5-pro-rata { color: #4B9609; }
+#calculation-details .calculation-pro-rata { color: #95c0ff  }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
@@ -206,21 +206,15 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements = (function($) {
       return;
     }
 
-    var calculationDescription = ts('' +
-      '((Base contractual entitlement + Public Holidays) ' +
-      '* ' +
-      '(No. of working days to work / No. of working days in period)) = ' +
-      '(Period pro rata) + (Brought Forward days) = Period Entitlement'
-    );
-    var calculationDetails = event.currentTarget.parentNode.dataset.calculationDetails;
-
-    if(!calculationDetails) {
-      return;
-    }
+    var query = {
+      'contact_id': event.currentTarget.parentNode.dataset.contact,
+      'type_id': event.currentTarget.parentNode.dataset.absenceType,
+      'period_id': event.currentTarget.parentNode.dataset.absencePeriod
+    };
 
     CRM.confirm({
       title: ts('Calculation details'),
-      message: calculationDescription + '<br /><br />' + calculationDetails,
+      url: CRM.url('civicrm/admin/leaveandabsences/periods/manage_entitlements/calculation_details', query),
       width: '70%',
       options: {}
     });

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
@@ -430,10 +430,14 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements.ProposedEntitlement = (functio
   ProposedEntitlement.prototype._makeEntitlementEditable = function() {
     this._overrideButton.hide();
     this._proposedValue.hide();
+
+    if(!this._overrideField.val()) {
+      this._overrideField.val(this._proposedValue.text())
+    }
     this._overrideField
-      .val(this._proposedValue.text())
       .show()
       .focus();
+
     this._overrideCheckbox.prop('checked', true);
     this._isOverridden = true;
   };

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/hrleaveandabsences.form.manage_entitlements.js
@@ -141,9 +141,9 @@ CRM.HRLeaveAndAbsencesApp.Form.ManageEntitlements = (function($) {
       });
 
       this._listElement
-        .find('tr:not(.hidden)')  // finds all the visible rows
-        .not(selectors.join(',')) // that doesn't match the select types
-        .addClass('hidden');      // and hide them
+        .find('tbody tr:not(.hidden)')  // finds all the visible rows
+        .not(selectors.join(','))       // that doesn't match the select types
+        .addClass('hidden');            // and hide them
     }
   };
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
@@ -78,7 +78,7 @@
       <td>{$calculation->getProRata()}</td>
       <td class="proposed-entitlement">
           <span class="proposed-value">{$calculation->getProposedEntitlement()}</span>
-          {$form.proposed_entitlement[$contact.id][$absenceTypeID].html}
+          {$form.overridden_entitlement[$contact.id][$absenceTypeID].html}
           <button type="button" class="borderless-button"><i class="fa fa-pencil"></i></button>
           <label for="override_checkbox_{$contact.id}_{$absenceTypeID}">
             <input id="override_checkbox_{$contact.id}_{$absenceTypeID}"

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
@@ -66,8 +66,10 @@
   {foreach from=$calculations item=calculation}
     {assign var=absenceType value=$calculation->getAbsenceType()}
     {assign var=absenceTypeID value=$absenceType->id}
+    {assign var=absencePeriod value=$calculation->getAbsencePeriod()}
+    {assign var=absencePeriodID value=$absencePeriod->id}
     {assign var=contact value=$calculation->getContact()}
-    <tr data-calculation-details="{$calculation}" data-absence-type="{$absenceTypeID}">
+    <tr data-contact="{$contact.id}" data-absence-type="{$absenceTypeID}" data-absence-period="{$absencePeriodID}">
       <td>{$contact.id}</td>
       <td>{$contact.display_name}</td>
       <td><span class="absence-type" style="background-color: {$absenceType->color};">{$absenceType->title}</span></td>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/EntitlementCalculationDetails.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/EntitlementCalculationDetails.tpl
@@ -1,0 +1,50 @@
+<div id="calculation-details">
+  <p>For each contract the default calculation is as follows:</p>
+
+  <p>1) Calculate period Pro Rata: ( (<span class="base-contractual-entitlement">Base contractual entitlement</span>) * (<span class="working-days-to-work">No of working days to work</span> /
+    <span class="working-days-in-period">No of working days in period</span>) ) = (Period pro rata)
+  <br>
+  2) Add Public Holidays in period of contract = Total Entitlement for this contract</p>
+
+  <p>Then we:</p>
+
+  <p>3) Sum all Total entitlements for all contracts
+  <br>
+  4) Add brought forward days to the Total entitlements for all contracts = "Period Entitlement".</p>
+
+  {assign var=contractsCalculations value=$calculation->getContractEntitlementCalculations()}
+  {foreach from=$contractsCalculations item=contractCalculation name=contractsCalculation}
+
+    {assign var=number value=$smarty.foreach.contractsCalculation.iteration}
+    {assign var=startDate value=$contractCalculation->getContractStartDate()|crmDate}
+    {assign var=endDate value=$contractCalculation->getContractEndDate()|crmDate}
+    {assign var=contractualEntitlement value=$contractCalculation->getContractualEntitlement()}
+    {assign var=workingDaysToWork value=$contractCalculation->getNumberOfWorkingDaysToWork()}
+    {assign var=workingDays value=$contractCalculation->getNumberOfWorkingDays()}
+    {assign var=proRata value=$contractCalculation->getProRata()|string_format:"%.2f"}
+    {assign var=publicHolidays value=$contractCalculation->getNumberOfPublicHolidaysInEntitlement()}
+    {assign var=totalEntitlement value=$contractCalculation->getTotalEntitlement()|string_format:"%.2f"}
+
+    <div>
+      <p>
+        Contract {$number}: {$startDate} - {$endDate}
+        <br>
+        1) ( (<span class="base-contractual-entitlement">{$contractualEntitlement}</span>) * (<span class="working-days-to-work">{$workingDaysToWork}</span> /
+            <span class="working-days-in-period">{$workingDays}</span>) ) = {$proRata}
+        <br>
+        2) ({$proRata}) + ({$publicHolidays}) = <span class="contract-{$number}-pro-rata">{$totalEntitlement}</span>
+      </p>
+    </div>
+  {/foreach}
+
+  Total:
+  {assign var=periodProRata value=$calculation->getProRata()}
+  {assign var=periodPublicHolidays value=$calculation->getNumberOfPublicHolidaysInEntitlement()}
+  {assign var=broughtForward value=$calculation->getBroughtForward()}
+  {assign var=periodEntitlement value=$calculation->getProposedEntitlement()}
+  <p>
+    3) {$proRataCalculationDescription} (Rounded up to the nearest half day)
+    <br>
+    4) <span class="calculation-pro-rata">{$periodProRata + $periodPublicHolidays}</span> + {$broughtForward} = Period entitlement: {$periodEntitlement}
+  </p>
+</div>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
@@ -415,6 +415,46 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends PHPUnit_Framework_Tes
     $this->assertEquals($period2->weight, $period3PreviousPeriod->weight);
   }
 
+  public function testNextPeriodShouldReturnNullIfTheresNoNextPeriod() {
+    $period = $this->createBasicPeriod();
+    $this->assertNull($period->getNextPeriod());
+  }
+
+  public function testNextPeriodShouldReturnAnAbsencePeriodInstanceWhenThereIsANextPeriod() {
+    $period1 = $this->createBasicPeriod([
+      'start_date' => CRM_Utils_Date::processDate('2015-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2015-01-02')
+    ]);
+
+    $period2 = $this->createBasicPeriod([
+      'start_date' => CRM_Utils_Date::processDate('2015-01-03'),
+      'end_date'   => CRM_Utils_Date::processDate('2015-01-04')
+    ]);
+
+    $period3 = $this->createBasicPeriod([
+      'start_date' => CRM_Utils_Date::processDate('2015-01-05'),
+      'end_date'   => CRM_Utils_Date::processDate('2015-01-06')
+    ]);
+
+    $period1NextPeriod = $period1->getNextPeriod();
+    $period2 = $this->findPeriodByID($period2->id);
+    $this->assertInstanceOf('CRM_HRLeaveAndAbsences_BAO_AbsencePeriod', $period1NextPeriod);
+    $this->assertEquals($period2->id, $period1NextPeriod->id);
+    $this->assertEquals($period2->title, $period1NextPeriod->title);
+    $this->assertEquals($period2->start_date, $period1NextPeriod->start_date);
+    $this->assertEquals($period2->end_date, $period1NextPeriod->end_date);
+    $this->assertEquals($period2->weight, $period1NextPeriod->weight);
+
+    $period2NextPeriod = $period2->getNextPeriod();
+    $period3 = $this->findPeriodByID($period3->id);
+    $this->assertInstanceOf('CRM_HRLeaveAndAbsences_BAO_AbsencePeriod', $period2NextPeriod);
+    $this->assertEquals($period3->id, $period2NextPeriod->id);
+    $this->assertEquals($period3->title, $period2NextPeriod->title);
+    $this->assertEquals($period3->start_date, $period2NextPeriod->start_date);
+    $this->assertEquals($period3->end_date, $period2NextPeriod->end_date);
+    $this->assertEquals($period3->weight, $period2NextPeriod->weight);
+  }
+
   public function testExpirationDateForAbsenceTypeWithoutCarryForwardShouldBeNull()
   {
     $type = new CRM_HRLeaveAndAbsences_BAO_AbsenceType();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/ContractEntitlementCalculationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/ContractEntitlementCalculationTest.php
@@ -1,0 +1,367 @@
+<?php
+require_once __DIR__."/ContractHelpersTrait.php";
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+use CRM_HRLeaveAndAbsences_ContractEntitlementCalculation as ContractEntitlementCalculation;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHoliday as PublicHolidayFabricator;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_EntitlementCalculationTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_ContractEntitlementCalculationTest extends PHPUnit_Framework_TestCase implements
+  HeadlessInterface, TransactionalInterface {
+
+  use CRM_HRLeaveAndAbsences_ContractHelpersTrait;
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+                     ->installMe(__DIR__)
+                     ->install('org.civicrm.hrjobcontract')
+                     ->apply();
+    $jobContractUpgrader = CRM_Hrjobcontract_Upgrader::instance();
+    $jobContractUpgrader->install();
+  }
+
+  public function setUp() {
+    $this->createContract();
+  }
+
+  public function testProRataShouldBeZeroIfThereIsNoContractualEntitlement() {
+    $this->contract['period_start_date'] = '2016-03-10';
+    $this->contract['period_end_date'] = '2016-09-23';
+
+    $type = AbsenceTypeFabricator::fabricate();
+
+    $period = $this->getAbsencePeriodMock([
+      'getNumberOfWorkingDays' => [
+        'willReturn' => 261
+      ],
+      'getNumberOfWorkingDaysToWork' => [
+        'withParams' => [
+          $this->contract['period_start_date'],
+          $this->contract['period_end_date']
+        ],
+        'willReturn' => 142
+      ]
+    ]);
+
+    $calculation = new ContractEntitlementCalculation($period, $this->contract, $type);
+
+    // 0 * (142/261) = 0
+    $this->assertEquals(0, $calculation->getProRata());
+  }
+
+  public function testProRataShouldNotIncludePublicHolidaysBetweenContractDatesEvenIfContractSaysPublicHolidaysShouldBeAdded() {
+    $this->contract['period_start_date'] = '2016-03-10';
+    $this->contract['period_end_date'] = '2016-09-23';
+
+    $type = AbsenceTypeFabricator::fabricate();
+
+    $period = $this->getAbsencePeriodMock([
+      'getNumberOfWorkingDays' => [
+        'willReturn' => 260
+      ],
+      'getNumberOfWorkingDaysToWork' => [
+        'withParams' => [
+          $this->contract['period_start_date'],
+          $this->contract['period_end_date']
+        ],
+        'willReturn' => 141
+      ]
+    ]);
+
+    $this->createJobLeaveEntitlement($type, 20, true);
+
+    // This is between the contract dates, but will not be included
+    PublicHolidayFabricator::fabricate([
+      'date' => date('YmdHis', strtotime('2016-05-18'))
+    ]);
+
+    $calculation = new ContractEntitlementCalculation($period, $this->contract, $type);
+
+    // 20 * (141/260) = 10.84 (If public holidays were included, this would be 11.84)
+    $this->assertEquals((20 * (141/260)), $calculation->getProRata());
+  }
+
+  public function testNumberOfWorkingDaysShouldBeTheNumberOfWorkingDaysInTheCalculationAbsencePeriod() {
+    $period = $this->getAbsencePeriodMock([
+      'getNumberOfWorkingDays' => [
+        'willReturn' => 260
+      ]
+    ]);
+
+    $calculation = new ContractEntitlementCalculation($period, [], new AbsenceType());
+
+    $this->assertEquals(260, $calculation->getNumberOfWorkingDays());
+  }
+
+  public function testNumberOfWorkingDaysToWorkShouldBeTheNumberOfWorkingDaysBetweenTheContractDates() {
+    $this->contract['period_start_date'] = '2016-03-10';
+    $this->contract['period_end_date'] = '2016-09-23';
+
+    $period = $this->getAbsencePeriodMock([
+      'getNumberOfWorkingDaysToWork' => [
+        'withParams' => [
+          $this->contract['period_start_date'],
+          $this->contract['period_end_date']
+        ],
+        'willReturn' => 150
+      ]
+    ]);
+
+    $calculation = new ContractEntitlementCalculation($period, $this->contract, new AbsenceType());
+
+    $this->assertEquals(150, $calculation->getNumberOfWorkingDaysToWork());
+  }
+
+  public function testContractualEntitlementShouldBeZeroIfThereIsNoContractualEntitlement() {
+    $calculation = new ContractEntitlementCalculation(new AbsencePeriod(), $this->contract, new AbsenceType());
+
+    $this->assertEquals(0, $calculation->getContractualEntitlement());
+  }
+
+  public function testContractualEntitlementShouldBeTheLeaveAmountInJobLeave() {
+    $type = AbsenceTypeFabricator::fabricate();
+    $this->createJobLeaveEntitlement($type, 17);
+
+    $calculation = new ContractEntitlementCalculation(new AbsencePeriod(), $this->contract, $type);
+
+    $this->assertEquals(17, $calculation->getContractualEntitlement());
+  }
+
+  public function testNumberOfPublicHolidaysInEntitlementShouldBeZeroIfThereIsNoContractualEntitlement() {
+    $calculation = new ContractEntitlementCalculation(new AbsencePeriod(), $this->contract, new AbsenceType());
+
+    $this->assertEquals(0, $calculation->getNumberOfPublicHolidaysInEntitlement());
+  }
+
+  public function testNumberOfPublicHolidaysInEntitlementShouldBeZeroIfTheContractDoesntAllowThemToBeAdded() {
+    $this->contract['period_start_date'] = '2016-03-10';
+    $this->contract['period_end_date'] = '2016-09-23';
+
+    $type = AbsenceTypeFabricator::fabricate();
+    $allowPublicHolidays = false;
+    $this->createJobLeaveEntitlement($type, 17, $allowPublicHolidays);
+
+    //Is between contract dates but will not be included
+    PublicHolidayFabricator::fabricate([
+      'date' => date('YmdHis', strtotime('2016-03-11'))
+    ]);
+
+    $calculation = new ContractEntitlementCalculation(new AbsencePeriod(), $this->contract, $type);
+
+    $this->assertEquals(0, $calculation->getNumberOfPublicHolidaysInEntitlement());
+  }
+
+  public function testNumberOfPublicHolidaysInEntitlementShouldBeZeroIfTheContractAllowsThemToBeAddedButTheresNoneBetweenTheContractDates() {
+    $this->contract['period_start_date'] = '2016-03-10';
+    $this->contract['period_end_date'] = '2016-09-23';
+
+    $type = AbsenceTypeFabricator::fabricate();
+    $allowPublicHolidays = true;
+    $this->createJobLeaveEntitlement($type, 17, $allowPublicHolidays);
+
+    //Before the start date. Will not be included
+    PublicHolidayFabricator::fabricate([
+      'date' => date('YmdHis', strtotime('2016-03-09'))
+    ]);
+
+    //After the end date. Will not be included
+    PublicHolidayFabricator::fabricate([
+      'date' => date('YmdHis', strtotime('2016-09-24'))
+    ]);
+
+    $calculation = new ContractEntitlementCalculation(new AbsencePeriod(), $this->contract, $type);
+
+    $this->assertEquals(0, $calculation->getNumberOfPublicHolidaysInEntitlement());
+  }
+
+  public function testNumberOfPublicHolidaysInEntitlementShouldBeTheNumberOfPublicHolidaysBetweenTheContractDates() {
+    $this->contract['period_start_date'] = '2016-03-10';
+    $this->contract['period_end_date'] = '2016-09-23';
+
+    $type = AbsenceTypeFabricator::fabricate();
+    $allowPublicHolidays = true;
+    $this->createJobLeaveEntitlement($type, 17, $allowPublicHolidays);
+
+    PublicHolidayFabricator::fabricate([
+      'date' => date('YmdHis', strtotime('2016-03-14'))
+    ]);
+
+    PublicHolidayFabricator::fabricate([
+      'date' => date('YmdHis', strtotime('2016-08-23'))
+    ]);
+
+    $calculation = new ContractEntitlementCalculation(new AbsencePeriod(), $this->contract, $type);
+
+    $this->assertEquals(2, $calculation->getNumberOfPublicHolidaysInEntitlement());
+  }
+
+  public function testPublicHolidaysInEntitlementShouldBeEmptyIfThereIsNoContractualEntitlement() {
+    $calculation = new ContractEntitlementCalculation(new AbsencePeriod(), $this->contract, new AbsenceType());
+
+    $this->assertEmpty($calculation->getPublicHolidaysInEntitlement());
+  }
+
+  public function testPublicHolidaysInEntitlementShouldBeEmptyIfTheContractDoesntAllowThemToBeAdded() {
+    $this->contract['period_start_date'] = '2016-03-10';
+    $this->contract['period_end_date'] = '2016-09-23';
+
+    $type = AbsenceTypeFabricator::fabricate();
+    $allowPublicHolidays = false;
+    $this->createJobLeaveEntitlement($type, 17, $allowPublicHolidays);
+
+    //Is between contract dates but will not be included
+    PublicHolidayFabricator::fabricate([
+      'date' => date('YmdHis', strtotime('2016-03-11'))
+    ]);
+
+    $calculation = new ContractEntitlementCalculation(new AbsencePeriod(), $this->contract, $type);
+
+    $this->assertEmpty($calculation->getPublicHolidaysInEntitlement());
+  }
+
+  public function testPublicHolidaysInEntitlementShouldBeEmptyIfTheContractAllowsThemToBeAddedButTheresNoneBetweenTheContractDates() {
+    $this->contract['period_start_date'] = '2016-03-10';
+    $this->contract['period_end_date'] = '2016-09-23';
+
+    $type = AbsenceTypeFabricator::fabricate();
+    $allowPublicHolidays = true;
+    $this->createJobLeaveEntitlement($type, 17, $allowPublicHolidays);
+
+    //Before the start date. Will not be included
+    PublicHolidayFabricator::fabricate([
+      'date' => date('YmdHis', strtotime('2016-03-09'))
+    ]);
+
+    //After the end date. Will not be included
+    PublicHolidayFabricator::fabricate([
+      'date' => date('YmdHis', strtotime('2016-09-24'))
+    ]);
+
+    $calculation = new ContractEntitlementCalculation(new AbsencePeriod(), $this->contract, $type);
+
+    $this->assertEmpty($calculation->getPublicHolidaysInEntitlement());
+  }
+
+  public function testPublicHolidaysInEntitlementShouldReturnThePublicHolidaysBetweenTheContractDates() {
+    $this->contract['period_start_date'] = '2016-03-10';
+    $this->contract['period_end_date'] = '2016-09-23';
+
+    $type = AbsenceTypeFabricator::fabricate();
+    $allowPublicHolidays = true;
+    $this->createJobLeaveEntitlement($type, 17, $allowPublicHolidays);
+
+    $publicHoliday1 = PublicHolidayFabricator::fabricate([
+      'date' => date('YmdHis', strtotime('2016-03-14'))
+    ]);
+
+    $publicHoliday2 = PublicHolidayFabricator::fabricate([
+      'date' => date('YmdHis', strtotime('2016-08-23'))
+    ]);
+
+    $calculation = new ContractEntitlementCalculation(new AbsencePeriod(), $this->contract, $type);
+
+    $publicHolidays = $calculation->getPublicHolidaysInEntitlement();
+    $this->assertCount(2, $publicHolidays);
+    $this->assertEquals($publicHoliday1->title, $publicHolidays[0]->title);
+    $this->assertEquals($publicHoliday2->title, $publicHolidays[1]->title);
+  }
+
+  public function testTotalEntitlementShouldBeProRataPlusNumberOfPublicHolidays() {
+    $this->contract['period_start_date'] = '2016-03-10';
+    $this->contract['period_end_date'] = '2016-09-23';
+
+    $type = AbsenceTypeFabricator::fabricate();
+
+    $period = $this->getAbsencePeriodMock([
+      'getNumberOfWorkingDays' => [
+        'expects' => $this->exactly(2),
+        'willReturn' => 260
+      ],
+      'getNumberOfWorkingDaysToWork' => [
+        'expects' => $this->exactly(2),
+        'withParams' => [
+          $this->contract['period_start_date'],
+          $this->contract['period_end_date']
+        ],
+        'willReturn' => 141
+      ]
+    ]);
+
+    $this->createJobLeaveEntitlement($type, 20, true);
+
+    PublicHolidayFabricator::fabricate([
+      'date' => date('YmdHis', strtotime('2016-05-18'))
+    ]);
+
+    $calculation = new ContractEntitlementCalculation($period, $this->contract, $type);
+
+    // 20 * (141/260) = 10.84 (If public holidays were included, this would be 11.84)
+    $expectedProRata = (20 * (141/260));
+    $this->assertEquals($expectedProRata, $calculation->getProRata());
+
+    $expectedNumberOfPublicHolidays = 1;
+    $this->assertEquals($expectedNumberOfPublicHolidays, $calculation->getNumberOfPublicHolidaysInEntitlement());
+
+    $expectedTotalEntitlement = $expectedProRata + $expectedNumberOfPublicHolidays;
+    $this->assertEquals($expectedTotalEntitlement, $calculation->getTotalEntitlement());
+  }
+
+  public function testGetContractStartDateReturnsTheContractPeriodStartDate() {
+    $this->contract['period_start_date'] = '2016-01-01';
+
+    $calculation = new ContractEntitlementCalculation(new AbsencePeriod(), $this->contract, new Absencetype());
+    $this->assertEquals($this->contract['period_start_date'], $calculation->getContractStartDate());
+  }
+
+  public function testGetContractEndDateReturnsTheContractPeriodEndDate() {
+    $this->contract['period_end_date'] = '2016-10-01';
+
+    $calculation = new ContractEntitlementCalculation(new AbsencePeriod(), $this->contract, new Absencetype());
+    $this->assertEquals($this->contract['period_end_date'], $calculation->getContractEndDate());
+  }
+
+  private function createJobLeaveEntitlement($type, $leaveAmount, $addPublicHolidays = false) {
+    CRM_Hrjobcontract_BAO_HRJobLeave::create([
+      'jobcontract_id' => $this->contract['id'],
+      'leave_type' => $type->id,
+      'leave_amount' => $leaveAmount,
+      'add_public_holidays' => $addPublicHolidays ? '1' : '0'
+    ]);
+  }
+
+  private function getAbsencePeriodMock($settings) {
+    $methodsToMock = array_keys($settings);
+
+    $period = $this->getMockBuilder(AbsencePeriod::class)
+                   ->setMethods($methodsToMock)
+                   ->getMock();
+
+    foreach($settings as $methodName => $methodSettings) {
+      if(array_key_exists('expects', $methodSettings)) {
+        $expects = $methodSettings['expects'];
+      } else {
+        $expects = $this->once();
+      }
+      $method = $period->expects($expects)
+            ->method($methodName);
+
+      if(array_key_exists('willReturn', $methodSettings)) {
+        $method->will($this->returnValue($methodSettings['willReturn']));
+      }
+
+      if(array_key_exists('withParams', $methodSettings)) {
+        call_user_func_array(array($method, 'with'), $methodSettings['withParams']);
+      }
+    }
+
+    return $period;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
@@ -116,6 +116,33 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
     $this->assertEquals(0, $calculation->getBroughtForward());
   }
 
+  public function testBroughtForwardShouldBeZeroIfThePreviousPeriodIsNotOverYet() {
+    // never expires
+    $type = $this->createAbsenceType([
+      'max_number_of_days_to_carry_forward' => 50,
+    ]);
+
+    $previousPeriod = AbsencePeriod::create([
+      'title' => 'Period 1',
+      'start_date' => date('YmdHis', strtotime('-7 days')),
+      'end_date' => date('YmdHis', strtotime('+5 days')),
+    ]);
+
+    $currentPeriod = AbsencePeriod::create([
+      'title' => 'Period 2',
+      'start_date' => date('YmdHis', strtotime('+6 days')),
+      'end_date' => date('YmdHis', strtotime('+10 days')),
+    ]);
+
+    //Load the period from the database to get the dates back in Y-m-d format.
+    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+
+    $this->createEntitlement($previousPeriod, $type);
+
+    $calculation = new EntitlementCalculation($currentPeriod, $this->contact, $type);
+    $this->assertEquals(0, $calculation->getBroughtForward());
+  }
+
   public function testBroughtForwardShouldNotBeMoreThanTheMaxNumberOfDaysAllowedToBeCarriedForward() {
     $this->setContractDates(date('YmdHis', strtotime('-2 days')), null);
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
@@ -732,62 +732,6 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
     $this->assertEquals($contact, $calculation->getContact());
   }
 
-//  public function testCalculationCanReturnItsStringRepresentation()
-//  {
-//    // To simplify the code, we use an Absence where the carried
-//    // forward never expires
-//    $type = $this->createAbsenceType([
-//      'max_number_of_days_to_carry_forward' => 5,
-//    ]);
-//
-//    $previousPeriod = AbsencePeriod::create([
-//      'title' => 'Period 1',
-//      'start_date' => date('YmdHis', strtotime('2015-01-01')),
-//      'end_date' => date('YmdHis', strtotime('2015-12-31')),
-//    ]);
-//
-//    // Set the previous period entitlement as 20 days
-//    $this->createEntitlement($previousPeriod, $type, 20);
-//
-//    // 261 working days - 2 public holidays = 259 working days
-//    $currentPeriod = AbsencePeriod::create([
-//      'title' => 'Period 2',
-//      'start_date' => date('YmdHis', strtotime('2016-01-01')),
-//      'end_date' => date('YmdHis', strtotime('2016-12-31')),
-//    ]);
-//    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
-//    PublicHoliday::create([
-//      'title' => 'Holiday 1',
-//      'date' => date('YmdHis', strtotime('2016-01-21'))
-//    ]);
-//    PublicHoliday::create([
-//      'title' => 'Holiday 2',
-//      'date' => date('YmdHis', strtotime('2016-03-16'))
-//    ]);
-//
-//    // Set the contractual entitlement as 20 days
-//    $this->createJobLeaveEntitlement($type, 20, true);
-//
-//    // 62 days to work (64 - the 2 public holidays)
-//    $this->setContractDates(
-//      date('YmdHis', strtotime('2016-01-01')),
-//      date('YmdHis', strtotime('2016-03-30'))
-//    );
-//
-//    $calculation = new EntitlementCalculation($currentPeriod, $this->contact, $type);
-//
-//    //Contractual Entitlement = 20
-//    //Number of Public Holidays = 2
-//    //Number of days to work = 62
-//    //Number of working days = 259
-//    //Pro rata = 5.5
-//    //Brought forward = 5
-//    //Proposed Entitlement = 10.5
-//    $expected = '((20 + 2) * (62 / 259)) = (5.5) + (5) = 10.5 days';
-//    $calculationDetails = sprintf('%s', $calculation);
-//    $this->assertEquals($expected, $calculationDetails);
-//  }
-
   public function testCalculationCanUseTheAbsencePeriodToCalculateTheBroughtForwardExpirationDate() {
     $absenceType = new AbsenceType();
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
@@ -4,13 +4,14 @@ require_once __DIR__."/ContractHelpersTrait.php";
 
 use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
-use CRM_Hrjobcontract_BAO_HRJobContract as JobContract;
 use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
 use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 use CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement as LeavePeriodEntitlement;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
-use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
 use CRM_HRLeaveAndAbsences_EntitlementCalculation as EntitlementCalculation;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHoliday as PublicHolidayFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod as AbsencePeriodFabricator;
 
 /**
  * Class CRM_HRLeaveAndAbsences_EntitlementCalculationTest
@@ -52,10 +53,9 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
 
   public function testBroughtForwardShouldBeZeroIfTheresNoPreviousPeriod()
   {
-    $type = $this->createAbsenceType();
+    $type = AbsenceTypeFabricator::fabricate();
 
-    $period = AbsencePeriod::create([
-      'title' => 'Period 1',
+    $period = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'end_date' => CRM_Utils_Date::processDate('2016-12-31'),
     ]);
@@ -66,16 +66,14 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
 
   public function testBroughtForwardShouldBeZeroIfThereIsNoEntitlementForPreviousPeriod()
   {
-    $type = $this->createAbsenceType();
+    $type = AbsenceTypeFabricator::fabricate();
 
-    AbsencePeriod::create([
-      'title' => 'Period 1',
+    AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2015-01-01'),
       'end_date' => CRM_Utils_Date::processDate('2015-12-31'),
     ]);
 
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 2',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'end_date' => CRM_Utils_Date::processDate('2016-12-31'),
     ]);
@@ -86,14 +84,13 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
 
   public function testBroughtForwardShouldBeZeroIfExpirationDurationHasExpired()
   {
-    $type = $this->createAbsenceType([
+    $type = AbsenceTypeFabricator::fabricate([
       'max_number_of_days_to_carry_forward' => 50,
       'carry_forward_expiration_unit'       => AbsenceType::EXPIRATION_UNIT_DAYS,
       'carry_forward_expiration_duration'   => 5
     ]);
 
-    $previousPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
+    $previousPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('-7 days')),
       'end_date' => date('YmdHis', strtotime('-6 days')),
     ]);
@@ -101,14 +98,10 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
     // The absence type says brought forward should expire in 5 days,
     // so we set the period start date to 5 days ago. Since the expiration date
     // is based on the period start date, it will be considered to have expired
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 2',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('-5 days')),
       'end_date' => date('YmdHis', strtotime('now')),
-    ]);
-
-    //Load the period from the database to get the dates back in Y-m-d format.
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     $this->createEntitlement($previousPeriod, $type);
 
@@ -118,24 +111,19 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
 
   public function testBroughtForwardShouldBeZeroIfThePreviousPeriodIsNotOverYet() {
     // never expires
-    $type = $this->createAbsenceType([
+    $type = AbsenceTypeFabricator::fabricate([
       'max_number_of_days_to_carry_forward' => 50,
     ]);
 
-    $previousPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
+    $previousPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('-7 days')),
       'end_date' => date('YmdHis', strtotime('+5 days')),
     ]);
 
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 2',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('+6 days')),
       'end_date' => date('YmdHis', strtotime('+10 days')),
-    ]);
-
-    //Load the period from the database to get the dates back in Y-m-d format.
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     $this->createEntitlement($previousPeriod, $type);
 
@@ -146,22 +134,19 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   public function testBroughtForwardShouldNotBeMoreThanTheMaxNumberOfDaysAllowedToBeCarriedForward() {
     $this->setContractDates(date('YmdHis', strtotime('-2 days')), null);
 
-    $type = $this->createAbsenceType([
+    $type = AbsenceTypeFabricator::fabricate([
       'max_number_of_days_to_carry_forward' => 5
     ]);
 
-    $previousPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
+    $previousPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('-2 days')),
       'end_date' => date('YmdHis', strtotime('-1 day')),
     ]);
 
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 2',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis'),
       'end_date' => date('YmdHis', strtotime('+1 day')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     $this->createEntitlement($previousPeriod, $type, 10);
 
@@ -178,22 +163,19 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   public function testBroughtForwardShouldNotBeMoreThanTheNumberOfRemainingDaysInPreviousEntitlement() {
     $this->setContractDates(date('YmdHis', strtotime('-2 days')), null);
 
-    $type = $this->createAbsenceType([
+    $type = AbsenceTypeFabricator::fabricate([
       'max_number_of_days_to_carry_forward' => 5
     ]);
 
-    $previousPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
+    $previousPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('-2 days')),
       'end_date' => date('YmdHis', strtotime('-1 day')),
     ]);
 
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 2',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis'),
       'end_date' => date('YmdHis', strtotime('+1 day')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     $this->createEntitlement($previousPeriod, $type, 3);
 
@@ -209,12 +191,10 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   public function testProRataShouldBeZeroIfTheContactHasNoContracts() {
     $type = new AbsenceType();
 
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 2',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis'),
       'end_date' => date('YmdHis', strtotime('+1 day')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     //A non-existing contact, which will have no contracts
     $contact = ['id' => 5321];
@@ -226,27 +206,23 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   public function testProRataShouldBeZeroIfTheContractDoesntHaveStartAndEndDates() {
     $type = new AbsenceType();
 
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 2',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis'),
       'end_date' => date('YmdHis', strtotime('+1 day')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     $calculation = new EntitlementCalculation($currentPeriod, $this->contact, $type);
     $this->assertEquals(0, $calculation->getProRata());
   }
 
   public function testProRataShouldBeRoundedToTheNearestHalfDay() {
-    $type = $this->createAbsenceType();
+    $type = AbsenceTypeFabricator::fabricate();
 
     // 261 working days
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 2',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2016-01-01')),
       'end_date' => date('YmdHis', strtotime('2016-12-31')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     // 21 days to work
     $this->setContractDates(
@@ -283,15 +259,13 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   }
 
   public function testProRataShouldNotIncludePublicHolidaysBetweenContractDatesEvenIfContractSaysPublicHolidaysShouldBeAdded() {
-    $type = $this->createAbsenceType();
+    $type = AbsenceTypeFabricator::fabricate();
 
     // 261 working days
-    $period = AbsencePeriod::create([
-      'title' => 'Period 1',
+    $period = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2016-01-01')),
       'end_date' => date('YmdHis', strtotime('2016-12-31')),
-    ]);
-    $period = $this->findAbsencePeriodByID($period->id);
+    ], true);
 
     // 141 working days to work (142 - 1 public holiday)
     $this->setContractDates(
@@ -301,8 +275,7 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
     $this->createJobLeaveEntitlement($type, 20, true);
 
     // This is between the contract dates, but will not be included
-    PublicHoliday::create([
-      'title' => 'Public Holiday 2',
+    PublicHolidayFabricator::fabricate([
       'date' => date('YmdHis', strtotime('2016-05-18'))
     ]);
 
@@ -313,18 +286,16 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   }
 
   public function testProRataShouldBeTheSumOfTheProRataForEachContractDuringTheAbsencePeriod() {
-    $type = $this->createAbsenceType();
+    $type = AbsenceTypeFabricator::fabricate();
 
     // Delete the contract created during setUp
     civicrm_api3('HRJobContract', 'deletecontract', ['id' => $this->contract['id']]);
 
     // 261 working days
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2016-01-01')),
       'end_date' => date('YmdHis', strtotime('2016-12-31')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     // 62 working days
     // 3 days of contractual entitlement
@@ -369,15 +340,11 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   }
 
   public function testTheProposedEntitlementForAContactWithoutAContractShouldBeZero() {
-    $type = $this->createAbsenceType();
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
+    $type = AbsenceTypeFabricator::fabricate();
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis'),
       'end_date' => date('YmdHis', strtotime('+1 days'))
-    ]);
-    // We need to load the period from the database to get the dates in the
-    // expected format: Y-m-d
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     // a contact without any contract
     $contact = ['id' => 3453];
@@ -387,29 +354,21 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   }
 
   public function testTheProposedEntitlementForAContractWithoutStartAndEndDatesShouldBeZero() {
-    $type = $this->createAbsenceType();
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
-      'start_date' => date('YmdHis'),
-      'end_date' => date('YmdHis', strtotime('+1 days'))
-    ]);
-    // We need to load the period from the database to get the dates in the
-    // expected format: Y-m-d
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    $type = AbsenceTypeFabricator::fabricate();
+    $currentPeriod = AbsencePeriodFabricator::fabricate([], true);
+
     $calculation = new EntitlementCalculation($currentPeriod, $this->contact, $type);
     $this->assertEquals(0, $calculation->getProposedEntitlement());
   }
 
   public function testTheProposedEntitlementForAPeriodWithPreviouslyOverriddenEntitlementShouldNotBeTheTheOverriddenValue() {
-    $type = $this->createAbsenceType();
+    $type = AbsenceTypeFabricator::fabricate();
     $startDate = date('YmdHis', strtotime('2016-01-01'));
     $endDate = date('YmdHis', strtotime('2016-04-01'));
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => $startDate,
       'end_date' => $endDate
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     // Set the contractual entitlement as 10 days
     $this->createJobLeaveEntitlement($type, 10);
@@ -432,12 +391,11 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   {
     // To simplify the code, we use an Absence where the carried
     // forward never expires
-    $type = $this->createAbsenceType([
+    $type = AbsenceTypeFabricator::fabricate([
       'max_number_of_days_to_carry_forward' => 20,
     ]);
 
-    $previousPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
+    $previousPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2015-01-01')),
       'end_date' => date('YmdHis', strtotime('2015-12-31')),
     ]);
@@ -446,12 +404,10 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
     $this->createEntitlement($previousPeriod, $type, 10);
 
     // 261 working days
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 2',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2016-01-01')),
       'end_date' => date('YmdHis', strtotime('2016-12-31')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     // Set the contractual entitlement as 10 days
     $this->createJobLeaveEntitlement($type, 10);
@@ -484,17 +440,15 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   }
 
   public function testProposedEntitlementShouldIncludePublicHolidaysBetweenContractsWhereTheyShouldBeAdded() {
-    $type = $this->createAbsenceType([
+    $type = AbsenceTypeFabricator::fabricate([
       'max_number_of_days_to_carry_forward' => 20,
     ]);
 
     // 261 working days
-    $currentPeriod = AbsencePeriod::create([
-      'title'      => 'Period 2',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2016-01-01')),
       'end_date'   => date('YmdHis', strtotime('2016-12-31')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     // Set the contractual entitlement as 10 days
     $this->createJobLeaveEntitlement($type, 10, TRUE);
@@ -506,28 +460,24 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
     );
 
     // This will not be included since it's before the contract start date
-    PublicHoliday::create([
-      'title' => 'Holiday 1',
+    PublicHolidayFabricator::fabricate([
       'date'  => date('YmdHis', strtotime('2015-01-01'))
     ]);
 
     // This will be included since it's between the contract dates
-    PublicHoliday::create([
-      'title' => 'Holiday 2',
+    PublicHolidayFabricator::fabricate([
       'date'  => date('YmdHis', strtotime('2016-01-01'))
     ]);
 
     // This will not be included since it's after the contract start date
-    PublicHoliday::create([
-      'title' => 'Holiday 3',
+    PublicHolidayFabricator::fabricate([
       'date'  => date('YmdHis', strtotime('2016-05-04'))
     ]);
 
     // Working days in Period = 261 - 3 (public holidays) = 259
     // Working days to work = 64 - 1 (the single public holiday between contract dates) = 63
     // (63/259) * 10 = 2.43 = 2.5 rounded
-    $calculation = new EntitlementCalculation($currentPeriod, $this->contact,
-      $type);
+    $calculation = new EntitlementCalculation($currentPeriod, $this->contact, $type);
     $this->assertEquals(2.5, $calculation->getProRata());
 
     // Number of days brought from previous period: 0 (No previous period)
@@ -543,30 +493,16 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   }
 
   public function testGetOverriddenEntitlementShouldBeZeroIfTheresNoPreviousPeriodEntitlement() {
-    $type = $this->createAbsenceType();
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
-      'start_date' => date('YmdHis'),
-      'end_date' => date('YmdHis', strtotime('+1 days'))
-    ]);
-    // We need to load the period from the database to get the dates in the
-    // expected format: Y-m-d
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    $type = AbsenceTypeFabricator::fabricate();
+    $currentPeriod = AbsencePeriodFabricator::fabricate([], true);
 
     $calculation = new EntitlementCalculation($currentPeriod, $this->contact, $type);
     $this->assertEquals(0, $calculation->getOverriddenEntitlement());
   }
 
   public function testGetOverriddenEntitlementShouldBeZeroIfThePreviousPeriodEntitlementIsNotOverridden() {
-    $type = $this->createAbsenceType();
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
-      'start_date' => date('YmdHis'),
-      'end_date' => date('YmdHis', strtotime('+1 days'))
-    ]);
-    // We need to load the period from the database to get the dates in the
-    // expected format: Y-m-d
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    $type = AbsenceTypeFabricator::fabricate();
+    $currentPeriod = AbsencePeriodFabricator::fabricate([], true);
 
     $this->createEntitlement($currentPeriod, $type, 10);
 
@@ -575,15 +511,8 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   }
 
   public function testGetOverriddenEntitlementShouldShouldBeTheOverriddenValueIfThePreviousPeriodEntitlementIsOverridden() {
-    $type = $this->createAbsenceType();
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
-      'start_date' => date('YmdHis'),
-      'end_date' => date('YmdHis', strtotime('+1 days'))
-    ]);
-    // We need to load the period from the database to get the dates in the
-    // expected format: Y-m-d
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    $type = AbsenceTypeFabricator::fabricate();
+    $currentPeriod = AbsencePeriodFabricator::fabricate([], true);
 
     $this->createEntitlement($currentPeriod, $type, 10, 50);
 
@@ -593,14 +522,12 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
 
   public function testPreviousPeriodProposedEntitlementShouldBeZeroIfThereIsNoPreviousPeriod()
   {
-    $type = $this->createAbsenceType();
+    $type = AbsenceTypeFabricator::fabricate();
 
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 2',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2016-01-01')),
       'end_date' => date('YmdHis', strtotime('2016-12-31')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     $calculation = new EntitlementCalculation($currentPeriod, $this->contact, $type);
     $this->assertEquals(0, $calculation->getPreviousPeriodProposedEntitlement());
@@ -608,20 +535,17 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
 
   public function testPreviousPeriodProposedEntitlementShouldBeZeroIfThereIsNoEntitlementForThePreviousPeriod()
   {
-    $type = $this->createAbsenceType();
+    $type = AbsenceTypeFabricator::fabricate();
 
-    $previousPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
+    AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2015-01-01')),
       'end_date' => date('YmdHis', strtotime('2015-12-31')),
     ]);
 
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 2',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2016-01-01')),
       'end_date' => date('YmdHis', strtotime('2016-12-31')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     $calculation = new EntitlementCalculation($currentPeriod, $this->contact, $type);
     $this->assertEquals(0, $calculation->getPreviousPeriodProposedEntitlement());
@@ -629,20 +553,17 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
 
   public function testPreviousPeriodProposedEntitlementShouldReturnTheProposedEntitlement()
   {
-    $type = $this->createAbsenceType();
+    $type = AbsenceTypeFabricator::fabricate();
 
-    $previousPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
+    $previousPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2015-01-01')),
       'end_date' => date('YmdHis', strtotime('2015-12-31')),
     ]);
 
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 2',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2016-01-01')),
       'end_date' => date('YmdHis', strtotime('2016-12-31')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     $this->createEntitlement($previousPeriod, $type, 10);
 
@@ -659,40 +580,35 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   }
 
   public function testNumberOfDaysTakenOnThePreviousPeriodShouldBeZeroIfThereIsNoPeriodEntitlementForThePreviousPeriod() {
-    $type = $this->createAbsenceType();
+    $type = AbsenceTypeFabricator::fabricate();
 
-    $previousPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
+    AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2015-01-01')),
       'end_date' => date('YmdHis', strtotime('2015-12-31')),
     ]);
 
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 2',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2016-01-01')),
       'end_date' => date('YmdHis', strtotime('2016-12-31')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     $calculation = new EntitlementCalculation($currentPeriod, $this->contact, $type);
     $this->assertEquals(0, $calculation->getNumberOfDaysTakenOnThePreviousPeriod());
   }
 
   public function testNumberOfDaysTakenOnThePreviousPeriodShouldBeZeroIfThereAreNoLeaveRequestsOnThePeriod() {
-    $type = $this->createAbsenceType();
+    $type = AbsenceTypeFabricator::fabricate();
 
-    $previousPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
+    $previousPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2015-01-01')),
       'end_date' => date('YmdHis', strtotime('2015-12-31')),
     ]);
 
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 2',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2016-01-01')),
       'end_date' => date('YmdHis', strtotime('2016-12-31')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
+
     $this->createEntitlement($previousPeriod, $type, 10);
 
     $calculation = new EntitlementCalculation($currentPeriod, $this->contact, $type);
@@ -704,9 +620,8 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
 
     $this->setContractDates(date('YmdHis', strtotime('2015-01-01')), null);
 
-    $type = $this->createAbsenceType();
-    $previousPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
+    $type = AbsenceTypeFabricator::fabricate();
+    $previousPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2015-01-01')),
       'end_date' => date('YmdHis', strtotime('2015-12-31')),
     ]);
@@ -731,12 +646,10 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
       date('Y-m-d', strtotime('+41 days', $previousPeriodStartDateTimeStamp))
     );
 
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 2',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2016-01-01')),
       'end_date' => date('YmdHis', strtotime('2016-12-31')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     $calculation = new EntitlementCalculation($currentPeriod, $this->contact, $type);
     $this->assertEquals(12, $calculation->getNumberOfDaysTakenOnThePreviousPeriod());
@@ -744,13 +657,11 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
 
   public function testNumberOfDaysRemainingInThePreviousPeriodShouldBeZeroIfThereIsNoPreviousPeriod()
   {
-    $type = $this->createAbsenceType();
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 2',
+    $type = AbsenceTypeFabricator::fabricate();
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2016-01-01')),
       'end_date' => date('YmdHis', strtotime('2016-12-31')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     $calculation = new EntitlementCalculation($currentPeriod, $this->contact, $type);
     $this->assertEquals(0, $calculation->getNumberOfDaysRemainingInThePreviousPeriod());
@@ -761,20 +672,17 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
 
     $this->setContractDates(date('YmdHis', strtotime('2015-01-01')), null);
 
-    $type = $this->createAbsenceType();
+    $type = AbsenceTypeFabricator::fabricate();
 
-    $previousPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
+    $previousPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2015-01-01')),
       'end_date' => date('YmdHis', strtotime('2015-12-31')),
     ]);
 
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 2',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis', strtotime('2016-01-01')),
       'end_date' => date('YmdHis', strtotime('2016-12-31')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     $this->createEntitlement($previousPeriod, $type, 10);
 
@@ -907,14 +815,12 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   }
 
   public function testGetPublicHolidaysShouldReturnAListOfPublicHolidaysAddedToTheEntitlement() {
-    $type = $this->createAbsenceType();
+    $type = AbsenceTypeFabricator::fabricate();
 
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis'),
       'end_date' => date('YmdHis', strtotime('+50 days')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     $this->setContractDates(
       date('YmdHis', strtotime('-5 days')),
@@ -925,11 +831,11 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
     $addPublicHolidays = true;
     $this->createJobLeaveEntitlement($type, $leaveAmount, $addPublicHolidays);
 
-    $publicHoliday1 = PublicHoliday::create([
+    $publicHoliday1 = PublicHolidayFabricator::fabricate([
       'title' => 'Holiday 1',
       'date' => date('YmdHis', strtotime('+1 day'))
     ]);
-    $publicHoliday2 = PublicHoliday::create([
+    $publicHoliday2 = PublicHolidayFabricator::fabricate([
       'title' => 'Holiday 2',
       'date' => date('YmdHis', strtotime('+3 days'))
     ]);
@@ -943,14 +849,12 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   }
 
   public function testGetPublicHolidaysShouldOnlyReturnPublicHolidaysWithDatesBetweenTheContractDatesAndAbsencePeriod() {
-    $type = $this->createAbsenceType();
+    $type = AbsenceTypeFabricator::fabricate();
 
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis'),
       'end_date' => date('YmdHis', strtotime('+50 days')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     // The contract starts 5 days prior to the AbsencePeriod and
     // ends before the AbsencePeriod
@@ -965,22 +869,20 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
 
     // This is between both the AbsencePeriod and the Contract dates,
     // so it should be returned
-    $publicHoliday1 = PublicHoliday::create([
+    $publicHoliday1 = PublicHolidayFabricator::fabricate([
       'title' => 'Holiday 1',
       'date' => date('YmdHis', strtotime('+1 day'))
     ]);
 
     // This is between the contract dates but prior to the AbsencePeriod
     // start_date, so it shouldn't be returned
-    $publicHoliday2 = PublicHoliday::create([
-      'title' => 'Holiday 2',
+    PublicHolidayFabricator::fabricate([
       'date' => date('YmdHis', strtotime('-3 days'))
     ]);
 
     // This is between the AbsencePeriod dates but after the contract end date,
     // so it shouldn't be returned
-    PublicHoliday::create([
-      'title' => 'Holiday 3',
+    PublicHolidayFabricator::fabricate([
       'date' => date('YmdHis', strtotime('+31 days'))
     ]);
 
@@ -992,22 +894,19 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   }
 
   public function testGetPublicHolidaysShouldReturnEmptyIfTheContractHasNoJobLeaveInformation() {
-    $type = $this->createAbsenceType();
+    $type = AbsenceTypeFabricator::fabricate();
 
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis'),
       'end_date' => date('YmdHis', strtotime('+50 days')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     $this->setContractDates(
       date('YmdHis'),
       date('YmdHis', strtotime('+30 days'))
     );
 
-    PublicHoliday::create([
-      'title' => 'Holiday 1',
+    PublicHolidayFabricator::fabricate([
       'date' => date('YmdHis', strtotime('+1 day'))
     ]);
 
@@ -1018,14 +917,12 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   }
 
   public function testGetPublicHolidaysShouldReturnEmptyIfJobLeaveDoesNotAllowPublicHolidaysToBeAdded() {
-    $type = $this->createAbsenceType();
+    $type = AbsenceTypeFabricator::fabricate();
 
-    $currentPeriod = AbsencePeriod::create([
-      'title' => 'Period 1',
+    $currentPeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => date('YmdHis'),
       'end_date' => date('YmdHis', strtotime('+50 days')),
-    ]);
-    $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
+    ], true);
 
     $leaveAmount = 10;
     $addPublicHolidays = false;
@@ -1036,8 +933,7 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
       date('YmdHis', strtotime('+30 days'))
     );
 
-    PublicHoliday::create([
-      'title' => 'Holiday 1',
+    PublicHolidayFabricator::fabricate([
       'date' => date('YmdHis', strtotime('+1 day'))
     ]);
 
@@ -1048,12 +944,8 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   }
 
   public function testIsCurrentPeriodEntitlementOverriddenShouldBeFalseIfThereIsNoPreviouslyCalculatedEntitlement() {
-    $type = $this->createAbsenceType();
-    $period = AbsencePeriod::create([
-      'title' => 'Period 1',
-      'start_date' => date('YmdHis'),
-      'end_date' => date('YmdHis', strtotime('+1 day'))
-    ]);
+    $type = AbsenceTypeFabricator::fabricate();
+    $period = AbsencePeriodFabricator::fabricate();
 
     $calculation = new EntitlementCalculation($period, $this->contact, $type);
     $this->assertFalse($calculation->isCurrentPeriodEntitlementOverridden());
@@ -1061,47 +953,34 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
 
   public function testIsCurrentPeriodEntitlementOverriddenShouldBeFalseIfThePreviouslyCalculatedEntitlementIsNotOverridden()
   {
-    $type = $this->createAbsenceType();
-    $period = AbsencePeriod::create([
-      'title' => 'Period 1',
-      'start_date' => date('YmdHis'),
-      'end_date' => date('YmdHis', strtotime('+1 day'))
-    ]);
+    $type = AbsenceTypeFabricator::fabricate();
+    $period = AbsencePeriodFabricator::fabricate();
     $this->createEntitlement($period, $type, 10);
+
     $calculation = new EntitlementCalculation($period, $this->contact, $type);
     $this->assertFalse($calculation->isCurrentPeriodEntitlementOverridden());
   }
 
   public function testIsCurrentPeriodEntitlementOverriddenShouldBeTrueIfThePreviouslyCalculatedEntitlementIsOverridden() {
-    $type = $this->createAbsenceType();
-    $period = AbsencePeriod::create([
-      'title' => 'Period 1',
-      'start_date' => date('YmdHis'),
-      'end_date' => date('YmdHis', strtotime('+1 day'))
-    ]);
+    $type = AbsenceTypeFabricator::fabricate();
+    $period = AbsencePeriodFabricator::fabricate();
     $this->createEntitlement($period, $type, 10, 20);
+
     $calculation = new EntitlementCalculation($period, $this->contact, $type);
     $this->assertTrue($calculation->isCurrentPeriodEntitlementOverridden());
   }
 
   public function testGetCurrentPeriodEntitlementCommentReturnsAnEmptyStringIfThereIsNoPreviouslyCalculatedEntitlement() {
-    $type = $this->createAbsenceType();
-    $period = AbsencePeriod::create([
-      'title' => 'Period 1',
-      'start_date' => date('YmdHis'),
-      'end_date' => date('YmdHis', strtotime('+1 day'))
-    ]);
+    $type = AbsenceTypeFabricator::fabricate();
+    $period = AbsencePeriodFabricator::fabricate();
+
     $calculation = new EntitlementCalculation($period, $this->contact, $type);
     $this->assertEmpty($calculation->getCurrentPeriodEntitlementComment());
   }
 
   public function testGetCurrentPeriodEntitlementCommentReturnsAnEmptyStringIfThereThePreviouslyCalculatedEntitlementHasNoComment() {
-    $type = $this->createAbsenceType();
-    $period = AbsencePeriod::create([
-      'title' => 'Period 1',
-      'start_date' => date('YmdHis'),
-      'end_date' => date('YmdHis', strtotime('+1 day'))
-    ]);
+    $type = AbsenceTypeFabricator::fabricate();
+    $period = AbsencePeriodFabricator::fabricate();
     $this->createEntitlement($period, $type, 10);
 
     $calculation = new EntitlementCalculation($period, $this->contact, $type);
@@ -1109,24 +988,13 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
   }
 
   public function testGetCurrentPeriodEntitlementCommentReturnsTheCommentIfThereThePreviouslyCalculatedEntitlementHasOne() {
-    $type = $this->createAbsenceType();
-    $period = AbsencePeriod::create([
-      'title' => 'Period 1',
-      'start_date' => date('YmdHis'),
-      'end_date' => date('YmdHis', strtotime('+1 day'))
-    ]);
+    $type = AbsenceTypeFabricator::fabricate();
+    $period = AbsencePeriodFabricator::fabricate();
     $comment = 'Lorem ipsum...';
     $this->createEntitlement($period, $type, 10, false, $comment);
 
     $calculation = new EntitlementCalculation($period, $this->contact, $type);
     $this->assertEquals($comment, $calculation->getCurrentPeriodEntitlementComment());
-  }
-
-  private function findAbsencePeriodByID($id) {
-    $currentPeriod     = new AbsencePeriod();
-    $currentPeriod->id = $id;
-    $currentPeriod->find(TRUE);
-    return $currentPeriod;
   }
 
   private function createEntitlement($period, $type, $numberOfDays = 20, $overridden = null, $comment = null) {
@@ -1152,19 +1020,6 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
     }
 
     return $periodEntitlement;
-  }
-
-  private function createAbsenceType($params = []) {
-    $basicRequiredFields = [
-      'title'                     => 'Type ' . microtime(),
-      'color'                     => '#000000',
-      'default_entitlement'       => 20,
-      'allow_request_cancelation' => 1,
-      'allow_carry_forward'       => 1,
-    ];
-
-    $params = array_merge($basicRequiredFields, $params);
-    return AbsenceType::create($params);
   }
 
   private function createJobLeaveEntitlement($type, $leaveAmount, $addPublicHolidays = false) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/EntitlementCalculationTest.php
@@ -666,7 +666,7 @@ class CRM_HRLeaveAndAbsences_EntitlementCalculationTest extends PHPUnit_Framewor
       'end_date' => date('YmdHis', strtotime('2016-12-31')),
     ]);
     $currentPeriod = $this->findAbsencePeriodByID($currentPeriod->id);
-
+    $this->createEntitlement($previousPeriod, $type, 10);
 
     $calculation = new EntitlementCalculation($currentPeriod, $this->contact, $type);
     $this->assertEquals(0, $calculation->getNumberOfDaysTakenOnThePreviousPeriod());

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/LeaveBalanceChangeHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/LeaveBalanceChangeHelpersTrait.php
@@ -39,6 +39,14 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
     );
   }
 
+  public function createOverriddenBalanceChange($entitlementID, $amount) {
+    return $this->createEntitlementBalanceChange(
+      $entitlementID,
+      $amount,
+      $this->getBalanceChangeTypeValue('Overridden')
+    );
+  }
+
   public function createBroughtForwardBalanceChange($entitlementID, $amount, $expiryDate = null) {
     return $this->createEntitlementBalanceChange(
       $entitlementID,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/Menu/hrleaveandabsences.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/Menu/hrleaveandabsences.xml
@@ -30,4 +30,10 @@
     <title>ManageEntitlements</title>
     <access_arguments>administer leave and absences</access_arguments>
   </item>
+  <item>
+    <path>civicrm/admin/leaveandabsences/periods/manage_entitlements/calculation_details</path>
+    <page_callback>CRM_HRLeaveAndAbsences_Page_EntitlementCalculationDetails</page_callback>
+    <title>Calculation details</title>
+    <access_arguments>administer leave and absences</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
The Manage Entitlements page was update to be able to handle multiple period and multiple contracts.

### Handling multiple periods
After saving the entitlements for one absence period, if there are other absence periods starting after it, the user will be taken to the page to calculate the entitlements for the next period. This will go on until there are no more next period.

In order to inform the user that he'll be taken to calculate the entitlements for the next period, the label of the save button was updated (only when there are more periods to process):
![captura de tela 2016-10-21 as 15 51 25](https://cloud.githubusercontent.com/assets/388373/19607105/5582a142-97a6-11e6-8985-0ccc1acacbcf.png)
(Note: the problem with the icon on top of the "S" is because of the new custom theme)

### Handling multiple contracts
The old way do display the calculation details wasn't enough to handle multiple contracts. In this scenario the calculation is a bit more complicate and needs a more descriptive approach.

This is how it looks now:
![captura de tela 2016-10-21 as 15 42 11](https://cloud.githubusercontent.com/assets/388373/19607185/db9dae34-97a6-11e6-835d-db40036ccbe7.png)

As one can see, there is a textual description of what it does followed by the actual calculation, with separate steps for each contract. Colors are used to help identify from where each value comes from.

In order to be able to access the information in a more granular way, the EntitlementCalculation class had to be refactored and some of it's logic was extracted to the ContractEntitlementCalculation class. 
This new class contains all the logic to do calculations based on a single contract and then the EntitlementCalculation does its calcs based on a set of ContractEntitlementCalculations.

### Other changes and fixes
The PR contains a few changes and fixes related to the Manage Entitlement:
- With recent changes in the civihr custom theme, the style of the overridden/not overridden filter tabs got a bit messed up and they were appearing as radios buttons. This has been fixed to hide the radio and this them as tabs
- Fixed a problem with the code that hides the table lines according to the selected Absence Type was also hiding the table header.
- Fixed the getNumberOfDaysTakenOnThePreviousPeriod() to not return a negative 0 if there are no leaves taken
- Change getBroughtForward() to not return the Brought Forward for a period that is not over yet (if it's not over, there's no way to know how many days should be carried over) 
