### PR TITLE
PCHR-1663: Brought Default Sytem E-mail from Database

### DIFF
--- a/hrabsence/CRM/HRAbsence/Form/AbsenceRequest.php
+++ b/hrabsence/CRM/HRAbsence/Form/AbsenceRequest.php
@@ -561,6 +561,7 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
     ));
     $mailprm[$this->_targetContactID]['display_name'] = $targetContactResult['values'][$this->_targetContactID]['display_name'];
     $mailprm[$this->_targetContactID]['email'] = $targetContactResult['values'][$this->_targetContactID]['email'];
+    $domainEmailAddress = CRM_Core_BAO_Domain::getNameAndEmail()[1];
 
     $tplParams = array(
       'messageTemplateID' => $msgTempResult['values'][$msgTempResult['id']]['id'],
@@ -634,7 +635,7 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
       }
 
       if (array_key_exists('_qf_AbsenceRequest_done_save', $submitValues)) {
-        $sendTemplateParams['from'] = $mailprm[$this->_targetContactID]['email'];
+        $sendTemplateParams['from'] = "{$mailprm[$this->_targetContactID]['display_name']} <$domainEmailAddress>";
         CRM_Core_Session::setStatus(ts('Absence(s) have been applied.'), ts('Saved'), 'success');
       }
       elseif (array_key_exists('_qf_AbsenceRequest_done_saveandapprove', $submitValues) || $isAdmin) {
@@ -642,7 +643,7 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
           $emailID = civicrm_api3('contact', 'get', array(
             'id' => $this->_loginUserID,
           ));
-          $sendTemplateParams['from'] = $emailID['values'][$emailID['id']]['email'];
+          $sendTemplateParams['from'] = "{$emailID['values'][$emailID['id']]['display_name']} <$domainEmailAddress>";
         }
         $sendTemplateParams['tplParams']['approval'] = TRUE;
         CRM_Core_Session::setStatus(ts('Absence(s) have been applied and approved.'), ts('Saved'), 'success');
@@ -676,7 +677,7 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
         foreach($subact['values'] as $key=>$val) {
           civicrm_api3('Activity', 'create', array('id' =>$val['id'] ,'status_id' => $statusId,));
         }
-        $sendTemplateParams['from'] = $mailprm[$this->_targetContactID]['email'];
+        $sendTemplateParams['from'] = "{$mailprm[$this->_targetContactID]['display_name']} <$domainEmailAddress>";
         $sendTemplateParams['tplParams']['cancel'] = $sendMail = TRUE;
         CRM_Core_Session::setStatus(ts('Absence(s) have been Cancelled.'), ts('Cancelled'), 'success');
         $session->pushUserContext(CRM_Utils_System::url('civicrm/absence/set', "reset=1&action=view&aid={$result['id']}"));
@@ -713,7 +714,7 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
           $emailID = civicrm_api3('contact', 'get', array(
             'id' => $this->_loginUserID,
           ));
-          $sendTemplateParams['from'] = $emailID['values'][$emailID['id']]['email'];
+          $sendTemplateParams['from'] = "{$emailID['values'][$emailID['id']]['display_name']} <$domainEmailAddress>";
         }
         $sendTemplateParams['tplParams']['approval'] = $sendMail = TRUE;
         CRM_Core_Session::setStatus(ts('Absence(s) have been Approved.'), ts('Approved'), 'success');
@@ -735,7 +736,7 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
           $emailID = civicrm_api3('contact', 'get', array(
             'id' => $this->_loginUserID,
           ));
-          $sendTemplateParams['from'] = $emailID['values'][$emailID['id']]['email'];
+          $sendTemplateParams['from'] = "{$emailID['values'][$emailID['id']]['display_name']} <$domainEmailAddress>";
         }
         $sendTemplateParams['tplParams']['reject'] = $sendMail = TRUE;
         CRM_Core_Session::setStatus(ts('Absence(s) have been Rejected.'), ts('Rejected'), 'success');
@@ -766,7 +767,7 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
         $buttonName = $this->controller->getButtonName();
         if ($buttonName == "_qf_AbsenceRequest_done_save") {
           $this->_aid = $submitValues['source_record_id'];
-          $sendTemplateParams['from'] = $mailprm[$this->_targetContactID]['email'];
+          $sendTemplateParams['from'] = "{$mailprm[$this->_targetContactID]['display_name']} <$domainEmailAddress>";
           $sendTemplateParams['tplParams']['save'] = $sendMail = TRUE;
           $session->pushUserContext(CRM_Utils_System::url('civicrm/absences', "reset=1&cid={$this->_targetContactID}", false, 'hrabsence/list'));
         }


### PR DESCRIPTION
Previous solution worked when using gmail as SMTP server, because gmail automatically replaces original "From" address for account bein used to send the e-mail.  Failed when testing aginst other SMTP servers (sender should always be system-wide email). So, used call to CRM core Domain Entity to obtain default system sender.

Tested on staging site by checking out branch directly.  Basically, all tests were succesful, except test on line 38, which requires clarification on how to replicate, and test 39, which failed.

Results for tests can be seen here:
https://docs.google.com/a/compucorp.co.uk/spreadsheets/d/1n4Uovt9URyErQ2pMqt-hTGUBb2ezCVLR0J017xk_eDI/edit?usp=sharing

