### PR TITLE
PCHR-1751: Fix Filtering of Contacts by Value of Region/Location on Search

### DIFF
--- a/contactaccessrights/CRM/Contactaccessrights/BAO/Rights.php
+++ b/contactaccessrights/CRM/Contactaccessrights/BAO/Rights.php
@@ -16,7 +16,7 @@ class CRM_Contactaccessrights_BAO_Rights extends CRM_Contactaccessrights_DAO_Rig
    * @return CRM_Contactaccessrights_DAO_Rights|NULL
    *
    */
-  public function create($params) {
+  public static function create($params) {
     $entityName = 'Rights';
     $hook = empty($params['id']) ? 'create' : 'edit';
 

--- a/contactaccessrights/CRM/Contactaccessrights/BAO/Rights.php
+++ b/contactaccessrights/CRM/Contactaccessrights/BAO/Rights.php
@@ -46,7 +46,8 @@ class CRM_Contactaccessrights_BAO_Rights extends CRM_Contactaccessrights_DAO_Rig
       rights.contact_id contact_id,
       rights.entity_type entity_type,
       rights.entity_id entity_id,
-      ov.label label
+      ov.label label,
+      ov.value value
 
     FROM civicrm_contactaccessrights_rights rights
 

--- a/contactaccessrights/CRM/Contactaccessrights/Test/Fabricator/Rights.php
+++ b/contactaccessrights/CRM/Contactaccessrights/Test/Fabricator/Rights.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Fabricates rights for tests.
+ */
+class CRM_Contactaccessrights_Test_Fabricator_Rights {
+
+  /**
+   * Fabricates Rights, given specific values for contact_id, entity_id and 
+   * entity_type.
+   * 
+   * @param array $params
+   *   Associative array of parameters to be used to store rights information in 
+   *   database.
+   * @return array
+   *   Holds values stored in database for created access right
+   */
+  public static function fabricate($params) {
+    $result = civicrm_api3('Rights', 'create', [
+      'sequential' => 1,
+      'contact_id' => $params['contact_id'],
+      'entity_id' => $params['entity_id'],
+      'entity_type' => $params['entity_type']
+    ]);
+
+    return array_shift($result['values']);
+  }
+
+}

--- a/contactaccessrights/CRM/Contactaccessrights/Utils/ACL.php
+++ b/contactaccessrights/CRM/Contactaccessrights/Utils/ACL.php
@@ -106,8 +106,8 @@ class CRM_Contactaccessrights_Utils_ACL {
    * @throws \CRM_Extension_Exception
    */
   private function addJobRolesClause() {
-    $locationIds = implode(', ', array_column($this->getLocations(), 'entity_id') ?: [0]);
-    $regionIds = implode(', ', array_column($this->getRegions(), 'entity_id') ?: [0]);
+    $locationIds = "'" . implode("', '", array_column($this->getLocations(), 'value') ?: [0]) . "'";
+    $regionIds = "'" . implode("', '", array_column($this->getRegions(), 'value') ?: [0]) . "'";
 
     $this->addWhereTable(
       'car_3_jr',

--- a/contactaccessrights/phpunit.xml.dist
+++ b/contactaccessrights/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/phpunit/bootstrap.php">
+  <testsuites>
+    <testsuite name="My Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/contactaccessrights/tests/phpunit/CRM/Contactaccessrights/Utils/ACLTest.php
+++ b/contactaccessrights/tests/phpunit/CRM/Contactaccessrights/Utils/ACLTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
+use CRM_HRCore_Test_Fabricator_OptionValue as OptionValueFabricator;
+use CRM_Contactaccessrights_Test_Fabricator_Rights as RightsFabricator;
+
+/**
+ * Class CRM_Contactaccessrights_BAO_RightsTest
+ * Tests Rights BAO class for contact's access rights to civicrm.
+ * 
+ * @group headless
+ */
+class CRM_Contactaccessrights_Utils_ACLTest extends PHPUnit_Framework_TestCase implements
+  HeadlessInterface, TransactionalInterface {
+
+  /**
+   * Installs extensions required for test
+   * 
+   * @return \Civi\Test\CiviEnvBuilder
+   */
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->install('uk.co.compucorp.civicrm.hrcore')
+      ->install('org.civicrm.hrjobcontract')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  /**
+   * Tests if ACL Utility class is building the Job Roles Clause appropriately,
+   * using option_value.value for Locations and Regions in the table join.
+   */
+  public function testJobRolesClauseWhereACL() {
+    // Setup local admin
+    $localAdmin = ContactFabricator::fabricate();
+
+    // Create Regions and Locations
+    $region1 = $this->createOptionValue('hrjc_region', 'Region 1');
+    $region2 = $this->createOptionValue('hrjc_region', 'Region 2');
+    $location1 = $this->createOptionValue('hrjc_location', 'Location 1');
+    $location2 = $this->createOptionValue('hrjc_location', 'Location 2');
+
+    // Add Regions / Locations to localAdmin's Rights
+    $this->setContactRights($localAdmin, $region1);
+    $this->setContactRights($localAdmin, $location1);
+    $this->setContactRights($localAdmin, $location2);
+
+    // Get Job Roles Clause
+    $aclUtil = new CRM_Contactaccessrights_Utils_ACL($localAdmin['id']);
+    $whereTables = $aclUtil->getWhereTables();
+    $jobsClause = $whereTables['car_3_jr'];
+
+    // Check Locations Clause
+    $locationMatches = [];
+    preg_match("/car_jr.location IN \(('[^']*'(, ?'[^']*')*)\)/", $jobsClause, $locationMatches);
+    $this->assertTrue(isset($locationMatches[1]), 'Jobs clause does not have expected format for locations.');
+
+    $locations = array_map('trim', explode(',', $locationMatches[1]));
+    $this->assertContains("'{$location1['value']}'", $locations, 'Expected value in clause for locations is not found.');
+    $this->assertContains("'{$location2['value']}'", $locations, 'Expected value in clause for locations is not found.');
+
+    // Check Regions Clause
+    $regionMatches = [];
+    preg_match("/car_jr.region IN \(('[^']*'(, ?'[^']*')*)\)/", $jobsClause, $regionMatches);
+    $this->assertTrue(isset($regionMatches[1]), 'Jobs clause does not have expected format for Regions.');
+
+    $regions = array_map('trim', explode(',', $regionMatches[1]));
+    $this->assertContains("'{$region1['value']}'", $regions);
+    $this->assertNotContains("'{$region2['value']}'", $regions);
+  }
+
+  /**
+   * Creates a new record for Rights entity for the given contact.
+   * 
+   * @param array $contact
+   *   Associative array with details for the contact
+   * @param array $entity
+   *   Details of either Region or Location for which the contact will be 
+   *   granted access
+   * @return array
+   *   Details of access right created in an associative array
+   */
+  private function setContactRights($contact, $entity) {
+    return RightsFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'entity_id' => $entity['id'],
+      'entity_type' => $entity['entity_type']
+    ]);
+  }
+
+  /**
+   * Creates a Record in Option Value for given Option Group
+   * 
+   * @param string $optionGroup
+   *   Name of the option group to which the option will be added
+   * @param string $value
+   *   Value for the new option value, used as its name, label and value
+   * @return array
+   *   Details of added option value + entity_type attribute
+   */
+  private function createOptionValue($optionGroup, $value) {
+    $params = [
+      'option_group_id' => $optionGroup,
+      'name' => $value,
+      'label' => $value,
+      'value' => $value
+    ];
+    $result = OptionValueFabricator::fabricate($params);
+    $result['entity_type'] = $optionGroup;
+    
+    return $result;
+  }
+
+}

--- a/contactaccessrights/tests/phpunit/bootstrap.php
+++ b/contactaccessrights/tests/phpunit/bootstrap.php
@@ -1,0 +1,49 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+eval(cv('php:boot --level=classloader', 'phpcode'));
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}


### PR DESCRIPTION
When a local admin user, configured to have access to specific region(s)/location(s) tried to search for contacts, the resut included all contacts in the system, when it should only show contacts with current job roles in the region(s)/location(s) administered by the local admin.

The search filter was trying to use option_value ID to filter job roles, when option_value value was being stored in roles table.  Thus, they never matched.  This also caused a type mismatch error when optionvalue.value was a string (like "Headquarters") and not an integer, which caused an exception that made the filter ignore ACL $where and $wheretables being built in contactaccessrights extension, thus performing search on all contacts. 

Fixed by adding option_value.value to query to obtain access rights for current user and imploded
resulting values as strings, instead of integers, when building inner join to job roles table.

Problem was probably introduced in https://github.com/civicrm/civihr/pull/955, when Regions and Locations were changed to be pseudoconstants to be stored in job roles table.