### PR TITLE
PCHR-1663: Changed Format of From Addresses

### DIFF
--- a/hrabsence/CRM/HRAbsence/Form/AbsenceRequest.php
+++ b/hrabsence/CRM/HRAbsence/Form/AbsenceRequest.php
@@ -634,7 +634,7 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
       }
 
       if (array_key_exists('_qf_AbsenceRequest_done_save', $submitValues)) {
-        $sendTemplateParams['from'] = $mailprm[$this->_targetContactID]['email'];
+        $sendTemplateParams['from'] = "{$mailprm[$this->_targetContactID]['display_name']} <{$mailprm[$this->_targetContactID]['email']}>";
         CRM_Core_Session::setStatus(ts('Absence(s) have been applied.'), ts('Saved'), 'success');
       }
       elseif (array_key_exists('_qf_AbsenceRequest_done_saveandapprove', $submitValues) || $isAdmin) {
@@ -642,7 +642,7 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
           $emailID = civicrm_api3('contact', 'get', array(
             'id' => $this->_loginUserID,
           ));
-          $sendTemplateParams['from'] = $emailID['values'][$emailID['id']]['email'];
+          $sendTemplateParams['from'] = "{$emailID['values'][$emailID['id']]['display_name']} <{$emailID['values'][$emailID['id']]['email']}>";
         }
         $sendTemplateParams['tplParams']['approval'] = TRUE;
         CRM_Core_Session::setStatus(ts('Absence(s) have been applied and approved.'), ts('Saved'), 'success');
@@ -676,7 +676,7 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
         foreach($subact['values'] as $key=>$val) {
           civicrm_api3('Activity', 'create', array('id' =>$val['id'] ,'status_id' => $statusId,));
         }
-        $sendTemplateParams['from'] = $mailprm[$this->_targetContactID]['email'];
+        $sendTemplateParams['from'] = "{$mailprm[$this->_targetContactID]['display_name']} <{$mailprm[$this->_targetContactID]['email']}>";
         $sendTemplateParams['tplParams']['cancel'] = $sendMail = TRUE;
         CRM_Core_Session::setStatus(ts('Absence(s) have been Cancelled.'), ts('Cancelled'), 'success');
         $session->pushUserContext(CRM_Utils_System::url('civicrm/absence/set', "reset=1&action=view&aid={$result['id']}"));
@@ -713,7 +713,7 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
           $emailID = civicrm_api3('contact', 'get', array(
             'id' => $this->_loginUserID,
           ));
-          $sendTemplateParams['from'] = $emailID['values'][$emailID['id']]['email'];
+          $sendTemplateParams['from'] = "{$emailID['values'][$emailID['id']]['display_name']} <{$emailID['values'][$emailID['id']]['email']}>";
         }
         $sendTemplateParams['tplParams']['approval'] = $sendMail = TRUE;
         CRM_Core_Session::setStatus(ts('Absence(s) have been Approved.'), ts('Approved'), 'success');
@@ -735,7 +735,7 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
           $emailID = civicrm_api3('contact', 'get', array(
             'id' => $this->_loginUserID,
           ));
-          $sendTemplateParams['from'] = $emailID['values'][$emailID['id']]['email'];
+          $sendTemplateParams['from'] = "{$emailID['values'][$emailID['id']]['display_name']} <{$emailID['values'][$emailID['id']]['email']}>";
         }
         $sendTemplateParams['tplParams']['reject'] = $sendMail = TRUE;
         CRM_Core_Session::setStatus(ts('Absence(s) have been Rejected.'), ts('Rejected'), 'success');
@@ -766,7 +766,7 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
         $buttonName = $this->controller->getButtonName();
         if ($buttonName == "_qf_AbsenceRequest_done_save") {
           $this->_aid = $submitValues['source_record_id'];
-          $sendTemplateParams['from'] = $mailprm[$this->_targetContactID]['email'];
+          $sendTemplateParams['from'] = "{$mailprm[$this->_targetContactID]['display_name']} <{$mailprm[$this->_targetContactID]['email']}>";
           $sendTemplateParams['tplParams']['save'] = $sendMail = TRUE;
           $session->pushUserContext(CRM_Utils_System::url('civicrm/absences', "reset=1&cid={$this->_targetContactID}", false, 'hrabsence/list'));
         }


### PR DESCRIPTION
Implemented so e-mails sent on associated absence events have the format:
userName <SystemEMail>.  In that way, when the e-mail gets to users, they'll see tha name of the user that caused it to be sent, but the e-mail which it was sent from remains to be the one configured as the system-wide default sender.