### PR TITLE
PCHR-1228: Add is_sick flag to AbsenceType Entity

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/AbsenceType.php
@@ -205,6 +205,12 @@ class CRM_HRLeaveAndAbsences_DAO_AbsenceType extends CRM_Core_DAO
    */
   public $carry_forward_expiration_unit;
   /**
+   * A flag which is used to determine if this Absence Type can be used for a Sickness Request
+   *
+   * @var boolean
+   */
+  public $is_sick;
+  /**
    * class constructor
    *
    * @return civicrm_hrleaveandabsences_absence_type
@@ -357,6 +363,11 @@ class CRM_HRLeaveAndAbsences_DAO_AbsenceType extends CRM_Core_DAO
           'title' => ts('Carry Forward Expiration Unit') ,
           'description' => 'The unit (months or days) of carry_forward_expiration_duration of this type default expiry',
         ) ,
+        'is_sick' => array(
+          'name' => 'is_sick',
+          'type' => CRM_Utils_Type::T_BOOLEAN,
+          'description' => 'A flag which is used to determine if this Absence Type can be used for a Sickness Request',
+        ) ,
       );
     }
     return self::$_fields;
@@ -393,6 +404,7 @@ class CRM_HRLeaveAndAbsences_DAO_AbsenceType extends CRM_Core_DAO
         'max_number_of_days_to_carry_forward' => 'max_number_of_days_to_carry_forward',
         'carry_forward_expiration_duration' => 'carry_forward_expiration_duration',
         'carry_forward_expiration_unit' => 'carry_forward_expiration_unit',
+        'is_sick' => 'is_sick',
       );
     }
     return self::$_fieldKeys;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
@@ -28,6 +28,7 @@ CREATE TABLE `civicrm_hrleaveandabsences_absence_type` (
      `max_number_of_days_to_carry_forward` int unsigned    ,
      `carry_forward_expiration_duration` int unsigned    COMMENT 'An amount of carry_forward_expiration_unit',
      `carry_forward_expiration_unit` int unsigned    COMMENT 'The unit (months or days) of carry_forward_expiration_duration of this type default expiry',
+     `is_sick` tinyint   DEFAULT 0 COMMENT 'A flag which is used to determine if this Absence Type can be used for a Sickness Request',
     PRIMARY KEY ( `id` ),
     UNIQUE INDEX `hrleaveandabsences_absence_type_title`(title)
 
@@ -111,7 +112,8 @@ INSERT INTO `civicrm_hrleaveandabsences_absence_type`(
   allow_request_cancelation,
   allow_overuse,
   is_reserved,
-  weight
+  weight,
+  is_sick
 ) VALUES (
   3,
   'Sick',
@@ -121,7 +123,8 @@ INSERT INTO `civicrm_hrleaveandabsences_absence_type`(
   1, -- no
   1,
   1,
-  3
+  3,
+  1
 );
 
 -- /*******************************************************

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_uninstall.sql
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_uninstall.sql
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS `civicrm_hrleaveandabsences_contact_work_pattern`;
+DROP TABLE IF EXISTS `civicrm_hrleaveandabsences_sickness_request`;
 DROP TABLE IF EXISTS `civicrm_hrleaveandabsences_leave_request_date`;
 DROP TABLE IF EXISTS `civicrm_hrleaveandabsences_leave_request`;
 DROP TABLE IF EXISTS `civicrm_hrleaveandabsences_leave_balance_change`;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -601,4 +601,27 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
 
     return null;
   }
+
+  public function testAbsenceTypeHasIsSickFlagAsFalseByDefault() {
+    $absenceType = AbsenceType::create([
+      'title' => 'Title 1',
+      'color' => '#000101',
+      'default_entitlement' => 21,
+      'allow_request_cancelation' => 1,
+      'is_active' => 1,
+    ]);
+    $this->assertEquals(0, $absenceType->is_sick);
+  }
+
+  public function testSetIsSickFlagForAbsenceType() {
+    $absenceType = AbsenceType::create([
+      'title' => 'Title 1',
+      'color' => '#000101',
+      'default_entitlement' => 21,
+      'allow_request_cancelation' => 1,
+      'is_active' => 1,
+      'is_sick' => 1
+    ]);
+    $this->assertEquals(1, $absenceType->is_sick);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/AbsenceType.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/AbsenceType.xml
@@ -154,5 +154,12 @@
     <type>int unsigned</type>
     <comment>The unit (months or days) of carry_forward_expiration_duration of this type default expiry</comment>
   </field>
+  <field>
+    <name>is_sick</name>
+    <label>Is Sick?</label>
+    <type>boolean</type>
+    <default>0</default>
+    <comment>A flag which is used to determine if this Absence Type can be used for a Sickness Request</comment>
+  </field>
 
 </table>


### PR DESCRIPTION
A new flag named is_sick is added to the AbsenceType Entity.
The flag is a boolean field and It's default value is *false*. 
The "Sick" (ID: 3) reserved absence type have this flag set as *true*.