### PR TITLE
PCHR-1371: Add the public_holiday param to the LeaveRequest.get API

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
@@ -1,0 +1,80 @@
+<?php
+
+use \Civi\API\SelectQuery;
+use \CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
+use \CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use \CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
+
+/**
+ * This class is basically a wrapper around Civi\API\SelectQuery.
+ *
+ * It's supposed to work just like SelectQuery, but it will automatically join
+ * the LeaveRequest with its LeaveRequestDates and LeaveBalanceChange, allowing
+ * us to filter the results based on balance change details, like returning only
+ * Public Holiday Leave Requests.
+ */
+class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
+
+  /**
+   * @var array
+   *   An array of params passed to an API endpoint
+   */
+  private $params;
+
+  /**
+   * @var \Civi\API\SelectQuery
+   *  The SelectQuery instance wrapped by this class
+   */
+  private $query;
+
+  public function __construct($params) {
+    $this->params = $params;
+    $this->query = new SelectQuery(LeaveRequest::class, $params, false);
+    $this->addJoins();
+  }
+
+  /**
+   * Add the joins required to join LeaveRequest with LeaveRequestDate and then
+   * with LeaveBalanceChange.
+   *
+   * If the $params array has the public_holiday flag set and it's true, the
+   * join condition will make sure only LeaveRequests linked to a LeaveBalanceChange
+   * of the Public Holiday type will be returned.
+   */
+  private function addJoins() {
+    $balanceChangeJoinConditions = [
+      'lbc.source_id = lrd.id',
+      "lbc.source_type = '" . LeaveBalanceChange::SOURCE_LEAVE_REQUEST_DAY . "'",
+    ];
+
+    $leaveBalanceChangeTypes = array_flip(LeaveBalanceChange::buildOptions('type_id'));
+    if(empty($this->params['public_holiday'])) {
+      $balanceChangeJoinConditions[] = "lbc.type_id <> {$leaveBalanceChangeTypes['Public Holiday']}";
+    } else {
+      $balanceChangeJoinConditions[] = "lbc.type_id = {$leaveBalanceChangeTypes['Public Holiday']}";
+    }
+
+    $this->query->join(
+      'INNER',
+      LeaveRequestDate::getTableName(),
+      'lrd',
+      ['lrd.leave_request_id = a.id']
+    );
+    $this->query->join(
+      'INNER',
+      LeaveBalanceChange::getTableName(),
+      'lbc',
+      $balanceChangeJoinConditions
+    );
+  }
+
+  /**
+   * Executes the query
+   *
+   * @return array
+   */
+  public function run() {
+    return $this->query->run();
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -64,33 +64,7 @@ function _civicrm_api3_leave_request_get_spec(&$spec) {
  * @throws CiviCRM_API3_Exception
  */
 function civicrm_api3_leave_request_get($params) {
-  $query = new \Civi\API\SelectQuery(CRM_HRLeaveAndAbsences_BAO_LeaveRequest::class, $params, false);
-
-  $balanceChangeJoinConditions = [
-    'lbc.source_id = lrd.id',
-    "lbc.source_type = '" . CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange::SOURCE_LEAVE_REQUEST_DAY . "'",
-  ];
-
-  $leaveBalanceChangeTypes = array_flip(CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange::buildOptions('type_id'));
-  if(empty($params['public_holiday'])) {
-    $balanceChangeJoinConditions[] = "lbc.type_id <> {$leaveBalanceChangeTypes['Public Holiday']}";
-  } else {
-    $balanceChangeJoinConditions[] = "lbc.type_id = {$leaveBalanceChangeTypes['Public Holiday']}";
-  }
-
-  $query->join(
-    'INNER',
-    CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate::getTableName(),
-    'lrd',
-    ['lrd.leave_request_id = a.id']
-  );
-  $query->join(
-    'INNER',
-    CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange::getTableName(),
-    'lbc',
-    $balanceChangeJoinConditions
-  );
-
+  $query = new CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect($params);
   return civicrm_api3_create_success($query->run(), $params, '', 'get');
 }
 


### PR DESCRIPTION
This new param will make, when present and its value is true, the LeaveRequest.get return only Public Holiday Leave Requests. Otherwise, all Leave Request will be returned (according to the given params), except for those linked to Public Holidays.

To know if a Leave Request is a Public Holiday Leave Request, we need to go to its LeaveBalanceChange, through its LeaveRequestDate, and check that its type is 'Public Holiday'. In order to do that, the _LeaveRequestSelect_ class was created to wrap and "extend" the regular _SelectQuery_ which is used by default on the get API. Basically, it add joins to the leave_request_date and leave_balance_change tables, in order to be able to add conditions based on field of those tables. It also checks for the presence of the _public_holiday_ param in order to set the right conditions to return only "public holiday"/"non-public holiday" leave request.

### Usage
Suppose you have 2 Leave Requests. One from 2016-01-10 to 2016-01-11 and another one for a Public Holiday, for 2016-07-08.

Calling this:
```php
civicrm_api3('LeaveRequest', 'get');
```

Will only return the regular Leave Request (from 2016-01-10 to 2016-01-11).

Now, calling this:

```php
civicrm_api3('LeaveRequest', 'get', ['public_holiday' => true]);
```

Will only return the Public Holiday Leave Request.

The response format is just like the one from a regular .get API call. All the other params and options work the same way as expected. You can even combine params like `['contact_id' => 1, 'public_holiday' => true]` which will return only Public Holiday Leave Requests for the contact with ID 1