### PR TITLE
PCHR-1692: Update entitlements when a new absence period is added

### DIFF
--- a/hrabsence/CRM/HRAbsence/BAO/HRAbsenceEntitlement.php
+++ b/hrabsence/CRM/HRAbsence/BAO/HRAbsenceEntitlement.php
@@ -185,4 +185,32 @@ class CRM_HRAbsence_BAO_HRAbsenceEntitlement extends CRM_HRAbsence_DAO_HRAbsence
 
     return $result['values'];
   }
+
+  /**
+   * Process all the items on the EntitlementRecalculation Queue
+   *
+   * @return int
+   *  The number of items processed
+   */
+  public static function processEntitlementRecalculationQueue() {
+    $numberOfItemsProcessed = 0;
+
+    $queue = CRM_HRAbsence_Queue_EntitlementRecalculation::getQueue();
+    $runner = new CRM_Queue_Runner([
+      'title' => ts('Entitlement Recalculation Runner'),
+      'queue' => $queue,
+      'errorMode'=> CRM_Queue_Runner::ERROR_CONTINUE,
+    ]);
+
+    $continue = true;
+    while($continue) {
+      $result = $runner->runNext(false);
+      $numberOfItemsProcessed++;
+      if (!$result['is_continue']) {
+        $continue = false; //all items in the queue are processed
+      }
+    }
+
+    return $numberOfItemsProcessed;
+  }
 }

--- a/hrabsence/CRM/HRAbsence/BAO/HRAbsencePeriod.php
+++ b/hrabsence/CRM/HRAbsence/BAO/HRAbsencePeriod.php
@@ -83,4 +83,53 @@ class CRM_HRAbsence_BAO_HRAbsencePeriod extends CRM_HRAbsence_DAO_HRAbsencePerio
     $absencePeriod->find(TRUE);
     $absencePeriod->delete();
   }
+
+  /**
+   * Returns an array of Absence Periods dates overlapping the given start and
+   * end dates
+   *
+   * @param string|null $startDate
+   * @param string|null $endDate
+   *
+   * @return array
+   *  An array of Absence Periods dates as:
+   *  [
+   *   ['start' => '2016-01-01', 'end' => '2016-12-31'],
+   *   ['start' => '2017-01-01', 'end' => '2017-12-31'],
+   *   ...
+   *  ]
+   */
+  public static function getAbsencePeriods($startDate = NULL, $endDate = NULL) {
+    $data       = [];
+    $query      = "SELECT * FROM civicrm_hrabsence_period ";
+    $where      = [];
+    $params     = [];
+    $whereQuery = '';
+
+    if ($startDate) {
+      $startDate = date('Y-m-d H:i:s', strtotime($startDate));
+      $where[]   = " end_date >= %1 ";
+      $params[1] = [$startDate, 'String'];
+    }
+
+    if ($endDate) {
+      $endDate   = date('Y-m-d H:i:s', strtotime($endDate));
+      $where[]   = " start_date < %2 ";
+      $params[2] = [$endDate, 'String'];
+    }
+
+    if (!empty($where)) {
+      $whereQuery = ' WHERE ' . implode(' AND ', $where);
+    }
+
+    $periods = CRM_Core_DAO::executeQuery($query . $whereQuery, $params);
+    while ($periods->fetch()) {
+      $data[$periods->id] = array(
+        'start' => $periods->start_date,
+        'end'   => $periods->end_date,
+      );
+    }
+
+    return $data;
+  }
 }

--- a/hrabsence/CRM/HRAbsence/BAO/HRAbsencePeriod.php
+++ b/hrabsence/CRM/HRAbsence/BAO/HRAbsencePeriod.php
@@ -47,6 +47,8 @@ class CRM_HRAbsence_BAO_HRAbsencePeriod extends CRM_HRAbsence_DAO_HRAbsencePerio
 
     CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
 
+    CRM_HRAbsence_BAO_HRAbsenceEntitlement::recalculateAbsenceEntitlementsForPeriod($instance->id);
+
     return $instance;
   }
 

--- a/hrabsence/CRM/HRAbsence/Queue/EntitlementRecalculation.php
+++ b/hrabsence/CRM/HRAbsence/Queue/EntitlementRecalculation.php
@@ -1,0 +1,25 @@
+<?php
+
+class CRM_HRAbsence_Queue_EntitlementRecalculation {
+
+  const QUEUE_NAME = 'org.civicrm.hrabsence.queue.entitlementrecalculation';
+
+  private static $queue;
+
+  /**
+   * Returns the Queue object wrapped by this class
+   *
+   * @return \CRM_Queue_Queue
+   */
+  public static function getQueue() {
+    if(!self::$queue) {
+      self::$queue = CRM_Queue_Service::singleton()->create([
+        'type' => 'Sql',
+        'name' => self::QUEUE_NAME,
+        'reset' => false,
+      ]);
+    }
+
+    return self::$queue;
+  }
+}

--- a/hrabsence/CRM/HRAbsence/Queue/Task/RecalculateContactsEntitlementForPeriod.php
+++ b/hrabsence/CRM/HRAbsence/Queue/Task/RecalculateContactsEntitlementForPeriod.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is the Queue Task which will be executed by the whenever the
+ * EntitlementRecalculation queue is processed.
+ *
+ * Basically, it fetches the period ID from the queue item and delegates the
+ * job to the recalculateAbsenceEntitlementsForPeriod method of the
+ * HRAbsenceEntitlement BAO
+ */
+class CRM_HRAbsence_Queue_Task_RecalculateContactsEntitlementForPeriod {
+
+  public function run(CRM_Queue_TaskContext $ctx, $periodID) {
+    CRM_HRAbsence_BAO_HRAbsenceEntitlement::recalculateAbsenceEntitlementsForPeriod($periodID);
+
+    return true;
+  }
+
+}

--- a/hrabsence/CRM/HRAbsence/Test/Fabricator/HRAbsencePeriod.php
+++ b/hrabsence/CRM/HRAbsence/Test/Fabricator/HRAbsencePeriod.php
@@ -1,0 +1,13 @@
+<?php
+
+class CRM_HRAbsence_Test_Fabricator_HRAbsencePeriod {
+
+  public static function fabricate($params = []) {
+    if(empty($params['title'])) {
+      $params['title'] = 'Absence Period ' . microtime();
+    }
+
+    return CRM_HRAbsence_BAO_HRAbsencePeriod::create($params);
+  }
+
+}

--- a/hrabsence/CRM/HRAbsence/Test/Fabricator/HRAbsenceType.php
+++ b/hrabsence/CRM/HRAbsence/Test/Fabricator/HRAbsenceType.php
@@ -1,0 +1,23 @@
+<?php
+
+class CRM_HRAbsence_Test_Fabricator_HRAbsenceType {
+
+  private static $defaultParams = [
+    'is_active' => 1,
+  ];
+
+  public static function fabricate($params = []) {
+    if(empty($params['title'])) {
+      $params['title'] = 'Absence Type ' . microtime();
+    }
+
+    if(empty($params['name'])) {
+      $params['name'] = 'Absence Type ' . microtime();
+    }
+
+    $params = array_merge(self::$defaultParams, $params);
+
+    return CRM_HRAbsence_BAO_HRAbsenceType::create($params);
+  }
+
+}

--- a/hrabsence/CRM/HRAbsence/Upgrader.php
+++ b/hrabsence/CRM/HRAbsence/Upgrader.php
@@ -536,4 +536,10 @@ class CRM_HRAbsence_Upgrader extends CRM_HRAbsence_Upgrader_Base {
 
     return TRUE;
   }
+
+  public function upgrade_1401() {
+    _hrabsence_add_processentitlementrecalculationqueue_scheduled_job();
+
+    return TRUE;
+  }
 }

--- a/hrabsence/api/v3/HRAbsenceEntitlement.php
+++ b/hrabsence/api/v3/HRAbsenceEntitlement.php
@@ -69,4 +69,19 @@ function civicrm_api3_h_r_absence_entitlement_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
 
-
+/**
+ * HRAbsenceEntitlement.processEntitlementRecalculationQueue API endpoint
+ *
+ * @param array $params
+ *
+ * @return array
+ *  API result descriptor
+ */
+function civicrm_api3_h_r_absence_entitlement_processentitlementrecalculationqueue($params) {
+  return civicrm_api3_create_success(
+    CRM_HRAbsence_BAO_HRAbsenceEntitlement::processEntitlementRecalculationQueue(),
+    $params,
+    _civicrm_api3_get_BAO(__FUNCTION__),
+    'processentitlementrecalculationqueue'
+  );
+}

--- a/hrabsence/hrabsence.php
+++ b/hrabsence/hrabsence.php
@@ -235,6 +235,8 @@ function hrabsence_civicrm_install() {
   );
   civicrm_api3('message_template', 'create', $msg_params);
 
+  _hrabsence_add_scheduled_jobs();
+
   return _hrabsence_civix_civicrm_install();
 }
 
@@ -585,5 +587,35 @@ function hrabsence_civicrm_pageRun($page) {
   if (preg_match("/^CRM_HRAbsence*/",  $page)) {
     CRM_Core_Resources::singleton()
       ->addStyleFile('org.civicrm.hrabsence', 'css/hrabsence.css');
+  }
+}
+
+/**
+ * Creates all the scheduled jobs for this extension
+ */
+function _hrabsence_add_scheduled_jobs() {
+  _hrabsence_add_processentitlementrecalculationqueue_scheduled_job();
+}
+
+/**
+ * Creates the scheduled job which process the entitlement recalculation queue
+ */
+function _hrabsence_add_processentitlementrecalculationqueue_scheduled_job() {
+  $dao             = new CRM_Core_DAO_Job();
+  $dao->api_entity = 'HRAbsenceEntitlement';
+  $dao->api_action = 'processentitlementrecalculationqueue';
+  $dao->find(TRUE);
+
+  if (!$dao->id) {
+    $dao                = new CRM_Core_DAO_Job();
+    $dao->api_entity    = 'HRAbsenceEntitlement';
+    $dao->api_action    = 'processentitlementrecalculationqueue';
+    $dao->domain_id     = CRM_Core_Config::domainID();
+    $dao->run_frequency = 'Hourly';
+    $dao->parameters    = NULL;
+    $dao->name          = 'Process the Entitlement Recalculation Queue';
+    $dao->description   = 'Recalculates the entitlement for newly added Absence Periods';
+    $dao->is_active     = 1;
+    $dao->save();
   }
 }

--- a/hrabsence/phpunit.xml.dist
+++ b/hrabsence/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="tests/phpunit/bootstrap.php"
+>
+  <testsuites>
+    <testsuite name="HRAbsences Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments></arguments>
+    </listener>
+  </listeners>
+</phpunit>

--- a/hrabsence/tests/phpunit/CRM/HRAbsence/BAO/HRAbsenceEntitlementTest.php
+++ b/hrabsence/tests/phpunit/CRM/HRAbsence/BAO/HRAbsenceEntitlementTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
+use CRM_HRAbsence_Test_Fabricator_HRAbsencePeriod as AbsencePeriodFabricator;
+use CRM_HRAbsence_Test_Fabricator_HRAbsenceType as AbsenceTypeFabricator;
+use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as JobContractFabricator;
+use CRM_Hrjobcontract_Test_Fabricator_HRJobLeave as JobLeaveFabricator;
+
+/**
+ * Class CRM_HRAbsence_BAO_HRAbsencePeriodTest
+ *
+ * @group headless
+ */
+class CRM_HRAbsence_BAO_HRAbsenceEntitlementTest extends PHPUnit_Framework_TestCase implements
+  HeadlessInterface, TransactionalInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->install('uk.co.compucorp.civicrm.hrcore')
+      ->install('org.civicrm.hrjobcontract')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function testRecalculateAbsenceEntitlementsForPeriodCreatesTheContactsEntitlementsForThatPeriod() {
+    $absenceType = AbsenceTypeFabricator::fabricate();
+
+    $contact1 = ContactFabricator::fabricate([]);
+    $contact2 = ContactFabricator::fabricate([]);
+
+    $contract1 = JobContractFabricator::fabricate(['contact_id' => $contact1['id']], [
+      'period_start_date' => '2015-01-01',
+      'period_end_date' => '2015-12-31',
+      'title' => 'Employee',
+      'position' => 'Employee'
+    ]);
+
+    JobLeaveFabricator::fabricate([
+      'jobcontract_id' => $contract1['id'],
+      'leave_amount' => 14,
+      'leave_type' => $absenceType->id
+    ]);
+
+    $contract2 = JobContractFabricator::fabricate(['contact_id' => $contact2['id']], [
+      'period_start_date' => '2015-07-23',
+      'title' => 'Employee 2',
+      'position' => 'Employee 2'
+    ]);
+
+    JobLeaveFabricator::fabricate([
+      'jobcontract_id' => $contract2['id'],
+      'leave_amount' => 23,
+      'leave_type' => $absenceType->id
+    ]);
+
+    $period = AbsencePeriodFabricator::fabricate([
+      'name' => 'Period 1',
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    CRM_HRAbsence_BAO_HRAbsenceEntitlement::recalculateAbsenceEntitlementsForPeriod($period->id);
+
+    $contact1Entitlement = new CRM_HRAbsence_BAO_HRAbsenceEntitlement();
+    $contact1Entitlement->contact_id = $contact1['id'];
+    $contact1Entitlement->period_id = $period->id;
+    $contact1Entitlement->type_id = $absenceType->id;
+    $contact1Entitlement->find(true);
+
+    // The absence_entitlement record is created for contact 1,
+    // but since their contract doesn't overlap the absence period,
+    // the leave_amount will be 0, meaning it doesn't have entitlement
+    // for that year
+    $this->assertEquals(1, $contact1Entitlement->N);
+    $this->assertEquals(0, $contact1Entitlement->amount);
+
+    $contact1Entitlement = new CRM_HRAbsence_BAO_HRAbsenceEntitlement();
+    $contact1Entitlement->contact_id = $contact2['id'];
+    $contact1Entitlement->period_id = $period->id;
+    $contact1Entitlement->type_id = $absenceType->id;
+    $contact1Entitlement->find(true);
+
+    // The absence_entitlement record is created for contact 2,
+    // and since their contract overlaps the absence period,
+    // the leave_amount will be fetched from the contractual
+    // entitlement set in Job Leave
+    $this->assertEquals(1, $contact1Entitlement->N);
+    $this->assertEquals(23, $contact1Entitlement->amount);
+  }
+
+
+
+}

--- a/hrabsence/tests/phpunit/CRM/HRAbsence/BAO/HRAbsencePeriodTest.php
+++ b/hrabsence/tests/phpunit/CRM/HRAbsence/BAO/HRAbsencePeriodTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+use CRM_HRAbsence_BAO_HRAbsencePeriod as AbsencePeriod;
+use CRM_HRAbsence_Test_Fabricator_HRAbsencePeriod as AbsencePeriodFabricator;
+
+/**
+ * Class CRM_HRAbsence_BAO_HRAbsencePeriodTest
+ *
+ * @group headless
+ */
+class CRM_HRAbsence_BAO_HRAbsencePeriodTest extends PHPUnit_Framework_TestCase implements
+  HeadlessInterface, TransactionalInterface {
+
+  /**
+   * @var array
+   *  An array of AbsencePeriods created by the setUp() method
+   */
+  private $absencePeriods = [];
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->installMe(__DIR__)->apply();
+  }
+
+  public function setUp() {
+    $absencePeriodTable = AbsencePeriod::getTableName();
+    // We need to disable fk checks in order to avoid constraint
+    // errors when truncating the absence period table
+    CRM_Core_DAO::executeQuery("SET foreign_key_checks = 0;");
+    CRM_Core_DAO::executeQuery("TRUNCATE $absencePeriodTable");
+    CRM_Core_DAO::executeQuery("SET foreign_key_checks = 1;");
+
+    $this->absencePeriods[] = AbsencePeriodFabricator::fabricate([
+      'name' => 'Period 1',
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    $this->absencePeriods[] = AbsencePeriodFabricator::fabricate([
+      'name' => 'Period 2',
+      'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2017-12-31'),
+    ]);
+
+    $this->absencePeriods[] = AbsencePeriodFabricator::fabricate([
+      'name' => 'Period 3',
+      'start_date' => CRM_Utils_Date::processDate('2018-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2018-12-31'),
+    ]);
+  }
+
+  public function testGetAbsencePeriodWithoutDatesReturnsAllTheAbsencePeriods() {
+    $periods = AbsencePeriod::getAbsencePeriods();
+    // Assert only that the number of items is the expected one,
+    // We cannot assert anything else because getAbsencePeriod() only returns
+    // dates and in a different format than the one used to create the object
+    $this->assertCount(count($this->absencePeriods), $periods);
+  }
+
+  public function testGetAbsencePeriodWithOnlyTheStartDateReturnsPeriodsOverlappingTheGivenDate() {
+    $periods = AbsencePeriod::getAbsencePeriods('2017-10-13');
+    // This should return 2017 and 2018
+    $this->assertCount(2, $periods);
+  }
+
+  public function testGetAbsencePeriodWithBothStartAndEndDatesReturnsPeriodsOverlappingTheGivenDates() {
+    $periods = AbsencePeriod::getAbsencePeriods('2017-10-13', '2017-12-31');
+    // This should return only 2017
+    $this->assertCount(1, $periods);
+  }
+}

--- a/hrabsence/tests/phpunit/bootstrap.php
+++ b/hrabsence/tests/phpunit/bootstrap.php
@@ -1,0 +1,49 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+eval(cv('php:boot --level=full -t', 'phpcode'));
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobLeave.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobLeave.php
@@ -99,20 +99,6 @@ class CRM_Hrjobcontract_BAO_HRJobLeave extends CRM_Hrjobcontract_DAO_HRJobLeave 
     }
   }
 
-  static function getAllAbsencePeriods() {
-    $data = array();
-    $result = civicrm_api3('HRAbsencePeriod', 'get', array(
-      'sequential' => 1,
-    ));
-    foreach ($result['values'] as $period) {
-      $data[$period['id']] = array(
-        'start' => $period['start_date'],
-        'end' => $period['end_date'],
-      );
-    }
-    return $data;
-  }
-
   static function getAbsencePeriods($startDate = null, $endDate = null) {
     $data = array();
     $query = "SELECT * FROM civicrm_hrabsence_period ";

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobLeave.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobLeave.php
@@ -50,85 +50,7 @@ class CRM_Hrjobcontract_BAO_HRJobLeave extends CRM_Hrjobcontract_DAO_HRJobLeave 
       return parent::create($params);
   }
 
-  /**
-   * Recalculating HR Absence Entitlement values for given Job Contract ID.
-   *
-   * @param int $jobContractId
-   * @throws \Exception
-   */
-  static function recalculateAbsenceEntitlement($jobContractId) {
-    try {
-      $jobContract = civicrm_api3('HRJobContract', 'getsingle', array(
-        'sequential' => 1,
-        'id' => $jobContractId,
-        'deleted' => 0,
-        'return' => "contact_id,period_start_date,period_end_date,deleted",
-      ));
-
-      $startDate = isset($jobContract['period_start_date']) ? date('Y-m-d H:i:s', strtotime($jobContract['period_start_date'])) : null;
-      $endDate = isset($jobContract['period_end_date']) ? date('Y-m-d H:i:s', strtotime($jobContract['period_end_date'])) : null;
-      $periods = CRM_Hrjobcontract_BAO_HRJobLeave::getAbsencePeriods($startDate, $endDate);
-
-      foreach ($periods as $periodId => $periodValue) {
-        $leaves = CRM_Hrjobcontract_BAO_HRJobLeave::getLeavesForPeriod($jobContract['contact_id'], $periodValue['start'], $periodValue['end']);
-        CRM_Hrjobcontract_BAO_HRJobLeave::overwriteAbsenceEntitlementPeriod($jobContract['contact_id'], $periodId, $leaves);
-      }
-
-    } catch (\Exception $e) {
-      throw new \Exception($e);
-    }
-  }
-
-  /**
-   * Recalculating HR Absence Entitlement values for given Contact.
-   *
-   * @param int $contactId
-   * @throws \Exception
-   */
-  static function recalculateAbsenceEntitlementForContact($contactId) {
-    try {
-      $periods = CRM_Hrjobcontract_BAO_HRJobLeave::getAbsencePeriods();
-
-      foreach ($periods as $periodId => $periodValue) {
-        $leaves = CRM_Hrjobcontract_BAO_HRJobLeave::getLeavesForPeriod($contactId, $periodValue['start'], $periodValue['end']);
-        CRM_Hrjobcontract_BAO_HRJobLeave::overwriteAbsenceEntitlementPeriod($contactId, $periodId, $leaves);
-      }
-
-    } catch (\Exception $e) {
-      throw new \Exception($e);
-    }
-  }
-
-  static function getAbsencePeriods($startDate = null, $endDate = null) {
-    $data = array();
-    $query = "SELECT * FROM civicrm_hrabsence_period ";
-    $where = array();
-    $params = array();
-    $whereQuery = '';
-    if ($startDate) {
-      $startDate = date('Y-m-d H:i:s', strtotime($startDate));
-      $where[] = " end_date >= %1 ";
-      $params[1] = array($startDate, 'String');
-    }
-    if ($endDate) {
-      $endDate = date('Y-m-d H:i:s', strtotime($endDate));
-      $where[] = " start_date < %2 ";
-      $params[2] = array($endDate, 'String');
-    }
-    if (!empty($where)) {
-      $whereQuery = ' WHERE ' . implode(' AND ', $where);
-    }
-    $periods = CRM_Core_DAO::executeQuery($query . $whereQuery, $params);
-    while ($periods->fetch()) {
-      $data[$periods->id] = array(
-        'start' => $periods->start_date,
-        'end' => $periods->end_date,
-      );
-    }
-    return $data;
-  }
-
-  static function getLeavesForPeriod($contactId, $startDate = null, $endDate = null) {
+  public static function getLeavesForPeriod($contactId, $startDate = null, $endDate = null) {
     $data = CRM_Hrjobcontract_BAO_HRJobLeave::createAbsenceArray();
     $jobContracts = civicrm_api3('HRJobContract', 'get', array(
       'sequential' => 1,
@@ -159,7 +81,7 @@ class CRM_Hrjobcontract_BAO_HRJobLeave extends CRM_Hrjobcontract_DAO_HRJobLeave 
     return $data;
   }
 
-  static function isJobDetailsInPeriod($jobDetails, $startDate = null, $endDate = null) {
+  public static function isJobDetailsInPeriod($jobDetails, $startDate = null, $endDate = null) {
     $result = true;
     if ($startDate && !empty($jobDetails['period_end_date'])) {
       if ($jobDetails['period_end_date'] < $startDate) {
@@ -174,7 +96,7 @@ class CRM_Hrjobcontract_BAO_HRJobLeave extends CRM_Hrjobcontract_DAO_HRJobLeave 
     return $result;
   }
 
-  static function createAbsenceArray() {
+  public static function createAbsenceArray() {
     $data = array();
     $absenceTypes = civicrm_api3('HRAbsenceType', 'get', array(
       'sequential' => 1,
@@ -183,25 +105,6 @@ class CRM_Hrjobcontract_BAO_HRJobLeave extends CRM_Hrjobcontract_DAO_HRJobLeave 
       $data[$absenceType['id']] = 0;
     }
     return $data;
-  }
-
-  static function overwriteAbsenceEntitlementPeriod($contactId, $periodId, array $leaves) {
-    CRM_Core_DAO::executeQuery('DELETE FROM civicrm_hrabsence_entitlement WHERE contact_id = %1 AND period_id = %2',
-      array(
-        1 => array($contactId, 'Integer'),
-        2 => array($periodId, 'Integer'),
-      )
-    );
-    foreach ($leaves as $leaveType => $leaveAmount) {
-      CRM_Core_DAO::executeQuery('INSERT INTO civicrm_hrabsence_entitlement SET contact_id = %1, period_id = %2, type_id = %3, amount = %4',
-      array(
-        1 => array($contactId, 'Integer'),
-        2 => array($periodId, 'Integer'),
-        3 => array($leaveType, 'Integer'),
-        4 => array($leaveAmount, 'Float'),
-      )
-    );
-    }
   }
 
   /**

--- a/hrjobcontract/api/v3/HRJobLeave.php
+++ b/hrjobcontract/api/v3/HRJobLeave.php
@@ -92,10 +92,10 @@ function civicrm_api3_h_r_job_leave_replace($params) {
         }
     }
     $result =  _civicrm_hrjobcontract_api3_replace(_civicrm_get_entity_name(_civicrm_api3_get_BAO(__FUNCTION__)), $params, $validRevisionId);
-    
+
     if (!empty($params['values'])) {
       $firstLeaveEntry = CRM_Utils_Array::first($params['values']);
-      
+
       $jobContractId = isset($firstLeaveEntry['jobcontract_id']) ? $firstLeaveEntry['jobcontract_id'] : null;
       if (!$jobContractId && isset($firstLeaveEntry['jobcontract_revision_id'])) {
         $revision = civicrm_api3('HRJobContractRevision', 'get', array(
@@ -105,11 +105,11 @@ function civicrm_api3_h_r_job_leave_replace($params) {
         $revisionData = CRM_Utils_Array::first($revision['values']);
         $jobContractId = $revisionData['jobcontract_id'];
       }
-      
+
       if ($jobContractId) {
-        CRM_Hrjobcontract_BAO_HRJobLeave::recalculateAbsenceEntitlement($jobContractId);
+        CRM_HRAbsence_BAO_HRAbsenceEntitlement::recalculateAbsenceEntitlement($jobContractId);
       }
     }
-    
+
     return $result;
 }

--- a/hrjobcontract/scripts/RecalculateAbsenceEntitlement.php
+++ b/hrjobcontract/scripts/RecalculateAbsenceEntitlement.php
@@ -7,7 +7,7 @@ $jobContracts = CRM_Core_DAO::executeQuery('SELECT * FROM civicrm_hrjobcontract 
 $i = 0;
 while ($jobContracts->fetch()) {
     echo "Recalculating Absence Entitlement by Job Contract #{$jobContracts->id}...";
-    CRM_Hrjobcontract_BAO_HRJobLeave::recalculateAbsenceEntitlement($jobContracts->id);
+    CRM_HRAbsence_BAO_HRAbsenceEntitlement::recalculateAbsenceEntitlement($jobContracts->id);
     echo "OK.\n";
     $i++;
 }

--- a/hrjobcontract/scripts/RecalculateAbsenceEntitlementByContacts.php
+++ b/hrjobcontract/scripts/RecalculateAbsenceEntitlementByContacts.php
@@ -7,7 +7,7 @@ $contacts = CRM_Core_DAO::executeQuery('SELECT * FROM civicrm_contact WHERE cont
 $i = 0;
 while ($contacts->fetch()) {
     echo "Recalculating Absence Entitlement for Contact #{$contacts->id}...";
-    CRM_Hrjobcontract_BAO_HRJobLeave::recalculateAbsenceEntitlementForContact($contacts->id);
+    CRM_HRAbsence_BAO_HRAbsenceEntitlement::recalculateAbsenceEntitlementForContact($contacts->id);
     echo "OK.\n";
     $i++;
 }


### PR DESCRIPTION
**Problem**
When a new absence period is added, the entitlement for each contact is set to 0 instead of fetching the value from the contractual entitlement (the value set on the Leave tab of the contract dialog)

**Solution**
Whenever a new absence period is saved, a new task, containing the ID of the just saved period, is added to a "Entitlement Recalculation Queue", which will be processed by a new scheduled job that will update the entitlements for that period for all contacts.

This was created as a scheduled job because organizations can have a lot of contacts and doing this calculation for all of them might take some time.

-------------------------------------------------------------------------

**Refactoring**
The HRJobLeave BAO had a lot of methods which accessed directly tables from other extensions. I moved these the extension/classes they belong to.

**Why some few tests?**
The hrabsence extension will soon be replaced by L&A, so there's no point on spending too much time on something that won't last long. I just added a few to check that the positive path is working.