### PR TITLE
PCHR-1756: Filter out leave requests not overlapping contracts

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
@@ -34,6 +34,7 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
     $this->params = $params;
     $this->query = new SelectQuery(LeaveRequest::class, $params, false);
     $this->addJoins();
+    $this->addGroupBy();
   }
 
   /**
@@ -135,6 +136,21 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
       'lbc',
       $balanceChangeJoinConditions
     );
+  }
+
+  /**
+   * Add a GROUP BY to the query, group the results
+   *
+   * Since we join with Leave Request Dates and Leave Balance Change, we might
+   * end up with multiple records for the same Leave Request. The API infrastructure
+   * is smart enough to remove those duplicates once the records are fetched, but
+   * this would cause problems with the LIMIT option, as it would be added to
+   * the query and the duplicated records would also be included on the limit.
+   */
+  private function addGroupBy() {
+    $groupBy = new CRM_Utils_SQL_Select(LeaveRequest::getTableName() . ' as a');
+    $groupBy->groupBy(['a.id']);
+    $this->query->merge($groupBy);
   }
 
 }


### PR DESCRIPTION
A Leave Request is not linked directly to a Contract. Instead it's linked to a Contact and we use the Leave Request dates in order to know with which contracts it overlaps. This means we can have "stale" requests, which don't overlap any existing contract (this can happen, for example, when a contract length is decreased).

A call to the LeaveRequest.get API endpoint, even without any params, should no include those "stale" requests, so this PR updates the query used by the API to filter out any Leave Request not overlapping a contract. This was implemented by updating the query to join Leave Request with Contracts using the contact_id. Next, we join the Contract with its details, through the Contract Revision, in order to finally be able to add the conditions to return only the Leave Requests where the from_date and to_date overlaps the Contract's period_start_date and period_end_date.