### PR TITLE
PCHR-1369: Add the LeaveRequest.getFull API endpoint

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -69,6 +69,39 @@ function civicrm_api3_leave_request_get($params) {
 }
 
 /**
+ * LeaveRequest.getFull API specification
+ *
+ * @param array $spec
+ */
+function _civicrm_api3_leave_request_getfull_spec(&$spec) {
+  $spec['public_holiday'] = [
+    'name' => 'public_holiday',
+    'title' => 'Include only Public Holiday Leave Requests?',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+    'api.required' => 0,
+  ];
+}
+
+/**
+ * LeaveRequest.getFull API
+ *
+ * This API works exactly as LeaveRequest.get, but it will, for each returned
+ * Leave Request, include the balance change and the Leave Request dates.
+ *
+ * @param array $params
+ *
+ * @return array API result descriptor
+ *
+ * @throws CiviCRM_API3_Exception
+ */
+function civicrm_api3_leave_request_getfull($params) {
+  $query = new CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect($params);
+  $query->setReturnFullDetails(true);
+
+  return civicrm_api3_create_success($query->run(), $params, '', 'getfull');
+}
+
+/**
  * LeaveRequest.calculateBalanceChange specification
  *
  * @param array $spec


### PR DESCRIPTION
This new API endpoint is an "extension" of the LeaveRequest.get and, in being so, it works exactly the same way and accepts the same params and options. The difference is on the returned values, where each Leave Request will include its balance and dates.

To call it, use:
```php
civicrm_api3('LeaveRequest', 'getFull');
```

And the response would be something like:
```json
{

    "is_error": 0,
    "version": 3,
    "count": 2,
    "values": [
        {
            "id": "17",
            "type_id": "1",
            "contact_id": "202",
            "status_id": "1",
            "from_date": "2016-02-01",
            "from_date_type": "1",
            "to_date": "2016-02-03",
            "to_date_type": "1",
            "balance_change": -3,
            "dates": [
                {
                    "id": "17",
                    "date": "2016-02-01"
                },
                {
                    "id": "18",
                    "date": "2016-02-02"
                },
                {
                    "id": "19",
                    "date": "2016-02-03"
                }
            ]
        },
        {
            "id": "19",
            "type_id": "1",
            "contact_id": "202",
            "status_id": "6",
            "from_date": "2016-01-30",
            "from_date_type": "1",
            "to_date": "2016-02-01",
            "to_date_type": "1",
            "balance_change": -3,
            "dates": [
                {
                    "id": "29",
                    "date": "2016-01-30"
                },
                {
                    "id": "30",
                    "date": "2016-01-31"
                },
                {
                    "id": "31",
                    "date": "2016-02-01"
                }
            ]
        }
   ]
}
```