### PR TITLE
PCHR-1701: Revert CiviHR version

### DIFF
--- a/com.civicrm.hrjobroles/info.xml
+++ b/com.civicrm.hrjobroles/info.xml
@@ -8,8 +8,8 @@
     <author>gregmeszaros</author>
     <email>meszaros275@gmail.com</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/contactaccessrights/info.xml
+++ b/contactaccessrights/info.xml
@@ -8,8 +8,8 @@
     <author>Robin Mitra</author>
     <email>robinmitra1@gmail.com</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/contactsummary/info.xml
+++ b/contactsummary/info.xml
@@ -8,8 +8,8 @@
     <author>Robin Mitra</author>
     <email>robinmitra1@gmail.com</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrabsence/info.xml
+++ b/hrabsence/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrbank/info.xml
+++ b/hrbank/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrcareer/info.xml
+++ b/hrcareer/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrcase/info.xml
+++ b/hrcase/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrdemog/info.xml
+++ b/hrdemog/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrident/info.xml
+++ b/hrident/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrim/info.xml
+++ b/hrim/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrjobcontract/info.xml
+++ b/hrjobcontract/info.xml
@@ -8,8 +8,8 @@
     <author>Mateusz Cieplinski</author>
     <email>mateusz@coldrun.pl</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrmed/info.xml
+++ b/hrmed/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrprofile/info.xml
+++ b/hrprofile/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrqual/info.xml
+++ b/hrqual/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrrecruitment/info.xml
+++ b/hrrecruitment/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrreport/info.xml
+++ b/hrreport/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrsampledata/info.xml
+++ b/hrsampledata/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrstaffdir/info.xml
+++ b/hrstaffdir/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrui/info.xml
+++ b/hrui/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrvisa/info.xml
+++ b/hrvisa/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/org.civicrm.bootstrapcivihr/info.xml
+++ b/org.civicrm.bootstrapcivihr/info.xml
@@ -8,8 +8,8 @@
     <author>Alessandro Verdura</author>
     <email>alessandro@compucorp.co.uk</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/org.civicrm.hremergency/info.xml
+++ b/org.civicrm.hremergency/info.xml
@@ -8,8 +8,8 @@
     <author>gregmeszaros</author>
     <email>meszaros275@gmail.com</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/org.civicrm.reqangular/info.xml
+++ b/org.civicrm.reqangular/info.xml
@@ -10,8 +10,8 @@
     <author>Mateusz Cieplinski</author>
     <email>mateusz@coldrun.pl</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/uk.co.compucorp.civicrm.appraisals/info.xml
+++ b/uk.co.compucorp.civicrm.appraisals/info.xml
@@ -8,8 +8,8 @@
     <author>coldrunKacper</author>
     <email>kacper@coldrun.pl</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/uk.co.compucorp.civicrm.hrcore/info.xml
+++ b/uk.co.compucorp.civicrm.hrcore/info.xml
@@ -8,8 +8,8 @@
     <author>Compucorp Ltd</author>
     <email>info@compucorp.co.uk</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/info.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/info.xml
@@ -8,8 +8,8 @@
     <author>Compucorp Ltd</author>
     <email>info@compucorp.co.uk</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>


### PR DESCRIPTION
After the 2016-11-03 release, additional fixes had to be added to the 1.6.3 release.
Since this is not a public release yet, it was decided we should move the tag
instead of applying hotfixes. That is why we need to revert the version and
updated the release date here.