### PR TITLE
PCHR-1645: Ensure revision is created for each job contract entity via the importer

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobLeave.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobLeave.php
@@ -158,8 +158,8 @@ class CRM_Hrjobcontract_BAO_HRJobLeave extends CRM_Hrjobcontract_DAO_HRJobLeave 
         continue;
       }
       $details = CRM_Utils_Array::first($jobContractDetails['values']);
-      $details['period_start_date'] = $details['period_start_date'] ? date('Y-m-d H:i:s', strtotime($details['period_start_date'])) : null;
-      $details['period_end_date'] = $details['period_end_date'] ? date('Y-m-d H:i:s', strtotime($details['period_end_date'])) : null;
+      $details['period_start_date'] = isset($details['period_start_date']) ? date('Y-m-d H:i:s', strtotime($details['period_start_date'])) : null;
+      $details['period_end_date'] = isset($details['period_end_date']) ? date('Y-m-d H:i:s', strtotime($details['period_end_date'])) : null;
       if (CRM_Hrjobcontract_BAO_HRJobLeave::isJobDetailsInPeriod($details, $startDate, $endDate)) {
         $leaves = civicrm_api3('HRJobLeave', 'get', array(
           'sequential' => 1,

--- a/hrjobcontract/CRM/Hrjobcontract/Import/EntityHandler/Generic.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/EntityHandler/Generic.php
@@ -8,15 +8,10 @@ class CRM_Hrjobcontract_Import_EntityHandler_Generic extends CRM_Hrjobcontract_I
   public function handle(array $params, CRM_Hrjobcontract_DAO_HRJobContractRevision $contractRevision, array &$previousRevision) {
     $entityParams = $this->extractFields($params);
 
-    if(count($entityParams) === 0) {
-      return array();
-    }
-
-    $entityParams['import'] = 1;
+    $entityParams['sequential'] = 1;
     $entityParams['jobcontract_id'] = $contractRevision->jobcontract_id;
     $entityParams['jobcontract_revision_id'] = $contractRevision->id;
 
-    $entityClass = 'CRM_Hrjobcontract_BAO_' . $this->getEntityName();
-    return array(call_user_func(array($entityClass, 'create'), $entityParams));
+    return civicrm_api3($this->getEntityName(), 'create', $entityParams)['values'][0];
   }
 }

--- a/hrjobcontract/CRM/Hrjobcontract/Import/EntityHandler/HRJobDetails.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/EntityHandler/HRJobDetails.php
@@ -15,15 +15,16 @@ class CRM_Hrjobcontract_Import_EntityHandler_HRJobDetails extends CRM_Hrjobcontr
       return array();
     }
 
-    $entityParams['import'] = 1;
+    $entityParams['sequential'] = 1;
     $entityParams['jobcontract_id'] = $contractRevision->jobcontract_id;
     $entityParams['jobcontract_revision_id'] = $contractRevision->id;
 
-    $detailsInstance = CRM_Hrjobcontract_BAO_HRJobDetails::create($entityParams);
+    $detailsInstance = civicrm_api3('HRJobDetails', 'create', $entityParams)['values'][0];
+
     if($this->isCurrent($entityParams)) {
       CRM_Hrjobcontract_BAO_HRJobContract::changePrimary($contractRevision->jobcontract_id);
     }
-    return array($detailsInstance);
+    return $detailsInstance;
   }
 
   /**

--- a/hrjobcontract/CRM/Hrjobcontract/Import/EntityHandler/HRJobHealth.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/EntityHandler/HRJobHealth.php
@@ -8,15 +8,11 @@ class CRM_Hrjobcontract_Import_EntityHandler_HRJobHealth extends CRM_Hrjobcontra
   public function handle(array $params, CRM_Hrjobcontract_DAO_HRJobContractRevision $contractRevision, array &$previousRevision) {
     $entityParams = $this->extractFields($params);
 
-    if(count($entityParams) === 0) {
-      return array();
-    }
-
-    $entityParams['import'] = 1;
+    $entityParams['sequential'] = 1;
     $entityParams['jobcontract_id'] = $contractRevision->jobcontract_id;
     $entityParams['jobcontract_revision_id'] = $contractRevision->id;
 
-    return array(CRM_Hrjobcontract_BAO_HRJobHealth::create($entityParams));
+    return civicrm_api3('HRJobHealth', 'create', $entityParams)['values'][0];
   }
 
   /**

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Parser/Api.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Parser/Api.php
@@ -478,7 +478,7 @@ class CRM_Hrjobcontract_Import_Parser_Api extends CRM_Hrjobcontract_Import_Parse
             : new CRM_Hrjobcontract_Import_EntityHandler_Generic($entity);
 
           $entityInstance = $handler->handle($params, $contractRevision, $this->_previousRevision);
-          $this->_previousRevision['local'][$tableName] = isset($entityInstance[0]) ? $entityInstance[0]->id : null;
+          $this->_previousRevision['local'][$tableName] = isset($entityInstance) ? $entityInstance['id'] : null;
           $this->_previousRevision['imported'][$tableName] = $revisionParams[$tableName . '_revision_id'];
         }
       }

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -541,6 +541,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     $this->upgrade_1015();
     $this->upgrade_1016();
     $this->upgrade_1017();
+    $this->upgrade_1020();
   }
 
   function upgrade_1001() {


### PR DESCRIPTION
## Problem

When importing contracts, if the data for specific entity is not exists such as leave entitlements or health data then no revision will get created for that entity which cause loading the imported contracts to fail, The problem does not happen when creating job contract from the UI because a revision for each entity will be created even if no data inserted for it.
## Solution

Changing the entity handler importer code for each entity to ensure the revision will get created , and changing how the contracts get imported via the API rather than calling the BAO methods directly for consistency since the API methods for some entities such as leave entity contain some additional logic not exits in BAO methods.
