### PR TITLE
PCHR-1177: Fixed API Call Error When Marking Tasks as Complete

### DIFF
--- a/hrcase/hrcase.php
+++ b/hrcase/hrcase.php
@@ -343,10 +343,14 @@ function hrcase_civicrm_alterContent( &$content, $context, $tplName, &$object ) 
 /**
  * Implementation of hook_civicrm_post, executed after task creation/update
  *
- * @param $op string, the type of operation being performed;
- * @param $objectName string, type of object being processed
- * @param $objectId string, id of object
- * @param $objectRef CRM_Activity_DAO_Activity, object being used to process operation.
+ * @param string $op
+ *   The type of operation being performed
+ * @param string $objectName
+ *   Type of object being processed
+ * @param string $objectId string 
+ *   Id of object
+ * @param CRM_Activity_DAO_Activity $objectRef
+ *   Object being used to process operation
  */
 function hrcase_civicrm_post( $op, $objectName, $objectId, &$objectRef ) {
   if ($objectName == 'Activity' && isset($objectRef->case_id) && !activityCreatedByTaskandAssignments($objectId)) {
@@ -461,7 +465,6 @@ function hrcase_getActionsSchedule($getNamesOnly = FALSE) {
 function activityCreatedByTaskandAssignments($activity_id) {
   $params = ['id' => $activity_id];
   $activity = CRM_Activity_BAO_Activity::retrieve($params);
-  $activity->activity_type_id;
 
   // check if task and assignments is enabled
   $isEnabled = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Extension', 'uk.co.compucorp.civicrm.tasksassignments', 'is_active', 'full_name');


### PR DESCRIPTION
Issue affected admin part of CiviHR also.  The problem seems to happen because the activity's data is never queried from the DB.  Thus, the activity's type is null when the check is performed, and causes the error when the null value is used to bring a single result from the activitytype table.

Fixed by passing activity id instead of activity_type_id to activityCreatedByTaskandAssignments(), so data can be loaded from DB within function.

Should inspect the code to assure this same assumption will not cause further issues (assuming the object is loaded with all the information in DB).