### PR TITLE
PCHR-1655: Cannot permanently delete individual user

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
@@ -616,4 +616,118 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
     }
     return null;
   }
+
+  /**
+   * Permanently delete all contracts for given contact ID.
+   *
+   * @param int $contactId
+   *
+   * @return boolean
+   * @throw Exception
+   */
+  public static function deleteAllContractsPermanently($contactId) {
+
+    if (empty($contactId)) {
+      throw new Exception('Please specify contact ID.');
+    }
+
+    $contract = new self();
+    $contract->contact_id = $contactId;
+    $contract->find();
+    while ($contract->fetch()) {
+      self::deleteContractPermanently($contract->id);
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Permanently delete whole contract with its all revisions and entities.
+   *
+   * @param int $contractId
+   *
+   * @return bool
+   * @throw Exception
+   */
+  public static function deleteContractPermanently($contractId) {
+
+    if (empty($contractId)) {
+      throw new Exception('Please specify contract ID to delete.');
+    }
+
+    $transaction = new CRM_Core_Transaction();
+    try {
+      $contract = new self();
+      $contract->id = $contractId;
+      $contract->find(TRUE);
+
+      if (empty($contract->id))
+      {
+          throw new Exception('Cannot find Job Contract with specified ID.');
+      }
+
+      $revision = new CRM_Hrjobcontract_BAO_HRJobContractRevision();
+      $revision->jobcontract_id = $contract->id;
+      $revision->find();
+
+      while ($revision->fetch()) {
+        self::deleteRevisionPermanently($revision);
+      }
+
+      $contract->delete();
+    } catch(Exception $e) {
+      $transaction->rollback();
+      throw new Exception($e);
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Delete all contract entities of given revision and the revision itself.
+   *
+   * @param CRM_Hrjobcontract_BAO_HRJobContractRevision $revision
+   */
+  protected static function deleteRevisionPermanently(CRM_Hrjobcontract_BAO_HRJobContractRevision $revision) {
+    $entityNames = array('HRJobDetails', 'HRJobHealth', 'HRJobHour', 'HRJobLeave', 'HRJobPay', 'HRJobPension', 'HRJobRole');
+
+    foreach ($entityNames as $entityName)
+    {
+      $tableName = _civicrm_get_table_name($entityName);
+      self::deleteEntityRevisionPermanently('CRM_Hrjobcontract_BAO_' . $entityName, $revision->{$tableName . '_revision_id'});
+    }
+
+    $deleteRevision = new CRM_Hrjobcontract_BAO_HRJobContractRevision();
+    $deleteRevision->id = $revision->id;
+    $deleteRevision->delete();
+  }
+
+  /**
+   * Delete each entity entry of specified revision ID.
+   *
+   * @param string $className
+   * @param int $revisionId
+   */
+  protected static function deleteEntityRevisionPermanently($className, $revisionId) {
+
+    $entity = new $className();
+    $entity->jobcontract_revision_id = $revisionId;
+    $entity->find();
+
+    while ($entity->fetch()) {
+      self::deleteEntityPermanently($className, $entity->id);
+    }
+  }
+
+  /**
+   * Delete a single entity entry of given class and ID.
+   *
+   * @param string $className
+   * @param int $entityId
+   */
+  protected static function deleteEntityPermanently($className, $entityId) {
+    $deleteEntity = new $className();
+    $deleteEntity->id = $entityId;
+    $deleteEntity->delete();
+  }
 }

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
@@ -666,6 +666,7 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
           throw new Exception('Cannot find Job Contract with specified ID.');
       }
 
+      $contactId = $contract->contact_id;
       $revision = new CRM_Hrjobcontract_BAO_HRJobContractRevision();
       $revision->jobcontract_id = $contract->id;
       $revision->find();
@@ -675,6 +676,8 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
       }
 
       $contract->delete();
+      CRM_Hrjobcontract_JobContractDates::removeDates($contractId);
+      self::updateLengthOfService($contactId);
     } catch(Exception $e) {
       $transaction->rollback();
       throw new Exception($e);

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
@@ -689,12 +689,20 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
    * @param CRM_Hrjobcontract_BAO_HRJobContractRevision $revision
    */
   protected static function deleteRevisionPermanently(CRM_Hrjobcontract_BAO_HRJobContractRevision $revision) {
-    $entityNames = array('HRJobDetails', 'HRJobHealth', 'HRJobHour', 'HRJobLeave', 'HRJobPay', 'HRJobPension', 'HRJobRole');
 
-    foreach ($entityNames as $entityName)
+    $entityNames = array(
+      'HRJobDetails' => 'details',
+      'HRJobHealth' => 'health',
+      'HRJobHour' => 'hour',
+      'HRJobLeave' => 'leave',
+      'HRJobPay' => 'pay',
+      'HRJobPension' => 'pension',
+      'HRJobRole' => 'role',
+    );
+
+    foreach ($entityNames as $entityName => $prefix)
     {
-      $tableName = _civicrm_get_table_name($entityName);
-      self::deleteEntityRevisionPermanently('CRM_Hrjobcontract_BAO_' . $entityName, $revision->{$tableName . '_revision_id'});
+      self::deleteEntityRevisionPermanently('CRM_Hrjobcontract_BAO_' . $entityName, $revision->{$prefix . '_revision_id'});
     }
 
     $deleteRevision = new CRM_Hrjobcontract_BAO_HRJobContractRevision();

--- a/hrjobcontract/api/v3/HRJobContract.php
+++ b/hrjobcontract/api/v3/HRJobContract.php
@@ -92,14 +92,31 @@ function civicrm_api3_h_r_job_contract_deletecontract($params) {
 }
 
 /**
- * HRJobContract.deletecontract API
+ * HRJobContract.deletecontractpermanently API
  *
  * @param array $params
  * @return array API result descriptor
  * @throws API_Exception
  */
 function civicrm_api3_h_r_job_contract_deletecontractpermanently($params) {
-  return _civicrm_hrjobcontract_api3_deletecontractpermanently($params);
+  if (empty($params['jobcontract_id'])) {
+    throw new API_Exception(ts("Please specify 'jobcontract_id' value."));
+  }
+  return CRM_Hrjobcontract_BAO_HRJobContract::deleteContractPermanently((int)$params['jobcontract_id']);
+}
+
+/**
+ * HRJobContract.deleteallcontractspermanently API
+ *
+ * @param array $params
+ * @return array API result descriptor
+ * @throws API_Exception
+ */
+function civicrm_api3_h_r_job_contract_deleteallcontractspermanently($params) {
+  if (empty($params['contact_id'])) {
+    throw new API_Exception(ts("Please specify 'contact_id' value."));
+  }
+  return CRM_Hrjobcontract_BAO_HRJobContract::deleteAllContractsPermanently((int)$params['contact_id']);
 }
 
 /**

--- a/hrjobcontract/hrjobcontract.php
+++ b/hrjobcontract/hrjobcontract.php
@@ -564,3 +564,17 @@ function getContractTypeOptions() {
 
   return $valueLabelMap;
 }
+
+/**
+ * Implementation of hook_civicrm_pre hook.
+ *
+ * @param string $op
+ * @param string $objectName
+ * @param int $objectId
+ * @param object $objectRef
+ */
+function hrjobcontract_civicrm_pre($op, $objectName, $objectId, &$objectRef) {
+  if ($objectName === 'Individual' && $op === 'delete') {
+    CRM_Hrjobcontract_BAO_HRJobContract::deleteAllContractsPermanently($objectId);
+  }
+}

--- a/hrjobcontract/tests/phpunit/CRM/Hrjobcontract/BAO/HRJobContractTest.php
+++ b/hrjobcontract/tests/phpunit/CRM/Hrjobcontract/BAO/HRJobContractTest.php
@@ -207,4 +207,35 @@ class CRM_Hrjobcontract_BAO_HRJobContractTest extends PHPUnit_Framework_TestCase
     $this->assertEquals($lengthOfServiceYmdExpected, CRM_Hrjobcontract_BAO_HRJobContract::getLengthOfServiceYmd($contactId));
   }
 
+  public function testPermanentlyDeleteAllContracts() {
+    $contact = array('first_name' => 'Timothy', 'last_name' => 'Dalton');
+    $contactId = $this->createContact($contact);
+
+    // Create three Job Contracts.
+    $params = array(
+      'position' => 'spiders boss1',
+      'title' => 'spiders boss1');
+    $this->createJobContract($contactId, '2014-06-01', '2014-10-01', $params);
+    $params = array(
+      'position' => 'spiders boss2',
+      'title' => 'spiders boss2');
+    $this->createJobContract($contactId, '2015-06-01', '2015-10-01', $params);
+    $params = array(
+      'position' => 'spiders boss3',
+      'title' => 'spiders boss3');
+    $this->createJobContract($contactId, '2016-06-01', '2016-10-01', $params);
+
+    // Check if there are three Job Contracts created.
+    $jobContract = new CRM_Hrjobcontract_BAO_HRJobContract();
+    $jobContract->contact_id = $contactId;
+    $jobContract->find();
+    $this->assertEquals(3, $jobContract->count());
+
+    // Permanently delete the Job Contracts.
+    CRM_Hrjobcontract_BAO_HRJobContract::deleteAllContractsPermanently($contactId);
+
+    // Check if there is no Job Contracts.
+    $jobContract->find();
+    $this->assertEquals(0, $jobContract->count());
+  }
 }


### PR DESCRIPTION
There was an error while permanently deleting of Individual user which already has existing Job Contract (database constrain violation).

- I've created a new BAO methods for permanently deleting Job Contracts for specified Contact ID and then I've used a hook_civicrm_pre hook for deleting Individual contact action to permanently delete all Job Contracts for the user so the user can be deleted without any problems.
- Also I removed old helper function for deleting job contracts permanently as it based on API calls instead of BAO methods.
- I've also created a phpunit test for testing CRM_Hrjobcontract_BAO_HRJobContract::deleteAllContractsPermanently() method.