### PR TITLE
PCHR-1411: Hide Blank Notice period 

### DIFF
--- a/hrjobcontract/views/contractSummary.html
+++ b/hrjobcontract/views/contractSummary.html
@@ -51,8 +51,8 @@
                     <div class="col-sm-6">
                         <p class="form-control-static">
                             <span class="subfield">({{details.period_start_date | formatDate}} - {{details.period_end_date | formatDate}})</span>
-                            <span ng-if="details.notice_amount" class="subfield"><strong>Notice <span ng-if="details.notice_amount_employee">(From Employer)</span>:</strong> {{details.notice_amount}} {{options.details.notice_unit[details.notice_unit]}}(s)</span>
-                            <span ng-if="details.notice_amount_employee" class="subfield"><strong>Notice <span>(From Employee)</span>:</strong> {{details.notice_amount_employee}} {{options.details.notice_unit_employee[details.notice_unit_employee]}}(s)</span>
+                            <span ng-if="details.notice_amount && details.notice_amount != 0" class="subfield"><strong>Notice <span ng-if="details.notice_amount_employee">(From Employer)</span>:</strong> {{details.notice_amount}} {{options.details.notice_unit[details.notice_unit]}}(s)</span>
+                            <span ng-if="details.notice_amount_employee && details.notice_amount != 0" class="subfield"><strong>Notice <span>(From Employee)</span>:</strong> {{details.notice_amount_employee}} {{options.details.notice_unit_employee[details.notice_unit_employee]}}(s)</span>
                             <span ng-if="details.end_reason" class="subfield"><strong>End Reason:</strong> {{options.details.end_reason[details.end_reason]}}</span>
                         </p>
                     </div>


### PR DESCRIPTION
**Problem:**
In Job contract, Notice period is visible even if amounts and units as blank
![_thumb_27316](https://cloud.githubusercontent.com/assets/5058867/19674720/8c3d599e-9aa7-11e6-8902-e05dd29c922f.png)

**Analysis & Fix:**
If Notice period is Zero a string value of 0 is set to `notice_amount`, and that is why `ng-if` is showing the value. 

Added condition to check whether the value is not 0
