### PR TITLE
PCHR-1677: Improvements to the Leave Request validation on save

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
@@ -543,7 +543,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
   }
 
   /**
-   * Returns the absence period that the contains both the fromdate and todate
+   * Returns the absence period that contains both the fromdate and todate
    * If the fromdate and todate have dates in two absence periods(i.e an overlap),
    * or if no valid absence period is found containing the dates, null is returned.
    *

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
@@ -545,7 +545,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
   /**
    * Returns the absence period that the contains both the fromdate and todate
    * If the fromdate and todate have dates in two absence periods(i.e an overlap),
-   * null is returned.
+   * or if no valid absence period is found containing the dates, null is returned.
    *
    * @param string $fromDate
    * @param string $toDate
@@ -573,7 +573,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
 
     $absencePeriod = CRM_Core_DAO::executeQuery($query, $queryParams, true, self::class);
 
-    if($absencePeriod->N == 1) {
+    if ($absencePeriod->N == 1) {
       $absencePeriod->fetch();
       return $absencePeriod;
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
@@ -552,7 +552,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    *
    * @return \CRM_HRLeaveAndAbsences_BAO_AbsencePeriod|null
    */
-  public static function getPeriodContainingDates(DateTime $fromDate, $toDate) {
+  public static function getPeriodContainingDates(DateTime $fromDate, DateTime $toDate = null) {
     $tableName = self::getTableName();
 
     if (!$toDate) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
@@ -541,4 +541,34 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
 
     return [$startDate, $endDate];
   }
+
+  /**
+   * Returns the absence period that the contains both the fromdate and todate
+   * If the fromdate and todate have dates in two absence periods(i.e an overlap),
+   * null is returned.
+   *
+   * @param string $fromDate
+   * @param string $toDate
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_AbsencePeriod|null
+   */
+  public static function getPeriodContainingDates($fromDate, $toDate) {
+    $tableName = self::getTableName();
+    $query = "
+      SELECT * FROM {$tableName}
+      WHERE (start_date <= %1) AND (end_date >= %2)
+    ";
+    $queryParams = [
+      1 => [CRM_Utils_Date::processDate($fromDate, null, false, 'Y-m-d'), 'String'],
+      2 => [CRM_Utils_Date::processDate($toDate, null, false, 'Y-m-d'), 'String']
+    ];
+
+    $absencePeriod = CRM_Core_DAO::executeQuery($query, $queryParams, true, self::class);
+
+    if($absencePeriod->N == 1) {
+      $absencePeriod->fetch();
+      return $absencePeriod;
+    }
+    return null;
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
@@ -555,13 +555,21 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
   public static function getPeriodContainingDates($fromDate, $toDate) {
     $tableName = self::getTableName();
     $query = "
-      SELECT * FROM {$tableName}
-      WHERE (start_date <= %1) AND (end_date >= %2)
-    ";
+      SELECT * FROM {$tableName} WHERE";
+
+    if (!empty($toDate)) {
+      $query .= " (start_date <= %1) AND (end_date >= %2)";
+    }
+    else{
+      $query .= " (start_date <= %1) AND (end_date >= %1)";
+    }
     $queryParams = [
       1 => [CRM_Utils_Date::processDate($fromDate, null, false, 'Y-m-d'), 'String'],
-      2 => [CRM_Utils_Date::processDate($toDate, null, false, 'Y-m-d'), 'String']
     ];
+
+    if (!empty($toDate)) {
+      $queryParams[2] = [CRM_Utils_Date::processDate($toDate, null, false, 'Y-m-d'), 'String'];
+    }
 
     $absencePeriod = CRM_Core_DAO::executeQuery($query, $queryParams, true, self::class);
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
@@ -127,11 +127,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
    *
    * @param int $contactId
    * @param int $periodId
+   * @param int|null $absenceTypeId
    *
    * @return CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement[]
    *   If there are no entitlements, an empty array will be returned
    */
-  public static function getPeriodEntitlementsForContact($contactId, $periodId) {
+  public static function getPeriodEntitlementsForContact($contactId, $periodId, $absenceTypeId = null) {
 
     if(!$contactId) {
       throw new InvalidArgumentException("You must inform the Contact ID");
@@ -142,6 +143,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
     $entitlement = new self();
     $entitlement->contact_id = (int)$contactId;
     $entitlement->period_id = (int)$periodId;
+
+    if ($absenceTypeId) {
+      $entitlement->type_id = $absenceTypeId;
+    }
     $entitlement->find();
     $leaveEntitlements = [];
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
@@ -124,6 +124,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
 
   /**
    * Returns an array of LeavePeriodEntitlements for a contact for a specific Absence Period ID
+   * If the Absence Type ID parameter is also supplied, it returns the LeavePeriodEntitlement for the absence type
    *
    * @param int $contactId
    * @param int $periodId

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -75,8 +75,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
   }
 
   /**
-   * This method validates that a leave request has a valid absence period
-   * and also that a leave request does not overlapp two or more absence periods
+   * This method validates that a leave request has dates within a valid absence period
+   * and also that a leave request dates does not overlap two or more absence periods
    *
    * @param array $params
    *   The params array received by the create method
@@ -88,6 +88,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     $period = AbsencePeriod::getPeriodContainingDates($params['from_date'], $toDate);
 
     //this condition means that no absence period was found that contains both the start and end date
+    //either there was an overlap or the absence period does not simply exist.
     if (!$period) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException(
         "The Leave request dates is not contained within a valid absence period"
@@ -364,7 +365,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
 
     $leaveRequest = CRM_Core_DAO::executeQuery($query, $params, true, self::class);
 
-    if($leaveRequest->N > 0) {
+    if ($leaveRequest->N > 0) {
       $overlappingLeaveRequests = [];
       while($leaveRequest->fetch()) {
         $overlappingLeaveRequests[] = clone $leaveRequest;
@@ -373,7 +374,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     }
     return null;
   }
-
 
   /**
    * Returns a list of all Absence Types, together with its total balance change.

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -84,7 +84,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
    */
   private static function validateAbsencePeriod($params) {
-    $toDate = !empty($params['to_date']) ? new DateTime($params['to_date']) : '';
+    $toDate = !empty($params['to_date']) ? new DateTime($params['to_date']) : null;
     $fromDate = new DateTime($params['from_date']);
     $period = AbsencePeriod::getPeriodContainingDates($fromDate, $toDate);
 
@@ -136,7 +136,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
    */
   private static function validateBalanceChange($params) {
-    $toDate = !empty($params['to_date']) ? new DateTime($params['to_date']) : '';
+    $toDate = !empty($params['to_date']) ? new DateTime($params['to_date']) : null;
     $fromDate = new DateTime($params['from_date']);
     $absenceType = AbsenceType::findById($params['type_id']);
     $period = AbsencePeriod::getPeriodContainingDates($fromDate, $toDate);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Exception/InvalidLeaveRequestException.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Exception/InvalidLeaveRequestException.php
@@ -1,0 +1,2 @@
+<?php
+class CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException extends Exception {}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -146,7 +146,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
       'status_id'      => $leaveRequestStatuses['Admin Approved'],
       'from_date'      => CRM_Utils_Date::processDate($publicHoliday->date),
       'from_date_type' => $leaveRequestDayTypes['All Day']
-    ]);
+    ], false);
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveBalanceChange.php
@@ -34,4 +34,28 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange {
       'type_id' => self::getTypeId('Leave')
     ];
   }
+
+  public static function fabricateForPublicHolidayLeaveRequest($leaveRequest) {
+    $leaveBalanceChangeTypes = array_flip(LeaveBalanceChange::buildOptions('type_id'));
+    foreach ($leaveRequest->getDates() as $date) {
+
+      $leaveDate = new DateTime($date->date);
+
+      $leaveBalanceChange = LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $leaveDate);
+
+      if($leaveBalanceChange) {
+        LeaveBalanceChange::create([
+          'id' => $leaveBalanceChange->id,
+          'amount' => 0
+        ]);
+      }
+
+      self::fabricate([
+        'source_id' => $date->id,
+        'source_type' => LeaveBalanceChange::SOURCE_LEAVE_REQUEST_DAY,
+        'type_id'     => $leaveBalanceChangeTypes['Public Holiday'],
+        'amount'      => -1
+      ]);
+    }
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveBalanceChange.php
@@ -34,26 +34,4 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange {
       'type_id' => self::getTypeId('Leave')
     ];
   }
-
-  public static function fabricateForPublicHolidayLeaveRequest($leaveRequest) {
-    $leaveBalanceChangeTypes = array_flip(LeaveBalanceChange::buildOptions('type_id'));
-    foreach ($leaveRequest->getDates() as $date) {
-      $leaveDate = new DateTime($date->date);
-      $leaveBalanceChange = LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $leaveDate);
-
-      if($leaveBalanceChange) {
-        LeaveBalanceChange::create([
-          'id' => $leaveBalanceChange->id,
-          'amount' => 0
-        ]);
-      }
-
-      self::fabricate([
-        'source_id' => $date->id,
-        'source_type' => LeaveBalanceChange::SOURCE_LEAVE_REQUEST_DAY,
-        'type_id'     => $leaveBalanceChangeTypes['Public Holiday'],
-        'amount'      => -1
-      ]);
-    }
-  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveBalanceChange.php
@@ -38,9 +38,7 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange {
   public static function fabricateForPublicHolidayLeaveRequest($leaveRequest) {
     $leaveBalanceChangeTypes = array_flip(LeaveBalanceChange::buildOptions('type_id'));
     foreach ($leaveRequest->getDates() as $date) {
-
       $leaveDate = new DateTime($date->date);
-
       $leaveBalanceChange = LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $leaveDate);
 
       if($leaveBalanceChange) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveRequest.php
@@ -2,6 +2,7 @@
 
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange as LeaveBalanceChangeFabricator;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
 
 class CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest {
 
@@ -50,4 +51,55 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest {
     return self::$dayTypes[$typeLabel];
   }
 
+  /**
+   * Creates a new Leave Request without running any validation. That is,
+   * the leave request is created without calling the create() method.
+   *
+   * @param array $params
+   * @param boolean $withBalanceChanges
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_LeaveRequest
+   */
+  public static function fabricateWithoutValidation($params = [], $withBalanceChanges = false) {
+    $leaveRequestFields = LeaveRequest::fields();
+    $leaveRequest = new LeaveRequest();
+    foreach($params as $field => $value) {
+      if(!array_key_exists($field, $leaveRequestFields)) {
+        continue;
+      }
+      $leaveRequest->$field = $value;
+    }
+    $leaveRequest->save();
+
+    LeaveRequestDate::deleteDatesForLeaveRequest($leaveRequest->id);
+    $startDate = new DateTime($leaveRequest->from_date);
+
+    if (!$leaveRequest->to_date) {
+      $endDate = new DateTime($leaveRequest->from_date);
+    }
+    else {
+      $endDate = new DateTime($leaveRequest->to_date);
+    }
+    // We need to add 1 day to the end date to include it
+    // when we loop through the DatePeriod
+    $endDate->modify('+1 day');
+
+    $interval   = new DateInterval('P1D');
+    $datePeriod = new DatePeriod($startDate, $interval, $endDate);
+
+    foreach ($datePeriod as $date) {
+      LeaveRequestDate::create([
+        'date' => $date->format('YmdHis'),
+        'leave_request_id' => $leaveRequest->id
+      ]);
+    }
+
+    if ($withBalanceChanges) {
+      foreach ($leaveRequest->getDates() as $date) {
+        LeaveBalanceChangeFabricator::fabricateForLeaveRequestDate($date);
+      }
+    }
+
+    return $leaveRequest;
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveRequest.php
@@ -61,17 +61,7 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest {
    * @return \CRM_HRLeaveAndAbsences_BAO_LeaveRequest
    */
   public static function fabricateWithoutValidation($params = [], $withBalanceChanges = false) {
-    $leaveRequestFields = LeaveRequest::fields();
-    $leaveRequest = new LeaveRequest();
-    foreach($params as $field => $value) {
-      if(!array_key_exists($field, $leaveRequestFields)) {
-        continue;
-      }
-      $leaveRequest->$field = $value;
-    }
-    $leaveRequest->save();
-
-    self::saveDates($leaveRequest);
+    $leaveRequest =  LeaveRequest::create($params, false);
 
     if ($withBalanceChanges) {
       foreach ($leaveRequest->getDates() as $date) {
@@ -80,30 +70,5 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest {
     }
 
     return $leaveRequest;
-  }
-
-  private static function saveDates($leaveRequest) {
-    LeaveRequestDate::deleteDatesForLeaveRequest($leaveRequest->id);
-    $startDate = new DateTime($leaveRequest->from_date);
-
-    if (!$leaveRequest->to_date) {
-      $endDate = new DateTime($leaveRequest->from_date);
-    }
-    else {
-      $endDate = new DateTime($leaveRequest->to_date);
-    }
-    // We need to add 1 day to the end date to include it
-    // when we loop through the DatePeriod
-    $endDate->modify('+1 day');
-
-    $interval   = new DateInterval('P1D');
-    $datePeriod = new DatePeriod($startDate, $interval, $endDate);
-
-    foreach ($datePeriod as $date) {
-      LeaveRequestDate::create([
-        'date' => $date->format('YmdHis'),
-        'leave_request_id' => $leaveRequest->id
-      ]);
-    }
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveRequest.php
@@ -71,6 +71,18 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest {
     }
     $leaveRequest->save();
 
+    self::saveDates($leaveRequest);
+
+    if ($withBalanceChanges) {
+      foreach ($leaveRequest->getDates() as $date) {
+        LeaveBalanceChangeFabricator::fabricateForLeaveRequestDate($date);
+      }
+    }
+
+    return $leaveRequest;
+  }
+
+  private static function saveDates($leaveRequest) {
     LeaveRequestDate::deleteDatesForLeaveRequest($leaveRequest->id);
     $startDate = new DateTime($leaveRequest->from_date);
 
@@ -93,13 +105,5 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest {
         'leave_request_id' => $leaveRequest->id
       ]);
     }
-
-    if ($withBalanceChanges) {
-      foreach ($leaveRequest->getDates() as $date) {
-        LeaveBalanceChangeFabricator::fabricateForLeaveRequestDate($date);
-      }
-    }
-
-    return $leaveRequest;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/PublicHolidayLeaveRequest.php
@@ -3,8 +3,13 @@
 use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
 use CRM_HRLeaveAndAbsences_Service_JobContract as JobContractService;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation as PublicHolidayLeaveRequestCreation;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange as LeaveBalanceChangeFabricator;
 
 class CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest {
+
+  use CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait;
 
   /**
    * This Fabricator is a bit different than the others, because a Public Holiday
@@ -20,6 +25,29 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest {
   public static function fabricate($contactID, PublicHoliday $publicHoliday) {
     $creationLogic = new PublicHolidayLeaveRequestCreation(new JobContractService());
     $creationLogic->createForContact($contactID, $publicHoliday);
+  }
+
+  public static function fabricateWithoutValidation($contactID, PublicHoliday $publicHoliday) {
+
+    $existingLeaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
+    if($existingLeaveRequest) {
+      return;
+    }
+
+    $publicHolidayDate = new DateTime($publicHoliday->date);
+    $absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
+
+    $leaveRequest = LeaveRequest::create([
+      'contact_id' => $contactID,
+      'type_id' => $absenceType->id,
+      'from_date' => $publicHolidayDate->format('YmdHis'),
+      'from_date_type' => 1,
+      'status_id' => $leaveRequestStatuses['Admin Approved'],
+    ], false);
+    LeaveBalanceChangeFabricator::fabricateForPublicHolidayLeaveRequest($leaveRequest);
+
+    return $leaveRequest;
   }
 
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/PublicHolidayLeaveRequest.php
@@ -26,28 +26,4 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest {
     $creationLogic = new PublicHolidayLeaveRequestCreation(new JobContractService());
     $creationLogic->createForContact($contactID, $publicHoliday);
   }
-
-  public static function fabricateWithoutValidation($contactID, PublicHoliday $publicHoliday) {
-
-    $existingLeaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
-    if($existingLeaveRequest) {
-      return;
-    }
-
-    $publicHolidayDate = new DateTime($publicHoliday->date);
-    $absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
-
-    $leaveRequest = LeaveRequest::create([
-      'contact_id' => $contactID,
-      'type_id' => $absenceType->id,
-      'from_date' => $publicHolidayDate->format('YmdHis'),
-      'from_date_type' => 1,
-      'status_id' => $leaveRequestStatuses['Admin Approved'],
-    ], false);
-    LeaveBalanceChangeFabricator::fabricateForPublicHolidayLeaveRequest($leaveRequest);
-
-    return $leaveRequest;
-  }
-
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
@@ -737,8 +737,8 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseHeadlessTest {
       'weight' => 2
     ]);
 
-    $fromDate = '2016-06-28';
-    $toDate = '2016-07-05';
+    $fromDate = new DateTime('2016-06-28');
+    $toDate = new DateTime('2016-07-05');
     $absencePeriod = AbsencePeriod::getPeriodContainingDates($fromDate, $toDate);
     $this->assertNull($absencePeriod);
   }
@@ -755,8 +755,8 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseHeadlessTest {
       'weight' => 2
     ]);
 
-    $fromDate = '2016-06-10';
-    $toDate = '2016-06-18';
+    $fromDate = new DateTime('2016-06-10');
+    $toDate = new DateTime('2016-06-18');
     $absencePeriod = AbsencePeriod::getPeriodContainingDates($fromDate, $toDate);
     $this->assertInstanceOf(AbsencePeriod::class, $absencePeriod);
     $this->assertEquals($period1->id, $absencePeriod->id);
@@ -779,8 +779,8 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseHeadlessTest {
       'weight' => 2
     ]);
 
-    $fromDate = '2015-11-10';
-    $toDate = '2015-11-18';
+    $fromDate = new DateTime('2015-11-10');
+    $toDate = new DateTime('2015-11-18');
     $absencePeriod = AbsencePeriod::getPeriodContainingDates($fromDate, $toDate);
     $this->assertNull($absencePeriod);
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
@@ -724,4 +724,59 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseHeadlessTest {
       [null]
     ];
   }
+
+  public function testGetPeriodContainingDatesReturnsNullWhenDatesOverlappTwoAbsencePeriods() {
+    $period1 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-06-30'),
+      'weight'    => 1
+    ]);
+    $period2 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-07-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+      'weight' => 2
+    ]);
+
+    $fromDate = '2016-06-28';
+    $toDate = '2016-07-05';
+    $absencePeriod = AbsencePeriod::getPeriodContainingDates($fromDate, $toDate);
+    $this->assertNull($absencePeriod);
+  }
+
+  public function testGetPeriodContainingDatesReturnsAbsencePeriodWhenStartAndEndDateAreContained() {
+    $period1 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-06-30'),
+      'weight'    => 1
+    ]);
+    $period2 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-07-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+      'weight' => 2
+    ]);
+
+    $fromDate = '2016-06-10';
+    $toDate = '2016-06-18';
+    $absencePeriod = AbsencePeriod::getPeriodContainingDates($fromDate, $toDate);
+    $this->assertInstanceOf(AbsencePeriod::class, $absencePeriod);
+    $this->assertEquals($period1->id, $absencePeriod->id);
+  }
+
+  public function testGetPeriodContainingDatesReturnsNullWhenStartAndEndDateIsNotInAnyPeriod() {
+    $period1 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-06-30'),
+      'weight'    => 1
+    ]);
+    $period2 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-07-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+      'weight' => 2
+    ]);
+
+    $fromDate = '2015-11-10';
+    $toDate = '2015-11-18';
+    $absencePeriod = AbsencePeriod::getPeriodContainingDates($fromDate, $toDate);
+    $this->assertNull($absencePeriod);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
@@ -760,6 +760,11 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseHeadlessTest {
     $absencePeriod = AbsencePeriod::getPeriodContainingDates($fromDate, $toDate);
     $this->assertInstanceOf(AbsencePeriod::class, $absencePeriod);
     $this->assertEquals($period1->id, $absencePeriod->id);
+
+    //without an end date
+    $absencePeriod2 = AbsencePeriod::getPeriodContainingDates($fromDate, '');
+    $this->assertInstanceOf(AbsencePeriod::class, $absencePeriod2);
+    $this->assertEquals($period1->id, $absencePeriod->id);
   }
 
   public function testGetPeriodContainingDatesReturnsNullWhenStartAndEndDateIsNotInAnyPeriod() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
@@ -762,7 +762,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseHeadlessTest {
     $this->assertEquals($period1->id, $absencePeriod->id);
 
     //without an end date
-    $absencePeriod2 = AbsencePeriod::getPeriodContainingDates($fromDate, '');
+    $absencePeriod2 = AbsencePeriod::getPeriodContainingDates($fromDate, null);
     $this->assertInstanceOf(AbsencePeriod::class, $absencePeriod2);
     $this->assertEquals($period1->id, $absencePeriod->id);
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -464,7 +464,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('Y-m-d', strtotime('+30 days'));
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($entitlement->contact_id, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate($entitlement->contact_id, $publicHoliday);
 
     // Balance excluding the days deducted from the leave request
     $excludePublicHolidays = true;
@@ -493,11 +493,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
     $publicHoliday1 = new PublicHoliday();
     $publicHoliday1->date = date('Y-m-d', strtotime('+30 days'));
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($entitlement->contact_id, $publicHoliday1);
+    PublicHolidayLeaveRequestFabricator::fabricate($entitlement->contact_id, $publicHoliday1);
 
     $publicHoliday2 = new PublicHoliday();
     $publicHoliday2->date = date('Y-m-d', strtotime('+47 days'));
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($entitlement->contact_id, $publicHoliday2);
+    PublicHolidayLeaveRequestFabricator::fabricate($entitlement->contact_id, $publicHoliday2);
 
     // Balance excluding the days deducted from the leave request
     $includePublicHolidaysOnly = true;
@@ -533,7 +533,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
     $publicHoliday1 = new PublicHoliday();
     $publicHoliday1->date = date('Y-m-d', strtotime('+30 days'));
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($entitlement->contact_id, $publicHoliday1);
+    PublicHolidayLeaveRequestFabricator::fabricate($entitlement->contact_id, $publicHoliday1);
 
     // Balance excluding the days deducted from the leave request
     $excludePublicHolidays = true;
@@ -732,7 +732,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = CRM_Utils_Date::processDate('2016-01-01');
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($leaveRequest->contact_id, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate($leaveRequest->contact_id, $publicHoliday);
 
     LeaveBalanceChange::createForLeaveRequest($leaveRequest);
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -464,7 +464,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('Y-m-d', strtotime('+30 days'));
-    PublicHolidayLeaveRequestFabricator::fabricate($entitlement->contact_id, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($entitlement->contact_id, $publicHoliday);
 
     // Balance excluding the days deducted from the leave request
     $excludePublicHolidays = true;
@@ -493,11 +493,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
     $publicHoliday1 = new PublicHoliday();
     $publicHoliday1->date = date('Y-m-d', strtotime('+30 days'));
-    PublicHolidayLeaveRequestFabricator::fabricate($entitlement->contact_id, $publicHoliday1);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($entitlement->contact_id, $publicHoliday1);
 
     $publicHoliday2 = new PublicHoliday();
     $publicHoliday2->date = date('Y-m-d', strtotime('+47 days'));
-    PublicHolidayLeaveRequestFabricator::fabricate($entitlement->contact_id, $publicHoliday2);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($entitlement->contact_id, $publicHoliday2);
 
     // Balance excluding the days deducted from the leave request
     $includePublicHolidaysOnly = true;
@@ -533,7 +533,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
     $publicHoliday1 = new PublicHoliday();
     $publicHoliday1->date = date('Y-m-d', strtotime('+30 days'));
-    PublicHolidayLeaveRequestFabricator::fabricate($entitlement->contact_id, $publicHoliday1);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($entitlement->contact_id, $publicHoliday1);
 
     // Balance excluding the days deducted from the leave request
     $excludePublicHolidays = true;
@@ -550,11 +550,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testTheLeaveRequestBreakdownReturnsOnlyTheLeaveBalanceChangesOfTheLeaveRequestDates() {
-    $leaveRequest = LeaveRequestFabricator::fabricate([
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-01-02'),
+      'status_id' => 1
     ]);
 
     $expectedLeaveBalanceChanges = [];
@@ -581,22 +582,24 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testTheLeaveRequestBreakdownReturnsAnEmptyArrayIfThereAreNoBalanceChangesForLeaveRequestDates() {
-    $leaveRequest = LeaveRequestFabricator::fabricate([
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-01-02'),
+      'status_id' => 1
     ]);
 
     $this->assertCount(0, LeaveBalanceChange::getBreakdownForLeaveRequest($leaveRequest));
   }
 
   public function testTheTotalBalanceChangeForALeaveRequestShouldBeTheSumOfAllItsLeaveBalanceChanges() {
-    $leaveRequest = LeaveRequestFabricator::fabricate([
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-01-04'),
+      'status_id' => 1
     ]);
 
     $expectedLeaveBalanceChanges = [];
@@ -610,11 +613,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testTheTotalBalanceChangeForALeaveRequestWithoutBalanceChangesShouldBeZero() {
-    $leaveRequest = LeaveRequestFabricator::fabricate([
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-01-04'),
+      'status_id' => 1
     ]);
 
     $this->assertEquals(0, LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest));
@@ -629,11 +633,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'effective_date' => CRM_Utils_Date::processDate('2016-01-01')
     ]);
 
-    $leaveRequest = LeaveRequestFabricator::fabricate([
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contactWorkPattern->contact_id,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'status_id' => 1
     ]);
 
     LeaveBalanceChange::createForLeaveRequest($leaveRequest);
@@ -657,11 +662,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $this->createContract();
     $this->setContractDates('2016-01-01', '2016-12-31');
 
-    $leaveRequest = LeaveRequestFabricator::fabricate([
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $this->contract['contact_id'],
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-08-05'), //Friday
       'to_date' => CRM_Utils_Date::processDate('2016-08-06'), //Saturday
+      'status_id' => 1
     ]);
 
     LeaveBalanceChange::createForLeaveRequest($leaveRequest);
@@ -676,11 +682,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   public function testTheBalanceChangesForALeaveRequestOfAContactWithoutAContractShouldBeZero() {
     WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
 
-    $leaveRequest = LeaveRequestFabricator::fabricate([
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 2,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-11-05'),
       'to_date' => CRM_Utils_Date::processDate('2016-11-08'),
+      'status_id' => 1
     ]);
 
     LeaveBalanceChange::createForLeaveRequest($leaveRequest);
@@ -698,11 +705,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $this->createContract();
     $this->setContractDates('2016-01-01', '2016-12-31');
 
-    $leaveRequest = LeaveRequestFabricator::fabricate([
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 2,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-11-05'),
       'to_date' => CRM_Utils_Date::processDate('2016-11-08'),
+      'status_id' => 1
     ]);
 
     LeaveBalanceChange::createForLeaveRequest($leaveRequest);
@@ -715,15 +723,16 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testTheBalanceChangeForALeaveRequestDateOverlappingAPublicHolidayLeaveRequestShouldBeZero() {
-    $leaveRequest = LeaveRequestFabricator::fabricate([
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 2,
       'type_id' => 1,
-      'from_date' => CRM_Utils_Date::processDate('2016-01-01')
+      'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'status_id' => 1
     ]);
 
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = CRM_Utils_Date::processDate('2016-01-01');
-    PublicHolidayLeaveRequestFabricator::fabricate($leaveRequest->contact_id, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($leaveRequest->contact_id, $publicHoliday);
 
     LeaveBalanceChange::createForLeaveRequest($leaveRequest);
 
@@ -737,10 +746,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $leaveRequest->contact_id = 2;
     $leaveRequest->type_id = 1;
 
-    LeaveRequestFabricator::fabricate([
+    LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $leaveRequest->contact_id,
       'type_id' => $leaveRequest->type_id,
-      'from_date' => CRM_Utils_Date::processDate('2016-01-01')
+      'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'status_id' => 1
     ], true);
 
     // Now we check that there's already a LeaveBalanceChange linked to a
@@ -761,10 +771,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $leaveRequest->contact_id = 2;
     $leaveRequest->type_id = 1;
 
-    LeaveRequestFabricator::fabricate([
+    LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => $leaveRequest->type_id,
-      'from_date' => $date->format('YmdHis')
+      'from_date' => $date->format('YmdHis'),
+      'status_id' => 1
     ], true);
 
     // Now we since the contact_id on $leaveRequest is different than the one
@@ -784,10 +795,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $leaveRequest->contact_id = 2;
     $leaveRequest->type_id = 1;
 
-    LeaveRequestFabricator::fabricate([
+    LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $leaveRequest->contact_id,
       'type_id' => $leaveRequest->type_id,
-      'from_date' => $date->format('YmdHis')
+      'from_date' => $date->format('YmdHis'),
+      'status_id' => 1
     ], true);
 
     // Now we check that there's already a LeaveBalanceChange linked to a

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
@@ -738,6 +738,27 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
     $this->assertEquals($periodEntitlement2->id, $entitlements[1]->id);
   }
 
+  public function testGetPeriodEntitlementsForContactWithTypeID() {
+    $contactId = 1;
+    $periodId = 1;
+    $typeID = 2;
+    $periodEntitlement1 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contactId,
+      'period_id' => $periodId
+    ]);
+    $periodEntitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contactId,
+      'period_id' => $periodId,
+      'type_id' => $typeID
+    ]);
+
+
+    $entitlements = LeavePeriodEntitlement::getPeriodEntitlementsForContact($contactId, $periodId, $typeID);
+    $this->assertCount(1, $entitlements);
+    $this->assertInstanceOf(LeavePeriodEntitlement::class, $entitlements[0]);
+    $this->assertEquals($periodEntitlement2->id, $entitlements[0]->id);
+  }
+
   public function testGetPeriodEntitlementsForContactWhenWrongContactIsPassed() {
     $contactId = 1;
     $periodId = 1;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
@@ -752,7 +752,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
       'type_id' => $typeID
     ]);
 
-
     $entitlements = LeavePeriodEntitlement::getPeriodEntitlementsForContact($contactId, $periodId, $typeID);
     $this->assertCount(1, $entitlements);
     $this->assertInstanceOf(LeavePeriodEntitlement::class, $entitlements[0]);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -130,7 +130,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday));
 
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contactID, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
 
     $leaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
     $this->assertInstanceOf(LeaveRequest::class, $leaveRequest);
@@ -320,7 +320,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('Y-m-d', strtotime('+40 days'));
 
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday);
 
     $publicHolidaysOnly = true;
     $result = LeaveRequest::getBalanceChangeByAbsenceType(
@@ -431,7 +431,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $publicHoliday->date = date('2016-11-14');
 
     $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday));
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday);
 
     $fromDate = date("2016-11-14");
     $toDate = date("2016-11-15");
@@ -813,7 +813,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
     ]);
 
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contactID, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
     $publicHolidayleaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
 
     $fromDate1 = new DateTime('2016-11-02');
@@ -890,7 +890,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'to_date_type' => 1
     ], true);
 
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contactID, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
     $publicHolidayLeaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
 
     //The start date and end date has dates in both leave request dates in both leaveRequest1,
@@ -954,7 +954,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'to_date_type' => 1
     ], true);
 
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contactID, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
     $publicHolidayLeaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
 
     //The start date and end date has dates in leave request dates for leaveRequest1, leaveRequest2
@@ -1061,7 +1061,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'pattern_id' => $workPattern->id
     ]);
 
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contactID, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
     $publicHolidayLeaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
 
     //this date overlapps with public holiday and a Rejected status leave request
@@ -1339,7 +1339,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = '2016-11-16';
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday);
 
     //there's a public holiday on the leave request day
     $fromDate = new DateTime("2016-11-16");

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -128,26 +128,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = '2016-01-01';
 
-    $period = AbsencePeriodFabricator::fabricate([
-      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
-      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
-    ]);
-
-    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
-      'type_id' => $this->absenceType->id,
-      'contact_id' => $contactID,
-      'period_id' => $period->id
-    ]);
-    $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
-    ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $contactID,
-      'pattern_id' => $workPattern->id
-    ]);
-    $this->createLeaveBalanceChange($periodEntitlement->id, 20);
-
     $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday));
 
-    PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contactID, $publicHoliday);
 
     $leaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
     $this->assertInstanceOf(LeaveRequest::class, $leaveRequest);
@@ -324,14 +307,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'type_id' => $this->absenceType->id,
     ]);
 
-    $this->createLeaveBalanceChange($periodEntitlement->id, 5);
-
-    $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
-    ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $contact['id'],
-      'pattern_id' => $workPattern->id
-    ]);
-
     $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
 
     LeaveRequestFabricator::fabricateWithoutValidation([
@@ -345,7 +320,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('Y-m-d', strtotime('+40 days'));
 
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday);
 
     $publicHolidaysOnly = true;
     $result = LeaveRequest::getBalanceChangeByAbsenceType(
@@ -439,12 +414,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'period_start_date' => $periodStartDate,
       'title' => $title
     ]);
-    $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
-
-    ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $contact['id'],
-      'pattern_id' => $workPattern->id
-    ]);
 
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
@@ -457,13 +426,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'type_id' => $this->absenceType->id,
     ]);
 
-    $this->createLeaveBalanceChange($periodEntitlement->id, 5);
     //create a public holiday for a date that is between the leave request days
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('2016-11-14');
 
     $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday));
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday);
 
     $fromDate = date("2016-11-14");
     $toDate = date("2016-11-15");
@@ -840,24 +808,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = '2016-11-11';
 
-    $period = AbsencePeriodFabricator::fabricate([
+    AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
     ]);
 
-    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
-      'type_id' => $this->absenceType->id,
-      'contact_id' => $contactID,
-      'period_id' => $period->id
-    ]);
-    $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
-    ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $contactID,
-      'pattern_id' => $workPattern->id
-    ]);
-    $this->createLeaveBalanceChange($periodEntitlement->id, 20);
-
-    PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contactID, $publicHoliday);
     $publicHolidayleaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
 
     $fromDate1 = new DateTime('2016-11-02');
@@ -914,19 +870,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
     ]);
-
-    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
-      'type_id' => $this->absenceType->id,
-      'contact_id' => $contactID,
-      'period_id' => $period->id
-    ]);
-    $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
-    ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $contactID,
-      'pattern_id' => $workPattern->id
-    ]);
-
-    $this->createLeaveBalanceChange($periodEntitlement->id, 20);
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => $this->absenceType->id,
       'contact_id' => $contactID,
@@ -947,7 +890,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'to_date_type' => 1
     ], true);
 
-    PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contactID, $publicHoliday);
     $publicHolidayLeaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
 
     //The start date and end date has dates in both leave request dates in both leaveRequest1,
@@ -980,24 +923,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromDate3 = new DateTime('2016-11-12');
     $toDate3 = new DateTime('2016-11-15');
 
-    $period = AbsencePeriodFabricator::fabricate([
-      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
-      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
-    ]);
-
-    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
-      'type_id' => $this->absenceType->id,
-      'contact_id' => $contactID,
-      'period_id' => $period->id
-    ]);
-    $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
-    ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $contactID,
-      'pattern_id' => $workPattern->id
-    ]);
-
-    $this->createLeaveBalanceChange($periodEntitlement->id, 20);
-
     $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => $this->absenceType->id,
@@ -1029,7 +954,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'to_date_type' => 1
     ], true);
 
-    PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contactID, $publicHoliday);
     $publicHolidayLeaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
 
     //The start date and end date has dates in leave request dates for leaveRequest1, leaveRequest2
@@ -1112,13 +1037,51 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     ]);
   }
 
-  public function testALeaveRequestWhenThereAreNoOverlappingLeaveRequests() {
+  public function testCreateLeaveRequestWhenThereIsOverlappingPublicHolidayLeaveRequest() {
     $contactID = 1;
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = '2016-11-11';
 
-    $fromDate1 = new DateTime('2016-11-02');
-    $toDate1 = new DateTime('2016-11-04');
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $this->absenceType->id,
+      'contact_id' => $contactID,
+      'period_id' => $period->id
+    ]);
+
+    $this->createLeaveBalanceChange($periodEntitlement->id, 20);
+
+    $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $contactID,
+      'pattern_id' => $workPattern->id
+    ]);
+
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contactID, $publicHoliday);
+    $publicHolidayLeaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
+
+    //this date overlapps with public holiday and a Rejected status leave request
+    $fromDate = new DateTime('2016-11-05');
+    $toDate = new DateTime('2016-11-11');
+    $leaveRequest = LeaveRequest::create([
+      'type_id' => $this->absenceType->id,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => 1,
+      'to_date' => $toDate->format('YmdHis'),
+      'to_date_type' => 1
+    ]);
+    $this->assertEquals($leaveRequest->from_date, $fromDate->format('YmdHis'));
+  }
+
+
+  public function testCreateLeaveRequestWhenThereAreNoOverlappingLeaveRequestsWithSpecificStatuses() {
+    $contactID = 1;
 
     $fromDate2 = new DateTime('2016-11-05');
     $toDate2 = new DateTime('2016-11-10');
@@ -1143,15 +1106,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     ]);
 
     $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
-    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
-      'type_id' => $this->absenceType->id,
-      'contact_id' => $contactID,
-      'status_id' => $leaveRequestStatuses['Waiting Approval'],
-      'from_date' => $fromDate1->format('YmdHis'),
-      'from_date_type' => 1,
-      'to_date' => $toDate1->format('YmdHis'),
-      'to_date_type' => 1
-    ], true);
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => $this->absenceType->id,
@@ -1163,10 +1117,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'to_date_type' => 1
     ], true);
 
-    PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
-    $publicHolidayLeaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
-
-    //this date overlapps with public holiday and a Rejected status leave request
+    //this date overlapps with a Rejected status leave request
     $fromDate = new DateTime('2016-11-05');
     $toDate = new DateTime('2016-11-11');
     $leaveRequest = LeaveRequest::create([
@@ -1185,7 +1136,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
    * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
    * @expectedExceptionMessage Balance change for the leave request cannot be greater than the remaining balance of the period
    */
-  public function testLeaveRequestCannotBeCreatedWhenBalanceChangeGreaterThanPeriodEntitlementBalanceChange() {
+  public function testLeaveRequestCannotBeCreatedWhenBalanceChangeGreaterThanPeriodEntitlementBalanceChangeWhenAllowOveruseFalse() {
     $contact = ContactFabricator::fabricate();
     $period = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
@@ -1194,13 +1145,14 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     $absenceType = AbsenceTypeFabricator::fabricate([
       'title' => 'Type 1',
-      ]);
+      'allow_overuse' => 0
+    ]);
 
     $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
       'type_id' => $absenceType->id,
       'contact_id' => $contact['id'],
       'period_id' => $period->id
-      ]);
+    ]);
 
     $this->createLeaveBalanceChange($periodEntitlement->id, 3);
     $periodStartDate = date('2016-01-01');
@@ -1237,7 +1189,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     ]);
   }
 
-  public function testLeaveRequestCanBeCreatedWhenBalanceChangeGreaterThanPeriodBalanceChangeAndAbsenceTypeAllowOveruse() {
+  public function testLeaveRequestCanBeCreatedWhenBalanceChangeGreaterThanPeriodBalanceChangeAndAbsenceTypeAllowOveruseTrue() {
     $contact = ContactFabricator::fabricate();
     $period = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
@@ -1349,9 +1301,64 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
   /**
    * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
+   * @expectedExceptionMessage Leave Request must have at least one working day to be created
+   */
+  public function testLeaveRequestCanNotBeCreatedWhenLeaveRequestDateIsAPublicHoliday() {
+    $contact = ContactFabricator::fabricate();
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'title' => 'Type 1',
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceType->id,
+      'contact_id' => $contact['id'],
+      'period_id' => $period->id
+    ]);
+
+    $this->createLeaveBalanceChange($periodEntitlement->id, 3);
+    $periodStartDate = date('2016-01-01');
+    $title = 'Job Title';
+
+    HRJobContractFabricator::fabricate([
+      'contact_id' => $contact['id']
+    ],
+    [
+      'period_start_date' => $periodStartDate,
+      'title' => $title
+    ]);
+    $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'pattern_id' => $workPattern->id
+    ]);
+
+    $publicHoliday = new PublicHoliday();
+    $publicHoliday->date = '2016-11-16';
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday);
+
+    //there's a public holiday on the leave request day
+    $fromDate = new DateTime("2016-11-16");
+    $fromType = $this->leaveRequestDayTypes['All Day']['id'];
+
+    LeaveRequest::create([
+      'type_id' => $absenceType->id,
+      'contact_id' => $contact['id'],
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => $fromType,
+    ]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
    * @expectedExceptionMessage The Leave request dates is not contained within a valid absence period
    */
-  public function testLeaveRequestCanNotBeCreatedWhenTheDatesAreNotContainedInvalidAbsencePeriod() {
+  public function testLeaveRequestCanNotBeCreatedWhenTheDatesAreNotContainedInValidAbsencePeriod() {
     $contact = ContactFabricator::fabricate();
     AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -42,8 +42,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $this->absenceType = AbsenceTypeFabricator::fabricate([
       'must_take_public_holiday_as_leave' => 1
     ]);
-
-
     $this->leaveRequestDayTypes = $this->leaveRequestDayTypeOptionsBuilder();
   }
 
@@ -54,7 +52,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   public function testALeaveRequestWithOnlyTheStartDateShouldCreateOnlyOneLeaveRequestDate()
   {
     $fromDate = new DateTime();
-
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => 1,
       'contact_id' => 1,
@@ -1002,7 +999,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $this->createLeaveBalanceChange($periodEntitlement->id, 20);
 
     $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
-    $leaveRequest1 = LeaveRequestFabricator::fabricate([
+    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => $this->absenceType->id,
       'contact_id' => $contactID,
       'status_id' => $leaveRequestStatuses['Waiting Approval'],
@@ -1012,7 +1009,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'to_date_type' => 1
     ], true);
 
-    $leaveRequest2 = LeaveRequestFabricator::fabricate([
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => $this->absenceType->id,
       'contact_id' => $contactID,
       'status_id' => $leaveRequestStatuses['More Information Requested'],
@@ -1022,7 +1019,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'to_date_type' => 1
     ], true);
 
-    $leaveRequest3 = LeaveRequestFabricator::fabricate([
+    $leaveRequest3 = LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => $this->absenceType->id,
       'contact_id' => $contactID,
       'status_id' => $leaveRequestStatuses['Rejected'],
@@ -1079,20 +1076,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
     ]);
 
-    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
-      'type_id' => $this->absenceType->id,
-      'contact_id' => $contactID,
-      'period_id' => $period->id
-    ]);
-    $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
-    ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $contactID,
-      'pattern_id' => $workPattern->id
-    ]);
-
-    $this->createLeaveBalanceChange($periodEntitlement->id, 20);
     $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
-    $leaveRequest1 = LeaveRequestFabricator::fabricate([
+    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => $this->absenceType->id,
       'contact_id' => $contactID,
       'status_id' => $leaveRequestStatuses['Waiting Approval'],
@@ -1102,7 +1087,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'to_date_type' => 1
     ], true);
 
-    $leaveRequest2 = LeaveRequestFabricator::fabricate([
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => $this->absenceType->id,
       'contact_id' => $contactID,
       'status_id' => $leaveRequestStatuses['Rejected'],
@@ -1112,9 +1097,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'to_date_type' => 1
     ], true);
 
-
+    //from date and to date have date in both leave request
     $fromDate = new DateTime('2016-11-03');
     $toDate = new DateTime('2016-11-05');
+
     LeaveRequest::create([
       'type_id' => $this->absenceType->id,
       'contact_id' => 1,
@@ -1233,16 +1219,14 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'pattern_id' => $workPattern->id
     ]);
 
-
     $fromDate = new DateTime("2016-11-14");
     $toDate = new DateTime("2016-11-17");
     $fromType = $this->leaveRequestDayTypes['All Day']['id'];
     $toType = $this->leaveRequestDayTypes['All Day']['id'];
 
     //four working days which will create a balance change of 4
-    $expectedBalanceChangeForLeaveRequest = -4.0;
 
-    $leaveRequest = LeaveRequest::create([
+    LeaveRequest::create([
       'type_id' => $absenceType->id,
       'contact_id' => $contact['id'],
       'status_id' => 1,
@@ -1251,7 +1235,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'to_date' => $toDate->format('YmdHis'),
       'to_date_type' => $toType
     ]);
-
   }
 
   public function testLeaveRequestCanBeCreatedWhenBalanceChangeGreaterThanPeriodBalanceChangeAndAbsenceTypeAllowOveruse() {
@@ -1283,12 +1266,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'period_start_date' => $periodStartDate,
       'title' => $title
     ]);
+
     $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
     ContactWorkPatternFabricator::fabricate([
       'contact_id' => $contact['id'],
       'pattern_id' => $workPattern->id
     ]);
-
 
     $fromDate = new DateTime("2016-11-14");
     $toDate = new DateTime("2016-11-17");
@@ -1296,7 +1279,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $toType = $this->leaveRequestDayTypes['All Day']['id'];
 
     //four working days which will create a balance change of 4
-    $expectedBalanceChangeForLeaveRequest = -4.0;
 
     $leaveRequest = LeaveRequest::create([
       'type_id' => $absenceType->id,
@@ -1348,13 +1330,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'pattern_id' => $workPattern->id
     ]);
 
-    //four working days which will create a balance change of 0 i.e the days are on weekends
+    //both days are on weekends
     $fromDate = new DateTime("2016-11-12");
     $toDate = new DateTime("2016-11-13");
     $fromType = $this->leaveRequestDayTypes['All Day']['id'];
     $toType = $this->leaveRequestDayTypes['All Day']['id'];
 
-    $leaveRequest = LeaveRequest::create([
+    LeaveRequest::create([
       'type_id' => $absenceType->id,
       'contact_id' => $contact['id'],
       'status_id' => 1,
@@ -1376,14 +1358,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
     ]);
 
-
-    //four working days which will create a balance change of 0 i.e the days are on weekends
+    //the dates are outside of the absence period dates
     $fromDate = new DateTime("2015-11-12");
     $toDate = new DateTime("2015-11-13");
     $fromType = $this->leaveRequestDayTypes['All Day']['id'];
     $toType = $this->leaveRequestDayTypes['All Day']['id'];
 
-    $leaveRequest = LeaveRequest::create([
+    LeaveRequest::create([
       'type_id' => 1,
       'contact_id' => $contact['id'],
       'status_id' => 1,
@@ -1415,7 +1396,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromType = $this->leaveRequestDayTypes['All Day']['id'];
     $toType = $this->leaveRequestDayTypes['All Day']['id'];
 
-    $leaveRequest = LeaveRequest::create([
+    LeaveRequest::create([
       'type_id' => 1,
       'contact_id' => $contact['id'],
       'status_id' => 1,
@@ -1476,12 +1457,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'pattern_id' => $workPattern->id
     ]);
 
+    //The from date and to date overlaps the two job contracts
     $fromDate = new DateTime("2016-06-25");
     $toDate = new DateTime("2016-07-13");
     $fromType = $this->leaveRequestDayTypes['All Day']['id'];
     $toType = $this->leaveRequestDayTypes['All Day']['id'];
 
-    $leaveRequest = LeaveRequest::create([
+    LeaveRequest::create([
       'type_id' => $absenceType->id,
       'contact_id' => $contact['id'],
       'status_id' => 1,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -74,10 +74,11 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
   public function testItUpdatesTheBalanceChangeForOverlappingLeaveRequestDayToZero() {
     $contactID = 2;
 
-    $leaveRequest = LeaveRequestFabricator::fabricate([
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contactID,
       'type_id' => $this->absenceType->id,
-      'from_date' => CRM_Utils_Date::processDate('2016-01-01')
+      'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'status_id' => 1
     ], true);
 
     $this->assertEquals(-1, LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest));

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
@@ -46,7 +46,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     $publicHoliday = $this->instantiatePublicHoliday('2016-01-01');
 
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($periodEntitlement->contact_id, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate($periodEntitlement->contact_id, $publicHoliday);
 
     $this->assertEquals(-1, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
 
@@ -74,7 +74,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     $this->assertEquals(-1, LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest));
 
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($this->contract['contact_id'], $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate($this->contract['contact_id'], $publicHoliday);
 
     $this->assertEquals(0, LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest));
 
@@ -111,9 +111,9 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     $publicHoliday3 = PublicHolidayFabricator::fabricateWithoutValidation([
       'date' => CRM_Utils_Date::processDate('+2 years')
     ]);
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday1);
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday2);
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday3);
+    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday1);
+    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday2);
+    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday3);
 
     $this->assertEquals(-3, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
 
@@ -154,9 +154,9 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     // The Fabricator will create the leave request even for public holidays in
     // the past
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday1);
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday2);
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday3);
+    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday1);
+    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday2);
+    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday3);
 
     $this->assertEquals(-3, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
 
@@ -197,9 +197,9 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     // The Fabricator will create the leave request even for public holidays in
     // the past
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday1);
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday2);
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday3);
+    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday1);
+    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday2);
+    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday3);
 
     $this->assertEquals(-3, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
 
@@ -215,7 +215,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     $contact = ContactFabricator::fabricate(['first_name' => 'Contact 1']);
 
     $publicHoliday = $this->instantiatePublicHoliday('today');
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday);
 
     $this->assertEquals(1, $this->countNumberOfPublicHolidayBalanceChanges());
 
@@ -243,8 +243,8 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     $publicHoliday = $this->instantiatePublicHoliday('+5 days');
 
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact1['id'], $publicHoliday);
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact2['id'], $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate($contact1['id'], $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate($contact2['id'], $publicHoliday);
 
     $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday));
     $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));
@@ -275,8 +275,8 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     $publicHoliday = $this->instantiatePublicHoliday('+1 day');
 
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact1['id'], $publicHoliday);
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact2['id'], $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate($contact1['id'], $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate($contact2['id'], $publicHoliday);
 
     $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday));
     $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
@@ -46,7 +46,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     $publicHoliday = $this->instantiatePublicHoliday('2016-01-01');
 
-    PublicHolidayLeaveRequestFabricator::fabricate($periodEntitlement->contact_id, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($periodEntitlement->contact_id, $publicHoliday);
 
     $this->assertEquals(-1, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
 
@@ -65,15 +65,16 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     $publicHoliday = $this->instantiatePublicHoliday('2016-10-10');
 
-    $leaveRequest = LeaveRequestFabricator::fabricate([
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'from_date' => CRM_Utils_Date::processDate($publicHoliday->date),
       'contact_id' => $this->contract['contact_id'],
-      'type_id' => $this->absenceType->id
+      'type_id' => $this->absenceType->id,
+      'status_id' => 1
     ], true);
 
     $this->assertEquals(-1, LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest));
 
-    PublicHolidayLeaveRequestFabricator::fabricate($this->contract['contact_id'], $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($this->contract['contact_id'], $publicHoliday);
 
     $this->assertEquals(0, LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest));
 
@@ -110,9 +111,9 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     $publicHoliday3 = PublicHolidayFabricator::fabricateWithoutValidation([
       'date' => CRM_Utils_Date::processDate('+2 years')
     ]);
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday1);
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday2);
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday3);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday1);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday2);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday3);
 
     $this->assertEquals(-3, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
 
@@ -153,9 +154,9 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     // The Fabricator will create the leave request even for public holidays in
     // the past
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday1);
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday2);
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday3);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday1);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday2);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday3);
 
     $this->assertEquals(-3, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
 
@@ -196,9 +197,9 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     // The Fabricator will create the leave request even for public holidays in
     // the past
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday1);
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday2);
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday3);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday1);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday2);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday3);
 
     $this->assertEquals(-3, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
 
@@ -214,7 +215,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     $contact = ContactFabricator::fabricate(['first_name' => 'Contact 1']);
 
     $publicHoliday = $this->instantiatePublicHoliday('today');
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday);
 
     $this->assertEquals(1, $this->countNumberOfPublicHolidayBalanceChanges());
 
@@ -242,8 +243,8 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     $publicHoliday = $this->instantiatePublicHoliday('+5 days');
 
-    PublicHolidayLeaveRequestFabricator::fabricate($contact1['id'], $publicHoliday);
-    PublicHolidayLeaveRequestFabricator::fabricate($contact2['id'], $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact1['id'], $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact2['id'], $publicHoliday);
 
     $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday));
     $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));
@@ -274,8 +275,8 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     $publicHoliday = $this->instantiatePublicHoliday('+1 day');
 
-    PublicHolidayLeaveRequestFabricator::fabricate($contact1['id'], $publicHoliday);
-    PublicHolidayLeaveRequestFabricator::fabricate($contact2['id'], $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact1['id'], $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact2['id'], $publicHoliday);
 
     $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday));
     $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -174,7 +174,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('Y-m-d', strtotime('+40 days'));
 
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday);
 
     // Passing the public_holiday param, it will sum the balance only for the
     // public holidays
@@ -220,7 +220,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('Y-m-d', strtotime('+10 days'));
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation(1, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate(1, $publicHoliday);
 
     $result = civicrm_api3('LeaveRequest', 'get');
     $this->assertCount(2, $result['values']);
@@ -266,7 +266,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('Y-m-d', strtotime('+10 days'));
-    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation(1, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricate(1, $publicHoliday);
 
     $result = civicrm_api3('LeaveRequest', 'get', ['public_holiday' => true, 'sequential' => 1]);
     $this->assertCount(1, $result['values']);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -104,7 +104,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
 
-    LeaveRequestFabricator::fabricate([
+    LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact['id'],
       'type_id' => $absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('+1 day'),
@@ -112,7 +112,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'status_id' => $leaveRequestStatuses['Approved']
     ], true);
 
-    LeaveRequestFabricator::fabricate([
+    LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact['id'],
       'type_id' => $absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('+8 days'),
@@ -120,7 +120,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'status_id' => $leaveRequestStatuses['Waiting Approval']
     ], true);
 
-    LeaveRequestFabricator::fabricate([
+    LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact['id'],
       'type_id' => $absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('+20 days'),
@@ -163,7 +163,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
 
-    LeaveRequestFabricator::fabricate([
+    LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact['id'],
       'type_id' => $absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('+1 day'),
@@ -174,7 +174,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('Y-m-d', strtotime('+40 days'));
 
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation($contact['id'], $publicHoliday);
 
     // Passing the public_holiday param, it will sum the balance only for the
     // public holidays
@@ -202,7 +202,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => true]);
 
-    $leaveRequest1 = LeaveRequestFabricator::fabricate([
+    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => $absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('+1 day'),
@@ -210,7 +210,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'status_id' => $leaveRequestStatuses['Approved']
     ], true);
 
-    $leaveRequest2 = LeaveRequestFabricator::fabricate([
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 2,
       'type_id' => $absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('+1 day'),
@@ -220,7 +220,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('Y-m-d', strtotime('+10 days'));
-    PublicHolidayLeaveRequestFabricator::fabricate(1, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation(1, $publicHoliday);
 
     $result = civicrm_api3('LeaveRequest', 'get');
     $this->assertCount(2, $result['values']);
@@ -248,7 +248,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => true]);
 
-    $leaveRequest1 = LeaveRequestFabricator::fabricate([
+    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => $absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('+1 day'),
@@ -256,7 +256,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'status_id' => $leaveRequestStatuses['Approved']
     ], true);
 
-    $leaveRequest2 = LeaveRequestFabricator::fabricate([
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 2,
       'type_id' => $absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('+1 day'),
@@ -266,7 +266,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('Y-m-d', strtotime('+10 days'));
-    PublicHolidayLeaveRequestFabricator::fabricate(1, $publicHoliday);
+    PublicHolidayLeaveRequestFabricator::fabricateWithoutValidation(1, $publicHoliday);
 
     $result = civicrm_api3('LeaveRequest', 'get', ['public_holiday' => true, 'sequential' => 1]);
     $this->assertCount(1, $result['values']);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestHelpersTrait.php
@@ -14,7 +14,8 @@ trait CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait {
       $leaveRequestDayTypeOptionsGroup[$label] = [
         'id' => $key,
         'value' => $key,
-        'name' => $name
+        'name' => $name,
+        'label' => $label
       ];
     }
     return $leaveRequestDayTypeOptionsGroup;


### PR DESCRIPTION
This PR is about improvements to the LeaveRequest Create Logic. More validations have been added. These validations include: 

- Do not allow creating a new Leave Request without a start date
- Do not allow creating a new Leave Request with an end date greater than the start date
- Do not allow creating a new Leave Request overlapping another Leave Request with the status is: Approved, Admin Approved (Exception: if the other Leave Request is a Public Holiday Leave Request, then it can overlap), Awaiting Approval or More Information Requested
- Do not allow creating a new Leave Request with a balance change bigger than the remaining balance of the period if the Request’s AbsenceType do not allow overuse
- Do not allow a Leave Request which overlaps two absence periods (the start date is in one absence period and the end date is in another absence period)
- Do not allow a Leave Request which overlaps two contracts (the start date is in one contract and the end date is in another contract)
- Do not allow creating a Leave Request for an Absence Period which doesn’t exist
- Do not allow saving a Leave Request which doesn't have at least one working day