### PR TITLE
PCHR-1274: Implement AbsenceType API, Model, ModelInstance

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/apis/absencetype-api.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/apis/absencetype-api.js
@@ -1,0 +1,28 @@
+define([
+  'leave-absences/shared/modules/apis',
+  'common/services/api'
+], function (apis) {
+  'use strict';
+
+  apis.factory('AbsenceTypeAPI', ['$log', 'api', function ($log, api) {
+    $log.debug('AbsenceTypeAPI');
+
+    return api.extend({
+
+      /**
+       * This method returns all the AbsenceTypes.
+       *
+       * @param  {Object} params  matches the api endpoint params (title, weight etc)
+       * @return {Promise}
+       */
+      all: function (params) {
+        $log.debug('AbsenceTypeAPI');
+
+        return this.sendGET('AbsenceType', 'get', params)
+          .then(function (data) {
+            return data.values;
+          });
+      }
+    });
+  }]);
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/models/absencetype-model.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/models/absencetype-model.js
@@ -1,0 +1,33 @@
+define([
+  'leave-absences/shared/modules/models',
+  'leave-absences/shared/models/instances/absencetype-instance',
+  'leave-absences/shared/apis/absencetype-api',
+  'common/models/model'
+], function (models) {
+  'use strict';
+
+  models.factory('AbsenceType', [
+    '$log', 'Model', 'AbsenceTypeAPI', 'AbsenceTypeInstance',
+    function ($log, Model, absencetypeAPI, instance) {
+      $log.debug('AbsenceType');
+
+      return Model.extend({
+        /**
+         * Calls the all() method of the AbsenceType API, and returns an
+         * AbsenceTypeInstance for each absencetype.
+         *
+         * @param  {Object} params  matches the api endpoint params (title, weight etc)
+         * @return {Promise}
+         */
+        all: function (params) {
+          return absencetypeAPI.all(params)
+            .then(function (absencetypes) {
+              return absencetypes.map(function (absencetype) {
+                return instance.init(absencetype, true);
+              });
+            });
+        }
+      });
+    }
+  ]);
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/models/instances/absencetype-instance.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/models/instances/absencetype-instance.js
@@ -1,0 +1,12 @@
+define([
+  'leave-absences/shared/modules/models-instances',
+  'common/models/instances/instance'
+], function (instances) {
+  'use strict';
+
+  instances.factory('AbsenceTypeInstance', ['$log', 'ModelInstance', function ($log, ModelInstance) {
+    $log.debug('AbsenceTypeInstance');
+
+    return ModelInstance.extend();
+  }]);
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/mocks/apis/absencetype-api-mock.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/mocks/apis/absencetype-api-mock.js
@@ -1,0 +1,17 @@
+define([
+  'mocks/module',
+  'mocks/data/absencetype-data',
+  'common/angularMocks',
+], function (mocks, mockData) {
+  'use strict';
+
+  mocks.factory('AbsenceTypeAPIMock', ['$q', function ($q) {
+    return {
+      all: function (params) {
+        return $q(function (resolve, reject) {
+          resolve(mockData.all().values);
+        });
+      }
+    }
+  }]);
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/mocks/data/absencetype-data.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/mocks/data/absencetype-data.js
@@ -1,0 +1,67 @@
+define(function () {
+  var all_data = {
+    "is_error": 0,
+    "version": 3,
+    "count": 3,
+    "values": [{
+      "id": "1",
+      "title": "Holiday / Vacation",
+      "weight": "1",
+      "color": "#151D2C",
+      "is_default": "1",
+      "is_reserved": "1",
+      "allow_request_cancelation": "3",
+      "allow_overuse": "0",
+      "must_take_public_holiday_as_leave": "1",
+      "default_entitlement": "20",
+      "add_public_holiday_to_entitlement": "1",
+      "is_active": "1",
+      "allow_accruals_request": "0",
+      "allow_accrue_in_the_past": "0",
+      "allow_carry_forward": "1",
+      "max_number_of_days_to_carry_forward": "5",
+      "carry_forward_expiration_duration": "12",
+      "carry_forward_expiration_unit": "2"
+    }, {
+      "id": "2",
+      "title": "TOIL",
+      "weight": "2",
+      "color": "#056780",
+      "is_default": "0",
+      "is_reserved": "1",
+      "allow_request_cancelation": "3",
+      "allow_overuse": "0",
+      "must_take_public_holiday_as_leave": "0",
+      "default_entitlement": "0",
+      "add_public_holiday_to_entitlement": "0",
+      "is_active": "1",
+      "allow_accruals_request": "1",
+      "max_leave_accrual": "5",
+      "allow_accrue_in_the_past": "0",
+      "accrual_expiration_duration": "3",
+      "accrual_expiration_unit": "2",
+      "allow_carry_forward": "0"
+    }, {
+      "id": "3",
+      "title": "Sick",
+      "weight": "3",
+      "color": "#B32E2E",
+      "is_default": "0",
+      "is_reserved": "1",
+      "allow_request_cancelation": "1",
+      "allow_overuse": "1",
+      "must_take_public_holiday_as_leave": "0",
+      "default_entitlement": "0",
+      "add_public_holiday_to_entitlement": "0",
+      "is_active": "1",
+      "allow_accruals_request": "0",
+      "allow_accrue_in_the_past": "0",
+      "allow_carry_forward": "0"
+    }]
+  }
+  return {
+    all: function () {
+      return all_data;
+    }
+  }
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/apis/absencetype-api_test.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/apis/absencetype-api_test.js
@@ -1,0 +1,69 @@
+define([
+    'mocks/data/absencetype-data',
+    'leave-absences/shared/apis/absencetype-api',
+  ],
+  function (mockData) {
+    'use strict'
+
+    describe("AbsenceTypeAPI", function () {
+      var AbsenceTypeAPI, $httpBackend;
+
+      beforeEach(module('leave-absences.apis'));
+
+      beforeEach(inject(function (_AbsenceTypeAPI_, _$httpBackend_) {
+        AbsenceTypeAPI = _AbsenceTypeAPI_;
+        $httpBackend = _$httpBackend_;
+      }));
+
+      it("has expected interface", function () {
+        expect(Object.keys(AbsenceTypeAPI)).toContain("all");
+      });
+
+      describe("all()", function () {
+        var absenceTypePromise, totalAbsenceTypes;
+
+        beforeEach(function () {
+          $httpBackend.whenGET(/action=get&entity=AbsenceType/)
+            .respond(mockData.all());
+        })
+
+        beforeEach(function () {
+          totalAbsenceTypes = mockData.all().values.length;
+          absenceTypePromise = AbsenceTypeAPI.all();
+        });
+
+        afterEach(function () {
+          //enforce flush to make calls to httpBackend
+          $httpBackend.flush();
+        });
+
+        it("with expected length", function () {
+          absenceTypePromise.then(function (result) {
+            expect(result.length).toEqual(totalAbsenceTypes);
+          });
+        });
+
+        it("with expected data", function () {
+          absenceTypePromise.then(function (result) {
+            var firstAbsenceType = result[0];
+
+            expect(firstAbsenceType.id).toBeDefined();
+            expect(firstAbsenceType.title).toBeDefined();
+            expect(firstAbsenceType.weight).toBeDefined();
+            expect(firstAbsenceType.color).toBeDefined();
+            expect(firstAbsenceType.is_default).toBeDefined();
+            expect(firstAbsenceType.is_reserved).toBeDefined();
+            expect(firstAbsenceType.allow_request_cancelation).toBeDefined();
+            expect(firstAbsenceType.allow_overuse).toBeDefined();
+            expect(firstAbsenceType.must_take_public_holiday_as_leave).toBeDefined();
+            expect(firstAbsenceType.default_entitlement).toBeDefined();
+            expect(firstAbsenceType.add_public_holiday_to_entitlement).toBeDefined();
+            expect(firstAbsenceType.is_active).toBeDefined();
+            expect(firstAbsenceType.allow_accruals_request).toBeDefined();
+            expect(firstAbsenceType.allow_accrue_in_the_past).toBeDefined();
+            expect(firstAbsenceType.allow_carry_forward).toBeDefined();
+          });
+        });
+      });
+    });
+  });

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/absencetype-model_test.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/absencetype-model_test.js
@@ -1,0 +1,57 @@
+define([
+  'leave-absences/shared/models/absencetype-model',
+  'mocks/apis/absencetype-api-mock',
+], function () {
+  'use strict'
+
+  describe('AbsenceType', function () {
+    var $provide, AbsenceType, AbsenceTypeAPI, $rootScope;
+
+    beforeEach(module('leave-absences.models', 'leave-absences.mocks', function (_$provide_) {
+      $provide = _$provide_;
+    }));
+
+    beforeEach(inject(function (_AbsenceTypeAPIMock_) {
+      $provide.value('AbsenceTypeAPI', _AbsenceTypeAPIMock_);
+    }));
+
+    beforeEach(inject(function (_AbsenceType_, _AbsenceTypeAPI_, _$rootScope_) {
+      AbsenceType = _AbsenceType_;
+      AbsenceTypeAPI = _AbsenceTypeAPI_;
+      $rootScope = _$rootScope_;
+
+      spyOn(AbsenceTypeAPI, 'all').and.callThrough();
+    }));
+
+    it('has expected interface', function () {
+      expect(Object.keys(AbsenceType)).toEqual(['all']);
+    });
+
+    describe('all()', function () {
+      var absencetypePromise;
+
+      beforeEach(function () {
+        absencetypePromise = AbsenceType.all();
+      });
+
+      afterEach(function () {
+        //to excute the promise force an digest
+        $rootScope.$apply();
+      });
+
+      it('calls equivalent API method', function () {
+        absencetypePromise.then(function (response) {
+          expect(AbsenceTypeAPI.all).toHaveBeenCalled();
+        });
+      });
+
+      it('returns model instances', function () {
+        absencetypePromise.then(function (response) {
+          expect(response.every(function (modelInstance) {
+            return 'init' in modelInstance;
+          })).toBe(true);
+        });
+      });
+    });
+  });
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/instances/absencetype-instance_test.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/instances/absencetype-instance_test.js
@@ -1,0 +1,67 @@
+define([
+  'mocks/apis/absencetype-api-mock',
+  'leave-absences/shared/models/instances/absencetype-instance',
+], function () {
+  'use strict'
+
+  describe('AbsenceTypeInstance', function () {
+    var AbsenceTypeInstance, ModelInstance;
+
+    beforeEach(module('leave-absences.models.instances'));
+
+    beforeEach(inject(function (_AbsenceTypeInstance_, _ModelInstance_) {
+      AbsenceTypeInstance = _AbsenceTypeInstance_;
+      ModelInstance = _ModelInstance_;
+    }));
+
+    it('inherits from ModelInstance', function () {
+      expect(_.functions(AbsenceTypeInstance)).toEqual(jasmine.arrayContaining(_.functions(ModelInstance)));
+    });
+
+    describe('init()', function () {
+      var instance;
+      var attributes = {
+        "id": "1",
+        "title": "Holiday / Vacation",
+        "weight": "1",
+        "color": "#151D2C",
+        "is_default": "1",
+        "is_reserved": "1",
+        "allow_request_cancelation": "3",
+        "allow_overuse": "0",
+        "must_take_public_holiday_as_leave": "1",
+        "default_entitlement": "20",
+        "add_public_holiday_to_entitlement": "1",
+        "is_active": "1",
+        "allow_accruals_request": "0",
+        "allow_accrue_in_the_past": "0",
+        "allow_carry_forward": "1",
+        "max_number_of_days_to_carry_forward": "5",
+        "carry_forward_expiration_duration": "12",
+        "carry_forward_expiration_unit": "2"
+      };
+
+      beforeEach(function () {
+        instance = AbsenceTypeInstance.init(attributes, true);
+      });
+
+      it('has expected data', function () {
+        expect(instance.id).toBe(attributes.id);
+        expect(instance.title).toEqual(jasmine.any(String));
+        expect(instance.weight).toEqual(jasmine.any(String));
+        expect(instance.color).toEqual(jasmine.any(String));
+        expect(instance.is_default).toEqual(jasmine.any(String));
+        expect(instance.is_reserved).toEqual(jasmine.any(String));
+        expect(instance.allow_request_cancelation).toEqual(jasmine.any(String));
+        expect(instance.allow_overuse).toEqual(jasmine.any(String));
+        expect(instance.must_take_public_holiday_as_leave).toEqual(jasmine.any(String));
+        expect(instance.default_entitlement).toEqual(jasmine.any(String));
+        expect(instance.add_public_holiday_to_entitlement).toEqual(jasmine.any(String));
+        expect(instance.is_active).toEqual(jasmine.any(String));
+        expect(instance.allow_accruals_request).toEqual(jasmine.any(String));
+        expect(instance.allow_accrue_in_the_past).toEqual(jasmine.any(String));
+        expect(instance.allow_carry_forward).toEqual(jasmine.any(String));
+      });
+    });
+  });
+});


### PR DESCRIPTION
# AbsenceType 
Implementation for absencetype api end points as per ticket [PCHR-1252](https://compucorp.atlassian.net/browse/PCHR-1252).

## API
`AbsenceTypeAPI` will get all the absencetypes from backends.

## Model
`AbsenceType` contains the absencetype data and is wrapper over the API.

## Instance 
`AbsenceTypeInstance` is the absencetype instance with helper method to get absencetype data.

## Source Code location
It is located under `civihr/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular`.

The implementation is located under shared folder. 
![image](https://cloud.githubusercontent.com/assets/89973/21139386/9dfab5a0-c158-11e6-8ed0-a706dacc1919.png)

The test cases are in tests folder. 
![image](https://cloud.githubusercontent.com/assets/89973/21139398/abc0d4d0-c158-11e6-91d5-9c19564e7639.png)

## Sample AbsenceType
A sample absence is presented below 

```json
{
  "id": "1",
  "title": "Holiday / Vacation",
  "weight": "1",
  "color": "#151D2C",
  "is_default": "1",
  "is_reserved": "1",
  "allow_request_cancelation": "3",
  "allow_overuse": "0",
  "must_take_public_holiday_as_leave": "1",
  "default_entitlement": "20",
  "add_public_holiday_to_entitlement": "1",
  "is_active": "1",
  "allow_accruals_request": "0",
  "allow_accrue_in_the_past": "0",
  "allow_carry_forward": "1",
  "max_number_of_days_to_carry_forward": "5",
  "carry_forward_expiration_duration": "12",
  "carry_forward_expiration_unit": "2"
}
```