### PR TITLE
PCHR-1689: Add the WorkPattern.getCalendar API endpoint

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/WorkPatternCalendar.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/WorkPatternCalendar.php
@@ -1,0 +1,316 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
+use CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern as ContactWorkPattern;
+use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
+use CRM_HRLeaveAndAbsences_Service_JobContract as JobContractService;
+
+/**
+ * This class calculates a calendar for a Contact and an Absence Period,
+ * based on the the contact's work pattern(s).
+ *
+ * A calendar is just a list of dates with information about its type, according
+ * to a work pattern (i.e. if it's a working day, non working day or weekend)
+ */
+class CRM_HRLeaveAndAbsences_Service_WorkPatternCalendar {
+
+  /**
+   * @var int
+   */
+  private $contactID;
+
+  /**
+   * @var \CRM_HRLeaveAndAbsences_BAO_AbsencePeriod
+   */
+  private $absencePeriod;
+
+  /**
+   * @var array
+   *   An array to cache the WorkPattern instances loaded by getWorkPatternById()
+   */
+  private $workPatternCache;
+
+  public function __construct($contactID, AbsencePeriod $absencePeriod, JobContractService $jobContractService) {
+    $this->contactID = $contactID;
+    $this->absencePeriod = $absencePeriod;
+    $this->jobContractService = $jobContractService;
+  }
+
+  /**
+   * Returns a list of all the dates on this calendar, on the same format as
+   * WorkPattern.getCalendar(). The difference from the method on the WorkPattern,
+   * is that this one only returns the dates between the calendar's contact
+   * contracts during the calendar's Absence Period. Also, it deals with the
+   * possibility of a contact having multiple work patterns during a single
+   * Absence Period.
+   *
+   * @see CRM_HRLeaveAndAbsences_BAO_WorkPattern.getCalendar()
+   *
+   * @return array
+   */
+  public function get() {
+    $workPatternsPeriods = $this->getWorkPatternsPeriods();
+
+    $calendar = [];
+    foreach($workPatternsPeriods as $workPatternPeriod) {
+      $workPattern = $this->getWorkPatternById($workPatternPeriod['pattern_id']);
+      $calendar = array_merge($calendar, $workPattern->getCalendar(
+        $workPatternPeriod['effective_date'],
+        $workPatternPeriod['period_start_date'],
+        $workPatternPeriod['period_end_date']
+      ));
+    }
+
+    return $calendar;
+  }
+
+  /**
+   * Given that a contact might have multiple active Work Patterns during a
+   * single Absence Period, this method returns a list of "Work Patterns Periods",
+   * which is a list of all the Work Patterns effective for this calendar's
+   * contact, during this calendar's Absence Period, together with information
+   * of during which dates this pattern was active during that period.
+   *
+   * This method take into account the contact's contracts during the period,
+   * and the returned dates are adjusted to match the contracts dates. That is,
+   * even if a contact has an effective work pattern for a given date, the
+   * method won't include that pattern unless the contact also has a contract
+   * during that date.
+   *
+   * @return array
+   *   An array of Work Patterns, organized according to the dates of the
+   *   contacts contracts during the Absence Period. Each entry has:
+   *   - pattern_id: The ID of the Work Pattern
+   *   - effective_date: The date this work pattern became active for one
+   *     specific contract. @see calculateWorkPatternEffectiveDateForContract
+   *   - period_start_date: The start date for this work pattern on the period
+   *     @see calculateWorkPatternPeriodStartDate
+   *   - period_end_date: The end date for this work pattern on the period
+   *     @see calculateWorkPatternPeriodEndDate
+   *
+   *   Given that gaps between contracts might exist and a single work pattern
+   *   might cover more than one contract, the returned array might include more
+   *   than one entry for the same work pattern (one for each contract covered
+   *   by that work pattern), but with different dates.
+   */
+  private function getWorkPatternsPeriods() {
+    $workPatterns = [];
+    $contracts = $this->getContractsWithAdjustedDatesForPeriod();
+
+    foreach($contracts as $contract) {
+      $contractStartDate = new DateTime($contract['period_start_date']);
+      $contractEndDate = new DateTime($contract['period_end_date']);
+      $contractOriginalStartDate = new DateTime($contract['original_start_date']);
+
+      $contactWorkPatterns = ContactWorkPattern::getAllForPeriod(
+        $this->contactID,
+        $contractStartDate,
+        $contractEndDate
+      );
+
+      // If there's no work pattern for this contract, we use the default one
+      // for its whole period
+      if(empty($contactWorkPatterns)) {
+        $workPattern = WorkPattern::getDefault();
+        $workPatterns[] = [
+          'pattern_id' => (int)$workPattern->id,
+          'effective_date' => $contractOriginalStartDate,
+          'period_start_date' => $contractStartDate,
+          'period_end_date' => $contractEndDate
+        ];
+
+        continue;
+      }
+
+      // If the first returned work pattern starts being effective after the
+      // contract start date, it means that, for some time, that contract's
+      // contact didn't have any work pattern assigned. In this case, we have to
+      // use the default work pattern for this period
+      $firstWorkPattern = reset($contactWorkPatterns);
+      $firstWorkPatternEffectiveDate = new DateTime($firstWorkPattern->effective_date);
+
+      if($firstWorkPatternEffectiveDate > $contractStartDate) {
+        $workPattern = WorkPattern::getDefault();
+
+        $workPatterns[] = [
+          'pattern_id' => (int)$workPattern->id,
+          'effective_date' => $contractStartDate,
+          'period_start_date' => $contractStartDate,
+          'period_end_date' => $firstWorkPatternEffectiveDate->modify('-1 day')
+        ];
+      }
+
+      foreach($contactWorkPatterns as $contactWorkPattern) {
+        $patternStartDate = $this->calculateWorkPatternEffectiveDateForContract($contactWorkPattern, $contract);
+        $patternEffectiveDate = $this->calculateWorkPatternPeriodStartDate($contactWorkPattern, $contract);
+        $patternEffectiveEndDate = $this->calculateWorkPatternPeriodEndDate($contactWorkPattern, $contract);
+
+        $workPatterns[] = [
+          'pattern_id' => (int)$contactWorkPattern->pattern_id,
+          'effective_date' => $patternStartDate,
+          'period_start_date' => $patternEffectiveDate,
+          'period_end_date' => $patternEffectiveEndDate
+        ];
+      }
+    }
+
+    return $workPatterns;
+  }
+
+  /**
+   * Returns all the contracts for this calendar's contact during the calendar's
+   * Absence Period.
+   *
+   * The dates of the contracts will be adjusted to be contained on absence
+   * period dates. That is:
+   * - If the contract's start date is less than the period start date, than it
+   * will be changed to be the period's one
+   * - If the contract's end date is greater than the period end date or if it is
+   * null, than it will be changed to be the period's one
+   *
+   * @return array
+   */
+  private function getContractsWithAdjustedDatesForPeriod() {
+    $contracts = $this->jobContractService->getContractsForPeriod(
+      new DateTime($this->absencePeriod->start_date),
+      new DateTime($this->absencePeriod->end_date)
+    );
+
+    foreach($contracts as $i => $contract) {
+      if(empty($contract['period_end_date'])) {
+        $contract['period_end_date'] = $this->absencePeriod->end_date;
+      }
+
+      list($startDate, $endDate) = $this->absencePeriod->adjustDatesToMatchPeriodDates(
+        $contract['period_start_date'],
+        $contract['period_end_date']
+      );
+
+      // We need the original date in order to calculate the effective date for
+      // the work patterns, so we keep it here in this "fake" field
+      $contract['original_start_date'] = $contract['period_start_date'];
+      $contract['period_start_date'] = $startDate;
+      $contract['period_end_date'] = $endDate;
+
+      $contracts[$i] = $contract;
+    }
+
+    return $contracts;
+  }
+
+  /**
+   * Returns a WorkPattern instance for the given ID.
+   *
+   * This method caches the loaded WorkPatterns, so calling it multiple times
+   * with the same ID will always return the same instance.
+   *
+   * @param int $id
+   *
+   * @return CRM_HRLeaveAndAbsences_BAO_WorkPattern
+   */
+  private function getWorkPatternById($id) {
+    if(empty($this->workPatternCache[$id])) {
+      $this->workPatternCache[$id] = WorkPattern::findById($id);
+    }
+
+    return $this->workPatternCache[$id];
+  }
+
+  /**
+   * Calculates the date the WorkPattern on the given ContactWorkPattern became
+   * effective for the given contract.
+   *
+   * The logic to calculate this date is:
+   * - If the WorkPattern became effective before the contract's start date,
+   * then we use the contract's start date as the effective date.
+   * - If the WorkPattern became effective after the contract's  start date, but
+   * before the contract's start on the absence period (a contract spanning two
+   * or more absence periods), then we use the pattern's effective date
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern $contactWorkPattern
+   * @param array $contract
+   *  An array with contact details, as returned by getContractsWithAdjustedDatesForPeriod()
+   *
+   * @return \DateTime
+   */
+  private function calculateWorkPatternEffectiveDateForContract(ContactWorkPattern $contactWorkPattern, $contract) {
+    $patternEffectiveDate = new DateTime($contactWorkPattern->effective_date);
+    $contractOriginalStartDate = new DateTime($contract['original_start_date']);
+
+    if ($patternEffectiveDate < $contractOriginalStartDate) {
+      $patternStartDate = clone $contractOriginalStartDate;
+    }
+
+    if ($patternEffectiveDate >= $contractOriginalStartDate) {
+      $patternStartDate = clone $patternEffectiveDate;
+    }
+
+    return $patternStartDate;
+  }
+
+  /**
+   * Calculates the start date for the WorkPattern of the given ContactWorkPattern,
+   * on the given contract.
+   *
+   * The logic is: if the pattern effective date is less than the contract start
+   * date on the period, then the start date will be the same as the contract's
+   * one. Otherwise, it will be pattern effective date.
+   *
+   * Note that this date is different from the one returned by the method
+   * calculateWorkPatternEffectiveDateForContract(). The former, doesn't care
+   * about absence periods and returns when a work pattern became effective for
+   * a contract. This one here, takes absence periods into account and returns
+   * when the pattern starts to be applying for a contact in the calendar's
+   * absence period.
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern $contactWorkPattern
+   * @param $contract
+   *   An array with contact details, as returned by getContractsWithAdjustedDatesForPeriod()
+   *
+   * @return \DateTime
+   */
+  private function calculateWorkPatternPeriodStartDate(ContactWorkPattern $contactWorkPattern, $contract) {
+    $patternEffectiveDate = new DateTime($contactWorkPattern->effective_date);
+    $contractStartDate = new DateTime($contract['period_start_date']);
+
+    if($patternEffectiveDate < $contractStartDate) {
+      $patternEffectiveDate = clone $contractStartDate;
+    }
+
+    return $patternEffectiveDate;
+  }
+
+  /**
+   * Calculates the end date for the WorkPattern of the given ContactWorkPattern,
+   * on the given contract.
+   *
+   * The logic is:
+   * - If the WorkPattern has an effective end date and it's less than the
+   * contract's end date on the period, then the pattern's effective date will
+   * be used.
+   * - If the WorkPattern doesn't have an effective end date, or it is greater
+   * than the contract's end date on the period, then the contract's end date
+   * will be used.
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern $contactWorkPattern
+   * @param $contract
+   *   An array with contact details, as returned by getContractsWithAdjustedDatesForPeriod()
+   *
+   * @return \DateTime
+   */
+  private function calculateWorkPatternPeriodEndDate(ContactWorkPattern $contactWorkPattern, $contract) {
+    $contractEndDate = new DateTime($contract['period_end_date']);
+
+    $patternEffectiveEndDate = NULL;
+    if ($contactWorkPattern->effective_end_date) {
+      $patternEffectiveEndDate = new DateTime($contactWorkPattern->effective_end_date);
+    }
+
+    if (!$patternEffectiveEndDate || $patternEffectiveEndDate > $contractEndDate) {
+      $patternEffectiveEndDate = clone $contractEndDate;
+    }
+
+    return $patternEffectiveEndDate;
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/WorkPattern.php
@@ -44,3 +44,48 @@ function civicrm_api3_work_pattern_delete($params) {
 function civicrm_api3_work_pattern_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
+
+/**
+ * WorkPattern.getCalendar API specification
+ *
+ * @param array $spec
+ */
+function _civicrm_api3_work_pattern_getcalendar_spec(&$spec) {
+  $spec['contact_id'] = [
+    'name' => 'contact_id',
+    'title' => 'Contact ID',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 1
+  ];
+
+  $spec['period_id'] = [
+    'name' => 'period_id',
+    'title' => 'Absence Period ID',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 1
+  ];
+}
+
+/**
+ * WorkPattern.getCalendar API
+ *
+ * This API endpoint returns a list of dates for the given Absence Period. The
+ * returned dates are only those within the contracts of the contact with the
+ * given contact_id. For each date, we use the work pattern(s) assign to the
+ * contact to check if it's a working day, non working day or weekend.
+ *
+ * @param array $params
+ *
+ * @return array
+ */
+function civicrm_api3_work_pattern_getcalendar($params) {
+  $jobContractService = new CRM_HRLeaveAndAbsences_Service_JobContract();
+  $absencePeriod = CRM_HRLeaveAndAbsences_BAO_AbsencePeriod::findById($params['period_id']);
+  $calendar = new CRM_HRLeaveAndAbsences_Service_WorkPatternCalendar(
+    $params['contact_id'],
+    $absencePeriod,
+    $jobContractService
+  );
+
+  return civicrm_api3_create_success($calendar->get());
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/WorkPatternCalendarTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/WorkPatternCalendarTest.php
@@ -1,0 +1,429 @@
+<?php
+
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
+use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
+use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
+use CRM_HRLeaveAndAbsences_Service_JobContract as JobContractService;
+use CRM_HRLeaveAndAbsences_Service_WorkPatternCalendar as WorkPatternCalendarService;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod as AbsencePeriodFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_ContactWorkPattern as ContactWorkPatternFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern as WorkPatternFabricator;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Service_WorkPatternCalendar
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_Service_WorkPatternCalendarTest extends BaseHeadlessTest {
+
+  use CRM_HRLeaveAndAbsences_WorkPatternHelpersTrait;
+
+  private $contact;
+  private $jobContractService;
+
+  public function setUp() {
+    $this->contact = ContactFabricator::fabricate();
+    $this->jobContractService = new JobContractService();
+
+    // We delete everything to avoid problems with the default work pattern
+    // created during the extension installation
+    $tableName = WorkPattern::getTableName();
+    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+  }
+
+  public function testGetShouldReturnEmptyForContactWithoutContractOnThePeriod() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2015-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2015-12-31'),
+    ]);
+
+    $calendar = new WorkPatternCalendarService($this->contact['id'], $absencePeriod, $this->jobContractService);
+    $this->assertEmpty($calendar->get());
+  }
+
+  public function testGetShouldUseTheDefaultWorkPatternIfTheContactHasNoActiveWorkPatternDuringTheContract() {
+    // 15 days absence period
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2015-01-05'),
+      'end_date'   => CRM_Utils_Date::processDate('2015-01-19'),
+    ]);
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => true]);
+    $multipleWeekWorkPattern = WorkPatternFabricator::fabricateWithTwoWeeksAnd31AndHalfHours();
+
+    // contract covers the whole period
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $this->contact['id']],
+      [
+        'period_start_date' => '2015-01-05',
+        'period_end_date' => '2015-01-19'
+      ]
+    );
+
+    // work pattern is effective only after the contract end
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $this->contact['id'],
+      'pattern_id' => $multipleWeekWorkPattern->id,
+      'effective_date' => CRM_Utils_Date::processDate('2015-02-05'),
+    ]);
+
+    $calendar = new WorkPatternCalendarService($this->contact['id'], $absencePeriod, $this->jobContractService);
+
+    $workDayTypes = $this->getWorkDayTypeOptionsArray();
+
+    $calendarDates = $calendar->get();
+    // Asserting ALL the dates would make the test too big, so we assert the
+    // total number of dates, the first and last ones and a few dates in the
+    // middle, assuming all the other will be correct.
+    $this->assertCount(15, $calendarDates);
+    $this->assertEquals('2015-01-05', $calendarDates[0]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[0]['type']);
+    $this->assertEquals('2015-01-08', $calendarDates[3]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[3]['type']);
+    $this->assertEquals('2015-01-11', $calendarDates[6]['date']);
+    $this->assertEquals($workDayTypes['weekend'], $calendarDates[6]['type']);
+    $this->assertEquals('2015-01-16', $calendarDates[11]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[11]['type']);
+    $this->assertEquals('2015-01-19', $calendarDates[14]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[14]['type']);
+  }
+
+  public function testGetShouldUseTheDefaultWorkPatternIfTheAssignedWorkPatternDoesntCoverTheWholeContractPeriod() {
+    // 31 days absence period
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2015-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2015-01-31'),
+    ]);
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => true]);
+    $multipleWeekWorkPattern = WorkPatternFabricator::fabricateWithTwoWeeksAnd31AndHalfHours();
+
+    // contract covers the whole period
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $this->contact['id']],
+      [
+        'period_start_date' => '2015-01-01',
+        'period_end_date' => '2015-01-31'
+      ]
+    );
+
+    // work pattern is effective only at the middle of the contract
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $this->contact['id'],
+      'pattern_id' => $multipleWeekWorkPattern->id,
+      'effective_date' => CRM_Utils_Date::processDate('2015-01-12'),
+    ]);
+
+    $calendar = new WorkPatternCalendarService($this->contact['id'], $absencePeriod, $this->jobContractService);
+
+    $workDayTypes = $this->getWorkDayTypeOptionsArray();
+
+    $calendarDates = $calendar->get();
+    // Asserting ALL the dates would make the test too big, so we assert the
+    // total number of dates, the first and last ones and a few dates in the
+    // middle, assuming all the other will be correct.
+    $this->assertCount(31, $calendarDates);
+    $this->assertEquals('2015-01-01', $calendarDates[0]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[0]['type']);
+
+    $this->assertEquals('2015-01-06', $calendarDates[5]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[5]['type']);
+
+    $this->assertEquals('2015-01-07', $calendarDates[6]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[6]['type']);
+
+    // this is a tuesday, which should be a working day on the default work pattern,
+    // but the multiple day work pattern became effective on 01-12, and tuesdays
+    // are non working days on it's first week
+    $this->assertEquals('2015-01-13', $calendarDates[12]['date']);
+    $this->assertEquals($workDayTypes['non_working_day'], $calendarDates[12]['type']);
+
+    // the next tuesday after 01-13 is 01-20, which is a working day on the second
+    // week of the work pattern
+    $this->assertEquals('2015-01-20', $calendarDates[19]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[19]['type']);
+
+    // and then the next tuesday is a non-working day again, because we're using
+    // the first week of the work pattern again
+    $this->assertEquals('2015-01-27', $calendarDates[26]['date']);
+    $this->assertEquals($workDayTypes['non_working_day'], $calendarDates[26]['type']);
+
+    $this->assertEquals('2015-01-31', $calendarDates[30]['date']);
+    $this->assertEquals($workDayTypes['weekend'], $calendarDates[30]['type']);
+  }
+
+  public function testGetShouldOnlyReturnDatesWithinTheContactContractsDuringThePeriod() {
+    // 31 days absence period
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2015-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2015-01-31'),
+    ]);
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => true]);
+
+    // create two contracts within the absence period, but with a gap
+    // between them.
+    // This first one has only 10 days
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $this->contact['id']],
+      [
+        'period_start_date' => '2015-01-01',
+        'period_end_date' => '2015-01-10'
+      ]
+    );
+
+    // This second contract has 17 days
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $this->contact['id']],
+      [
+        'period_start_date' => '2015-01-15',
+        'period_end_date' => '2015-01-31'
+      ]
+    );
+
+    $calendar = new WorkPatternCalendarService($this->contact['id'], $absencePeriod, $this->jobContractService);
+    $calendarDates = $calendar->get();
+
+    // 27 (10 from one contract + 17 from the other) instead of 31 for the whole period
+    $this->assertCount(27, $calendarDates);
+
+    $dates = array_column($calendarDates, 'date');
+    // Again, to avoid a huge test, we only assert for boundary dates and the
+    // gap dates
+    $this->assertContains('2015-01-01', $dates);
+    $this->assertContains('2015-01-10', $dates);
+    $this->assertNotContains('2015-01-11', $dates);
+    $this->assertNotContains('2015-01-12', $dates);
+    $this->assertNotContains('2015-01-13', $dates);
+    $this->assertNotContains('2015-01-14', $dates);
+    $this->assertContains('2015-01-15', $dates);
+    $this->assertContains('2015-01-31', $dates);
+  }
+
+  public function testGetCanGenerateCalendarForAContractWhichStartedBeforeThePeriodStartDateWithDefaultWorkPattern() {
+    // 10 days absence period
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2015-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2015-01-10'),
+    ]);
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => true]);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $this->contact['id']],
+      [
+        'period_start_date' => '2014-12-25',
+        'period_end_date' => '2015-01-10'
+      ]
+    );
+
+    $calendar = new WorkPatternCalendarService($this->contact['id'], $absencePeriod, $this->jobContractService);
+    $calendarDates = $calendar->get();
+
+    $this->assertCount(10, $calendarDates);
+    $this->assertEquals('2015-01-01', $calendarDates[0]['date']);
+    $this->assertEquals('2015-01-01', $calendarDates[0]['date']);
+    $this->assertEquals('2015-01-10', $calendarDates[9]['date']);
+  }
+
+  public function testGetCanCycleTheWeeksOfAWorkPatternEffectiveBeforeTheAbsencePeriod() {
+    // 10 days absence period
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2015-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2015-01-10'),
+    ]);
+
+    $workPattern = WorkPatternFabricator::fabricateWithTwoWeeksAnd31AndHalfHours(['is_default' => true]);
+
+    // Make the pattern effective on the previous absence period
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $this->contact['id'],
+      'pattern_id' => $workPattern->id,
+      'effective_date' => CRM_Utils_Date::processDate('2014-12-25'),
+    ]);
+
+    // The contract also starts on the previous year
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $this->contact['id']],
+      [
+        'period_start_date' => '2014-12-25',
+        'period_end_date' => '2015-01-10'
+      ]
+    );
+
+    $calendar = new WorkPatternCalendarService($this->contact['id'], $absencePeriod, $this->jobContractService);
+    $calendarDates = $calendar->get();
+
+    $workDayTypes = $this->getWorkDayTypeOptionsArray();
+
+    $this->assertCount(10, $calendarDates);
+    // even though the period starts on 2015-01-01, the weeks cycle starts at the
+    // work patter effective date, 2014-12-25. This puts 2015-01-01 on the second
+    // week. That day is a thursday, which is a working day on the second week
+    $this->assertEquals('2015-01-01', $calendarDates[0]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[0]['type']);
+
+    // 2015-01-02 is a friday, which is a non-working day on the second week
+    $this->assertEquals('2015-01-02', $calendarDates[1]['date']);
+    $this->assertEquals($workDayTypes['non_working_day'], $calendarDates[1]['type']);
+
+    // 2015-01-09 is ne next friday after 02-01, so we cycle back to the pattern
+    // first week. On it, fridays are working days
+    $this->assertEquals('2015-01-09', $calendarDates[8]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[8]['type']);
+
+    // just checking that the last day is present
+    $this->assertEquals('2015-01-10', $calendarDates[9]['date']);
+    $this->assertEquals($workDayTypes['weekend'], $calendarDates[9]['type']);
+  }
+
+  public function testGetUsesTheContractStartDateToCycleWeeksIfTheWorkPatternEffectiveDateIsBeforeTheContractStartDate() {
+    // A period with 2 weeks
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2015-01-05'),
+      'end_date'   => CRM_Utils_Date::processDate('2015-01-19'),
+    ]);
+
+    $workPattern = WorkPatternFabricator::fabricateWithTwoWeeksAnd31AndHalfHours(['is_default' => true]);
+
+    // this contract covers the first week of the period
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $this->contact['id']],
+      [
+        'period_start_date' => '2015-01-05',
+        'period_end_date' => '2015-01-11'
+      ]
+    );
+
+    // this contract covers the second week of the period
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $this->contact['id']],
+      [
+        'period_start_date' => '2015-01-12',
+        'period_end_date' => '2015-01-18'
+      ]
+    );
+
+    //For the first contract, the patter will be effective on the same date as
+    // its start date, but for the second one, it will be effective before
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $this->contact['id'],
+      'pattern_id' => $workPattern->id,
+      'effective_date' => CRM_Utils_Date::processDate('2015-01-01'),
+    ]);
+
+    $calendar = new WorkPatternCalendarService($this->contact['id'], $absencePeriod, $this->jobContractService);
+    $calendarDates = $calendar->get();
+
+    $workDayTypes = $this->getWorkDayTypeOptionsArray();
+
+    $this->assertCount(14, $calendarDates);
+    $this->assertEquals('2015-01-05', $calendarDates[0]['date']);
+    // the first day, a monday, is using the first week, so it's a working day
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[0]['type']);
+
+    $this->assertEquals('2015-01-09', $calendarDates[4]['date']);
+    // 01-09 is a friday on the first week, so it's also a working day
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[4]['type']);
+
+    $this->assertEquals('2015-01-12', $calendarDates[7]['date']);
+    // 01-12 is a monday and it's on the second week since the pattern effective
+    // date, but since it's within another contract, we start counting it again
+    // from first week instead of the second week, meaning it's going to be a
+    // working day
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[7]['type']);
+
+    $this->assertEquals('2015-01-16', $calendarDates[11]['date']);
+    // and the same way, 01-16, a friday, will also be a working day
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[11]['type']);
+  }
+
+  public function testGetUsesThePeriodEndDateWhenTheContractDoesntHaveAndEndDate() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2015-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2015-01-05'),
+    ]);
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => true]);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $this->contact['id']],
+      [
+        'period_start_date' => '2015-01-02'
+      ]
+    );
+
+    $calendar = new WorkPatternCalendarService($this->contact['id'], $absencePeriod, $this->jobContractService);
+    $calendarDates = $calendar->get();
+
+    $dates = array_column($calendarDates, 'date');
+    // Even though the contract doesn't have an end date, we'll only return the
+    // dates within the absence period, from 2015-01-02 (contract start) to
+    // 2015-01-05 (period end)
+    $this->assertCount(4, $calendarDates);
+    $this->assertNotContains('2015-01-01', $dates);
+    $this->assertContains('2015-01-02', $dates);
+    $this->assertContains('2015-01-03', $dates);
+    $this->assertContains('2015-01-04', $dates);
+    $this->assertContains('2015-01-05', $dates);
+    $this->assertNotContains('2015-01-06', $dates);
+  }
+
+  public function testItCanGenerateTheCalendarWhenThereAreMultiplesWorkPatternsWithinASingleContractStartAndEndDates() {
+    // a 19 days period
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2015-01-05'),
+      'end_date'   => CRM_Utils_Date::processDate('2015-01-23'),
+    ]);
+
+    $workPattern1 = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
+    $workPattern2 = WorkPatternFabricator::fabricateWithTwoWeeksAnd31AndHalfHours();
+
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $this->contact['id'],
+      'pattern_id' => $workPattern1->id,
+      'effective_date' => CRM_Utils_Date::processDate('2015-01-01'),
+    ]);
+
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $this->contact['id'],
+      'pattern_id' => $workPattern2->id,
+      'effective_date' => CRM_Utils_Date::processDate('2015-01-07'),
+    ]);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $this->contact['id']],
+      [
+        'period_start_date' => '2015-01-05',
+        'period_end_date' => '2015-01-16'
+      ]
+    );
+
+    $calendar = new WorkPatternCalendarService($this->contact['id'], $absencePeriod, $this->jobContractService);
+    $calendarDates = $calendar->get();
+
+    $workDayTypes = $this->getWorkDayTypeOptionsArray();
+
+    $this->assertCount(12, $calendarDates);
+
+    $this->assertEquals('2015-01-05', $calendarDates[0]['date']);
+    // a monday on the first week. The 40 hours work pattern was effective on this
+    // date, so it's a working day
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[0]['type']);
+
+    $this->assertEquals('2015-01-08', $calendarDates[3]['date']);
+    // a thursday on the first week. But now, the 31 and 1/4 hours work pattern is
+    // effective, so we use that pattern first week and a thursday is a non
+    // working day on it
+    $this->assertEquals($workDayTypes['non_working_day'], $calendarDates[3]['type']);
+
+    $this->assertEquals('2015-01-09', $calendarDates[4]['date']);
+    // And the next day, a friday, will be a working day
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[4]['type']);
+
+    $this->assertEquals('2015-01-16', $calendarDates[11]['date']);
+    // This is a friday. We keep using that work pattern for the next week. So, now we use its
+    // second week and a friday is a non working day on it
+    $this->assertEquals($workDayTypes['non_working_day'], $calendarDates[11]['type']);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/WorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/WorkPatternTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
+use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
+use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
+use CRM_HRLeaveAndAbsences_Service_JobContract as JobContractService;
+use CRM_HRLeaveAndAbsences_Service_WorkPatternCalendar as WorkPatternCalendarService;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod as AbsencePeriodFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_ContactWorkPattern as ContactWorkPatternFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern as WorkPatternFabricator;
+
+/**
+ * Class api_v3_WorkPatternTest
+ *
+ * @group headless
+ */
+class api_v3_WorkPatternTest extends BaseHeadlessTest {
+
+  use CRM_HRLeaveAndAbsences_WorkPatternHelpersTrait;
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage Mandatory key(s) missing from params array: contact_id, period_id
+   */
+  public function testGetCalendarRequiresContactIdAndPeriodID() {
+    civicrm_api3('WorkPattern', 'getCalendar');
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage Mandatory key(s) missing from params array: contact_id
+   */
+  public function testGetCalendarRequiresContactIdIfPeriodIDIsNotEmpty() {
+    civicrm_api3('WorkPattern', 'getCalendar', ['period_id' => 1]);
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage Mandatory key(s) missing from params array: period_id
+   */
+  public function testGetCalendarRequiresPeriodIdIfContactIDIsNotEmpty() {
+    civicrm_api3('WorkPattern', 'getCalendar', ['contact_id' => 1]);
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage Unable to find a CRM_HRLeaveAndAbsences_BAO_AbsencePeriod with id 99989389121.
+   */
+  public function testGetCalendarThrowsAnErrorIfThePeriodIDIsNotForAnExistentAbsencePeriod() {
+    civicrm_api3('WorkPattern', 'getCalendar', ['contact_id' => 1, 'period_id' => 99989389121]);
+  }
+
+  public function testGetCalendarShouldReturnEmptyIfTheGivenContactDoesntExists() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2015-01-05'),
+      'end_date'   => CRM_Utils_Date::processDate('2015-01-19'),
+    ]);
+
+    $result = civicrm_api3('WorkPattern', 'getCalendar', ['contact_id' => 321, 'period_id' => $absencePeriod->id]);
+    $this->assertEmpty($result['values']);
+  }
+
+  /**
+   * Just an small test to make sure it can call the service and return the dates
+   */
+  public function testGetCalendarUsesTheWorkPatternCalendarService() {
+    $contact = ContactFabricator::fabricate();
+
+    // 15 days absence period
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2015-01-05'),
+      'end_date'   => CRM_Utils_Date::processDate('2015-01-19'),
+    ]);
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => true]);
+    $multipleWeekWorkPattern = WorkPatternFabricator::fabricateWithTwoWeeksAnd31AndHalfHours();
+
+    // contract covers the whole period
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact['id']],
+      [
+        'period_start_date' => '2015-01-05',
+        'period_end_date' => '2015-01-19'
+      ]
+    );
+
+    // work pattern is effective only after the contract end
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'pattern_id' => $multipleWeekWorkPattern->id,
+      'effective_date' => CRM_Utils_Date::processDate('2015-02-05'),
+    ]);
+
+    $workDayTypes = $this->getWorkDayTypeOptionsArray();
+
+    $calendarDates = civicrm_api3('WorkPattern', 'getCalendar', [
+      'period_id' => $absencePeriod->id,
+      'contact_id' => $contact['id']
+    ])['values'];
+
+    // Asserting ALL the dates would make the test too big, so we assert the
+    // total number of dates, the first and last ones and a few dates in the
+    // middle, assuming all the other will be correct.
+    $this->assertCount(15, $calendarDates);
+    $this->assertEquals('2015-01-05', $calendarDates[0]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[0]['type']);
+    $this->assertEquals('2015-01-08', $calendarDates[3]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[3]['type']);
+    $this->assertEquals('2015-01-11', $calendarDates[6]['date']);
+    $this->assertEquals($workDayTypes['weekend'], $calendarDates[6]['type']);
+    $this->assertEquals('2015-01-16', $calendarDates[11]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[11]['type']);
+    $this->assertEquals('2015-01-19', $calendarDates[14]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[14]['type']);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
@@ -10,6 +10,7 @@ require_once 'helpers/LeaveBalanceChangeHelpersTrait.php';
 require_once 'helpers/LeavePeriodEntitlementHelpersTrait.php';
 require_once 'helpers/LeaveRequestHelpersTrait.php';
 require_once 'helpers/SicknessRequestHelpersTrait.php';
+require_once 'helpers/WorkPatternHelpersTrait.php';
 
 /**
  * Call the "cv" command.

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/WorkPatternHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/WorkPatternHelpersTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+trait CRM_HRLeaveAndAbsences_WorkPatternHelpersTrait {
+
+  public function getWorkDayTypeOptionsArray() {
+    $result = $result = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => 'hrleaveandabsences_work_day_type',
+    ]);
+
+    $options = [];
+    foreach($result['values'] as $value) {
+      $options[$value['name']] = [
+        'value' => $value['value'],
+        'name' => $value['name'],
+        'label' => $value['label']
+      ];
+    }
+
+    return $options;
+  }
+
+}


### PR DESCRIPTION
This API endpoint accepts only 2 params: `contact_id` and `period_id`. Based on that, it returns the contact calendar for the given period. The calendar is a list of dates with information about it's type, wether it's a working day, non-working day or weekend. The type information is fetched using the WorkPattern.

The dates returned are only those between the start and end date of the given absence period AND between any of the contacts contracts within the absence period. Example:

Given an Absence Period from 2015-01-01 to 2015-12-31 and given a Contract from 2015-02-01 to 2015-06-20 and another Contract from 2015-10-11 to 2016-03-04. The returned dates will be:
- From 2015-02-01 to 2015-06-20 (the period for the first contract)
- From 2015-10-11 to 2015-12-31 (the days of the contract overlapping the 2016 period won't be returned)

### Calling the API
The API can be called as:
```php
civicrm_api3('WorkPattern', 'getCalendar', [
  'contact_id' => 2,
  'period_id' => 2
]);
```

The return format is:
```json
{

    "is_error": 0,
    "version": 3,
    "count": 3,
    "values": [
        {
            "date": "2015-08-04",
            "type": {
                "value": "2",
                "name": "working_day",
                "label": "Yes"
            }
        },
        {
            "date": "2015-08-05",
            "type": {
                "value": "2",
                "name": "working_day",
                "label": "Yes"
            }
        },
        {
            "date": "2015-08-06",
            "type": {
                "value": "2",
                "name": "working_day",
                "label": "Yes"
            }
        },
    ]
}
```

### About the implementation
Even though the endpoint is inside the WorkPattern API, the whole logic is inside a separate service named WorkPatternCalendar. The Reason for this is to keep the BAO only responsible for fetching WorkPattern information and doing simple calculations based on it's own data. Building the calendar involves much more than that (like dealing with ContactWorkPattern, effective date calculation, Contracts and Absence Periods), so it's better to keep this in a separate class.

There is a `WorkPattern.getCalendar` method though, but it's much more simpler than that. Basically, it receives a start date and an end date, and call `getWorkDayTypeForDate()` for each of the dates in the period.