### PR TITLE
PCHR-1655 - Cannot permanently delete individual user

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -967,6 +967,17 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     return true;
   }
 
+  /**
+   * Update Job Contract tables constraints with cascade delete.
+   *
+   * @return TRUE
+   */
+  function upgrade_1021() {
+    $this->executeSqlFile('sql/pchr-1655-alter_constraints_on_delete_cascade.sql');
+
+    return TRUE;
+  }
+
   function decToFraction($fte) {
     $fteDecimalPart = explode('.', $fte);
     $array = array();

--- a/hrjobcontract/sql/install.sql
+++ b/hrjobcontract/sql/install.sql
@@ -96,7 +96,7 @@ CREATE TABLE IF NOT EXISTS `civicrm_hrjobcontract_details` (
     KEY `index_contract_typ` (`contract_type`),
     KEY `index_location` (`location`),
     KEY `index_jobcontract_revision_id` (`jobcontract_revision_id`),
-    CONSTRAINT `FK_civicrm_hrjobcontract_details_contract_revision_id` FOREIGN KEY (`jobcontract_revision_id`) REFERENCES `civicrm_hrjobcontract_revision` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+    CONSTRAINT `FK_civicrm_hrjobcontract_details_contract_revision_id` FOREIGN KEY (`jobcontract_revision_id`) REFERENCES `civicrm_hrjobcontract_revision` (`details_revision_id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
 
 
@@ -122,7 +122,7 @@ CREATE TABLE `civicrm_hrjobcontract_pay` (
     INDEX `index_pay_scale`(pay_scale),
     INDEX `index_is_paid`(is_paid),
     INDEX `index_jobcontract_revision_id` (jobcontract_revision_id ASC),
-    CONSTRAINT `FK_civicrm_hrjobcontract_pay_jobcontract_revision_id`  FOREIGN KEY (`jobcontract_revision_id`)  REFERENCES `civicrm_hrjobcontract_revision` (`id`)  ON DELETE NO ACTION  ON UPDATE NO ACTION
+    CONSTRAINT `FK_civicrm_hrjobcontract_pay_jobcontract_revision_id`  FOREIGN KEY (`jobcontract_revision_id`)  REFERENCES `civicrm_hrjobcontract_revision` (`pay_revision_id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
 
 
@@ -153,7 +153,7 @@ CREATE TABLE `civicrm_hrjobcontract_health` (
     INDEX `index_jobcontract_revision_id` (jobcontract_revision_id ASC),
     CONSTRAINT `FK_civicrm_hrjobcontract_health_provider` FOREIGN KEY (`provider`)  REFERENCES `civicrm_contact`(`id`) ON DELETE SET NULL,
     CONSTRAINT `FK_civicrm_hrjobcontract_health_provider_life_insurance` FOREIGN KEY (`provider_life_insurance`)  REFERENCES `civicrm_contact`(`id`) ON DELETE SET NULL,
-    CONSTRAINT `FK_civicrm_hrjobcontract_health_jobcontract_revision_id` FOREIGN KEY (`jobcontract_revision_id`)  REFERENCES `civicrm_hrjobcontract_revision` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+    CONSTRAINT `FK_civicrm_hrjobcontract_health_jobcontract_revision_id` FOREIGN KEY (`jobcontract_revision_id`)  REFERENCES `civicrm_hrjobcontract_revision` (`health_revision_id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
 
 
@@ -177,7 +177,7 @@ CREATE TABLE `civicrm_hrjobcontract_hour` (
     PRIMARY KEY ( `id` ),
     INDEX `index_hours_type`(hours_type),
     INDEX `index_jobcontract_revision_id` (jobcontract_revision_id ASC),
-    CONSTRAINT `FK_civicrm_hrjobcontract_hour_jobcontract_revision_id` FOREIGN KEY (`jobcontract_revision_id`)  REFERENCES `civicrm_hrjobcontract_revision` (`id`)  ON DELETE NO ACTION  ON UPDATE NO ACTION
+    CONSTRAINT `FK_civicrm_hrjobcontract_hour_jobcontract_revision_id` FOREIGN KEY (`jobcontract_revision_id`)  REFERENCES `civicrm_hrjobcontract_revision` (`hour_revision_id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
 
 
@@ -196,7 +196,7 @@ CREATE TABLE `civicrm_hrjobcontract_leave` (
     `jobcontract_revision_id` INT(10) UNSIGNED DEFAULT NULL,
     PRIMARY KEY ( `id` ),
     INDEX `index_jobcontract_revision_id` (jobcontract_revision_id ASC),
-    CONSTRAINT `FK_civicrm_hrjobcontract_leave_jobcontract_revision_id`  FOREIGN KEY (`jobcontract_revision_id`)  REFERENCES `civicrm_hrjobcontract_revision` (`id`)  ON DELETE NO ACTION  ON UPDATE NO ACTION
+    CONSTRAINT `FK_civicrm_hrjobcontract_leave_jobcontract_revision_id`  FOREIGN KEY (`jobcontract_revision_id`)  REFERENCES `civicrm_hrjobcontract_revision` (`leave_revision_id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
 
 
@@ -220,7 +220,7 @@ CREATE TABLE `civicrm_hrjobcontract_pension` (
     PRIMARY KEY ( `id` ),
     INDEX `index_is_enrolled`(is_enrolled),
     INDEX `index_jobcontract_revision_id` (jobcontract_revision_id ASC),
-    CONSTRAINT `FK_civicrm_hrjobcontract_pension_jobcontract_revision_id`  FOREIGN KEY (`jobcontract_revision_id`)  REFERENCES `civicrm_hrjobcontract_revision` (`id`)  ON DELETE NO ACTION  ON UPDATE NO ACTION
+    CONSTRAINT `FK_civicrm_hrjobcontract_pension_jobcontract_revision_id`  FOREIGN KEY (`jobcontract_revision_id`)  REFERENCES `civicrm_hrjobcontract_revision` (`pension_revision_id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
 
 
@@ -262,7 +262,7 @@ CREATE TABLE `civicrm_hrjobcontract_role` (
     INDEX `index_location`(location),
     INDEX `index_jobcontract_revision_id` (jobcontract_revision_id ASC),
     CONSTRAINT FK_civicrm_hrjobcontract_role_manager_contact_id FOREIGN KEY (`manager_contact_id`) REFERENCES `civicrm_contact`(`id`) ON DELETE SET NULL,
-    CONSTRAINT `FK_civicrm_hrjobcontract_role_jobcontract_revision_id`  FOREIGN KEY (`jobcontract_revision_id`)  REFERENCES `civicrm_hrjobcontract_revision` (`id`)  ON DELETE NO ACTION  ON UPDATE NO ACTION
+    CONSTRAINT `FK_civicrm_hrjobcontract_role_jobcontract_revision_id`  FOREIGN KEY (`jobcontract_revision_id`)  REFERENCES `civicrm_hrjobcontract_revision` (`role_revision_id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
 
 SET FOREIGN_KEY_CHECKS=1;

--- a/hrjobcontract/sql/pchr-1655-alter_constraints_on_delete_cascade.sql
+++ b/hrjobcontract/sql/pchr-1655-alter_constraints_on_delete_cascade.sql
@@ -1,0 +1,79 @@
+# civicrm_hrjobcontract
+
+ALTER TABLE `civicrm_hrjobcontract` 
+DROP FOREIGN KEY `FK_civicrm_hrjobcontract_contact_id`;
+
+ALTER TABLE `civicrm_hrjobcontract` 
+ADD CONSTRAINT `FK_civicrm_hrjobcontract_contact_id` FOREIGN KEY (`contact_id`) REFERENCES `civicrm_contact` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION;
+
+
+# civicrm_hrjobcontract_revision
+
+ALTER TABLE `civicrm_hrjobcontract_revision`
+DROP FOREIGN KEY `FK_civicrm_hrjobcontract_revision_jobcontract_id`;
+
+ALTER TABLE `civicrm_hrjobcontract_revision`
+ADD CONSTRAINT `FK_civicrm_hrjobcontract_revision_jobcontract_id` FOREIGN KEY (`jobcontract_id`) REFERENCES `civicrm_hrjobcontract` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION;
+
+
+# civicrm_hrjobcontract_details
+
+ALTER TABLE `civicrm_hrjobcontract_details`
+DROP FOREIGN KEY `FK_civicrm_hrjobcontract_details_contract_revision_id`;
+
+ALTER TABLE `civicrm_hrjobcontract_details`
+ADD CONSTRAINT `FK_civicrm_hrjobcontract_details_contract_revision_id` FOREIGN KEY (`jobcontract_revision_id`) REFERENCES `civicrm_hrjobcontract_revision` (`details_revision_id`) ON DELETE CASCADE ON UPDATE NO ACTION;
+
+
+# civicrm_hrjobcontract_pay
+
+ALTER TABLE `civicrm_hrjobcontract_pay`
+DROP FOREIGN KEY `FK_civicrm_hrjobcontract_pay_jobcontract_revision_id`;
+
+ALTER TABLE `civicrm_hrjobcontract_pay`
+ADD CONSTRAINT `FK_civicrm_hrjobcontract_pay_jobcontract_revision_id`  FOREIGN KEY (`jobcontract_revision_id`)  REFERENCES `civicrm_hrjobcontract_revision` (`pay_revision_id`) ON DELETE CASCADE ON UPDATE NO ACTION;
+
+
+# civicrm_hrjobcontract_health
+
+ALTER TABLE `civicrm_hrjobcontract_health`
+DROP FOREIGN KEY `FK_civicrm_hrjobcontract_health_jobcontract_revision_id`;
+
+ALTER TABLE `civicrm_hrjobcontract_health`
+ADD CONSTRAINT `FK_civicrm_hrjobcontract_health_jobcontract_revision_id`  FOREIGN KEY (`jobcontract_revision_id`)  REFERENCES `civicrm_hrjobcontract_revision` (`health_revision_id`) ON DELETE CASCADE ON UPDATE NO ACTION;
+
+
+# civicrm_hrjobcontract_hour
+
+ALTER TABLE `civicrm_hrjobcontract_hour`
+DROP FOREIGN KEY `FK_civicrm_hrjobcontract_hour_jobcontract_revision_id`;
+
+ALTER TABLE `civicrm_hrjobcontract_hour`
+ADD CONSTRAINT `FK_civicrm_hrjobcontract_hour_jobcontract_revision_id`  FOREIGN KEY (`jobcontract_revision_id`)  REFERENCES `civicrm_hrjobcontract_revision` (`hour_revision_id`) ON DELETE CASCADE ON UPDATE NO ACTION;
+
+
+# civicrm_hrjobcontract_leave
+
+ALTER TABLE `civicrm_hrjobcontract_leave`
+DROP FOREIGN KEY `FK_civicrm_hrjobcontract_leave_jobcontract_revision_id`;
+
+ALTER TABLE `civicrm_hrjobcontract_leave`
+ADD CONSTRAINT `FK_civicrm_hrjobcontract_leave_jobcontract_revision_id`  FOREIGN KEY (`jobcontract_revision_id`)  REFERENCES `civicrm_hrjobcontract_revision` (`leave_revision_id`) ON DELETE CASCADE ON UPDATE NO ACTION;
+
+
+# civicrm_hrjobcontract_pension
+
+ALTER TABLE `civicrm_hrjobcontract_pension`
+DROP FOREIGN KEY `FK_civicrm_hrjobcontract_pension_jobcontract_revision_id`;
+
+ALTER TABLE `civicrm_hrjobcontract_pension`
+ADD CONSTRAINT `FK_civicrm_hrjobcontract_pension_jobcontract_revision_id`  FOREIGN KEY (`jobcontract_revision_id`)  REFERENCES `civicrm_hrjobcontract_revision` (`pension_revision_id`) ON DELETE CASCADE ON UPDATE NO ACTION;
+
+
+# civicrm_hrjobcontract_role
+
+ALTER TABLE `civicrm_hrjobcontract_role`
+DROP FOREIGN KEY `FK_civicrm_hrjobcontract_role_jobcontract_revision_id`;
+
+ALTER TABLE `civicrm_hrjobcontract_role`
+ADD CONSTRAINT `FK_civicrm_hrjobcontract_role_jobcontract_revision_id`  FOREIGN KEY (`jobcontract_revision_id`)  REFERENCES `civicrm_hrjobcontract_revision` (`role_revision_id`) ON DELETE CASCADE ON UPDATE NO ACTION;


### PR DESCRIPTION
When trying to permanently delete a Contact there is an error if the Contact has Job Contracts existing in the database. To fix it I modified SQL tables definitions so now the Job Contracts are deleted with their revisions and entities while permanently deleting Contact from database.

Within this PR I did as follows:
- Creating upgrader script which modifies constraints on Job Contract tables
- Modifying install.sql script
- Creating unit test for checking delete cascade on Job Contract tables when deleting Contact.