### PR TITLE
PCHR-1196: Trigger Public Holiday Leave Requests creation/deletion when updating/deleting Absence Types

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
@@ -336,7 +336,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
         }
       }
 
-      $numberOfPublicHolidays = PublicHoliday::getNumberOfPublicHolidaysForPeriod(
+      $numberOfPublicHolidays = PublicHoliday::getCountForPeriod(
         $this->start_date,
         $this->end_date,
         true

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -101,8 +101,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    *
    * @throws \CRM_HRLeaveAndAbsences_Exception_OperationNotAllowedException
    */
-  public static function del($id)
-  {
+  public static function del($id) {
     $absenceType = new CRM_HRLeaveAndAbsences_DAO_AbsenceType();
     $absenceType->id = $id;
     $absenceType->find(true);
@@ -112,6 +111,10 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
     }
 
     $absenceType->delete();
+
+    if($absenceType->must_take_public_holiday_as_leave) {
+      self::enqueuePublicHolidayLeaveRequestUpdateTask();
+    }
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -471,4 +471,23 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
 
     return $absenceTypes;
   }
+
+  /**
+   * Returns the AbsenceType where the must_take_public_holiday_as_leave option
+   * is set
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_AbsenceType|null
+   */
+  public static function getOneWithMustTakePublicHolidayAsLeaveRequest() {
+    $absenceType = new self();
+    $absenceType->must_take_public_holiday_as_leave = 1;
+    $absenceType->is_active = 1;
+
+    $absenceType->find();
+    if($absenceType->fetch()) {
+      return $absenceType;
+    }
+
+    return null;
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/PublicHoliday.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/PublicHoliday.php
@@ -9,7 +9,8 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
   /**
    * Create a new PublicHoliday based on array-data
    *
-   * @param array $params key-value pairs
+   * @param array $params
+   *   key-value pairs
    * @return CRM_HRLeaveAndAbsences_DAO_PublicHoliday|NULL
    **/
   public static function create($params) {
@@ -45,6 +46,7 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
    * Return an array containing properties of Public Holiday with given ID.
    *
    * @param int $id
+   *
    * @return array|NULL
    */
   public static function getValuesArray($id) {
@@ -215,7 +217,7 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
    * Returns the number of Public Holidays in the Current Period
    *
    * @param bool $excludeWeekends
-   *  If true, public holidays that falls on a weekend won't be counted. Default is false
+   *   If true, public holidays that falls on a weekend won't be counted. Default is false
    *
    * @return int
    */
@@ -295,7 +297,7 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
    * today at 00:00:00
    *
    * @param string $date
-   *  A date string in any format supported by strtotime
+   *   A date string in any format supported by strtotime
    *
    * @return bool
    */
@@ -313,7 +315,7 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
    * updated.
    *
    * @param array $params
-   *  The params array passed to the create() method
+   *   The params array passed to the create() method
    *
    * @return string|null
    */
@@ -355,7 +357,7 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
    * Process all the items on the PublicHolidayLeaveRequestUpdates Queue
    *
    * @return int
-   *  The number of items processed
+   *   The number of items processed
    */
   public static function processPublicHolidayLeaveRequestUpdatesQueue() {
     $numberOfItemsProcessed = 0;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/PublicHoliday.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/PublicHoliday.php
@@ -174,7 +174,7 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
    *
    * @return int The Number of Public Holidays for the given Period
    */
-  public static function getNumberOfPublicHolidaysForPeriod($startDate, $endDate = null, $excludeWeekends = false) {
+  public static function getCountForPeriod($startDate, $endDate = null, $excludeWeekends = false) {
     $startDate = CRM_Utils_Date::processDate($startDate, null, false, 'Ymd');
 
     $queryParams = [
@@ -218,14 +218,14 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
    *
    * @return int
    */
-  public static function getNumberOfPublicHolidaysForCurrentPeriod($excludeWeekends = false) {
+  public static function getCountForCurrentPeriod($excludeWeekends = false) {
     $currentPeriod = AbsencePeriod::getCurrentPeriod();
 
     if(!$currentPeriod) {
       return 0;
     }
 
-    return self::getNumberOfPublicHolidaysForPeriod(
+    return self::getCountForPeriod(
       $currentPeriod->start_date,
       $currentPeriod->end_date,
       $excludeWeekends
@@ -248,7 +248,7 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
    *
    * @return CRM_HRLeaveAndAbsences_BAO_PublicHoliday[]
    */
-  public static function getPublicHolidaysForPeriod($startDate, $endDate = null, $excludeWeekends = false) {
+  public static function getAllForPeriod($startDate, $endDate = null, $excludeWeekends = false) {
     $startDate = CRM_Utils_Date::processDate($startDate, null, false, 'Ymd');
 
     $queryParams = [
@@ -347,6 +347,6 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
    * @return \CRM_HRLeaveAndAbsences_BAO_PublicHoliday[]
    */
   public static function getAllInFuture() {
-    return self::getPublicHolidaysForPeriod(date('Ymd'));
+    return self::getAllForPeriod(date('Ymd'));
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/PublicHoliday.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/PublicHoliday.php
@@ -339,4 +339,14 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHoliday extends CRM_HRLeaveAndAbsences_DA
       throw new InvalidPublicHolidayException('The date cannot be outside the existing absence periods');
     }
   }
+
+  /**
+   * Returns all the Public Holidays in the future. That is, all where date is
+   * >= today. Including Public Holidays that fall on weekends
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_PublicHoliday[]
+   */
+  public static function getAllInFuture() {
+    return self::getPublicHolidaysForPeriod(date('Ymd'));
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/ContractEntitlementCalculation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/ContractEntitlementCalculation.php
@@ -101,7 +101,7 @@ class CRM_HRLeaveAndAbsences_ContractEntitlementCalculation {
     $jobLeave = $this->getJobLeave();
 
     if(!empty($jobLeave['add_public_holidays'])) {
-      return PublicHoliday::getNumberOfPublicHolidaysForPeriod(
+      return PublicHoliday::getCountForPeriod(
         $this->contract['period_start_date'],
         $this->contract['period_end_date']
       );
@@ -120,7 +120,7 @@ class CRM_HRLeaveAndAbsences_ContractEntitlementCalculation {
     $jobLeave = $this->getJobLeave();
 
     if(!empty($jobLeave['add_public_holidays'])) {
-      return PublicHoliday::getPublicHolidaysForPeriod(
+      return PublicHoliday::getAllForPeriod(
         $this->contract['period_start_date'],
         $this->contract['period_end_date']
       );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/PublicHolidayLeaveRequestUpdates.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/PublicHolidayLeaveRequestUpdates.php
@@ -1,0 +1,35 @@
+<?php
+
+class CRM_HRLeaveAndAbsences_Queue_PublicHolidayLeaveRequestUpdates {
+
+  const QUEUE_NAME = 'hrleaveandabsences.publicholidayleaverequestupdates';
+
+  private static $queue;
+
+  /**
+   * Returns the Queue object wrapped by this class
+   *
+   * @return \CRM_Queue_Queue
+   */
+  public static function getQueue() {
+    if(!self::$queue) {
+      self::$queue = CRM_Queue_Service::singleton()->create([
+        'type' => 'Sql',
+        'name' => self::QUEUE_NAME,
+        'reset' => false,
+      ]);
+    }
+
+    return self::$queue;
+  }
+
+  /**
+   * Adds a new tasks to the queue
+   *
+   * @param object $task
+   * @param array $options
+   */
+  public static function createItem($task, $options = []) {
+    self::getQueue()->createItem($task, $options);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/Task/UpdateAllFuturePublicHolidayLeaveRequests.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/Task/UpdateAllFuturePublicHolidayLeaveRequests.php
@@ -1,0 +1,25 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest as PublicHolidayLeaveRequestService;
+use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation as PublicHolidayLeaveRequestCreation;
+use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion as PublicHolidayLeaveRequestDeletion;
+
+
+/**
+ * This is the Queue Task which will be executed by the whenever the
+ * PublicHolidayLeaveRequestUpdates queue is processed.
+ *
+ * Basically, it uses the PublicHolidayLeaveRequest service to update all leave
+ * requests for public holidays in the future
+ */
+class CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequests {
+
+  public function run(CRM_Queue_TaskContext $ctx) {
+    $creationLogic = new PublicHolidayLeaveRequestCreation();
+    $deletionLogic = new PublicHolidayLeaveRequestDeletion();
+
+    $service = new PublicHolidayLeaveRequestService($creationLogic, $deletionLogic);
+    $service->updateAllLeaveRequestsInTheFuture();
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation as CreationLogic;
+use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion as DeletionLogic;
+
+class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest {
+
+  /**
+   * @var \CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation
+   */
+  private $creationLogic;
+
+  /**
+   * @var \CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion
+   */
+  private $deletionLogic;
+
+  public function __construct(CreationLogic $creationLogic, DeletionLogic $deletionLogic) {
+    $this->creationLogic = $creationLogic;
+    $this->deletionLogic = $deletionLogic;
+  }
+
+  /**
+   * Updates all the Leave Requests for Public Holidays in the future.
+   *
+   * Basically, this uses the Deletion Logic to delete all the leave requests
+   * for public holidays in the future and, then, uses the Creation Logic to
+   * create leave requests to public holidays in the future.
+   *
+   * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion::deleteAllInTheFuture()
+   * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation::createForAllInTheFuture()
+   */
+  public function updateAllLeaveRequestsInTheFuture() {
+    $this->deletionLogic->deleteAllInTheFuture();
+    $this->creationLogic->createForAllInTheFuture();
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -159,7 +159,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
    * dates of the given $contract
    *
    * @param array $contract
-   *  An contract as returned by the HRJobContract.getcontractswithdetailsinperiod API
+   *   An contract as returned by the HRJobContract.getcontractswithdetailsinperiod API
    * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
    *
    * @return bool

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -19,7 +19,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
    */
   public function createForAbsenceType(AbsenceType $absenceType) {
     if(!$absenceType->must_take_public_holiday_as_leave) {
-      return;
+      throw new InvalidArgumentException("It's not possible to create Public Holidays for Absence Types where 'Must take public holiday as leave' is false");
     }
 
     $futurePublicHolidays = PublicHoliday::getAllInFuture();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -9,17 +9,17 @@ use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
 class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
 
   /**
-   * Creates Public Holiday Leave Requests based on an AbsenceType.
+   * Creates Public Holiday Leave Requests for all the existing Public Holidays
+   * int the future
    *
-   * This method will get all Public Holidays in the future and then will
-   * create a Leave Request for each of them, for all the contacts with
-   * contracts overlapping any of the holiday dates
-   *
-   * @param \CRM_HRLeaveAndAbsences_BAO_AbsenceType $absenceType
+   * For each contract overlapping one Public Holiday, a Leave Request will be
+   * created for the contract's contact and the public holiday date.
    */
-  public function createForAbsenceType(AbsenceType $absenceType) {
-    if(!$absenceType->must_take_public_holiday_as_leave) {
-      throw new InvalidArgumentException("It's not possible to create Public Holidays for Absence Types where 'Must take public holiday as leave' is false");
+  public function createForAllInTheFuture() {
+    $absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
+
+    if(!$absenceType) {
+      return;
     }
 
     $futurePublicHolidays = PublicHoliday::getAllInFuture();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -47,10 +47,8 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
    * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
    */
   public function createForContact($contactID, PublicHoliday $publicHoliday) {
-    $absenceTypes = $this->getAbsenceTypesWherePublicHolidaysMustBeTakenAsLeave();
-    foreach($absenceTypes as $absenceType) {
-      $this->create($contactID, $absenceType, $publicHoliday);
-    }
+    $absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
+    $this->create($contactID, $absenceType, $publicHoliday);
   }
 
   /**
@@ -64,20 +62,6 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
   private function create($contactID, AbsenceType $absenceType, PublicHoliday $publicHoliday) {
     $leaveRequest = $this->createLeaveRequest($contactID, $absenceType, $publicHoliday);
     $this->createLeaveBalanceChangeRecord($leaveRequest);
-  }
-
-  /**
-   * Returns a list of all enabled Absence Types where the "Must Take Public
-   * Holiday as Leave" option is set
-   *
-   * @return \CRM_HRLeaveAndAbsences_BAO_AbsenceType[]
-   */
-  private function getAbsenceTypesWherePublicHolidaysMustBeTakenAsLeave() {
-    $allAbsenceTypes = AbsenceType::getEnabledAbsenceTypes();
-
-    return array_filter($allAbsenceTypes, function(AbsenceType $absenceType) {
-      return boolval($absenceType->must_take_public_holiday_as_leave);
-    });
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -9,6 +9,37 @@ use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
 class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
 
   /**
+   * Creates Public Holiday Leave Requests based on an AbsenceType.
+   *
+   * This method will get all Public Holidays in the future and then will
+   * create a Leave Request for each of them, for all the contacts with
+   * contracts overlapping any of the holiday dates
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_AbsenceType $absenceType
+   */
+  public function createForAbsenceType(AbsenceType $absenceType) {
+    if(!$absenceType->must_take_public_holiday_as_leave) {
+      return;
+    }
+
+    $futurePublicHolidays = PublicHoliday::getAllInFuture();
+    $lastPublicHoliday = end($futurePublicHolidays);
+
+    $contracts = $this->getContractsForPeriod(
+      new DateTime(),
+      new DateTime($lastPublicHoliday->date)
+    );
+
+    foreach($contracts as $contract) {
+      foreach($futurePublicHolidays as $publicHoliday) {
+        if($this->publicHolidayOverlapsContract($contract, $publicHoliday)) {
+          $this->create($contract['contact_id'], $absenceType, $publicHoliday);
+        }
+      }
+    }
+  }
+
+  /**
    * Creates a Public Holiday Leave Request for the contact with the
    * given $contactId
    *
@@ -18,9 +49,21 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
   public function createForContact($contactID, PublicHoliday $publicHoliday) {
     $absenceTypes = $this->getAbsenceTypesWherePublicHolidaysMustBeTakenAsLeave();
     foreach($absenceTypes as $absenceType) {
-      $leaveRequest = $this->createLeaveRequest($contactID, $absenceType, $publicHoliday);
-      $this->createLeaveBalanceChangeRecord($leaveRequest);
+      $this->create($contactID, $absenceType, $publicHoliday);
     }
+  }
+
+  /**
+   * Creates a Public Holiday Leave Request for the given $contactID, Absence
+   * Type and Public Holiday
+   *
+   * @param int $contactID
+   * @param \CRM_HRLeaveAndAbsences_BAO_AbsenceType $absenceType
+   * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
+   */
+  private function create($contactID, AbsenceType $absenceType, PublicHoliday $publicHoliday) {
+    $leaveRequest = $this->createLeaveRequest($contactID, $absenceType, $publicHoliday);
+    $this->createLeaveBalanceChangeRecord($leaveRequest);
   }
 
   /**
@@ -107,6 +150,42 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
         'amount' => 0
       ]);
     }
+  }
+
+  /**
+   * Gets all the contracts overlapping the given $startDate and $endDate
+   *
+   * @param \DateTime $startDate
+   * @param \DateTime $endDate
+   *
+   * @return mixed
+   */
+  private function getContractsForPeriod(DateTime $startDate, DateTime $endDate) {
+    $result = civicrm_api3('HRJobContract', 'getcontractswithdetailsinperiod', [
+      'start_date' => $startDate->format('Y-m-d'),
+      'end_date' => $endDate->format('Y-m-d'),
+      'sequential' => 1
+    ]);
+
+    return $result['values'];
+  }
+
+  /**
+   * Checks if the date of the given PublicHoliday overlaps the start and end
+   * dates of the given $contract
+   *
+   * @param array $contract
+   *  An contract as returned by the HRJobContract.getcontractswithdetailsinperiod API
+   * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
+   *
+   * @return bool
+   */
+  private function publicHolidayOverlapsContract($contract, PublicHoliday $publicHoliday) {
+    $startDate = new DateTime($contract['period_start_date']);
+    $endDate = empty($contract['period_end_date']) ? null : new DateTime($contract['period_end_date']);
+    $publicHolidayDate = new DateTime($publicHoliday->date);
+
+    return $startDate <= $publicHolidayDate && (!$endDate || $endDate >= $publicHolidayDate);
   }
 
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/PublicHoliday.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/PublicHoliday.php
@@ -64,5 +64,5 @@ function _civicrm_api3_public_holiday_getcountforcurrentperiod_spec(&$spec) {
  */
 function civicrm_api3_public_holiday_getcountforcurrentperiod($params) {
   $excludeWeekends = empty($params['exclude_weekends']) ? false : true;
-  return CRM_HRLeaveAndAbsences_BAO_PublicHoliday::getNumberOfPublicHolidaysForCurrentPeriod($excludeWeekends);
+  return CRM_HRLeaveAndAbsences_BAO_PublicHoliday::getCountForCurrentPeriod($excludeWeekends);
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/PublicHoliday.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/PublicHoliday.php
@@ -58,11 +58,38 @@ function _civicrm_api3_public_holiday_getcountforcurrentperiod_spec(&$spec) {
 /**
  * PublicHoliday.getcountforcurrentperiod API
  *
- * @param $params
  * @param array $params
  * @return array API result descriptor
  */
 function civicrm_api3_public_holiday_getcountforcurrentperiod($params) {
   $excludeWeekends = empty($params['exclude_weekends']) ? false : true;
   return CRM_HRLeaveAndAbsences_BAO_PublicHoliday::getCountForCurrentPeriod($excludeWeekends);
+}
+
+/**
+ * PublicHoliday.process_public_holiday_leave_request_updates_queue API specification
+ *
+ * @param array $spec
+ *  Description of fields supported by this API call
+ *
+ * @return void
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ */
+function _civicrm_api3_public_holiday_process_public_holiday_leave_request_updates_queue_spec(&$spec) {
+}
+
+/**
+ * PublicHoliday.process_public_holiday_leave_request_updates_queue API
+ *
+ * Execute all the jobs added to the ProcessPublicHolidayLeaveRequestUpdates Queue
+ *
+ * @param array $params
+ *
+ * @return array
+ */
+function civicrm_api3_public_holiday_process_public_holiday_leave_request_updates_queue($params) {
+  return civicrm_api3_create_success(
+    CRM_HRLeaveAndAbsences_BAO_PublicHoliday::processPublicHolidayLeaveRequestUpdatesQueue(),
+    $params
+  );
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -156,6 +156,7 @@ function _hrleaveandabsences_add_navigation_menu($params)
  */
 function _hrleaveandabsences_add_scheduled_jobs() {
   _hrleaveandabsences_add_create_expiration_records_scheduled_job();
+  _hrleaveandabsences_add_process_public_holiday_leave_requests_updates_scheduled_job();
 }
 
 /**
@@ -173,6 +174,29 @@ function _hrleaveandabsences_add_create_expiration_records_scheduled_job() {
     $dao->parameters    = NULL;
     $dao->name          = 'Create expiration records for expired LeaveBalanceChange records';
     $dao->description   = 'Creates a record with a negative balance for any balance change';
+    $dao->is_active     = 1;
+    $dao->save();
+  }
+}
+
+/**
+ * Adds the "Process Public Holiday Leave Requests Update" scheduled job.
+ */
+function _hrleaveandabsences_add_process_public_holiday_leave_requests_updates_scheduled_job() {
+  $dao             = new CRM_Core_DAO_Job();
+  $dao->api_entity = 'PublicHoliday';
+  $dao->api_action = 'process_public_holiday_leave_request_updates_queue';
+  $dao->find(TRUE);
+
+  if (!$dao->id) {
+    $dao                = new CRM_Core_DAO_Job();
+    $dao->api_entity    = 'PublicHoliday';
+    $dao->api_action    = 'process_public_holiday_leave_request_updates_queue';
+    $dao->domain_id     = CRM_Core_Config::domainID();
+    $dao->run_frequency = 'Always';
+    $dao->parameters    = NULL;
+    $dao->name          = 'Process Public Holiday Leave Requests Updates';
+    $dao->description   = 'Process all the tasks on the "Public Holiday Leave Requests Update" queue';
     $dao->is_active     = 1;
     $dao->save();
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/BaseHeadlessTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/BaseHeadlessTest.php
@@ -9,6 +9,7 @@ abstract class BaseHeadlessTest extends PHPUnit_Framework_TestCase implements
   public function setUpHeadless() {
     return \Civi\Test::headless()
       ->installMe(__DIR__)
+      ->install('uk.co.compucorp.civicrm.hrcore')
       ->install('org.civicrm.hrjobcontract')
       ->apply();
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -511,6 +511,24 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     $this->assertEquals(1, $queue->numberOfItems());
   }
 
+  public function testItDoesntEnqueueAnUpdateWhenDeletingAnAbsenceTypeWithoutMustTakePublicHolidayAsLeave() {
+    $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => false]);
+    AbsenceType::del($absenceType->id);
+
+    $queue = PublicHolidayLeaveRequestUpdatesQueue::getQueue();
+    $this->assertEquals(0, $queue->numberOfItems());
+  }
+
+  public function testItShouldEnqueueAnUpdateWhenDeletingAnAbsenceTypeWithMustTakePublicHolidayAsLeave() {
+    $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => true]);
+    AbsenceType::del($absenceType->id);
+
+    $queue = PublicHolidayLeaveRequestUpdatesQueue::getQueue();
+    // The number is two because another update was added when the absence type was
+    // created
+    $this->assertEquals(2, $queue->numberOfItems());
+  }
+
   private function updateBasicType($id, $params) {
     $params['id'] = $id;
     return AbsenceTypeFabricator::fabricate($params);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -65,7 +65,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
 
   /**
    * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
-   * @expectedException There is already one Absence Type where "Must staff take public holiday as leave" is selected
+   * @expectedExceptionMessage There is already one Absence Type where public holidays should be added to it
    */
   public function testThereShouldBeOnlyOneTypeWithAddPublicHolidayToEntitlementOnCreate() {
     $basicEntity = $this->createBasicType(['add_public_holiday_to_entitlement' => true]);
@@ -77,7 +77,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
 
   /**
    * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
-   * @expectedException There is already one Absence Type where "Must staff take public holiday as leave" is selected
+   * @expectedExceptionMessage There is already one Absence Type where public holidays should be added to it
    */
   public function testThereShouldBeOnlyOneTypeWithAddPublicHolidayToEntitlementOnUpdate() {
     $basicEntity1 = $this->createBasicType(['add_public_holiday_to_entitlement' => true]);
@@ -96,6 +96,41 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     $this->assertEquals(1, $entity1->add_public_holiday_to_entitlement);
 
     $this->updateBasicType($entity1->id, ['add_public_holiday_to_entitlement' => true]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
+   * @expectedExceptionMessage There is already one Absence Type where "Must staff take public holiday as leave" is selected
+   */
+  public function testThereShouldBeOnlyOneTypeWithMustTakePublicHolidayAsLeaveOnCreate() {
+    $basicEntity = $this->createBasicType(['must_take_public_holiday_as_leave' => true]);
+    $entity1 = $this->findTypeByID($basicEntity->id);
+    $this->assertEquals(1, $entity1->must_take_public_holiday_as_leave);
+
+    $this->createBasicType(['must_take_public_holiday_as_leave' => true]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
+   * @expectedExceptionMessage There is already one Absence Type where "Must staff take public holiday as leave" is selected
+   */
+  public function testThereShouldBeOnlyOneTypeWithMustTakePublicHolidayAsLeaveOnUpdate() {
+    $basicEntity1 = $this->createBasicType(['must_take_public_holiday_as_leave' => true]);
+    $basicEntity2 = $this->createBasicType();
+    $entity1 = $this->findTypeByID($basicEntity1->id);
+    $entity2 = $this->findTypeByID($basicEntity2->id);
+    $this->assertEquals(1, $entity1->must_take_public_holiday_as_leave);
+    $this->assertEquals(0, $entity2->must_take_public_holiday_as_leave);
+
+    $this->updateBasicType($basicEntity2->id, ['must_take_public_holiday_as_leave' => true]);
+  }
+
+  public function testUpdatingATypeWithMustTakePublicHolidayAsLeaveShouldNotTriggerErrorAboutHavingAnotherTypeWithItSelected() {
+    $basicEntity = $this->createBasicType(['must_take_public_holiday_as_leave' => true]);
+    $entity1 = $this->findTypeByID($basicEntity->id);
+    $this->assertEquals(1, $entity1->must_take_public_holiday_as_leave);
+
+    $this->updateBasicType($entity1->id, ['must_take_public_holiday_as_leave' => true]);
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+
 /**
  * Class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest
  *
@@ -435,6 +437,30 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
 
     $absenceTypes = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getEnabledAbsenceTypes();
     $this->assertCount(1, $absenceTypes);
+  }
+
+  public function testGetOneWithMustTakePublicHolidayAsLeaveRequestShouldReturnTheAbsenceTypeIfItExists() {
+    $expectedAbsenceType = $this->createBasicType(['must_take_public_holiday_as_leave' => true, 'is_active' => true]);
+
+    $absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
+
+    $this->assertEquals($expectedAbsenceType->id, $absenceType->id);
+  }
+
+  public function testGetOneWithMustTakePublicHolidayAsLeaveRequestShouldReturnADisabledAbsenceType() {
+    $this->createBasicType(['must_take_public_holiday_as_leave' => true, 'is_active' => false]);
+
+    $absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
+
+    $this->assertNull($absenceType);
+  }
+
+  public function testGetOneWithMustTakePublicHolidayAsLeaveRequestShouldReturnNullIfThereIsNoSuchAbsenceType() {
+    $this->createBasicType(['must_take_public_holiday_as_leave' => false]);
+
+    $absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
+
+    $this->assertNull($absenceType);
   }
 
   private function createBasicType($params = array()) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/PublicHolidayTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/PublicHolidayTest.php
@@ -182,7 +182,7 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
     ]);
   }
 
-  public function testGetNumberOfPublicHolidaysForPeriod() {
+  public function testGetCountForPeriod() {
     PublicHolidayFabricator::fabricateWithoutValidation([
       'date' => CRM_Utils_Date::processDate('2016-01-01')
     ]);
@@ -210,36 +210,36 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
 
     $this->assertEquals(
       8,
-      PublicHoliday::getNumberOfPublicHolidaysForPeriod('2016-01-01', '2016-12-31')
+      PublicHoliday::getCountForPeriod('2016-01-01', '2016-12-31')
     );
 
     $this->assertEquals(
       1,
-      PublicHoliday::getNumberOfPublicHolidaysForPeriod('2016-01-01', '2016-01-31')
+      PublicHoliday::getCountForPeriod('2016-01-01', '2016-01-31')
     );
 
     $this->assertEquals(
       0,
-      PublicHoliday::getNumberOfPublicHolidaysForPeriod('2016-02-01', '2016-02-29')
+      PublicHoliday::getCountForPeriod('2016-02-01', '2016-02-29')
     );
 
     $this->assertEquals(
       1,
-      PublicHoliday::getNumberOfPublicHolidaysForPeriod('2016-02-02', '2016-03-31')
+      PublicHoliday::getCountForPeriod('2016-02-02', '2016-03-31')
     );
 
     $this->assertEquals(
       3,
-      PublicHoliday::getNumberOfPublicHolidaysForPeriod('2016-04-01', '2016-08-30')
+      PublicHoliday::getCountForPeriod('2016-04-01', '2016-08-30')
     );
 
     $this->assertEquals(
       3,
-      PublicHoliday::getNumberOfPublicHolidaysForPeriod('2016-08-30', '2016-12-28')
+      PublicHoliday::getCountForPeriod('2016-08-30', '2016-12-28')
     );
   }
 
-  public function testGetNumberOfPublicHolidaysDoesntCountNonActiveHolidays() {
+  public function testGetCountForPeriodDoesntCountNonActiveHolidays() {
     PublicHolidayFabricator::fabricateWithoutValidation([
       'date' => CRM_Utils_Date::processDate('2016-02-01')
     ]);
@@ -253,11 +253,11 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
 
     $this->assertEquals(
       2,
-      PublicHoliday::getNumberOfPublicHolidaysForPeriod('2016-02-01', '2016-12-31')
+      PublicHoliday::getCountForPeriod('2016-02-01', '2016-12-31')
     );
   }
 
-  public function testGetNumberOfPublicHolidaysCanExcludeWeekendsFromCount() {
+  public function testGetCountForPeriodCanExcludeWeekendsFromCount() {
     PublicHolidayFabricator::fabricateWithoutValidation([
       'date' => CRM_Utils_Date::processDate('2016-02-01')
     ]);
@@ -273,11 +273,11 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
 
     $this->assertEquals(
       2,
-      PublicHoliday::getNumberOfPublicHolidaysForPeriod('2016-02-01', '2016-12-31', true)
+      PublicHoliday::getCountForPeriod('2016-02-01', '2016-12-31', true)
     );
   }
 
-  public function testGetNumberOfPublicHolidaysForCurrentPeriod() {
+  public function testGetCountForCurrentPeriod() {
     AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('first day of January'),
       'end_date' => CRM_Utils_Date::processDate('last day of December'),
@@ -305,11 +305,11 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
 
     $this->assertEquals(
       5,
-      PublicHoliday::getNumberOfPublicHolidaysForCurrentPeriod()
+      PublicHoliday::getCountForCurrentPeriod()
     );
   }
 
-  public function testGetNumberOfPublicHolidaysForCurrentPeriodCanExcludeWeekendsFromCount() {
+  public function testGetCountForCurrentPeriodCanExcludeWeekendsFromCount() {
     AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('first day of January'),
       'end_date' => CRM_Utils_Date::processDate('last day of December'),
@@ -325,11 +325,11 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
     $excludeWeekends = true;
     $this->assertEquals(
       1,
-      PublicHoliday::getNumberOfPublicHolidaysForCurrentPeriod($excludeWeekends)
+      PublicHoliday::getCountForCurrentPeriod($excludeWeekends)
     );
   }
 
-  public function testGetNumberOfPublicHolidaysForPeriodWithoutEndDateShouldCountAllTheHolidaysStartingFromTheStartDate() {
+  public function testGetCountForPeriodWithoutEndDateShouldCountAllTheHolidaysStartingFromTheStartDate() {
     PublicHolidayFabricator::fabricateWithoutValidation([
       'date' => CRM_Utils_Date::processDate('2016-01-01'),
     ]);
@@ -346,10 +346,10 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
       'date' => CRM_Utils_Date::processDate('2090-12-13')
     ]);
 
-    $this->assertEquals(2, PublicHoliday::getNumberOfPublicHolidaysForPeriod('2016-01-03'));
+    $this->assertEquals(2, PublicHoliday::getCountForPeriod('2016-01-03'));
   }
 
-  public function testGetPublicHolidaysForPeriod() {
+  public function testGetAllForPeriod() {
     PublicHolidayFabricator::fabricateWithoutValidation([
       'title' => 'Holiday 1',
       'date' => CRM_Utils_Date::processDate('2016-01-01')
@@ -367,7 +367,7 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
       'date' => CRM_Utils_Date::processDate('2016-12-27')
     ]);
 
-    $publicHolidays = PublicHoliday::getPublicHolidaysForPeriod('2016-01-01', '2016-12-31');
+    $publicHolidays = PublicHoliday::getAllForPeriod('2016-01-01', '2016-12-31');
     $this->assertCount(4, $publicHolidays);
     $this->assertEquals('Holiday 1', $publicHolidays[0]->title);
     $this->assertEquals('Holiday 2', $publicHolidays[1]->title);
@@ -375,20 +375,20 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
     $this->assertEquals('Holiday 4', $publicHolidays[3]->title);
 
 
-    $publicHolidays = PublicHoliday::getPublicHolidaysForPeriod('2016-01-01', '2016-01-31');
+    $publicHolidays = PublicHoliday::getAllForPeriod('2016-01-01', '2016-01-31');
     $this->assertCount(1, $publicHolidays);
     $this->assertEquals('Holiday 1', $publicHolidays[0]->title);
 
-    $publicHolidays = PublicHoliday::getPublicHolidaysForPeriod('2016-02-01', '2016-02-29');
+    $publicHolidays = PublicHoliday::getAllForPeriod('2016-02-01', '2016-02-29');
     $this->assertCount(0, $publicHolidays);
 
-    $publicHolidays = PublicHoliday::getPublicHolidaysForPeriod('2016-12-01', '2016-12-29');
+    $publicHolidays = PublicHoliday::getAllForPeriod('2016-12-01', '2016-12-29');
     $this->assertCount(2, $publicHolidays);
     $this->assertEquals('Holiday 3', $publicHolidays[0]->title);
     $this->assertEquals('Holiday 4', $publicHolidays[1]->title);
   }
 
-  public function testGetPublicHolidaysForPeriodShouldOnlyReturnActivePublicHolidays() {
+  public function testGetAllForPeriodShouldOnlyReturnActivePublicHolidays() {
     PublicHolidayFabricator::fabricateWithoutValidation([
       'title' => 'Holiday 1',
       'date' => CRM_Utils_Date::processDate('2016-01-01'),
@@ -403,13 +403,13 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
       'date' => CRM_Utils_Date::processDate('2016-01-03')
     ]);
 
-    $publicHolidays = PublicHoliday::getPublicHolidaysForPeriod('2016-01-01', '2016-01-31');
+    $publicHolidays = PublicHoliday::getAllForPeriod('2016-01-01', '2016-01-31');
     $this->assertCount(2, $publicHolidays);
     $this->assertEquals('Holiday 2', $publicHolidays[0]->title);
     $this->assertEquals('Holiday 3', $publicHolidays[1]->title);
   }
 
-  public function testGetPublicHolidaysForPeriodCanExcludeWeekends() {
+  public function testGetAllForPeriodCanExcludeWeekends() {
     PublicHolidayFabricator::fabricateWithoutValidation([
       'title' => 'Holiday 1',
       'date' => CRM_Utils_Date::processDate('2016-01-01'),
@@ -426,12 +426,12 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
     ]);
 
     $excludeWeekends = true;
-    $publicHolidays = PublicHoliday::getPublicHolidaysForPeriod('2016-01-01', '2016-01-31', $excludeWeekends);
+    $publicHolidays = PublicHoliday::getAllForPeriod('2016-01-01', '2016-01-31', $excludeWeekends);
     $this->assertCount(1, $publicHolidays);
     $this->assertEquals('Holiday 1', $publicHolidays[0]->title);
   }
 
-  public function testGetPublicHolidaysForPeriodWithoutEndDateShouldReturnAllTheHolidaysStartingFromTheStartDate() {
+  public function testGetAllForPeriodWithoutEndDateShouldReturnAllTheHolidaysStartingFromTheStartDate() {
     PublicHolidayFabricator::fabricateWithoutValidation([
       'date' => CRM_Utils_Date::processDate('2016-01-01'),
     ]);
@@ -448,7 +448,7 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
       'date' => CRM_Utils_Date::processDate('2090-12-13')
     ]);
 
-    $publicHolidays = PublicHoliday::getPublicHolidaysForPeriod('2016-01-03');
+    $publicHolidays = PublicHoliday::getAllForPeriod('2016-01-03');
     $this->assertCount(2, $publicHolidays);
     $this->assertEquals($publicHoliday1->title, $publicHolidays[0]->title);
     $this->assertEquals($publicHoliday1->id, $publicHolidays[0]->id);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/PublicHolidayTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/PublicHolidayTest.php
@@ -239,8 +239,7 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
     );
   }
 
-  public function testGetNumberOfPublicHolidaysDoesntCountNonActiveHolidays()
-  {
+  public function testGetNumberOfPublicHolidaysDoesntCountNonActiveHolidays() {
     PublicHolidayFabricator::fabricateWithoutValidation([
       'date' => CRM_Utils_Date::processDate('2016-02-01')
     ]);
@@ -258,8 +257,7 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
     );
   }
 
-  public function testGetNumberOfPublicHolidaysCanExcludeWeekendsFromCount()
-  {
+  public function testGetNumberOfPublicHolidaysCanExcludeWeekendsFromCount() {
     PublicHolidayFabricator::fabricateWithoutValidation([
       'date' => CRM_Utils_Date::processDate('2016-02-01')
     ]);
@@ -279,8 +277,7 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
     );
   }
 
-  public function testGetNumberOfPublicHolidaysForCurrentPeriod()
-  {
+  public function testGetNumberOfPublicHolidaysForCurrentPeriod() {
     AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('first day of January'),
       'end_date' => CRM_Utils_Date::processDate('last day of December'),
@@ -312,8 +309,7 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
     );
   }
 
-  public function testGetNumberOfPublicHolidaysForCurrentPeriodCanExcludeWeekendsFromCount()
-  {
+  public function testGetNumberOfPublicHolidaysForCurrentPeriodCanExcludeWeekendsFromCount() {
     AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('first day of January'),
       'end_date' => CRM_Utils_Date::processDate('last day of December'),
@@ -331,6 +327,26 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
       1,
       PublicHoliday::getNumberOfPublicHolidaysForCurrentPeriod($excludeWeekends)
     );
+  }
+
+  public function testGetNumberOfPublicHolidaysForPeriodWithoutEndDateShouldCountAllTheHolidaysStartingFromTheStartDate() {
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' => CRM_Utils_Date::processDate('2016-01-01'),
+    ]);
+
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' => CRM_Utils_Date::processDate('2016-01-02')
+    ]);
+
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' => CRM_Utils_Date::processDate('2017-05-03')
+    ]);
+
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' => CRM_Utils_Date::processDate('2090-12-13')
+    ]);
+
+    $this->assertEquals(2, PublicHoliday::getNumberOfPublicHolidaysForPeriod('2016-01-03'));
   }
 
   public function testGetPublicHolidaysForPeriod() {
@@ -413,6 +429,32 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
     $publicHolidays = PublicHoliday::getPublicHolidaysForPeriod('2016-01-01', '2016-01-31', $excludeWeekends);
     $this->assertCount(1, $publicHolidays);
     $this->assertEquals('Holiday 1', $publicHolidays[0]->title);
+  }
+
+  public function testGetPublicHolidaysForPeriodWithoutEndDateShouldReturnAllTheHolidaysStartingFromTheStartDate() {
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' => CRM_Utils_Date::processDate('2016-01-01'),
+    ]);
+
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' => CRM_Utils_Date::processDate('2016-01-02')
+    ]);
+
+    $publicHoliday1 = PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' => CRM_Utils_Date::processDate('2017-05-03')
+    ]);
+
+    $publicHoliday2 = PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' => CRM_Utils_Date::processDate('2090-12-13')
+    ]);
+
+    $publicHolidays = PublicHoliday::getPublicHolidaysForPeriod('2016-01-03');
+    $this->assertCount(2, $publicHolidays);
+    $this->assertEquals($publicHoliday1->title, $publicHolidays[0]->title);
+    $this->assertEquals($publicHoliday1->id, $publicHolidays[0]->id);
+
+    $this->assertEquals($publicHoliday2->title, $publicHolidays[1]->title);
+    $this->assertEquals($publicHoliday2->id, $publicHolidays[1]->id);
   }
 
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/PublicHolidayTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/PublicHolidayTest.php
@@ -457,4 +457,37 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
     $this->assertEquals($publicHoliday2->id, $publicHolidays[1]->id);
   }
 
+  public function testGetAllInFutureShouldReturnOnlyFutureHolidays() {
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' => CRM_Utils_Date::processDate('yesterday'),
+    ]);
+
+    $today = PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' => CRM_Utils_Date::processDate('today')
+    ]);
+
+    $tomorrow = PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' => CRM_Utils_Date::processDate('tomorrow')
+    ]);
+
+    $publicHolidays = PublicHoliday::getAllInFuture();
+    $this->assertCount(2, $publicHolidays);
+    $this->assertEquals($today->title, $publicHolidays[0]->title);
+    $this->assertEquals($today->id, $publicHolidays[0]->id);
+
+    $this->assertEquals($tomorrow->title, $publicHolidays[1]->title);
+    $this->assertEquals($tomorrow->id, $publicHolidays[1]->id);
+  }
+
+  public function testGetAllInFutureShouldIncludeFutureHolidaysOnAWeekend() {
+    $nextSunday = PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' => CRM_Utils_Date::processDate('next sunday')
+    ]);
+
+    $publicHolidays = PublicHoliday::getAllInFuture();
+    $this->assertCount(1, $publicHolidays);
+    $this->assertEquals($nextSunday->title, $publicHolidays[0]->title);
+    $this->assertEquals($nextSunday->id, $publicHolidays[0]->id);
+  }
+
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -70,7 +70,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
   }
 
   public function testCanCreatePublicHolidayLeaveRequestsForAllPublicHolidaysInTheFuture() {
-    $contact = ContactFabricator::fabricate(['first_name' => 'Contact 1']);
+    $contact = ContactFabricator::fabricate();
 
     $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
       new DateTime('2016-01-01'),
@@ -110,7 +110,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
   public function testItDoesntCreateLeaveRequestsForAllPublicHolidaysInTheFutureIfThereIsNoMTPHLAbsenceTypes() {
     AbsenceType::del($this->absenceType->id);
 
-    $contact = ContactFabricator::fabricate(['first_name' => 'Contact 1']);
+    $contact = ContactFabricator::fabricate();
 
     $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
       new DateTime()

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
 use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation as PublicHolidayLeaveRequestCreation;
@@ -100,5 +101,18 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $creationLogic->createForAbsenceType($this->absenceType);
 
     $this->assertEquals(-2, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
+  }
+
+  /**
+   * @expectedException InvalidArgumentException
+   * @expectedExceptionMessage It's not possible to create Public Holidays for Absence Types where 'Must take public holiday as leave' is false
+   */
+  public function testTryingToCreatePublicHolidaysLeaveRequestsForAnAbsenceTypeWithoutMTPHLShouldThrowAnException() {
+    $absenceType = new AbsenceType();
+    // MTPHL: must take public holiday as leave
+    $absenceType->must_take_public_holiday_as_leave = false;
+
+    $creationLogic = new PublicHolidayLeaveRequestCreation();
+    $creationLogic->createForAbsenceType($absenceType);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -72,7 +72,10 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
   public function testCanCreatePublicHolidayLeaveRequestsForAllPublicHolidaysInTheFuture() {
     $contact = ContactFabricator::fabricate(['first_name' => 'Contact 1']);
 
-    $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests();
+    $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
+      new DateTime('2016-01-01'),
+      new DateTime('+10 days')
+    );
     $periodEntitlement->contact_id = $contact['id'];
     $periodEntitlement->type_id = $this->absenceType->id;
 
@@ -109,7 +112,9 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
 
     $contact = ContactFabricator::fabricate(['first_name' => 'Contact 1']);
 
-    $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests();
+    $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
+      new DateTime()
+    );
     $periodEntitlement->contact_id = $contact['id'];
     $periodEntitlement->type_id = $this->absenceType->id;
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
@@ -82,7 +82,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
   }
 
   public function testCanDeleteAllPublicHolidayLeaveRequestsForFuturePublicHolidays() {
-    $contact = ContactFabricator::fabricate(['first_name' => 'Contact 1']);
+    $contact = ContactFabricator::fabricate();
 
     $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
       new DateTime('2016-01-01'),

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest as PublicHolidayLeaveRequestService;
+use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation as PublicHolidayLeaveRequestCreation;
+use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion as PublicHolidayLeaveRequestDeletion;
+
+/**
+* Class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest
+*
+* @group headless
+*/
+class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseHeadlessTest {
+
+  public function testUpdateAllLeaveRequestsInTheFuture() {
+    $deletionLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestDeletion::class)
+                              ->setMethods(['deleteAllInTheFuture'])
+                              ->getMock();
+
+    $deletionLogicMock->expects($this->once())
+                      ->method('deleteAllInTheFuture');
+
+    $creationLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestCreation::class)
+                              ->setMethods(['createForAllInTheFuture'])
+                              ->getMock();
+
+    $creationLogicMock->expects($this->once())
+                      ->method('createForAllInTheFuture');
+
+    $service = new PublicHolidayLeaveRequestService($creationLogicMock, $deletionLogicMock);
+    $service->updateAllLeaveRequestsInTheFuture();
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeavePeriodEntitlementHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeavePeriodEntitlementHelpersTrait.php
@@ -6,20 +6,33 @@ trait CRM_HRLeaveAndAbsences_LeavePeriodEntitlementHelpersTrait {
    * Creates a mock to be used on tests for the geBalance() method.
    *
    * For these, we mock the getStartAndEndDates() method, so we don't need an
-   * actual AbsencePeriod record on the database.
+   * actual AbsencePeriod record on the database. Optionally, you can pass the
+   * start and end dates returned by this method.
    *
-   * @return CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement
+   * @param \DateTime $startDate
+   * @param \DateTime $endDate
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement
    */
-  public function createLeavePeriodEntitlementMockForBalanceTests() {
+  public function createLeavePeriodEntitlementMockForBalanceTests(DateTime $startDate = null, DateTime $endDate = null) {
     $periodEntitlement = $this->getMockBuilder(CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement::class)
                               ->setMethods(['getStartAndEndDates'])
                               ->getMock();
 
+    if(!$startDate) {
+      $startDate = new DateTime(date('Y-01-01'));
+    }
+
+    if(!$endDate) {
+      $endDate = clone $startDate;
+      $endDate->modify('+1 year')->modify('-1 day');
+    }
+
     $periodEntitlement->expects($this->any())
                       ->method('getStartAndEndDates')
                       ->will($this->returnValue([[
-                        'start_date' => date('Y-01-01'),
-                        'end_date' => date('Y-12-31')
+                        'start_date' => $startDate->format('Y-m-d'),
+                        'end_date' => $endDate->format('Y-m-d')
                       ]]));
 
     $periodEntitlement->id = 1;


### PR DESCRIPTION
The logic should be executed on the following situations:
- When creating a new Absence Type where "Must Take Public Holiday as Leave" is true
- When updating an existing Absence Type change the value of "Must Take Public Holiday as Leave" (either from true to false or from false to true)
- When deleting an Absence Type with "Must Take Public Holiday as Leave"

### How this is implemented?
The PublicHolidayLeaveRequestCreation service was augmented with a new method to create public holiday leave requests for all public holidays in the future. It works by fetching all the dates and all the contracts which overlap those dates. Finally, it loop through all this and add a leave request for each date for each of the contracts contacts.

The PublicHolidayLeaveRequestDeletion service was augmented with a new method to delete all the public holiday leave requests for public holidays in the future. It works by fetching all the dates and then delete the leave requests for those dates.

One more service was created. It is the PublicHolidayLeaveRequest service and it has a single method named updateAllLeaveRequestsInTheFuture(), which basically runs the deletion logic first, deleting everything for public holidays in the future, and then runs the creation logic to create new leave requests for the dates in the future.

Finally, the AbsenceType BAO was updated to enqueue a new background task whenever it gets updated and we identify that the public holiday leave requests must also be updated. This task, when consumed, will use the PublicHolidayLeaveRequest service to update everything. This is done in background because update things for all public holidays in the future and to all contacts might take some time, so it's better for to be executed later and not right after saving the changes. A new scheduled job was created to process this background task queue.

### Why always execute both the deletion and the creation logic?
The deletion only deletes existing leave requests and doesn't thrown an error is none exists. So it's safe (and fast) to execute it if there are no leave requests yet. The creation only creates leave request if there is one Absence Type with "Must Take public holiday as leave". So it's safe (and fast) to execute it if there are no MTPHL Absence Types.

This is how it works in practice:
- A new MTPHL Absence Type is created:
  - Deletion logic is executed. Doesn't delete anything (because there was no MTPHL type before)
  - Creation logic is executed. Leave Requests are created

- A non-MTPHL Absence Type is updated to be MTPHL:
  - Deletion logic is executed. Doesn't delete anything (because there was no MTPHL type before)
  - Creation logic is executed. Leave Requests are created

- A MTPHL Absence Type is updated to be non-MTPHL:
  - Deletion logic is executed. Existing Leave Requests are deleted
  - Creation logic is executed. Nothing is created (because there is no MTPHL type anymore)

- A MTPHL Absence is deleted:
  - Deletion logic is executed. Existing Leave Requests are deleted
  - Creation logic is executed. Nothing is created (because there is no MTPHL type anymore)

Note: This only works because we can have only one MTPHL Absence Type on the system

### What else is included on this PR?
I did some refactoring the the AbsenceType tests to use fabricators and follow our current code style. I also added a validation to the AbsenceType BAO to allow only one type to be MTPHL.