### PR TITLE
PCHR-1760: Replace class constants in WorkDay BAO with an OptionGroup

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/ContactWorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/ContactWorkPattern.php
@@ -181,7 +181,7 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern extends CRM_HRLeaveAndAbsenc
     $startDate = self::getStartDate($contactId, $date);
 
     if(!$workPattern || !$startDate) {
-      return Workday::WORK_DAY_OPTION_NO;
+      return Workday::getNonWorkingDayTypeValue();
     }
 
     $workDayTypeId = $workPattern->getWorkDayTypeForDate($date, $startDate);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -268,13 +268,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     $leaveRequestDayTypes = array_flip(self::buildOptions('from_date_type'));
 
     switch($type) {
-      case WorkDay::WORK_DAY_OPTION_NO:
+      case WorkDay::getNonWorkingDayTypeValue():
         return $leaveRequestDayTypes['Non Working Day'];
 
-      case WorkDay::WORK_DAY_OPTION_YES:
+      case WorkDay::getWorkingDayTypeValue():
         return $leaveRequestDayTypes['All Day'];
 
-      case WorkDay::WORK_DAY_OPTION_WEEKEND:
+      case WorkDay::getWeekendTypeValue():
         return $leaveRequestDayTypes['Weekend'];
 
       default:

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkDay.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkDay.php
@@ -64,7 +64,7 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDay extends CRM_HRLeaveAndAbsences_DAO_Work
       });
     }
 
-    return self::$workDayTypes[$optionName];
+    return empty(self::$workDayTypes[$optionName]) ? null : self::$workDayTypes[$optionName];
   }
 
   /**
@@ -92,23 +92,6 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDay extends CRM_HRLeaveAndAbsences_DAO_Work
    */
   public static function getWeekendTypeValue() {
     return self::getTypeValue('weekend');
-  }
-
-  /**
-   * Return a list of possible options for the WorkDay::type field.
-   *
-   * The list is the format $value => $label, so it can be used
-   * to populate select controls.
-   *
-   * @return array the list of possible options
-   */
-  public static function getWorkTypeOptions()
-  {
-    return [
-      self::getNonWorkingDayTypeValue() => ts('No'),
-      self::getWorkingDayTypeValue() => ts('Yes'),
-      self::getWeekendTypeValue() => ts('Weekend'),
-    ];
   }
 
   private static function validateParams($params) {
@@ -178,9 +161,20 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDay extends CRM_HRLeaveAndAbsences_DAO_Work
     }
   }
 
+  /**
+   * Validates if the the type of the given work day is one of the values of the
+   * option values in the Work Day Type option group
+   *
+   * @param array $params
+   *   The array passed to the create method
+   *
+   * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException
+   */
   private static function validateWorkDayType($params) {
     $type = empty($params['type']) ? null : $params['type'];
-    if(!in_array($type, array_keys(self::getWorkTypeOptions()))) {
+    $validTypes = array_keys(self::buildOptions('type'));
+
+    if(!in_array($type, $validTypes)) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException(
         'Invalid Work Day Type'
       );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkWeek.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkWeek.php
@@ -95,7 +95,7 @@ class CRM_HRLeaveAndAbsences_BAO_WorkWeek extends CRM_HRLeaveAndAbsences_DAO_Wor
         'type' => $day['type']
       ];
 
-      if($day['type'] == CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_YES) {
+      if($day['type'] == CRM_HRLeaveAndAbsences_BAO_WorkDay::getWorkingDayTypeValue()) {
         $workDayParams['time_from'] = $day['time_from'];
         $workDayParams['time_to'] = $day['time_to'];
         $workDayParams['break'] = $day['break'];

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkWeek.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkWeek.php
@@ -1,5 +1,9 @@
 <?php
 
+use CRM_HRLeaveAndAbsences_BAO_WorkDay as WorkDay;
+use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
+use CRM_HRLeaveAndAbsences_Exception_InvalidWorkWeekException as InvalidWorkWeekException;
+
 class CRM_HRLeaveAndAbsences_BAO_WorkWeek extends CRM_HRLeaveAndAbsences_DAO_WorkWeek {
 
   /**
@@ -43,7 +47,7 @@ class CRM_HRLeaveAndAbsences_BAO_WorkWeek extends CRM_HRLeaveAndAbsences_DAO_Wor
     }
 
     CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
-    $instance = new CRM_HRLeaveAndAbsences_BAO_WorkWeek();
+    $instance = new self();
     $instance->copyValues($params);
 
     $transaction = new CRM_Core_Transaction();
@@ -75,15 +79,15 @@ class CRM_HRLeaveAndAbsences_BAO_WorkWeek extends CRM_HRLeaveAndAbsences_DAO_Wor
    *
    * @param array $days An array of days. It must contain exactly 7 days
    *
-   * @throws \Exception
+   * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidWorkWeekException
    */
   private function saveDays($days) {
     if(!$this->id) {
-      throw new CRM_HRLeaveAndAbsences_Exception_InvalidWorkWeekException(ts('It is not possible to add days to an non-existing Work Week'));
+      throw new InvalidWorkWeekException(ts('It is not possible to add days to an non-existing Work Week'));
     }
 
     if(!is_array($days) || count($days) != 7) {
-      throw new CRM_HRLeaveAndAbsences_Exception_InvalidWorkWeekException(ts('A Work Week must contain EXACTLY 7 days'));
+      throw new InvalidWorkWeekException(ts('A Work Week must contain EXACTLY 7 days'));
     }
 
     $this->deleteDays();
@@ -95,14 +99,14 @@ class CRM_HRLeaveAndAbsences_BAO_WorkWeek extends CRM_HRLeaveAndAbsences_DAO_Wor
         'type' => $day['type']
       ];
 
-      if($day['type'] == CRM_HRLeaveAndAbsences_BAO_WorkDay::getWorkingDayTypeValue()) {
+      if($day['type'] == WorkDay::getWorkingDayTypeValue()) {
         $workDayParams['time_from'] = $day['time_from'];
         $workDayParams['time_to'] = $day['time_to'];
         $workDayParams['break'] = $day['break'];
         $workDayParams['leave_days'] = $day['leave_days'];
       }
 
-      CRM_HRLeaveAndAbsences_BAO_WorkDay::create($workDayParams);
+      WorkDay::create($workDayParams);
       $dayOfTheWeek++;
     }
   }
@@ -110,9 +114,8 @@ class CRM_HRLeaveAndAbsences_BAO_WorkWeek extends CRM_HRLeaveAndAbsences_DAO_Wor
   /**
    * Deletes all the dasy related to this WorkWeek
    */
-  private function deleteDays()
-  {
-    $workWeekEntity = new CRM_HRLeaveAndAbsences_BAO_WorkDay();
+  private function deleteDays() {
+    $workWeekEntity = new WorkDay();
     $workWeekEntity->whereAdd('week_id = '. $this->id);
     $workWeekEntity->delete(true);
   }
@@ -126,8 +129,7 @@ class CRM_HRLeaveAndAbsences_BAO_WorkWeek extends CRM_HRLeaveAndAbsences_DAO_Wor
    * @return int the maximum week number
    *
    */
-  private static function getMaxWeekNumberForWorkPattern($workPatternId)
-  {
+  private static function getMaxWeekNumberForWorkPattern($workPatternId) {
     $tableName = self::getTableName();
     $query = "
       SELECT MAX(number) as max_number
@@ -141,10 +143,14 @@ class CRM_HRLeaveAndAbsences_BAO_WorkWeek extends CRM_HRLeaveAndAbsences_DAO_Wor
     return 0;
   }
 
-  public function links()
-  {
-    $workPatternTable = CRM_HRLeaveAndAbsences_BAO_WorkPattern::getTableName();
-    $workDayTable = CRM_HRLeaveAndAbsences_BAO_WorkDay::getTableName();
+  /**
+   * Declares the relationship between work patterns and work days
+   *
+   * @return array
+   */
+  public function links() {
+    $workPatternTable = WorkPattern::getTableName();
+    $workDayTable = WorkDay::getTableName();
     return [
       'pattern_id' => "{$workPatternTable}:id",
       'id' => "{$workDayTable}:week_id"

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/WorkDay.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/WorkDay.php
@@ -93,9 +93,9 @@ class CRM_HRLeaveAndAbsences_DAO_WorkDay extends CRM_Core_DAO
    */
   public $day_of_the_week;
   /**
-   * The type of this day: yes (working day), no (non working day), weekend
+   * The type of this day, according to the values on the Work Day Type Option Group
    *
-   * @var int unsigned
+   * @var string
    */
   public $type;
   /**
@@ -182,10 +182,16 @@ class CRM_HRLeaveAndAbsences_DAO_WorkDay extends CRM_Core_DAO
         ) ,
         'type' => array(
           'name' => 'type',
-          'type' => CRM_Utils_Type::T_INT,
+          'type' => CRM_Utils_Type::T_STRING,
           'title' => ts('Type') ,
-          'description' => 'The type of this day: yes (working day), no (non working day), weekend',
+          'description' => 'The type of this day, according to the values on the Work Day Type Option Group',
           'required' => true,
+          'maxlength' => 512,
+          'size' => CRM_Utils_Type::HUGE,
+          'pseudoconstant' => array(
+            'optionGroupName' => 'hrleaveandabsences_work_day_type',
+            'optionEditPath' => 'civicrm/admin/options/hrleaveandabsences_work_day_type',
+          )
         ) ,
         'time_from' => array(
           'name' => 'time_from',

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/WorkPattern.php
@@ -2,6 +2,9 @@
 
 require_once 'CRM/Core/Form.php';
 
+use CRM_HRLeaveAndAbsences_BAO_WorkDay as WorkDay;
+use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
+
 /**
  * Form controller class
  *
@@ -36,7 +39,7 @@ class CRM_HRLeaveAndAbsences_Form_WorkPattern extends CRM_Core_Form
     public function setDefaultValues() {
       if (empty($this->defaultValues)) {
         if ($this->_id) {
-          $this->defaultValues = CRM_HRLeaveAndAbsences_BAO_WorkPattern::getValuesArray($this->_id);
+          $this->defaultValues = WorkPattern::getValuesArray($this->_id);
           $this->setIsVisibleForWeeksInDefaultValues();
 
         } else {
@@ -48,13 +51,13 @@ class CRM_HRLeaveAndAbsences_Form_WorkPattern extends CRM_Core_Form
               [
                 'is_visible' => true,
                 'days' => [
-                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::getWorkingDayTypeValue()],
-                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::getWorkingDayTypeValue()],
-                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::getWorkingDayTypeValue()],
-                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::getWorkingDayTypeValue()],
-                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::getWorkingDayTypeValue()],
-                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::getWeekendTypeValue()],
-                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::getWeekendTypeValue()],
+                  ['type' => WorkDay::getWorkingDayTypeValue()],
+                  ['type' => WorkDay::getWorkingDayTypeValue()],
+                  ['type' => WorkDay::getWorkingDayTypeValue()],
+                  ['type' => WorkDay::getWorkingDayTypeValue()],
+                  ['type' => WorkDay::getWorkingDayTypeValue()],
+                  ['type' => WorkDay::getWeekendTypeValue()],
+                  ['type' => WorkDay::getWeekendTypeValue()],
                 ]
               ]
             ]
@@ -116,7 +119,7 @@ class CRM_HRLeaveAndAbsences_Form_WorkPattern extends CRM_Core_Form
 
             $actionDescription = ($this->_action & CRM_Core_Action::UPDATE) ? 'updated' : 'created';
             try {
-                $workPattern = CRM_HRLeaveAndAbsences_BAO_WorkPattern::create($params);
+                $workPattern = WorkPattern::create($params);
                 CRM_Core_Session::setStatus(ts("The Work Pattern '%1' has been $actionDescription.", array( 1 => $workPattern->label)), 'Success', 'success');
             } catch(Exception $ex) {
                 $message = ts("The Work Pattern could not be $actionDescription.");
@@ -174,7 +177,7 @@ class CRM_HRLeaveAndAbsences_Form_WorkPattern extends CRM_Core_Form
             'select',
             "weeks[$i][days][$j][type]",
             false,
-            CRM_HRLeaveAndAbsences_BAO_WorkDay::buildOptions('type'),
+            WorkDay::buildOptions('type'),
             false,
             ['class' => 'work-day-type']
           );
@@ -269,7 +272,7 @@ class CRM_HRLeaveAndAbsences_Form_WorkPattern extends CRM_Core_Form
      */
     private function validateWorkDay($weekIndex, $dayIndex, $day, &$errors)
     {
-      if($day['type'] == CRM_HRLeaveAndAbsences_BAO_WorkDay::getWorkingDayTypeValue()) {
+      if($day['type'] == WorkDay::getWorkingDayTypeValue()) {
         $this->validateWorkingDay($weekIndex, $dayIndex, $day, $errors);
       } else {
         $this->validateNonWorkingDay($weekIndex, $dayIndex, $day, $errors);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/WorkPattern.php
@@ -174,7 +174,7 @@ class CRM_HRLeaveAndAbsences_Form_WorkPattern extends CRM_Core_Form
             'select',
             "weeks[$i][days][$j][type]",
             false,
-            CRM_HRLeaveAndAbsences_BAO_WorkDay::getWorkTypeOptions(),
+            CRM_HRLeaveAndAbsences_BAO_WorkDay::buildOptions('type'),
             false,
             ['class' => 'work-day-type']
           );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/WorkPattern.php
@@ -48,13 +48,13 @@ class CRM_HRLeaveAndAbsences_Form_WorkPattern extends CRM_Core_Form
               [
                 'is_visible' => true,
                 'days' => [
-                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_YES],
-                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_YES],
-                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_YES],
-                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_YES],
-                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_YES],
-                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_WEEKEND],
-                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_WEEKEND],
+                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::getWorkingDayTypeValue()],
+                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::getWorkingDayTypeValue()],
+                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::getWorkingDayTypeValue()],
+                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::getWorkingDayTypeValue()],
+                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::getWorkingDayTypeValue()],
+                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::getWeekendTypeValue()],
+                  ['type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::getWeekendTypeValue()],
                 ]
               ]
             ]
@@ -269,7 +269,7 @@ class CRM_HRLeaveAndAbsences_Form_WorkPattern extends CRM_Core_Form
      */
     private function validateWorkDay($weekIndex, $dayIndex, $day, &$errors)
     {
-      if($day['type'] == CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_YES) {
+      if($day['type'] == CRM_HRLeaveAndAbsences_BAO_WorkDay::getWorkingDayTypeValue()) {
         $this->validateWorkingDay($weekIndex, $dayIndex, $day, $errors);
       } else {
         $this->validateNonWorkingDay($weekIndex, $dayIndex, $day, $errors);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/WorkPattern.php
@@ -43,7 +43,7 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
     return [[
       'days' => [
         [
-          'type' => WorkDay::WORK_DAY_OPTION_YES,
+          'type' => WorkDay::getWorkingDayTypeValue(),
           'day_of_week' => 1,
           'time_from' => '09:00',
           'time_to' => '18:00',
@@ -51,7 +51,7 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
           'leave_days' => 1
         ],
         [
-          'type' => WorkDay::WORK_DAY_OPTION_YES,
+          'type' => WorkDay::getWorkingDayTypeValue(),
           'day_of_week' => 2,
           'time_from' => '09:00',
           'time_to' => '18:00',
@@ -59,7 +59,7 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
           'leave_days' => 1
         ],
         [
-          'type' => WorkDay::WORK_DAY_OPTION_YES,
+          'type' => WorkDay::getWorkingDayTypeValue(),
           'day_of_week' => 3,
           'time_from' => '09:00',
           'time_to' => '18:00',
@@ -67,7 +67,7 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
           'leave_days' => 1
         ],
         [
-          'type' => WorkDay::WORK_DAY_OPTION_YES,
+          'type' => WorkDay::getWorkingDayTypeValue(),
           'day_of_week' => 4,
           'time_from' => '09:00',
           'time_to' => '18:00',
@@ -75,7 +75,7 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
           'leave_days' => 1
         ],
         [
-          'type' => WorkDay::WORK_DAY_OPTION_YES,
+          'type' => WorkDay::getWorkingDayTypeValue(),
           'day_of_week' => 5,
           'time_from' => '09:00',
           'time_to' => '18:00',
@@ -83,12 +83,12 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
           'leave_days' => 1
         ],
         [
-          'type' => WorkDay::WORK_DAY_OPTION_WEEKEND,
+          'type' => WorkDay::getWeekendTypeValue(),
           'day_of_week' => 6,
           'leave_days' => 0
         ],
         [
-          'type' => WorkDay::WORK_DAY_OPTION_WEEKEND,
+          'type' => WorkDay::getWeekendTypeValue(),
           'day_of_week' => 7,
           'leave_days' => 0
         ],
@@ -107,7 +107,7 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
       [
         'days' => [
           [
-            'type'            => WorkDay::WORK_DAY_OPTION_YES,
+            'type'            => WorkDay::getWorkingDayTypeValue(),
             'day_of_the_week' => 1,
             'time_from'       => '07:00',
             'time_to'         => '15:30',
@@ -115,11 +115,11 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
             'leave_days'      => 1
           ],
           [
-            'type'            => WorkDay::WORK_DAY_OPTION_NO,
+            'type'            => WorkDay::getNonWorkingDayTypeValue(),
             'day_of_the_week' => 2,
           ],
           [
-            'type'            => WorkDay::WORK_DAY_OPTION_YES,
+            'type'            => WorkDay::getWorkingDayTypeValue(),
             'day_of_the_week' => 3,
             'time_from'       => '07:00',
             'time_to'         => '15:30',
@@ -127,11 +127,11 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
             'leave_days'      => 1
           ],
           [
-            'type'            => WorkDay::WORK_DAY_OPTION_NO,
+            'type'            => WorkDay::getNonWorkingDayTypeValue(),
             'day_of_the_week' => 4,
           ],
           [
-            'type'            => WorkDay::WORK_DAY_OPTION_YES,
+            'type'            => WorkDay::getWorkingDayTypeValue(),
             'day_of_the_week' => 5,
             'time_from'       => '07:00',
             'time_to'         => '15:30',
@@ -139,11 +139,11 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
             'leave_days'      => 1
           ],
           [
-            'type'            => WorkDay::WORK_DAY_OPTION_WEEKEND,
+            'type'            => WorkDay::getWeekendTypeValue(),
             'day_of_the_week' => 6,
           ],
           [
-            'type'            => WorkDay::WORK_DAY_OPTION_WEEKEND,
+            'type'            => WorkDay::getWeekendTypeValue(),
             'day_of_the_week' => 7,
           ]
         ]
@@ -151,11 +151,11 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
       [
         'days' => [
           [
-            'type'            => WorkDay::WORK_DAY_OPTION_NO,
+            'type'            => WorkDay::getNonWorkingDayTypeValue(),
             'day_of_the_week' => 1,
           ],
           [
-            'type'            => WorkDay::WORK_DAY_OPTION_YES,
+            'type'            => WorkDay::getWorkingDayTypeValue(),
             'day_of_the_week' => 2,
             'time_from'       => '07:00',
             'time_to'         => '12:00',
@@ -163,11 +163,11 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
             'leave_days'      => 1
           ],
           [
-            'type'            => WorkDay::WORK_DAY_OPTION_NO,
+            'type'            => WorkDay::getNonWorkingDayTypeValue(),
             'day_of_the_week' => 3,
           ],
           [
-            'type'            => WorkDay::WORK_DAY_OPTION_YES,
+            'type'            => WorkDay::getWorkingDayTypeValue(),
             'day_of_the_week' => 4,
             'time_from'       => '07:00',
             'time_to'         => '12:00',
@@ -175,15 +175,15 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
             'leave_days'      => 1
           ],
           [
-            'type'            => WorkDay::WORK_DAY_OPTION_NO,
+            'type'            => WorkDay::getNonWorkingDayTypeValue(),
             'day_of_the_week' => 5,
           ],
           [
-            'type'            => WorkDay::WORK_DAY_OPTION_WEEKEND,
+            'type'            => WorkDay::getWeekendTypeValue(),
             'day_of_the_week' => 6,
           ],
           [
-            'type'            => WorkDay::WORK_DAY_OPTION_WEEKEND,
+            'type'            => WorkDay::getWeekendTypeValue(),
             'day_of_the_week' => 7,
           ]
         ]

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
@@ -195,7 +195,7 @@ CREATE TABLE `civicrm_hrleaveandabsences_work_day` (
 
      `id` int unsigned NOT NULL AUTO_INCREMENT  COMMENT 'Unique WorkDay ID',
      `day_of_the_week` int unsigned NOT NULL   COMMENT 'A number between 1 and 7, following ISO-8601. 1 is Monday and 7 is Sunday',
-     `type` int unsigned NOT NULL   COMMENT 'The type of this day: yes (working day), no (non working day), weekend',
+     `type` varchar(512) NOT NULL   COMMENT 'The type of this day, according to the values on the Work Day Type Option Group',
      `time_from` char(5)    COMMENT 'The start time of this work day. This field is a char because CiviCRM can\'t handle TIME fields.',
      `time_to` char(5)    COMMENT 'The end time of this work day. This field is a char because CiviCRM can\'t handle TIME fields.',
      `break` decimal(20,2)    COMMENT 'The amount of break time (in hours) allowed for this day. ',
@@ -222,13 +222,13 @@ VALUES(1, 1, 1);
 
 INSERT INTO civicrm_hrleaveandabsences_work_day(week_id, day_of_the_week, type, time_from, time_to, break, leave_days, number_of_hours)
 VALUES
-  (1, 1, 2, '09:00', '17:30', 1, 1, 7.5),
-  (1, 2, 2, '09:00', '17:30', 1, 1, 7.5),
-  (1, 3, 2, '09:00', '17:30', 1, 1, 7.5),
-  (1, 4, 2, '09:00', '17:30', 1, 1, 7.5),
-  (1, 5, 2, '09:00', '17:30', 1, 1, 7.5),
-  (1, 6, 3, NULL, NULL, NULL, NULL, NULL),
-  (1, 7, 3, NULL, NULL, NULL, NULL, NULL);
+  (1, '1', 2, '09:00', '17:30', 1, 1, 7.5),
+  (1, '2', 2, '09:00', '17:30', 1, 1, 7.5),
+  (1, '3', 2, '09:00', '17:30', 1, 1, 7.5),
+  (1, '4', 2, '09:00', '17:30', 1, 1, 7.5),
+  (1, '5', 2, '09:00', '17:30', 1, 1, 7.5),
+  (1, '6', 3, NULL, NULL, NULL, NULL, NULL),
+  (1, '7', 3, NULL, NULL, NULL, NULL, NULL);
 
 -- /*******************************************************
 -- *

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/ContactWorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/ContactWorkPatternTest.php
@@ -359,11 +359,11 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest extends BaseHeadlessTest
 
     $startDateTime = new DateTime('2016-11-30');
     $dayType = ContactWorkPattern::getWorkDayType($contact['id'], $startDateTime);
-    $this->assertEquals(WorkDay::WORK_DAY_OPTION_YES, $dayType);
+    $this->assertEquals(WorkDay::getWorkingDayTypeValue(), $dayType);
 
     $startDateTime2 = new DateTime('2016-11-27');
     $dayType = ContactWorkPattern::getWorkDayType($contact['id'], $startDateTime2);
-    $this->assertEquals(WorkDay::WORK_DAY_OPTION_WEEKEND, $dayType);
+    $this->assertEquals(WorkDay::getWeekendTypeValue(), $dayType);
   }
 
   public function testGetWorkDayTypeForWorkPatternWithMultipleWeeks() {
@@ -387,14 +387,14 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest extends BaseHeadlessTest
     //A sunday which is weekend on week 1
     $startDateTime1 = new DateTime('2016-07-31');
     $dayType = ContactWorkPattern::getWorkDayType($contact['id'], $startDateTime1);
-    $this->assertEquals(WorkDay::WORK_DAY_OPTION_WEEKEND, $dayType);
+    $this->assertEquals(WorkDay::getWeekendTypeValue(), $dayType);
 
     // Since the start date is a sunday, the end of the week, the following day
     // (2016-08-01) should be on the second week. Monday of the second week is
     // not a working day
     $startDateTime2 = new DateTime('2016-08-01');
     $dayType = ContactWorkPattern::getWorkDayType($contact['id'], $startDateTime2);
-    $this->assertEquals(WorkDay::WORK_DAY_OPTION_NO, $dayType);
+    $this->assertEquals(WorkDay::getNonWorkingDayTypeValue(), $dayType);
 
     // Now, since we hit sunday, the following day will be on the third week
     // since the start date, but the work pattern only has 2 weeks, so we
@@ -402,7 +402,7 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest extends BaseHeadlessTest
     // Monday is a working day on the first week
     $startDateTime3 = new DateTime('2016-08-08');
     $dayType = ContactWorkPattern::getWorkDayType($contact['id'], $startDateTime3);
-    $this->assertEquals(WorkDay::WORK_DAY_OPTION_YES, $dayType);
+    $this->assertEquals(WorkDay::getWorkingDayTypeValue(), $dayType);
 
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkDayTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkDayTest.php
@@ -62,7 +62,7 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends BaseHeadlessTest {
    */
   public function testTimeFromTimeToAndBreakShouldBeRequiredIfItsAWorkingDay($timeTo, $timeFrom, $break) {
     $params = [
-      'type' => WorkDay::WORK_DAY_OPTION_YES,
+      'type' => WorkDay::getWorkingDayTypeValue(),
       'time_to' => $timeTo,
       'time_from' => $timeFrom,
       'break' => $break
@@ -78,7 +78,7 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends BaseHeadlessTest {
    */
   public function testTimeFromTimeToAndBreakShouldBeEmptyIfItsNotAWorkingDay($timeTo, $timeFrom, $break) {
     $params = [
-      'type' => WorkDay::WORK_DAY_OPTION_NO,
+      'type' => WorkDay::getNonWorkingDayTypeValue(),
       'time_to' => $timeTo,
       'time_from' => $timeFrom,
       'break' => $break
@@ -107,7 +107,7 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends BaseHeadlessTest {
    */
   public function testBreakShouldNotBeGreaterThenThePeriodBetweenTimeFromAndTimeTo($timeFrom, $timeTo, $break) {
     $params = [
-      'type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::WORK_DAY_OPTION_YES,
+      'type' => CRM_HRLeaveAndAbsences_BAO_WorkDay::getWorkingDayTypeValue(),
       'time_to' => $timeTo,
       'time_from' => $timeFrom,
       'break' => $break
@@ -126,7 +126,7 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends BaseHeadlessTest {
     // If type is not Working Day, we must set times and break to null,
     // otherwise we will get another validation error
     $params = ['type' => $type];
-    if($type != WorkDay::WORK_DAY_OPTION_YES) {
+    if($type != WorkDay::getWorkingDayTypeValue()) {
       $params['time_from'] = null;
       $params['time_to'] = null;
       $params['break'] = null;
@@ -168,10 +168,25 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends BaseHeadlessTest {
     $this->assertEquals($expectedNumberOfHours, $entity->number_of_hours);
   }
 
+  public function testGetNonWorkingDayTypeValueReturnsTheOptionValueValueAsString() {
+    $workDayTypes = array_flip(WorkDay::buildOptions('type', 'validate'));
+    $this->assertSame((string)$workDayTypes['non_working_day'], WorkDay::getNonWorkingDayTypeValue());
+  }
+
+  public function testGetWorkingDayTypeValueReturnsTheOptionValueValueAsString() {
+    $workDayTypes = array_flip(WorkDay::buildOptions('type', 'validate'));
+    $this->assertSame((string)$workDayTypes['working_day'], WorkDay::getWorkingDayTypeValue());
+  }
+
+  public function testGetWeekendTypeValueReturnsTheOptionValueValueAsString() {
+    $workDayTypes = array_flip(WorkDay::buildOptions('type', 'validate'));
+    $this->assertSame((string)$workDayTypes['weekend'], WorkDay::getWeekendTypeValue());
+  }
+
   private function createBasicWorkDay($params = []) {
     $basicDefaultParams = [
       'day_of_the_week' => 1,
-      'type' => WorkDay::WORK_DAY_OPTION_YES,
+      'type' => WorkDay::getWorkingDayTypeValue(),
       'week_id' => $this->workWeek->id,
       'time_from' => '09:00',
       'time_to' => '18:00',
@@ -278,9 +293,9 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends BaseHeadlessTest {
   public function workDayTypeDataProvider() {
     return [
       [0, true],
-      [WorkDay::WORK_DAY_OPTION_YES, false],
-      [WorkDay::WORK_DAY_OPTION_NO, false],
-      [WorkDay::WORK_DAY_OPTION_WEEKEND, false],
+      [WorkDay::getWorkingDayTypeValue(), false],
+      [WorkDay::getNonWorkingDayTypeValue(), false],
+      [WorkDay::getWeekendTypeValue(), false],
       ['adasdsa', true],
       [rand(4, PHP_INT_MAX), true],
     ];

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
@@ -382,37 +382,37 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends BaseHeadlessTest {
     $start = new DateTime('2016-01-01');
 
     // A friday
-    $this->assertEquals(WorkDay::WORK_DAY_OPTION_YES, $pattern->getWorkDayTypeForDate(
+    $this->assertEquals(WorkDay::getWorkingDayTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-01-01'), $start
     ));
 
     // A saturday
-    $this->assertEquals(WorkDay::WORK_DAY_OPTION_WEEKEND, $pattern->getWorkDayTypeForDate(
+    $this->assertEquals(WorkDay::getWeekendTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-02-13'), $start
     ));
 
     // A sunday
-    $this->assertEquals(WorkDay::WORK_DAY_OPTION_WEEKEND, $pattern->getWorkDayTypeForDate(
+    $this->assertEquals(WorkDay::getWeekendTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-03-06'), $start
     ));
 
     // A monday
-    $this->assertEquals(WorkDay::WORK_DAY_OPTION_YES, $pattern->getWorkDayTypeForDate(
+    $this->assertEquals(WorkDay::getWorkingDayTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-04-04'), $start
     ));
 
     // A tuesday
-    $this->assertEquals(WorkDay::WORK_DAY_OPTION_YES, $pattern->getWorkDayTypeForDate(
+    $this->assertEquals(WorkDay::getWorkingDayTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-05-24'), $start
     ));
 
     // A wednesday
-    $this->assertEquals(WorkDay::WORK_DAY_OPTION_YES, $pattern->getWorkDayTypeForDate(
+    $this->assertEquals(WorkDay::getWorkingDayTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-06-15'), $start
     ));
 
     // A thursday
-    $this->assertEquals(WorkDay::WORK_DAY_OPTION_YES, $pattern->getWorkDayTypeForDate(
+    $this->assertEquals(WorkDay::getWorkingDayTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-07-28'), $start
     ));
   }
@@ -427,33 +427,33 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends BaseHeadlessTest {
     // Since the start date is a sunday, the end of the week, the following day
     // (2016-08-01) should be on the second week. Monday of the second week is
     // not a working day
-    $this->assertSame(WorkDay::WORK_DAY_OPTION_NO, $pattern->getWorkDayTypeForDate(
+    $this->assertSame(WorkDay::getNonWorkingDayTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-08-01'), $start
     ));
 
     // The next day is a tuesday, which is a working day on the second week, so
-    $this->assertSame(WorkDay::WORK_DAY_OPTION_YES, $pattern->getWorkDayTypeForDate(
+    $this->assertSame(WorkDay::getWorkingDayTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-08-02'), $start
     ));
 
     // Wednesday is not a working day on the second week
-    $this->assertSame(WorkDay::WORK_DAY_OPTION_NO, $pattern->getWorkDayTypeForDate(
+    $this->assertSame(WorkDay::getNonWorkingDayTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-08-03'), $start
     ));
 
     // Thursday is a working day on the second week
-    $this->assertSame(WorkDay::WORK_DAY_OPTION_YES, $pattern->getWorkDayTypeForDate(
+    $this->assertSame(WorkDay::getWorkingDayTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-08-04'), $start
     ));
 
     // Friday, Saturday and Sunday are not working days on the second week,
-    $this->assertSame(WorkDay::WORK_DAY_OPTION_NO, $pattern->getWorkDayTypeForDate(
+    $this->assertSame(WorkDay::getNonWorkingDayTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-08-05'), $start
     ));
-    $this->assertSame(WorkDay::WORK_DAY_OPTION_WEEKEND, $pattern->getWorkDayTypeForDate(
+    $this->assertSame(WorkDay::getWeekendTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-08-06'), $start
     ));
-    $this->assertSame(WorkDay::WORK_DAY_OPTION_WEEKEND, $pattern->getWorkDayTypeForDate(
+    $this->assertSame(WorkDay::getWeekendTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-08-07'), $start
     ));
 
@@ -462,35 +462,35 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends BaseHeadlessTest {
     // rotate back to use the week 1 from the pattern
 
     // Monday is a working day on the first week
-    $this->assertSame(WorkDay::WORK_DAY_OPTION_YES, $pattern->getWorkDayTypeForDate(
+    $this->assertSame(WorkDay::getWorkingDayTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-08-08'), $start
     ));
 
     // Tuesday is not a working day on the first week
-    $this->assertSame(WorkDay::WORK_DAY_OPTION_NO, $pattern->getWorkDayTypeForDate(
+    $this->assertSame(WorkDay::getNonWorkingDayTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-08-09'), $start
     ));
 
     // Wednesday is a working day on the first week
-    $this->assertSame(WorkDay::WORK_DAY_OPTION_YES, $pattern->getWorkDayTypeForDate(
+    $this->assertSame(WorkDay::getWorkingDayTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-08-10'), $start
     ));
 
     // Thursday is not a working day on the first week
-    $this->assertSame(WorkDay::WORK_DAY_OPTION_NO, $pattern->getWorkDayTypeForDate(
+    $this->assertSame(WorkDay::getNonWorkingDayTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-08-11'), $start
     ));
 
     // Friday is a working day on the first week
-    $this->assertSame(WorkDay::WORK_DAY_OPTION_YES, $pattern->getWorkDayTypeForDate(
+    $this->assertSame(WorkDay::getWorkingDayTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-08-12'), $start
     ));
 
     // Saturday and Sunday are not working days on the first week
-    $this->assertSame(WorkDay::WORK_DAY_OPTION_WEEKEND, $pattern->getWorkDayTypeForDate(
+    $this->assertSame(WorkDay::getWeekendTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-08-13'), $start
     ));
-    $this->assertSame(WorkDay::WORK_DAY_OPTION_WEEKEND, $pattern->getWorkDayTypeForDate(
+    $this->assertSame(WorkDay::getWeekendTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-08-14'), $start
     ));
 
@@ -498,7 +498,7 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends BaseHeadlessTest {
     // The work pattern will rotate and use the week 2
 
     // Monday is not a working day on week 2
-    $this->assertSame(WorkDay::WORK_DAY_OPTION_NO, $pattern->getWorkDayTypeForDate(
+    $this->assertSame(WorkDay::getNonWorkingDayTypeValue(), $pattern->getWorkDayTypeForDate(
       new DateTime('2016-08-15'), $start
     ));
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/option_groups/work_day_type_install.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/option_groups/work_day_type_install.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="iso-8859-1" ?>
+
+<CustomData>
+
+  <OptionGroups>
+    <OptionGroup>
+      <name>hrleaveandabsences_work_day_type</name>
+      <title>Work Day Types</title>
+      <is_reserved>1</is_reserved>
+      <is_active>1</is_active>
+    </OptionGroup>
+  </OptionGroups>
+
+  <OptionValues>
+    <OptionValue>
+      <label>No</label>
+      <value>1</value>
+      <name>non_working_day</name>
+      <is_default>0</is_default>
+      <weight>0</weight>
+      <is_optgroup>0</is_optgroup>
+      <is_reserved>1</is_reserved>
+      <is_active>1</is_active>
+      <option_group_name>hrleaveandabsences_work_day_type</option_group_name>
+    </OptionValue>
+
+    <OptionValue>
+      <label>Yes</label>
+      <value>2</value>
+      <name>working_day</name>
+      <is_default>0</is_default>
+      <weight>1</weight>
+      <is_optgroup>0</is_optgroup>
+      <is_reserved>1</is_reserved>
+      <is_active>1</is_active>
+      <option_group_name>hrleaveandabsences_work_day_type</option_group_name>
+    </OptionValue>
+
+    <OptionValue>
+      <label>Weekend</label>
+      <value>3</value>
+      <name>weekend</name>
+      <is_default>0</is_default>
+      <weight>2</weight>
+      <is_optgroup>0</is_optgroup>
+      <is_reserved>1</is_reserved>
+      <is_active>1</is_active>
+      <option_group_name>hrleaveandabsences_work_day_type</option_group_name>
+    </OptionValue>
+
+  </OptionValues>
+</CustomData>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/WorkDay.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/WorkDay.xml
@@ -31,11 +31,15 @@
 
   <field>
     <name>type</name>
-    <type>int unsigned</type>
+    <type>varchar</type>
+    <length>512</length>
     <label>Type</label>
     <required>true</required>
-    <comment>The type of this day: yes (working day), no (non working day), weekend</comment>
+    <comment>The type of this day, according to the values on the Work Day Type Option Group</comment>
     <add>4.4</add>
+    <pseudoconstant>
+      <optionGroupName>hrleaveandabsences_work_day_type</optionGroupName>
+    </pseudoconstant>
   </field>
 
   <field>


### PR DESCRIPTION
The valid values for the Work Day type were hardcoded as a set of constants on the WorkDay BAO. This would make it harder to change the option labels, add or remove new options and to return them on API responses in a consistent way. So, in order to avoid those problems, they were replaced with an option group named "Work Day Type".

The option group options are:

| label   | value | name            |
|---------|-------|-----------------|
| No      | 1     | non_working_day |
| Yes     | 2     | working_day     |
| Weekend | 3     | weekend         |

Every call to one of the removed constants was replaced with a call to a method which returns the respective option value value:
- `WorkDay::WORK_DAY_OPTION_NO` was replaced by `WorkDay::getNonWorkingDayTypeValue()`
- `WorkDay::WORK_DAY_OPTION_YES` was replaced by `WorkDay::getWorkingDayTypeValue()`
- `WorkDay::WORK_DAY_OPTION_WEEKEND` was replaced by `WorkDay::getWeekendDayTypeValue()`

Because an Option Value value is a string, I changed the data type of the WorkDay type field to also be a string, with the same size of the Option Value value.