### PR TITLE
PCHR-1197: Trigger Public Holiday leave requests logic when updating contract

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/PublicHolidayLeaveRequestService.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/PublicHolidayLeaveRequestService.php
@@ -1,0 +1,28 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_JobContract as JobContractService;
+use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest as PublicHolidayLeaveRequestService;
+use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation as PublicHolidayLeaveRequestCreation;
+use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion as PublicHolidayLeaveRequestDeletion;
+
+/**
+ * A factory for the PublicHolidayLeaveRequest service, which can be used
+ * to get instances of this service without having to manually create all of
+ * its dependencies
+ */
+class CRM_HRLeaveAndAbsences_Factory_PublicHolidayLeaveRequestService {
+
+  /**
+   * Returns a new instance of a PublicHolidayLeaveRequest Service
+   *
+   * @return \CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest
+   */
+  public static function create() {
+    $jobContractService = new JobContractService();
+    $creationLogic = new PublicHolidayLeaveRequestCreation($jobContractService);
+    $deletionLogic = new PublicHolidayLeaveRequestDeletion($jobContractService);
+
+    return new PublicHolidayLeaveRequestService($creationLogic, $deletionLogic);
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/Task/UpdateAllFuturePublicHolidayLeaveRequests.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/Task/UpdateAllFuturePublicHolidayLeaveRequests.php
@@ -1,5 +1,6 @@
 <?php
 
+use CRM_HRLeaveAndAbsences_Services_JobContract as JobContractService;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest as PublicHolidayLeaveRequestService;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation as PublicHolidayLeaveRequestCreation;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion as PublicHolidayLeaveRequestDeletion;
@@ -15,8 +16,9 @@ use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion as PublicHo
 class CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequests {
 
   public function run(CRM_Queue_TaskContext $ctx) {
-    $creationLogic = new PublicHolidayLeaveRequestCreation();
-    $deletionLogic = new PublicHolidayLeaveRequestDeletion();
+    $jobContractService = new JobContractService();
+    $creationLogic = new PublicHolidayLeaveRequestCreation($jobContractService);
+    $deletionLogic = new PublicHolidayLeaveRequestDeletion($jobContractService);
 
     $service = new PublicHolidayLeaveRequestService($creationLogic, $deletionLogic);
     $service->updateAllLeaveRequestsInTheFuture();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/Task/UpdateAllFuturePublicHolidayLeaveRequests.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/Task/UpdateAllFuturePublicHolidayLeaveRequests.php
@@ -21,7 +21,7 @@ class CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequest
     $deletionLogic = new PublicHolidayLeaveRequestDeletion($jobContractService);
 
     $service = new PublicHolidayLeaveRequestService($creationLogic, $deletionLogic);
-    $service->updateAllLeaveRequestsInTheFuture();
+    $service->updateAllInTheFuture();
   }
 
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/Task/UpdateAllFuturePublicHolidayLeaveRequests.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/Task/UpdateAllFuturePublicHolidayLeaveRequests.php
@@ -1,10 +1,6 @@
 <?php
 
-use CRM_HRLeaveAndAbsences_Services_JobContract as JobContractService;
-use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest as PublicHolidayLeaveRequestService;
-use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation as PublicHolidayLeaveRequestCreation;
-use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion as PublicHolidayLeaveRequestDeletion;
-
+use CRM_HRLeaveAndAbsences_Factory_PublicHolidayLeaveRequestService as PublicHolidayLeaveRequestServiceFactory;
 
 /**
  * This is the Queue Task which will be executed by the whenever the
@@ -16,11 +12,7 @@ use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion as PublicHo
 class CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequests {
 
   public function run(CRM_Queue_TaskContext $ctx) {
-    $jobContractService = new JobContractService();
-    $creationLogic = new PublicHolidayLeaveRequestCreation($jobContractService);
-    $deletionLogic = new PublicHolidayLeaveRequestDeletion($jobContractService);
-
-    $service = new PublicHolidayLeaveRequestService($creationLogic, $deletionLogic);
+    $service = PublicHolidayLeaveRequestServiceFactory::create();
     $service->updateAllInTheFuture();
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/JobContract.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/JobContract.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * This class is basically a wrapper around the HRJobContract API.
+ *
+ * It has some utility methods which make the job of calling that API easier by
+ * automatically adding some default params and parsing the returned result.
+ */
+class CRM_HRLeaveAndAbsences_Service_JobContract {
+
+  /**
+   * Uses the HRJobContract.get API endpoint to fetch the contract with the
+   * given ID.
+   *
+   * It returns an array with all the job contract fields + the contract details
+   *
+   * @param int $id
+   *   The ID of the Contract
+   *
+   * @return array|null
+   *   The output of the API or null if no contract was found
+   */
+  public function getContractByID($id) {
+    $returnFields = [
+      'id',
+      'contact_id',
+      'position',
+      'title',
+      'funding_notes',
+      'contract_type',
+      'period_start_date',
+      'period_end_date',
+      'end_reason',
+      'notice_amount',
+      'notice_amount_employee',
+      'notice_unit_employee',
+      'location'
+    ];
+
+    $result = $this->callHRJobContractGet([
+      'sequential' => 1,
+      'id'         => $id,
+      'return'     => $returnFields
+    ]);
+
+    if(!$result) {
+      return null;
+    }
+
+    $contract = $result[0];
+
+    if(!array_key_exists('period_end_date', $contract)) {
+      $contract['period_end_date'] = null;
+    }
+
+    return $contract;
+  }
+
+  /**
+   * Uses the HRJobContract.getcontractswithdetailsinperiod API endpoint to
+   * return a list of contracts for the given overlapping the given start and
+   * end dates
+   *
+   * @param \DateTime $startDate
+   * @param \DateTime|NULL $endDate
+   *
+   * @return mixed
+   */
+  public function getContractsForPeriod(DateTime $startDate, DateTime $endDate) {
+    $result = $this->callHRJobContractAPI('getcontractswithdetailsinperiod', [
+      'start_date' => $startDate->format('Y-m-d'),
+      'end_date' => $endDate->format('Y-m-d'),
+    ]);
+
+    return $result['values'];
+  }
+
+  /**
+   * Wrapper for the get action on the HRJobContract API
+   *
+   * @param array $params
+   *   An array of $params to be passed to the API
+   *
+   * @return array|null
+   */
+  private function callHRJobContractGet($params) {
+    $result = $this->callHRJobContractAPI('get', $params);
+
+    if(empty($result['values'])) {
+      return null;
+    }
+
+    return $result['values'];
+  }
+
+  /**
+   * Wrapper for the HRJobContract API
+   *
+   * @param string $action
+   *   The API action to be executed (e.g. get, delete, etc)
+   * @param array $params
+   *   An array of $params to be passed to the API
+   *
+   * @return array
+   */
+  private function callHRJobContractAPI($action, $params) {
+    $defaultParams = ['sequential' => 1];
+    $params = array_merge($defaultParams, $params);
+
+    return civicrm_api3('HRJobContract', $action, $params);
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
@@ -35,4 +35,18 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest {
     $this->creationLogic->createForAllInTheFuture();
   }
 
+  /**
+   * Updates all the Leave Requests for Public Holidays in the future between
+   * the start and end dates of the given contract.
+   *
+   * @param int $contractID
+   *
+   * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion::deleteAllForContract()
+   * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation::createAllForContract()
+   */
+  public function updateAllInTheFutureForContract($contractID) {
+    $this->deletionLogic->deleteAllForContract($contractID);
+    $this->creationLogic->createAllForContract($contractID);
+  }
+
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
@@ -30,7 +30,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest {
    * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion::deleteAllInTheFuture()
    * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation::createForAllInTheFuture()
    */
-  public function updateAllLeaveRequestsInTheFuture() {
+  public function updateAllInTheFuture() {
     $this->deletionLogic->deleteAllInTheFuture();
     $this->creationLogic->createForAllInTheFuture();
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -40,6 +40,31 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
   }
 
   /**
+   * Creates Public Holiday Leave Requests for all Public Holidays in the
+   * Future overlapping the start and end dates of the given contract
+   *
+   * @param $contractID
+   */
+  public function createAllForContract($contractID) {
+    $contract = $this->getContractByID($contractID);
+
+    if (!$contract) {
+      return;
+    }
+
+    $publicHolidays = PublicHoliday::getAllForPeriod(
+      $contract['period_start_date'],
+      $contract['period_end_date']
+    );
+
+    foreach($publicHolidays as $publicHoliday) {
+      if(strtotime($publicHoliday->date) >= strtotime('today')) {
+        $this->createForContact($contract['contact_id'], $publicHoliday);
+      }
+    }
+  }
+
+  /**
    * Creates a Public Holiday Leave Request for the contact with the
    * given $contactId
    *
@@ -170,6 +195,35 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
     $publicHolidayDate = new DateTime($publicHoliday->date);
 
     return $startDate <= $publicHolidayDate && (!$endDate || $endDate >= $publicHolidayDate);
+  }
+
+  /**
+   * Uses the HRJobContract API to get the contract for the given ID.
+   *
+   * The returned fields are: id, contact_id, period_start_date and period_end_date
+   *
+   * @param int $contractID
+   *
+   * @return array|null
+   */
+  private function getContractByID($contractID) {
+    $result = civicrm_api3('HRJobContract', 'get', [
+      'sequential' => 1,
+      'id'         => $contractID,
+      'return'     => 'period_start_date,period_end_date,id,contact_id'
+    ]);
+
+    if(empty($result['values'])) {
+      return null;
+    }
+
+    $contract = $result['values'][0];
+
+    if(!array_key_exists('period_end_date', $contract)) {
+      $contract['period_end_date'] = null;
+    }
+
+    return $contract;
   }
 
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/PublicHolidayLeaveRequest.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
+use CRM_HRLeaveAndAbsences_Service_JobContract as JobContractService;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation as PublicHolidayLeaveRequestCreation;
 
 class CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest {
@@ -17,7 +18,7 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest {
    * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
    */
   public static function fabricate($contactID, PublicHoliday $publicHoliday) {
-    $creationLogic = new PublicHolidayLeaveRequestCreation();
+    $creationLogic = new PublicHolidayLeaveRequestCreation(new JobContractService());
     $creationLogic->createForContact($contactID, $publicHoliday);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -10,7 +10,7 @@ use CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern as ContactWorkPattern;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange as LeaveBalanceChangeFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern as WorkPatternFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
-use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation as PublicHolidayLeaveRequestCreation;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest as PublicHolidayLeaveRequestFabricator;
 
 /**
  * Class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest
@@ -617,8 +617,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = CRM_Utils_Date::processDate('2016-01-01');
-    $publicHolidayLeaveRequestCreation = new PublicHolidayLeaveRequestCreation();
-    $publicHolidayLeaveRequestCreation->createForContact($leaveRequest->contact_id, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate($leaveRequest->contact_id, $publicHoliday);
 
     LeaveBalanceChange::createForLeaveRequest($leaveRequest);
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Factory/PublicHolidayLeaveRequestServiceTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Factory/PublicHolidayLeaveRequestServiceTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest as PublicHolidayLeaveRequest;
+use CRM_HRLeaveAndAbsences_Factory_PublicHolidayLeaveRequestService as PublicHolidayLeaveRequestServiceFactory;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Factory_PublicHolidayLeaveRequestService
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_Factory_PublicHolidayLeaveRequestServiceTest extends BaseHeadlessTest  {
+
+  public function testCreate() {
+    $service = PublicHolidayLeaveRequestServiceFactory::create();
+
+    $this->assertInstanceOf(PublicHolidayLeaveRequest::class, $service);
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/JobContractTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/JobContractTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
+use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
+use CRM_HRLeaveAndAbsences_Service_JobContract as JobContractService;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Service_JobContractTest
+ *
+ * The JobContract service is nothing but a wrapper for the JobContract API, so
+ * all the tests here are just very basic and were created just to verify that
+ * the proper API endpoints are being used and the expected values are returned.
+ * More complete tests should be on the HRJobContract extension.
+ *
+ * Ideally, these tests would mock the API and just check if the methods have
+ * been called, but currently it's not possible to mock api calls in CiviCRM.
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_Service_JobContractTest extends BaseHeadlessTest {
+
+  /**
+   * @var array
+   */
+  private $contact;
+
+  /**
+   * @var \CRM_HRLeaveAndAbsences_Service_JobContract
+   */
+  private $jobContractService;
+
+  public function setUp() {
+    $this->contact = ContactFabricator::fabricate();
+    $this->jobContractService= new JobContractService();
+  }
+
+  public function testGetContractById() {
+    $expectedContract = HRJobContractFabricator::fabricate([
+      'contact_id' => $this->contact['id']
+    ]);
+
+    $contract = $this->jobContractService->getContractByID($expectedContract['id']);
+    $this->assertEquals($expectedContract['id'], $contract['id']);
+    $this->assertEquals($expectedContract['contact_id'], $contract['contact_id']);
+  }
+
+  public function testGetContractByIdWithoutPeriodEndDate() {
+    $title = 'Title';
+    $periodStartDate = '2016-01-01';
+
+    $expectedContract = HRJobContractFabricator::fabricate([
+      'contact_id' => $this->contact['id']
+    ],
+    [
+      'period_start_date' => $periodStartDate,
+      'title' => $title
+    ]);
+
+    $contract = $this->jobContractService->getContractByID($expectedContract['id']);
+    $this->assertEquals($periodStartDate, $contract['period_start_date']);
+    $this->assertEquals($title, $contract['title']);
+    $this->assertNull($contract['period_end_date']);
+  }
+
+  public function testGetContractsForPeriod() {
+    $contract1 = HRJobContractFabricator::fabricate([
+      'contact_id' => $this->contact['id']
+    ],
+    [
+      'period_start_date' => '2016-01-01',
+      'period_end_date' => '2016-03-15',
+    ]);
+
+    $contract2 = HRJobContractFabricator::fabricate([
+      'contact_id' => $this->contact['id']
+    ],
+      [
+        'period_start_date' => '2016-04-02',
+        'period_end_date' => '2016-11-30',
+      ]);
+
+    $contract3 = HRJobContractFabricator::fabricate([
+      'contact_id' => $this->contact['id']
+    ],
+    [
+      'period_start_date' => '2016-12-01'
+    ]);
+
+    $contracts = $this->jobContractService->getContractsForPeriod(
+      new DateTime('2016-07-01'),
+      new DateTime('2016-12-21')
+    );
+
+    $this->assertCount(2, $contracts);
+    $this->assertEquals($contract2['id'], $contracts[0]['id']);
+    $this->assertEquals($contract3['id'], $contracts[1]['id']);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -3,6 +3,7 @@
 use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
 use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
+use CRM_HRLeaveAndAbsences_Service_JobContract as JobContractService;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation as PublicHolidayLeaveRequestCreation;
 use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
 use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
@@ -40,7 +41,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $periodEntitlement->contact_id = 2;
     $periodEntitlement->type_id = $this->absenceType->id;
 
-    $creationLogic = new PublicHolidayLeaveRequestCreation();
+    $creationLogic = new PublicHolidayLeaveRequestCreation(new JobContractService());
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = CRM_Utils_Date::processDate('first monday of this year');
 
@@ -60,7 +61,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
 
     $this->assertEquals(-1, LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest));
 
-    $creationLogic = new PublicHolidayLeaveRequestCreation();
+    $creationLogic = new PublicHolidayLeaveRequestCreation(new JobContractService());
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = CRM_Utils_Date::processDate('2016-01-01');
 
@@ -99,7 +100,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'date' =>  CRM_Utils_Date::processDate('+5 days')
     ]);
 
-    $creationLogic = new PublicHolidayLeaveRequestCreation();
+    $creationLogic = new PublicHolidayLeaveRequestCreation(new JobContractService());
     $creationLogic->createForAllInTheFuture();
 
     // It's -2 instead of -3 because the first public holiday is in the past
@@ -124,7 +125,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'date' =>  CRM_Utils_Date::processDate('tomorrow')
     ]);
 
-    $creationLogic = new PublicHolidayLeaveRequestCreation();
+    $creationLogic = new PublicHolidayLeaveRequestCreation(new JobContractService());
     $creationLogic->createForAllInTheFuture();
 
     // The Balance is still 0 because no Leave Request was created
@@ -166,7 +167,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'date' =>  CRM_Utils_Date::processDate('+101 days')
     ]);
 
-    $creationLogic = new PublicHolidayLeaveRequestCreation();
+    $creationLogic = new PublicHolidayLeaveRequestCreation(new JobContractService());
     $creationLogic->createAllForContract($contract['id']);
 
     // The balance should be -2 because only two leave requests were created:
@@ -208,7 +209,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'date' =>  CRM_Utils_Date::processDate('+332 days')
     ]);
 
-    $creationLogic = new PublicHolidayLeaveRequestCreation();
+    $creationLogic = new PublicHolidayLeaveRequestCreation(new JobContractService());
     $creationLogic->createAllForContract($contract['id']);
 
     // Since there's no end date for the contract,
@@ -218,7 +219,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
   }
 
   public function testItDoesntCreateAnythingIfTheContractIDDoesntExist() {
-    $creationLogic = new PublicHolidayLeaveRequestCreation();
+    $creationLogic = new PublicHolidayLeaveRequestCreation(new JobContractService());
     $creationLogic->createAllForContract(9998398298);
 
     $this->assertEquals(0, $this->countNumberOfPublicHolidayBalanceChanges());

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -130,4 +130,107 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     // The Balance is still 0 because no Leave Request was created
     $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
   }
+
+  public function testItCreatesLeaveRequestsForAllPublicHolidaysInTheFutureOverlappingTheContractDates() {
+    $contact = ContactFabricator::fabricate(['first_name' => 'Contact 1']);
+
+    $contract = HRJobContractFabricator::fabricate([
+      'contact_id' => $contact['id']
+    ], [
+      'period_start_date' =>  CRM_Utils_Date::processDate('yesterday'),
+      'period_end_date' =>   CRM_Utils_Date::processDate('+100 days'),
+    ]);
+
+    $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
+      new DateTime('-10 days'),
+      new DateTime('+200 days')
+    );
+    $periodEntitlement->contact_id = $contact['id'];
+    $periodEntitlement->type_id = $this->absenceType->id;
+
+    $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
+
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('yesterday')
+    ]);
+
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('+5 days')
+    ]);
+
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('+47 days')
+    ]);
+
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('+101 days')
+    ]);
+
+    $creationLogic = new PublicHolidayLeaveRequestCreation();
+    $creationLogic->createAllForContract($contract['id']);
+
+    // The balance should be -2 because only two leave requests were created:
+    // The one for +5 days and the other one for + 47 days.
+    // The holiday for "yesterday" overlaps the contract, but it is in the past,
+    // so nothing will be created. The holiday for "+101 days" is in the future,
+    // but it doesn't overlap the contract dates and no leave request will be
+    // created for it as well
+    $this->assertEquals(-2, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
+  }
+
+  public function testItCreatesLeaveRequestsForAllPublicHolidaysInTheFutureOverlappingAContractWithNoEndDate() {
+    $contact = ContactFabricator::fabricate(['first_name' => 'Contact 1']);
+
+    $contract = HRJobContractFabricator::fabricate([
+      'contact_id' => $contact['id']
+    ], [
+      'period_start_date' =>  CRM_Utils_Date::processDate('yesterday'),
+    ]);
+
+    $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
+      new DateTime('-10 days'),
+      new DateTime('+400 days')
+    );
+    $periodEntitlement->contact_id = $contact['id'];
+    $periodEntitlement->type_id = $this->absenceType->id;
+
+    $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
+
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('+5 days')
+    ]);
+
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('+47 days')
+    ]);
+
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('+332 days')
+    ]);
+
+    $creationLogic = new PublicHolidayLeaveRequestCreation();
+    $creationLogic->createAllForContract($contract['id']);
+
+    // Since there's no end date for the contract,
+    // leave request will be created for all the public holidays in the
+    // future
+    $this->assertEquals(-3, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
+  }
+
+  public function testItDoesntCreateAnythingIfTheContractIDDoesntExist() {
+    $creationLogic = new PublicHolidayLeaveRequestCreation();
+    $creationLogic->createAllForContract(9998398298);
+
+    $this->assertEquals(0, $this->countNumberOfPublicHolidayBalanceChanges());
+  }
+
+  private function countNumberOfPublicHolidayBalanceChanges() {
+    $balanceChangeTypes = array_flip(LeaveBalanceChange::buildOptions('type_id'));
+
+    $bao = new LeaveBalanceChange();
+    $bao->type_id = $balanceChangeTypes['Public Holiday'];
+    $bao->source_type = LeaveBalanceChange::SOURCE_LEAVE_REQUEST_DAY;
+
+    return $bao->count();
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
@@ -2,6 +2,7 @@
 
 use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
 use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
+use CRM_HRLeaveAndAbsences_Service_JobContract as JobContractService;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion as PublicHolidayLeaveRequestDeletion;
 use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
 use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
@@ -48,7 +49,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     $this->assertEquals(-1, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
 
-    $deletionLogic = new PublicHolidayLeaveRequestDeletion();
+    $deletionLogic = new PublicHolidayLeaveRequestDeletion(new JobContractService());
     $deletionLogic->deleteForContact($periodEntitlement->contact_id, $publicHoliday);
 
     $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
@@ -75,7 +76,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     $this->assertEquals(0, LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest));
 
-    $deletionLogic = new PublicHolidayLeaveRequestDeletion();
+    $deletionLogic = new PublicHolidayLeaveRequestDeletion(new JobContractService());
     $deletionLogic->deleteForContact($this->contract['contact_id'], $publicHoliday);
 
     $this->assertEquals(-1, LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest));
@@ -114,7 +115,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     $this->assertEquals(-3, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
 
-    $deletionLogic = new PublicHolidayLeaveRequestDeletion();
+    $deletionLogic = new PublicHolidayLeaveRequestDeletion(new JobContractService());
     $deletionLogic->deleteAllInTheFuture();
 
     // It's -1 instead of 0 because the public holiday 1 is in the past and its
@@ -157,7 +158,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     $this->assertEquals(-3, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
 
-    $deletionLogic = new PublicHolidayLeaveRequestDeletion();
+    $deletionLogic = new PublicHolidayLeaveRequestDeletion(new JobContractService());
     $deletionLogic->deleteAllForContract($contract['id']);
 
     // It's -2 instead of 0 because the public holiday 1 is in the past and its
@@ -200,7 +201,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     $this->assertEquals(-3, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
 
-    $deletionLogic = new PublicHolidayLeaveRequestDeletion();
+    $deletionLogic = new PublicHolidayLeaveRequestDeletion(new JobContractService());
     $deletionLogic->deleteAllForContract($contract['id']);
 
     // It's -1 instead of 0 because the public holiday 1 is in the past and its
@@ -216,7 +217,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     $this->assertEquals(1, $this->countNumberOfPublicHolidayBalanceChanges());
 
-    $deletionLogic = new PublicHolidayLeaveRequestDeletion();
+    $deletionLogic = new PublicHolidayLeaveRequestDeletion(new JobContractService());
     $deletionLogic->deleteAllForContract(9998398298);
 
     $this->assertEquals(1, $this->countNumberOfPublicHolidayBalanceChanges());

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
@@ -1,5 +1,12 @@
 <?php
 
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
+use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHoliday as PublicHolidayFabricator;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest as PublicHolidayLeaveRequestService;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation as PublicHolidayLeaveRequestCreation;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion as PublicHolidayLeaveRequestDeletion;
@@ -10,6 +17,22 @@ use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion as PublicHo
 * @group headless
 */
 class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseHeadlessTest {
+
+  /**
+   * @var CRM_HRLeaveAndAbsences_BAO_AbsenceType
+   */
+  private $absenceType;
+
+  public function setUp() {
+    // We delete everything two avoid problems with the default absence types
+    // created during the extension installation
+    $tableName = AbsenceType::getTableName();
+    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+
+    $this->absenceType = AbsenceTypeFabricator::fabricate([
+      'must_take_public_holiday_as_leave' => 1
+    ]);
+  }
 
   public function testUpdateAllLeaveRequestsInTheFuture() {
     $deletionLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestDeletion::class)
@@ -55,5 +78,95 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseH
 
     $service = new PublicHolidayLeaveRequestService($creationLogicMock, $deletionLogicMock);
     $service->updateAllInTheFutureForContract($contactID);
+  }
+
+  /**
+   * This is an integration test to check that the PublicHolidayLeaveRequest
+   * service is used to update Public Holiday Leave Requests after a contract
+   * (with details) is created.
+   *
+   * We use a hook to do this update, and there isn't really a way to check if
+   * a hook gets called, so what we do here is check that there are no leave
+   * requests before creating the contract and then checking that they were
+   * created after the contract gets saved.
+   */
+  public function testItUpdateAllInTheFutureWhenTheContractDetailsAreCreated() {
+    $datePublicHoliday1 = new DateTime('yesterday');
+    $datePublicHoliday2 = new DateTime('+5 days');
+    $datePublicHoliday3 = new DateTime('+25 days');
+
+    PublicHolidayFabricator::fabricateWithoutValidation(['date' => $datePublicHoliday1->format('YmdHis')]);
+    PublicHolidayFabricator::fabricateWithoutValidation(['date' => $datePublicHoliday2->format('YmdHis')]);
+    PublicHolidayFabricator::fabricateWithoutValidation(['date' => $datePublicHoliday3->format('YmdHis')]);
+
+    $contact = ContactFabricator::fabricate();
+
+    $leaveRequest = new LeaveRequest();
+    $leaveRequest->contact_id = $contact['id'];
+    $leaveRequest->type_id = $this->absenceType->id;
+
+    $this->assertNull(LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $datePublicHoliday1));
+    $this->assertNull(LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $datePublicHoliday2));
+    $this->assertNull(LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $datePublicHoliday3));
+
+    $contract = HRJobContractFabricator::fabricate([
+      'contact_id' => $contact['id']
+    ],
+    [
+      'period_start_date' =>  CRM_Utils_Date::processDate('today'),
+    ]);
+
+    // Nothing should be created for the first public holiday as its date is
+    // before the contract start date
+    $this->assertNull(LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $datePublicHoliday1));
+    $this->assertNotNull(LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $datePublicHoliday2));
+    $this->assertNotNull(LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $datePublicHoliday3));
+  }
+
+  /**
+   * This is an integration test to check that the PublicHolidayLeaveRequest
+   * service is used to update Public Holiday Leave Requests after a contract
+   * (with details) is updated.
+   *
+   * We use a hook to do this update, and there isn't really a way to check if
+   * a hook gets called, so what we do here is check that there are no leave
+   * requests before creating the contract and then checking that they were
+   * created after the contract gets saved.
+   */
+  public function testItUpdateAllInTheFutureWhenTheContractDetailsAreUpdated() {
+    $datePublicHoliday1 = new DateTime('+5 days');
+    $datePublicHoliday2 = new DateTime('+25 days');
+
+    PublicHolidayFabricator::fabricateWithoutValidation(['date' => $datePublicHoliday1->format('YmdHis')]);
+    PublicHolidayFabricator::fabricateWithoutValidation(['date' => $datePublicHoliday2->format('YmdHis')]);
+
+    $contact = ContactFabricator::fabricate();
+
+    $leaveRequest = new LeaveRequest();
+    $leaveRequest->contact_id = $contact['id'];
+    $leaveRequest->type_id = $this->absenceType->id;
+
+    $contract = HRJobContractFabricator::fabricate(
+      [ 'contact_id' => $contact['id'] ],
+      [ 'period_start_date' => CRM_Utils_Date::processDate('today') ]
+    );
+
+    $this->assertNotNull(LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $datePublicHoliday1));
+    $this->assertNotNull(LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $datePublicHoliday2));
+
+    // Add a new Public holiday
+    $datePublicHoliday3 = new DateTime('+30 days');
+    PublicHolidayFabricator::fabricateWithoutValidation(['date' => $datePublicHoliday3->format('YmdHis')]);
+
+    // Update the contract with an end date which will still overlap the
+    // new public holiday
+    civicrm_api3('HRJobDetails', 'create', [
+      'jobcontract_id' => $contract['id'],
+      'period_end_date' => CRM_Utils_Date::processDate('+30 days')
+    ]);
+
+    $this->assertNotNull(LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $datePublicHoliday1));
+    $this->assertNotNull(LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $datePublicHoliday2));
+    $this->assertNotNull(LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $datePublicHoliday3));
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
@@ -32,4 +32,28 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseH
     $service->updateAllLeaveRequestsInTheFuture();
   }
 
+  public function testUpdateAllInTheFutureForContract() {
+    $contactID = 10;
+
+    $deletionLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestDeletion::class)
+                              ->disableOriginalConstructor()
+                              ->setMethods(['deleteAllForContract'])
+                              ->getMock();
+
+    $deletionLogicMock->expects($this->once())
+                      ->method('deleteAllForContract')
+                      ->with($this->identicalTo($contactID));
+
+    $creationLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestCreation::class)
+                              ->disableOriginalConstructor()
+                              ->setMethods(['createAllForContract'])
+                              ->getMock();
+
+    $creationLogicMock->expects($this->once())
+                      ->method('createAllForContract')
+                      ->with($this->identicalTo($contactID));
+
+    $service = new PublicHolidayLeaveRequestService($creationLogicMock, $deletionLogicMock);
+    $service->updateAllInTheFutureForContract($contactID);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
@@ -13,6 +13,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseH
 
   public function testUpdateAllLeaveRequestsInTheFuture() {
     $deletionLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestDeletion::class)
+                              ->disableOriginalConstructor()
                               ->setMethods(['deleteAllInTheFuture'])
                               ->getMock();
 
@@ -20,6 +21,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseH
                       ->method('deleteAllInTheFuture');
 
     $creationLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestCreation::class)
+                              ->disableOriginalConstructor()
                               ->setMethods(['createForAllInTheFuture'])
                               ->getMock();
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
@@ -29,7 +29,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseH
                       ->method('createForAllInTheFuture');
 
     $service = new PublicHolidayLeaveRequestService($creationLogicMock, $deletionLogicMock);
-    $service->updateAllLeaveRequestsInTheFuture();
+    $service->updateAllInTheFuture();
   }
 
   public function testUpdateAllInTheFutureForContract() {


### PR DESCRIPTION
When we update a contract, more specifically its details (HRJobDetails) we must also update the Public Holiday Leave Requests accordingly to the contract dates. The contract period might have changed and then we will need to add new leave requests for public holidays overlapping the new period.

### How this was implemented?
A new method was added to the PublicHolidayLeaveRequest service: `updateAllInTheFutureForContract()`. This method receives the ID of a contract and then:
1. Delete all leave requests for public holidays which are both in the future and overlaps the contract start and end dates
2. Creates leave requests for all public holidays which are both in the future and overlaps the contract start and end dates

Finally, using the `hook_civicrm_post()` hook, we call this new method every time a HRJobDetails is created or updated. The hook was used in order to tight couple the l&a extension with the hrjobcontract extension.

### What else has changed?
A new service, named JobContract, was created. It's kind of a wrapper around the HRJobContract API. Initially it was added as ways to remove some duplicated code among other services, but in the future it can be used to include other methods and be as a replacement in places where the civicrm_api3 is called directly, allowing us to mock API calls in tests.