### PR TITLE
PCHR-1665: fix civihr core extension key in drush-install

### DIFF
--- a/bin/drush-install.sh
+++ b/bin/drush-install.sh
@@ -9,7 +9,7 @@
 ##################################
 ## List of CiviHR core extensions
 CORE_EXTS=\
-uk.co.compucorp.civicrm.civihrcore
+uk.co.compucorp.civicrm.hrcore
 
 ## List of extensions defining basic entity types
 ENTITY_EXTS=\


### PR DESCRIPTION
when creating a new site via the buildkit you wil get the following :
```
Array
(
is_error => 1
error_message => Unknown extension: uk.co.compucorp.civicrm.civihrcore
)
```
that's because the extension name is changed to uk.co.compucorp.civicrm.hrcore but it was not changed in in drush-install.sh file which was causing the issue.
