### PR TITLE
PCHR-1265: Add the LeaveRequest.getBalanceChangeByAbsenceType API endpoint

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -206,11 +206,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
    *
    * @param \CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement $periodEntitlement
    * @param array $leaveRequestStatus
-   *    An array of values from Leave Request Status option list
+   *   An array of values from Leave Request Status option list
    * @param \DateTime $dateLimit
-   *    When given, will make the method count only days taken as leave up to this date
+   *   When given, will make the method count only days taken as leave up to this date
    * @param \DateTime $dateStart
-   *    When given, will make the method count only days taken as leave starting from this date
+   *   When given, will make the method count only days taken as leave starting from this date
+   * @param bool $excludePublicHolidays
+   *   When true, it won't sum the balance changes for Public Holiday Leave Requests
    *
    * @return float
    */
@@ -218,7 +220,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
     LeavePeriodEntitlement $periodEntitlement,
     $leaveRequestStatus = [],
     DateTime $dateLimit = NULL,
-    DateTime $dateStart = NULL
+    DateTime $dateStart = NULL,
+    $excludePublicHolidays = false
   ) {
 
     $balanceChangeTable = self::getTableName();
@@ -241,15 +244,20 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
 
     if(is_array($leaveRequestStatus) && !empty($leaveRequestStatus)) {
       array_walk($leaveRequestStatus, 'intval');
-      $query .= ' AND leave_request.status_id IN('. implode(', ', $leaveRequestStatus) .')';
+      $query .= ' AND leave_request.status_id IN('. implode(', ', $leaveRequestStatus) .') ';
     }
 
     if($dateLimit) {
-      $query .= " AND leave_request_date.date <= '{$dateLimit->format('Y-m-d')}'";
+      $query .= " AND leave_request_date.date <= '{$dateLimit->format('Y-m-d')}' ";
     }
 
     if($dateStart) {
-      $query .= " AND leave_request_date.date >= '{$dateStart->format('Y-m-d')}'";
+      $query .= " AND leave_request_date.date >= '{$dateStart->format('Y-m-d')}' ";
+    }
+
+    if($excludePublicHolidays) {
+      $balanceChangeTypes = array_flip(self::buildOptions('type_id'));
+      $query .= " AND leave_balance_change.type_id != '{$balanceChangeTypes['Public Holiday']}'";
     }
 
     $result = CRM_Core_DAO::executeQuery($query);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -91,19 +91,38 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    * That is, the sum of all the Leave Balance Changes for Leave Requests of that
    * Absence Type, for the given $contactID during the given $periodID.
    *
+   * Balance Changes for Public Holiday Leave Requests won't be considered,
+   * except when $publicHolidays is true. In that case, on the balance changes
+   * for that type of request will be considered.
+   *
    * @param int $contactID
    * @param int $periodID
    * @param array $leaveRequestStatus
    *   And array of values from the Leave Request Status OptionGroup
+   * @param bool $publicHolidaysOnly
+   *   When true, will get the balance change only for the Public Holiday Leave Requests
    *
    * @return array
    */
-  public static function getBalanceChangeByAbsenceType($contactID, $periodID, $leaveRequestStatus = []) {
+  public static function getBalanceChangeByAbsenceType(
+    $contactID,
+    $periodID,
+    $leaveRequestStatus = [],
+    $publicHolidaysOnly = false
+  ) {
     $periodEntitlements = LeavePeriodEntitlement::getPeriodEntitlementsForContact($contactID, $periodID);
 
     $results = [];
+    $excludePublicHolidays = !$publicHolidaysOnly;
     foreach($periodEntitlements as $periodEntitlement) {
-      $balance = LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement, $leaveRequestStatus);
+      $balance = LeaveBalanceChange::getLeaveRequestBalanceForEntitlement(
+        $periodEntitlement,
+        $leaveRequestStatus,
+        null,
+        null,
+        $excludePublicHolidays,
+        $publicHolidaysOnly
+      );
       $results[$periodEntitlement->type_id] = $balance;
     }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -2,6 +2,7 @@
 
 use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
 use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
+use CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement as LeavePeriodEntitlement;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
 
 class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO_LeaveRequest {
@@ -83,6 +84,28 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     }
 
     return null;
+  }
+
+  /**
+   * Returns a list of all Absence Types, together with its total balance change.
+   * That is, the sum of all the Leave Balance Changes for Leave Requests of that
+   * Absence Type, for the given $contactID during the given $periodID.
+   *
+   * @param int $contactID
+   * @param int $periodID
+   *
+   * @return array
+   */
+  public static function getBalanceChangeByAbsenceType($contactID, $periodID) {
+    $periodEntitlements = LeavePeriodEntitlement::getPeriodEntitlementsForContact($contactID, $periodID);
+
+    $results = [];
+    foreach($periodEntitlements as $periodEntitlement) {
+      $balance = LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement);
+      $results[$periodEntitlement->type_id] = $balance;
+    }
+
+    return $results;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -93,15 +93,17 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    *
    * @param int $contactID
    * @param int $periodID
+   * @param array $leaveRequestStatus
+   *   And array of values from the Leave Request Status OptionGroup
    *
    * @return array
    */
-  public static function getBalanceChangeByAbsenceType($contactID, $periodID) {
+  public static function getBalanceChangeByAbsenceType($contactID, $periodID, $leaveRequestStatus = []) {
     $periodEntitlements = LeavePeriodEntitlement::getPeriodEntitlementsForContact($contactID, $periodID);
 
     $results = [];
     foreach($periodEntitlements as $periodEntitlement) {
-      $balance = LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement);
+      $balance = LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement, $leaveRequestStatus);
       $results[$periodEntitlement->type_id] = $balance;
     }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -44,3 +44,57 @@ function civicrm_api3_leave_request_delete($params) {
 function civicrm_api3_leave_request_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
+
+/**
+ * LeaveRequest.getBalanceChangeByAbsenceType API spec
+ *
+ * @param array $spec
+ */
+function _civicrm_api3_leave_request_getbalancechangebyabsencetype_spec(&$spec) {
+  $spec['contact_id'] = [
+    'name' => 'contact_id',
+    'title' => 'Contact ID',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 1,
+  ];
+
+  $spec['period_id'] = [
+    'name' => 'period_id',
+    'title' => 'Absence Period ID',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 1,
+  ];
+
+  $spec['statuses'] = [
+    'name' => 'statuses',
+    'title' => 'Leave Request status',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 0,
+  ];
+
+  $spec['public_holiday'] = [
+    'name' => 'public_holiday',
+    'title' => 'Include only Public Holiday Leave Requests?',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+    'api.required' => 0,
+  ];
+}
+
+/**
+ * LeaveRequest.getBalanceChangeByAbsenceType API
+ *
+ * Returns the total balance change for each
+ *
+ * @param array $params
+ *  An array of params passed to the API
+ *
+ * @return array
+ */
+function civicrm_api3_leave_request_getbalancechangebyabsencetype($params) {
+  $values = CRM_HRLeaveAndAbsences_BAO_LeaveRequest::getBalanceChangeByAbsenceType(
+    $params['contact_id'],
+    $params['period_id']
+  );
+
+  return civicrm_api3_create_success($values);
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -92,11 +92,13 @@ function _civicrm_api3_leave_request_getbalancechangebyabsencetype_spec(&$spec) 
  */
 function civicrm_api3_leave_request_getbalancechangebyabsencetype($params) {
   $statuses = _civicrm_api3_leave_request_get_statuses_from_params($params);
+  $publicHolidayOnly = empty($params['public_holiday']) ? false : true;
 
   $values = CRM_HRLeaveAndAbsences_BAO_LeaveRequest::getBalanceChangeByAbsenceType(
     $params['contact_id'],
     $params['period_id'],
-    $statuses
+    $statuses,
+    $publicHolidayOnly
   );
 
   return civicrm_api3_create_success($values);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -91,10 +91,41 @@ function _civicrm_api3_leave_request_getbalancechangebyabsencetype_spec(&$spec) 
  * @return array
  */
 function civicrm_api3_leave_request_getbalancechangebyabsencetype($params) {
+  $statuses = _civicrm_api3_leave_request_get_statuses_from_params($params);
+
   $values = CRM_HRLeaveAndAbsences_BAO_LeaveRequest::getBalanceChangeByAbsenceType(
     $params['contact_id'],
-    $params['period_id']
+    $params['period_id'],
+    $statuses
   );
 
   return civicrm_api3_create_success($values);
+}
+
+/**
+ * Extracts the list of statuses from the $params array
+ *
+ * Currently, we only support the IN operator for passing an array of statuses.
+ * Supporting other operators would be extremely complex and it would not even
+ * make sense to support operators like >= and <.
+ *
+ * @param array $params
+ *   The $params array passed to the LeaveRequest.getBalanceChangeByAbsenceType API
+ *
+ * @return array
+ */
+function _civicrm_api3_leave_request_get_statuses_from_params($params) {
+  if(empty($params['statuses'])) {
+    return [];
+  }
+
+  if(!is_array($params['statuses'])) {
+    return [$params['statuses']];
+  }
+
+  if(!array_key_exists('IN', $params['statuses'])) {
+    throw new InvalidArgumentException('The statuses parameter only supports the IN operator');
+  }
+
+  return $params['statuses']['IN'];
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -192,8 +192,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   public function testGetBalanceChangeByAbsenceTypeShouldShouldReturn0ForAnAbsenceTypeWithNoLeaveRequests() {
     $contact = ContactFabricator::fabricate();
 
-    $absenceType1 = AbsenceTypeFabricator::fabricate();
-
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-10 days'),
       'end_date' => CRM_Utils_Date::processDate('+100 days')
@@ -202,12 +200,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     LeavePeriodEntitlementFabricator::fabricate([
       'contact_id' => $contact['id'],
       'period_id' => $absencePeriod->id,
-      'type_id' => $absenceType1->id
+      'type_id' => $this->absenceType->id
     ]);
 
     $result = LeaveRequest::getBalanceChangeByAbsenceType($contact['id'], $absencePeriod->id);
 
-    $expectedResult = [ $absenceType1->id => 0];
+    $expectedResult = [ $this->absenceType->id => 0];
 
     $this->assertEquals($expectedResult, $result);
   }
@@ -215,8 +213,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   public function testGetBalanceChangeByAbsenceTypeCanReturnTheBalanceForLeaveRequestsWithSpecificsStatuses() {
     $contact = ContactFabricator::fabricate();
 
-    $absenceType = AbsenceTypeFabricator::fabricate();
-
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-10 days'),
       'end_date' => CRM_Utils_Date::processDate('+100 days')
@@ -225,14 +221,14 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     LeavePeriodEntitlementFabricator::fabricate([
       'contact_id' => $contact['id'],
       'period_id' => $absencePeriod->id,
-      'type_id' => $absenceType->id,
+      'type_id' => $this->absenceType->id,
     ]);
 
     $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
 
     LeaveRequestFabricator::fabricate([
       'contact_id' => $contact['id'],
-      'type_id' => $absenceType->id,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('+1 day'),
       'to_date' => CRM_Utils_Date::processDate('+2 days'),
       'status_id' => $leaveRequestStatuses['Waiting Approval']
@@ -240,7 +236,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     LeaveRequestFabricator::fabricate([
       'contact_id' => $contact['id'],
-      'type_id' => $absenceType->id,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('+3 days'),
       'to_date' => CRM_Utils_Date::processDate('+5 days'),
       'status_id' => $leaveRequestStatuses['More Information Requested']
@@ -248,7 +244,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     LeaveRequestFabricator::fabricate([
       'contact_id' => $contact['id'],
-      'type_id' => $absenceType->id,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('+6 days'),
       'to_date' => CRM_Utils_Date::processDate('+9 days'),
       'status_id' => $leaveRequestStatuses['Cancelled']
@@ -259,7 +255,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       $absencePeriod->id,
       [$leaveRequestStatuses['Waiting Approval']]
     );
-    $expectedResult = [$absenceType->id => -2];
+    $expectedResult = [$this->absenceType->id => -2];
     $this->assertEquals($expectedResult, $result);
 
     $result = LeaveRequest::getBalanceChangeByAbsenceType(
@@ -267,7 +263,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       $absencePeriod->id,
       [$leaveRequestStatuses['More Information Requested']]
     );
-    $expectedResult = [$absenceType->id => -3];
+    $expectedResult = [$this->absenceType->id => -3];
     $this->assertEquals($expectedResult, $result);
 
     $result = LeaveRequest::getBalanceChangeByAbsenceType(
@@ -279,7 +275,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
         $leaveRequestStatuses['Cancelled'],
       ]
     );
-    $expectedResult = [$absenceType->id => -9];
+    $expectedResult = [$this->absenceType->id => -9];
     $this->assertEquals($expectedResult, $result);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -1,11 +1,27 @@
 <?php
 
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod as AbsencePeriodFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_LeavePeriodEntitlement as LeavePeriodEntitlementFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest as PublicHolidayLeaveRequestFabricator;
+
 /**
  * Class api_v3_LeaveRequestTest
  *
  * @group headless
  */
 class api_v3_LeaveRequestTest extends BaseHeadlessTest {
+
+  public function setUp() {
+    // We delete everything two avoid problems with the default absence types
+    // created during the extension installation
+    $tableName = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getTableName();
+    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+  }
 
   /**
    * @expectedException CiviCRM_API3_Exception
@@ -57,6 +73,58 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ]);
 
     $this->assertEquals(0, $values['is_error']);
+  }
+
+  public function testGetBalanceChangeByAbsenceTypeCanBeFilteredForPublicHolidays() {
+    $contact = ContactFabricator::fabricate();
+
+    $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => true]);
+
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-10 days'),
+      'end_date' => CRM_Utils_Date::processDate('+100 days')
+    ]);
+
+    LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'period_id' => $absencePeriod->id,
+      'type_id' => $absenceType->id,
+    ]);
+
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
+
+    LeaveRequestFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'type_id' => $absenceType->id,
+      'from_date' => CRM_Utils_Date::processDate('+1 day'),
+      'to_date' => CRM_Utils_Date::processDate('+2 days'),
+      'status_id' => $leaveRequestStatuses['Approved']
+    ], true);
+
+    $publicHoliday = new PublicHoliday();
+    $publicHoliday->date = date('Y-m-d', strtotime('+40 days'));
+
+    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday);
+
+    // Passing the public_holiday param, it will sum the balance only for the
+    // public holidays
+    $publicHolidaysOnly = true;
+    $result = civicrm_api3('LeaveRequest', 'getbalancechangebyabsencetype', [
+      'contact_id' => $contact['id'],
+      'period_id' => $absencePeriod->id,
+      'public_holiday' => $publicHolidaysOnly
+    ]);
+    $expectedResult = [$absenceType->id => -1];
+    $this->assertEquals($expectedResult, $result['values']);
+
+    // Without passing the public_holiday param, it will sum the balance
+    // for everything, except the public holidays
+    $result = civicrm_api3('LeaveRequest', 'getbalancechangebyabsencetype', [
+      'contact_id' => $contact['id'],
+      'period_id' => $absencePeriod->id,
+    ]);
+    $expectedResult = [$absenceType->id => -2];
+    $this->assertEquals($expectedResult, $result['values']);
   }
 
   public function invalidGetBalanceChangeByAbsenceTypeStatusesOperators() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Class api_v3_LeaveRequestTest
+ *
+ * @group headless
+ */
+class api_v3_LeaveRequestTest extends BaseHeadlessTest {
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage Mandatory key(s) missing from params array: contact_id, period_id
+   */
+  public function testGetBalanceChangeByAbsenceTypeShouldNotAllowParamsWithoutContactIDAndPeriodID() {
+    civicrm_api3('LeaveRequest', 'getbalancechangebyabsencetype', []);
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage Mandatory key(s) missing from params array: contact_id
+   */
+  public function testGetBalanceChangeByAbsenceTypeShouldNotAllowParamsWithoutContactID() {
+    civicrm_api3('LeaveRequest', 'getbalancechangebyabsencetype', [
+      'period_id' => 1
+    ]);
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage Mandatory key(s) missing from params array: period_id
+   */
+  public function testGetBalanceChangeByAbsenceTypeShouldNotAllowParamsWithoutPeriodID() {
+    civicrm_api3('LeaveRequest', 'getbalancechangebyabsencetype', [
+      'contact_id' => 1
+    ]);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -34,4 +34,46 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => 1
     ]);
   }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage The statuses parameter only supports the IN operator
+   *
+   * @dataProvider invalidGetBalanceChangeByAbsenceTypeStatusesOperators
+   */
+  public function testGetBalanceChangeByAbsenceTypeShouldOnlyAllowTheINOperator($operator) {
+    civicrm_api3('LeaveRequest', 'getbalancechangebyabsencetype', [
+      'contact_id' => 1,
+      'period_id' => 1,
+      'statuses' => [$operator => [1]]
+    ]);
+  }
+
+  public function testGetBalanceChangeByAbsenceTypeDoesNotThrowAnErrorWhenUsingTheEqualsOperatorForStatuses() {
+    $values = civicrm_api3('LeaveRequest', 'getbalancechangebyabsencetype', [
+      'contact_id' => 1,
+      'period_id' => 1,
+      'statuses' => 1
+    ]);
+
+    $this->assertEquals(0, $values['is_error']);
+  }
+
+  public function invalidGetBalanceChangeByAbsenceTypeStatusesOperators() {
+    return [
+      ['>'],
+      ['>='],
+      ['<='],
+      ['<'],
+      ['<>'],
+      ['!='],
+      ['BETWEEN'],
+      ['NOT BETWEEN'],
+      ['LIKE'],
+      ['NOT LIKE'],
+      ['NOT IN'],
+      ['IS NULL'],
+      ['IS NOT NULL'],
+    ];
+  }
 }


### PR DESCRIPTION
This PR introduces the `LeaveRequest.getBalanceChangeByAbsenceType` API endpoint, which will return the total change in balance that is caused by the leave requests of a given absence type, or of all the absence types of a given contact and period.

This endpoint supports the following parameters:
- **contact_id**: Mandatory The ID of the Contact to get the balance change for
- **period_id**: Mandatory The ID of the Absence Period to get the balance change for
- **statuses**: Optional (Default: null) An array of OptionValue values which the list will be filtered by
- **public_holiday**: Optional (Default: false) Based on the value of this param, the calculation will include only the leave requests that aren't/are public holidays

The output is going to be a list of Absence Types ids followed by their respective total change in balance.

#### Examples
Say you have the following Leave Requests (all during the same absence period and for the same contact):

 type_id | status | public holiday | balance change
---------|------------------|----------------|----------------
 1 | Approved | false | -4
 1 | Cancelled | false | -1
 1 | Waiting Approval | false | -3
 2 | Admin Approved | true | -1
 2 | Rejected | false | -5

Calling this:
```php
civicrm_api3('LeaveRequest', 'getBalanceChangeByAbsenceType', [
  'contact_id' => 1,
  'period_id' => 1
]);
```

Would return this:
```javascript
{
   "1": -8, // including everything from absence type 1
   "2": -5 // including everything from absence type 2, except for the public holiday
}
```

Now, if we only want the public holidays, the API can be called like this:

```php 
civicrm_api3('LeaveRequest', 'getBalanceChangeByAbsenceType', [
  'contact_id' => 1,
  'period_id' => 1,
  'public_holiday' => true
]);
```

Which will return this:
```javascript
{
   "1": 0, // since there is no public holiday leave requests for absence type 1
   "2": -1
}
```

Using the `statuses` parameter, it's possible to return the balance change considering only Leave Requests with specific statuses:

```php
civicrm_api3('LeaveRequest', 'getBalanceChangeByAbsenceType', [
  'contact_id' => 1,
  'period_id' => 1,
  'statuses' => ['IN' => ['Cancelled', 'Rejected']]
]);
```

That would return:
```javascript
{
  "1": -1, //there only one cancelled leave request for absence type 1
  "2": -5 // there is rejected leave request for absence type 2
}
```

Note that, currently, `IN` is the only supported operator for the `statuses` parameter. That is enough for what we need at the moment and it would be extremely complex to support all the other operators. Trying to use any other operator with it will result in an error.