### PR TITLE
 PCHR-1353: Add test to ensure that styleguide opens

### DIFF
--- a/org.civicrm.styleguide/README.md
+++ b/org.civicrm.styleguide/README.md
@@ -1,0 +1,54 @@
+# CiviCRM Style Guide (org.civicrm.styleguide)
+
+Demonstrate common HTMTL/CSS styling conventions used within CiviCRM.
+
+This extension adds a new submenu, "Support => Developer => Style Guides"
+with a list of demo pages.
+
+## Installation (WIP)
+
+> These steps are subject to change. The extension will move to https://github.com/civicrm/org.civicrm.styleguide
+
+```
+mkdir sites/all/modules/civicrm/ext
+git clone https://github.com/civicrm/civihr sites/all/modules/civicrm/ext/civichr
+cd sites/all/modules/civicrm/ext/civichr/
+cv api extension.refresh
+cv api extension.install keys=org.civicrm.styleguide,org.civicrm.bootstrapcivicrm
+```
+
+## Creating Additional Style Guides
+
+If you write an extension with a distinctive set of HTML/CSS conventions,
+then you can create additional guides. This requires a small hook and some HTML files.
+
+Suppose your extension is `org.example.myextension`; the hook might look like:
+
+```php
+function myextension_civicrm_styleGuides($styleGuides) {
+  $styleGuides->add(array(
+    'name' => 'my-guide',
+    'label' => ts('My Guide'),
+    'path' => Civi::resources()->getPath('org.example.myextension') . '/guide',
+  ));
+}
+```
+
+Then, in the source tree for `org.example.myextension`, create a set of folders
+to store the HTML snippets:
+
+```
+cd /path/to/org.example.myextension
+mkdir guide guide/docs  guide/foundation
+mkdir guide/markup{,/base,/patterns}
+mkdir guide/usage{,/base/patterns}
+```
+
+and create your first HTML snippet:
+
+```
+<!-- FILE: guide/docs/about.html -->
+<p>This is the new style guide for my extension, org.example.myextension</p>
+```
+
+and navigate to ""Support => Developer => Style Guides => My Guide"

--- a/org.civicrm.styleguide/README.md
+++ b/org.civicrm.styleguide/README.md
@@ -52,3 +52,16 @@ and create your first HTML snippet:
 ```
 
 and navigate to ""Support => Developer => Style Guides => My Guide"
+
+## Tests
+
+The browser-level integration tests are implemented with `protractor` and stored
+under `tests/protractor/`.  (If you have not already installed Protractor, then
+follow [the setup instructions from `protractortest.org`](http://www.protractortest.org/).)
+
+Then run:
+
+```
+cd org.civicrm.styleguide
+protractor tests/protractor/conf.js
+```

--- a/org.civicrm.styleguide/package.json
+++ b/org.civicrm.styleguide/package.json
@@ -4,11 +4,12 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "protractor tests/protractor/conf.js"
   },
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "civicrm-cv": "civicrm/cv-nodejs",
     "gulp": "^3.9.0",
     "gulp-sass": "^2.1.0",
     "gulp-sass-bulk-import": "^0.3.2",

--- a/org.civicrm.styleguide/tests/protractor/conf.js
+++ b/org.civicrm.styleguide/tests/protractor/conf.js
@@ -1,0 +1,5 @@
+exports.config = {
+  seleniumAddress: 'http://localhost:4444/wd/hub',
+  beforeLaunch: 'lib/init.js',
+  specs: ['*-spec.js']
+};

--- a/org.civicrm.styleguide/tests/protractor/lib/init.js
+++ b/org.civicrm.styleguide/tests/protractor/lib/init.js
@@ -1,0 +1,59 @@
+// This initializes the test environment; specifically:
+//   1. Ensure that the right extensions are active.
+//   2. Load metadata about the local CiviCRM instance.
+
+var cv = require('civicrm-cv')({mode: 'sync'});
+cv('api extension.install keys=org.civicrm.styleguide,org.civicrm.bootstrapcivicrm');
+
+/**
+ * The _CV variable stores a cache of metadata about the local CiviCRM instance.
+ *
+ * Obtaining this data incurs a small overhead, so we only do it once - during initialization.
+ *
+ * Typical properties:
+ * {
+ *   "ADMIN_EMAIL": "admin@example.com",
+ *   "ADMIN_PASS": "admin",
+ *   "ADMIN_USER": "admin",
+ *
+ *   "DEMO_EMAIL": "demo@example.com",
+ *   "DEMO_PASS": "demo",
+ *   "DEMO_USER": "demo",
+ *
+ *   "CIVI_CORE": "/home/myuser/buildkit/build/dmaster/sites/all/modules/civicrm/",
+ *   "CIVI_SETTINGS": "/home/myuser/buildkit/build/dmaster/sites/default/civicrm.settings.php",
+ *   "CIVI_SITE_KEY": "t0ps3cr3t",
+ *   "CIVI_UF": "Drupal",
+ *   "CIVI_URL": "http://dmaster.l/sites/all/modules/civicrm/",
+ *   "CIVI_VERSION": "4.7.13",
+ *
+ *   "CMS_ROOT": "/home/myuser/buildkit/build/dmaster/",
+ *   "CMS_URL": "http://dmaster.l/",
+ *   "CMS_VERSION": "7.41",
+ *
+ *   "CIVI_DB_ARGS": "-h 127.0.0.1 -u dmasterciv_jr7lx -pdmasterciv_jr7lx -P 3307 dmasterciv_jr7lx",
+ *   "CIVI_DB_DSN": "mysql://dmasterciv_jr7lx:t0ps3cr3t@127.0.0.1:3307/dmasterciv_jr7lx?new_link=true",
+ *   "CIVI_DB_HOST": "127.0.0.1",
+ *   "CIVI_DB_NAME": "dmasterciv_jr7lx",
+ *   "CIVI_DB_PASS": "t0ps3cr3t",
+ *   "CIVI_DB_PORT": 3307,
+ *   "CIVI_DB_USER": "dmasterciv_jr7lx",
+ *
+ *   "CMS_DB_ARGS": "-h 127.0.0.1 -u dmastercms_3vky1 -pdmastercms_3vky1 -P 3307 dmastercms_3vky1",
+ *   "CMS_DB_DSN": "mysql://dmastercms_3vky1:t0ps3cr3t@127.0.0.1:3307/dmastercms_3vky1?new_link=true",
+ *   "CMS_DB_HOST": "127.0.0.1",
+ *   "CMS_DB_NAME": "dmastercms_3vky1",
+ *   "CMS_DB_PASS": "t0ps3cr3t",
+ *   "CMS_DB_PORT": 3307,
+ *   "CMS_DB_USER": "dmastercms_3vky1",
+ *
+ *   "TEST_DB_ARGS": "-h 127.0.0.1 -u dmastertes_6n6z6 -pdmastertes_6n6z6 -P 3307 dmastertes_6n6z6",
+ *   "TEST_DB_DSN": "mysql://dmastertes_6n6z6:t0ps3cr3t@127.0.0.1:3307/dmastertes_6n6z6?new_link=true",
+ *   "TEST_DB_HOST": "127.0.0.1",
+ *   "TEST_DB_NAME": "dmastertes_6n6z6",
+ *   "TEST_DB_PASS": "t0ps3cr3t",
+ *   "TEST_DB_PORT": 3307,
+ *   "TEST_DB_USER": "dmastertes_6n6z6",
+ * }
+ */
+global._CV = cv('vars:show');

--- a/org.civicrm.styleguide/tests/protractor/lib/login-page.js
+++ b/org.civicrm.styleguide/tests/protractor/lib/login-page.js
@@ -1,0 +1,71 @@
+// The LoginPage provides helper functions for logging in.
+// It abstracts the differences between the login forms on
+// each supported CMS.
+
+var prtr = require('./protractor-util');
+
+var loginHandlers = {
+  Backdrop: function(username, password, loginType) {
+    expect(false).toBe(true); // FIXME: Implement Backdrop
+  },
+  Drupal: function(username, password, loginType) {
+    prtr.withoutAngular(function() {
+      browser.get(_CV.CMS_URL + '/user/login');
+      element(by.css('#user-login input[name=name]')).sendKeys(username);
+      element(by.css('#user-login input[name=pass]')).sendKeys(password);
+      element(by.css('#user-login .form-submit')).click();
+    });
+  },
+  Drupal6: function(username, password, loginType) {
+    expect(false).toBe(true); // FIXME: Implement Drupal6
+  },
+  Drupal8: function(username, password, loginType) {
+    expect(false).toBe(true); // FIXME: Implement Drupal8
+  },
+  Joomla: function(username, password, loginType) {
+    expect(false).toBe(true); // FIXME: Implement Joomla
+  },
+  WordPress: function(username, password, loginType) {
+    expect(false).toBe(true); // FIXME: Implement WordPress
+  }
+};
+
+module.exports = {
+
+  /**
+   * Perform a login.
+   *
+   * @param username String, required
+   * @param password String, required
+   * @param loginType String, optional
+   *   Either 'backend' or 'frontend'.
+   *   Default: 'backend'.
+   */
+  login: function(username, password, loginType) {
+    loginType = (loginType === undefined) ? 'backend' : loginType;
+    return loginHandlers[_CV.CIVI_UF](username, password, loginType);
+  },
+
+  /**
+   * Perform a login as administrator.
+   *
+   * @param loginType String, optional
+   *   Default: 'backend'.
+   */
+  loginAsAdmin: function loginAsAdmin(loginType) {
+    loginType = (loginType === undefined) ? 'backend' : loginType;
+    return loginHandlers[_CV.CIVI_UF](_CV.ADMIN_USER, _CV.ADMIN_PASS, loginType);
+  },
+
+  /**
+   * Perform a login as demo user.
+   *
+   * @param loginType String, optional
+   *   Default: 'frontend'.
+   */
+  loginAsDemo: function loginAsDemo(loginType) {
+    loginType = (loginType === undefined) ? 'frontend' : loginType;
+    return loginHandlers[_CV.CIVI_UF](_CV.DEMO_USER, _CV.DEMO_PASS, loginType);
+  }
+
+};

--- a/org.civicrm.styleguide/tests/protractor/lib/navbar.js
+++ b/org.civicrm.styleguide/tests/protractor/lib/navbar.js
@@ -1,0 +1,48 @@
+var prtr = require('./protractor-util');
+
+/**
+ * The CiviCRM navbar waits for the mouse to hover before exposing nested elements.
+ * This constant specifies the #milliseconds to hover an element before moving
+ * on to the next child.
+ *
+ * This is likely to be a systemic performance drag on the test-suite...
+ *
+ * @type {number}
+ */
+var HOVER_DELAY = 250;
+
+module.exports = {
+
+  /**
+   * Navigate to an item using the global CiviCRM navbar.
+   *
+   * Ex: NavBar.goto(['Support', 'Developer', 'API Explorer']);
+   *
+   * @param parts string|array
+   */
+  goto: function(parts) {
+    prtr.withoutAngular(function() {
+      if (typeof parts === 'string') {
+        parts = [parts];
+      }
+
+      var navItem = element(by.cssContainingText('#civicrm-menu li', parts[0]));
+      browser.actions().mouseMove(navItem).click().perform();
+
+      if (parts.length === 1) {
+        return;
+      }
+
+      for (var i = 1; i < parts.length - 1; i++) {
+        navItem = element(by.cssContainingText('.menu-item span', parts[i]));
+        expect(navItem.getText()).toBe(parts[i]);
+        browser.actions().mouseMove(navItem).perform();
+        browser.sleep(HOVER_DELAY);
+      }
+
+      navItem = element(by.cssContainingText('.menu-item a', parts[parts.length - 1]));
+      navItem.click()
+    });
+  }
+
+};

--- a/org.civicrm.styleguide/tests/protractor/lib/protractor-util.js
+++ b/org.civicrm.styleguide/tests/protractor/lib/protractor-util.js
@@ -1,0 +1,41 @@
+/**
+ * Protractor is primarily designed for working with AngularJS pages. However, CiviCRM includes
+ * a mix of Angular and non-angular pages.
+ *
+ * @type {{withoutAngular: module.exports.withoutAngular, withAngular: module.exports.withoutAngular}}
+ */
+module.exports = {
+
+  /**
+   * Temporarily disable Angular handling while executing the callback.
+   *
+   * @param callback
+   * @returns {*}
+   */
+  withoutAngular: function withoutAngular(callback) {
+    var oldSync = browser.ignoreSynchronization;
+    browser.ignoreSynchronization = true;
+    try {
+      return callback();
+    } finally {
+      browser.ignoreSynchronization = oldSync;
+    }
+  },
+
+  /**
+   * Temporarily enable Angular handling while executing the callback.
+   *
+   * @param callback
+   * @returns {*}
+   */
+  withAngular: function withoutAngular(callback) {
+    var oldSync = browser.ignoreSynchronization;
+    browser.ignoreSynchronization = false;
+    try {
+      return callback();
+    } finally {
+      browser.ignoreSynchronization = oldSync;
+    }
+  }
+
+};

--- a/org.civicrm.styleguide/tests/protractor/styleguide-spec.js
+++ b/org.civicrm.styleguide/tests/protractor/styleguide-spec.js
@@ -1,0 +1,18 @@
+var LoginPage = require('./lib/login-page');
+var NavBar = require('./lib/navbar');
+var prtr = require('./lib/protractor-util');
+
+describe('civicrm style-guide', function() {
+
+  it('should display the crm-star styleguide', function() {
+    prtr.withoutAngular(function() {
+      LoginPage.loginAsAdmin();
+
+      NavBar.goto(['Support', 'Developer', 'Style Guide', 'crm-*']);
+
+      expect(browser.getCurrentUrl()).toMatch(/civicrm\/styleguide\/crm-star/)
+      expect(element(by.css('.sg-body')).getText()).toMatch(/demonstrates the traditional CSS elements/);
+    });
+  });
+
+});


### PR DESCRIPTION
This uses `protractor` and `cv` to login and open the style-guide screen.

It includes a handful of utilities.  These probably belong in a separate
project, but for the moment it's convenient to have them here while folks
get a first look.
