### PR TITLE
PCHR-1389: Calculate Toil expiry date API

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/AbsenceType.php
@@ -44,3 +44,50 @@ function civicrm_api3_absence_type_delete($params) {
 function civicrm_api3_absence_type_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
+
+
+/**
+ * AbsenceType.calculateToilExpiryDate Specification
+ *
+ * @param array $spec
+ */
+function _civicrm_api3_absence_type_calculatetoilexpirydate_spec(&$spec) {
+  $spec['absence_type_id'] = [
+    'name' => 'absence_type_id',
+    'title' => 'Absence Type ID',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 1
+  ];
+
+  $spec['date'] = [
+    'name' => 'date',
+    'title' => 'Date to calculate TOIL expiry for',
+    'type' => CRM_Utils_Type::T_DATE,
+    'api.required' => 1
+  ];
+}
+
+/**
+ * AbsenceType.calculateToilExpiryDate API
+ *
+ * @param array $params
+ *   An array of parameters passed to the API
+ *
+ * @return array API result descriptor
+ *
+ * @throws API_Exception
+ */
+function civicrm_api3_absence_type_calculatetoilexpirydate($params) {
+  $absenceType = CRM_HRLeaveAndAbsences_BAO_AbsenceType::findById($params['absence_type_id']);
+
+  $expiry = $absenceType->calculateToilExpiryDate(new DateTime($params['date']));
+  $expiryDate = false;
+
+  if($expiry instanceof DateTime){
+    $expiryDate = $expiry->format('Y-m-d');
+  }
+
+  $result = ['expiry_date' => $expiryDate];
+  return civicrm_api3_create_success($result);
+}
+

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/AbsenceTypeTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+
+/**
+ * Class api_v3_AbsenceTypeTest
+ *
+ * @group headless
+ */
+class api_v3_AbsenceTypeTest extends BaseHeadlessTest {
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage Mandatory key(s) missing from params array: date
+   */
+  public function testOnCalculateToilExpiryDateDoesNotAcceptAbsenceTypeIdWithoutDate() {
+    civicrm_api3('AbsenceType', 'calculatetoilexpirydate', ['absence_type_id' => 1]);
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage Mandatory key(s) missing from params array: absence_type_id
+   */
+  public function testOnCalculateToilExpiryDateDoesNotAcceptDateWithoutAbsenceTypeId() {
+    civicrm_api3('AbsenceType', 'calculatetoilexpirydate', ['date' => '2016-10-05']);
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage date is not a valid date: 2016-30-05
+   */
+  public function testOnCalculateToilExpiryDateDoesNotAcceptInvalidDate() {
+    civicrm_api3('AbsenceType', 'calculatetoilexpirydate', ['absence_type_id' => 1, 'date' => '2016-30-05']);
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage Unable to find a CRM_HRLeaveAndAbsences_BAO_AbsenceType with id 20.
+   */
+  public function testOnCalculateToilExpiryDateWhenAbsenceTypeIsInvalid() {
+    civicrm_api3('AbsenceType', 'calculatetoilexpirydate', ['absence_type_id' => 20, 'date' => '2016-10-05']);
+  }
+
+  public function testCalculateToilExpiryDateWhenAbsenceTypeAllowsAccrualsRequestAndNeverExpires() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'title' => 'Title 1',
+      'allow_accruals_request' => true,
+      'accrual_expiration_unit' => null,
+      'accrual_expiration_duration' => null,
+      'is_active' => 1,
+    ]);
+    //date to calculate TOIL expiry for
+    $date = '2016-11-10';
+    $result = civicrm_api3('AbsenceType', 'calculatetoilexpirydate', ['absence_type_id' => $absenceType->id, 'date' => $date]);
+    $expected_result = ['expiry_date' => false];
+    $this->assertEquals($expected_result, $result['values']);
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage This Absence Type does not allow Accruals Request
+   */
+  public function testCalculateToilExpiryDateWhenAbsenceTypeDoesNotAllowAccrualsRequest() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'title' => 'Title 1',
+      'allow_accruals_request' => false,
+      'is_active' => 1,
+    ]);
+    //date to calculate TOIL expiry for
+    $date = '2016-11-10';
+    civicrm_api3('AbsenceType', 'calculatetoilexpirydate', ['absence_type_id' => $absenceType->id, 'date' => $date]);
+  }
+
+  public function testCalculateToilExpiryDateWhenAbsenceTypeAllowsAccrualsRequestAndExpiryDurationSet() {
+    //Duration set in days
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'title' => 'Title 1',
+      'allow_accruals_request' => true,
+      'accrual_expiration_duration' => 10,
+      'accrual_expiration_unit' => AbsenceType::EXPIRATION_UNIT_DAYS,
+      'is_active' => 1,
+    ]);
+    //date to calculate TOIL expiry for
+    $date = '2016-11-10';
+    $result = civicrm_api3('AbsenceType', 'calculatetoilexpirydate', ['absence_type_id' => $absenceType->id, 'date' => $date]);
+    $expected_result = ['expiry_date' => '2016-11-20'];
+    $this->assertEquals($expected_result, $result['values']);
+
+    //Duration set in months
+    $absenceType2 = AbsenceTypeFabricator::fabricate([
+      'title' => 'Title 2',
+      'allow_accruals_request' => true,
+      'accrual_expiration_duration' => 10,
+      'accrual_expiration_unit' => AbsenceType::EXPIRATION_UNIT_MONTHS,
+      'is_active' => 1,
+    ]);
+    //date to calculate TOIL expiry for
+    $date = '2016-11-10';
+    $result = civicrm_api3('AbsenceType', 'calculatetoilexpirydate', ['absence_type_id' => $absenceType2->id, 'date' => $date]);
+    $expected_result = ['expiry_date' => '2017-09-10'];
+    $this->assertEquals($expected_result, $result['values']);
+  }
+}


### PR DESCRIPTION
In this PR, The AbsenceType.calculateToilExpiryDate endpoint which, given a date, it calculates when the toil would expire is created. The endpoint supports the following parameters:

- id(required): The id of the absence type.
- date(required) : The date to calculate TOIL expiry for.

| absence_type_id  | allow_accruals_request  | accrual_expiration_duration|accrual_expiration_unit |
| ------------- | ------------- | ------------- |------------- |
| 1  | 0  |   |  |
| 2  | 1  |  |  |
| 3  | 1  | 10  |1  |

```php
$result = civicrm_api3('AbsenceType', 'calculatetoilexpirydate', array(
  'absence_type_id' => 1,
  'date' => "2016-10-11",
));
```
**$result =** 
```json 
{

    "is_error": 1,
    "error_message": "This Absence Type does not allow Accruals Request"
}
```

```php
$result = civicrm_api3('AbsenceType', 'calculatetoilexpirydate', array(
  'absence_type_id' => 2,
  'date' => "2016-10-11",
));
```
**$result['values'] =** 
```json 
{

    "expiry_date": false,
}
```


```php
$result = civicrm_api3('AbsenceType', 'calculatetoilexpirydate', array(
  'absence_type_id' => 3,
  'date' => "2016-11-10",
));
```
**$result['values'] =** 
```json 
{

    "expiry_date": "2016-11-20",
}
```