### PR TITLE
PCHR-1707: Don't update absence period entitlement from contract after contract change

### DIFF
--- a/hrabsence/tests/phpunit/CRM/HRAbsence/BAO/HRAbsenceEntitlementTest.php
+++ b/hrabsence/tests/phpunit/CRM/HRAbsence/BAO/HRAbsenceEntitlementTest.php
@@ -63,11 +63,11 @@ class CRM_HRAbsence_BAO_HRAbsenceEntitlementTest extends PHPUnit_Framework_TestC
 
     CRM_HRAbsence_BAO_HRAbsenceEntitlement::recalculateAbsenceEntitlementsForPeriod($period->id);
 
-    $contact1Entitlement = new CRM_HRAbsence_BAO_HRAbsenceEntitlement();
-    $contact1Entitlement->contact_id = $contact1['id'];
-    $contact1Entitlement->period_id = $period->id;
-    $contact1Entitlement->type_id = $absenceType->id;
-    $contact1Entitlement->find(true);
+    $contact1Entitlement = $entitlement = $this->getAbsenceTypeEntitlementForPeriod(
+      $contact1['id'],
+      $period->id,
+      $absenceType->id
+    );
 
     // The absence_entitlement record is created for contact 1,
     // but since their contract doesn't overlap the absence period,
@@ -76,11 +76,11 @@ class CRM_HRAbsence_BAO_HRAbsenceEntitlementTest extends PHPUnit_Framework_TestC
     $this->assertEquals(1, $contact1Entitlement->N);
     $this->assertEquals(0, $contact1Entitlement->amount);
 
-    $contact2Entitlement = new CRM_HRAbsence_BAO_HRAbsenceEntitlement();
-    $contact2Entitlement->contact_id = $contact2['id'];
-    $contact2Entitlement->period_id = $period->id;
-    $contact2Entitlement->type_id = $absenceType->id;
-    $contact2Entitlement->find(true);
+    $contact2Entitlement = $this->getAbsenceTypeEntitlementForPeriod(
+      $contact2['id'],
+      $period->id,
+      $absenceType->id
+    );
 
     // The absence_entitlement record is created for contact 2,
     // and since their contract overlaps the absence period,

--- a/hrabsence/tests/phpunit/CRM/HRAbsence/BAO/HRAbsenceEntitlementTest.php
+++ b/hrabsence/tests/phpunit/CRM/HRAbsence/BAO/HRAbsenceEntitlementTest.php
@@ -27,8 +27,8 @@ class CRM_HRAbsence_BAO_HRAbsenceEntitlementTest extends PHPUnit_Framework_TestC
   public function testRecalculateAbsenceEntitlementsForPeriodCreatesTheContactsEntitlementsForThatPeriod() {
     $absenceType = AbsenceTypeFabricator::fabricate();
 
-    $contact1 = ContactFabricator::fabricate([]);
-    $contact2 = ContactFabricator::fabricate([]);
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
 
     $contract1 = JobContractFabricator::fabricate(['contact_id' => $contact1['id']], [
       'period_start_date' => '2015-01-01',
@@ -93,7 +93,7 @@ class CRM_HRAbsence_BAO_HRAbsenceEntitlementTest extends PHPUnit_Framework_TestC
   public function testRecalculateAbsenceEntitlementDoesNotOverwriteExistingEntitlements() {
     $absenceType = AbsenceTypeFabricator::fabricate();
 
-    $contact = ContactFabricator::fabricate([]);
+    $contact = ContactFabricator::fabricate();
 
     $contract = JobContractFabricator::fabricate(['contact_id' => $contact['id']], [
       'period_start_date' => '2016-01-01',

--- a/hrabsence/tests/phpunit/CRM/HRAbsence/BAO/HRAbsenceEntitlementTest.php
+++ b/hrabsence/tests/phpunit/CRM/HRAbsence/BAO/HRAbsenceEntitlementTest.php
@@ -76,20 +76,18 @@ class CRM_HRAbsence_BAO_HRAbsenceEntitlementTest extends PHPUnit_Framework_TestC
     $this->assertEquals(1, $contact1Entitlement->N);
     $this->assertEquals(0, $contact1Entitlement->amount);
 
-    $contact1Entitlement = new CRM_HRAbsence_BAO_HRAbsenceEntitlement();
-    $contact1Entitlement->contact_id = $contact2['id'];
-    $contact1Entitlement->period_id = $period->id;
-    $contact1Entitlement->type_id = $absenceType->id;
-    $contact1Entitlement->find(true);
+    $contact2Entitlement = new CRM_HRAbsence_BAO_HRAbsenceEntitlement();
+    $contact2Entitlement->contact_id = $contact2['id'];
+    $contact2Entitlement->period_id = $period->id;
+    $contact2Entitlement->type_id = $absenceType->id;
+    $contact2Entitlement->find(true);
 
     // The absence_entitlement record is created for contact 2,
     // and since their contract overlaps the absence period,
     // the leave_amount will be fetched from the contractual
     // entitlement set in Job Leave
-    $this->assertEquals(1, $contact1Entitlement->N);
-    $this->assertEquals(23, $contact1Entitlement->amount);
+    $this->assertEquals(1, $contact2Entitlement->N);
+    $this->assertEquals(23, $contact2Entitlement->amount);
   }
-
-
 
 }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Test/Fabricator/Contact.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Test/Fabricator/Contact.php
@@ -9,7 +9,7 @@ class CRM_HRCore_Test_Fabricator_Contact {
     'sequential'   => 1
   ];
 
-  public static function fabricate($params) {
+  public static function fabricate($params = []) {
     $params                 = array_merge(self::$defaultParams, $params);
     $params['display_name'] = "{$params['first_name']} {$params['last_name']}";
 


### PR DESCRIPTION
**Problem**
The period entitlement could be updated in two different ways:
- Manually, by clicking on the Absence tab of the contact page and then setting the values for each type and period
- Automatically, after updating a contract. In this case, the period entitlement is updated with whichever value is set on the leave tab of the contract dialog

The problem with the automatic update is that it would overwrite any existing entitlement set manually.

**Solution**
No, in order to no overwrite things, the method which recalculates the entitlement, will only save the new value if there is no existing entitlement for a contact and absence type during a given period. 