### PR TITLE
PCHR-1275: PublicHoliday API,Model,ModelInstance

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/apis/public-holiday-api.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/apis/public-holiday-api.js
@@ -1,0 +1,27 @@
+define([
+  'leave-absences/shared/modules/apis',
+  'common/services/api'
+], function (apis) {
+  'use strict';
+
+  apis.factory('PublicHolidayAPI', ['$log', 'api', function ($log, api) {
+    $log.debug('PublicHolidayAPI');
+
+    return api.extend({
+      /**
+       * This method returns all the PublicHolidays.
+       *
+       * @param  {Object} params  matches the api endpoint params (title, date etc)
+       * @return {Promise}
+       */
+      all: function (params) {
+        $log.debug('PublicHolidayAPI');
+
+        return this.sendGET('PublicHoliday', 'get', params)
+          .then(function (data) {
+            return data.values;
+          });
+      }
+    });
+  }]);
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/models/instances/public-holiday-instance.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/models/instances/public-holiday-instance.js
@@ -1,0 +1,12 @@
+define([
+  'leave-absences/shared/modules/models-instances',
+  'common/models/instances/instance'
+], function (instances) {
+  'use strict';
+
+  instances.factory('PublicHolidayInstance', ['$log', 'ModelInstance', function ($log, ModelInstance) {
+    $log.debug('PublicHolidayInstance');
+
+    return ModelInstance.extend({});
+  }]);
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/models/public-holiday-model.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/models/public-holiday-model.js
@@ -1,0 +1,58 @@
+define([
+  'leave-absences/shared/modules/models',
+  'common/moment',
+  'leave-absences/shared/models/instances/public-holiday-instance',
+  'leave-absences/shared/apis/public-holiday-api',
+  'common/models/model',
+  'common/services/hr-settings',
+], function (models, moment) {
+  'use strict';
+
+  models.factory('PublicHoliday', [
+    '$log', 'Model', 'PublicHolidayAPI', 'PublicHolidayInstance', 'HR_settings',
+    function ($log, Model, publicHolidayAPI, instance, HR_settings) {
+      $log.debug('PublicHoliday');
+
+      return Model.extend({
+        /**
+         * Calls the all() method of the PublicHoliday API, and returns an
+         * PublicHolidayInstance for each public holiday.
+         *
+         * @param  {Object} params  matches the api endpoint params (title, date etc)
+         * @return {Promise}
+         */
+        all: function (params) {
+          return publicHolidayAPI.all(params)
+            .then(function (publicHolidays) {
+              return publicHolidays.map(function (publicHoliday) {
+                return instance.init(publicHoliday, true);
+              });
+            });
+        },
+        /**
+         *  Finds out if given date is a public holiday.
+         *
+         * @return {Bool} returns true if date is a public holday else false
+         */
+        isPublicHoliday: function (whichDate) {
+          var dateFormat = HR_settings.DATE_FORMAT.toUpperCase();
+          var checkDate = moment(whichDate).format(dateFormat);
+
+          var params = {
+            'sequential': 1,
+            'date': checkDate
+          };
+
+          return publicHolidayAPI.all(params)
+            .then(function (publicHolidays) {
+              if (publicHolidays.length) {
+                return true;
+              }
+
+              return false;
+            });
+        }
+      });
+    }
+  ]);
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/models/public-holiday-model.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/models/public-holiday-model.js
@@ -32,6 +32,7 @@ define([
         /**
          *  Finds out if given date is a public holiday.
          *
+         * @param  {Date} whichDate given date either as Date object or its string representation
          * @return {Bool} returns true if date is a public holday else false
          */
         isPublicHoliday: function (whichDate) {
@@ -39,13 +40,12 @@ define([
           var checkDate = moment(whichDate).format(dateFormat);
 
           var params = {
-            'sequential': 1,
             'date': checkDate
           };
 
           return publicHolidayAPI.all(params)
             .then(function (publicHolidays) {
-              if (publicHolidays.length) {
+              if (!!publicHolidays.length) {
                 return true;
               }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/mocks/apis/public-holiday-api-mock.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/mocks/apis/public-holiday-api-mock.js
@@ -1,0 +1,31 @@
+define([
+  'mocks/module',
+  'mocks/data/public-holiday-data',
+  'common/moment',
+  'common/angularMocks',
+  'common/mocks/services/hr-settings-mock',
+], function (mocks, mockData, moment) {
+  'use strict';
+
+  mocks.factory('PublicHolidayAPIMock', ['$q', 'HR_settingsMock', function ($q, HR_settingsMock) {
+    return {
+      all: function (params) {
+        return $q(function (resolve, reject) {
+          if (params && 'date' in params) {
+            var dateFormat = HR_settingsMock.DATE_FORMAT.toUpperCase();
+            var checkDate = moment(params.date, dateFormat);
+
+            var mockPeriod = mockData.all().values.filter(function (value) {
+              var valueDate = moment(value.date);
+
+              return checkDate.isSame(valueDate);
+            });
+
+            resolve(mockPeriod);
+          }
+          resolve(mockData.all().values);
+        });
+      }
+    };
+  }]);
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/mocks/data/public-holiday-data.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/mocks/data/public-holiday-data.js
@@ -1,0 +1,93 @@
+define(function () {
+  var all_data = {
+    "is_error": 0,
+    "version": 3,
+    "count": 16,
+    "values": [{
+      "id": "1",
+      "title": "New Year's Day",
+      "date": "2016-01-01",
+      "is_active": "1"
+    }, {
+      "id": "2",
+      "title": "Good Friday",
+      "date": "2016-03-25",
+      "is_active": "1"
+    }, {
+      "id": "3",
+      "title": "Easter Monday",
+      "date": "2016-03-28",
+      "is_active": "1"
+    }, {
+      "id": "4",
+      "title": "Early May bank holiday",
+      "date": "2016-05-02",
+      "is_active": "1"
+    }, {
+      "id": "5",
+      "title": "Spring bank holiday",
+      "date": "2016-05-30",
+      "is_active": "1"
+    }, {
+      "id": "6",
+      "title": "Summer bank holiday",
+      "date": "2016-08-29",
+      "is_active": "1"
+    }, {
+      "id": "7",
+      "title": "Boxing Day",
+      "date": "2016-12-26",
+      "is_active": "1"
+    }, {
+      "id": "8",
+      "title": "Christmas Day (substitue day)",
+      "date": "2016-12-27",
+      "is_active": "1"
+    }, {
+      "id": "9",
+      "title": "New Year's Day (substitute day)",
+      "date": "2017-01-02",
+      "is_active": "1"
+    }, {
+      "id": "10",
+      "title": "Good Friday",
+      "date": "2017-04-14",
+      "is_active": "1"
+    }, {
+      "id": "11",
+      "title": "Easter Monday",
+      "date": "2017-04-17",
+      "is_active": "1"
+    }, {
+      "id": "12",
+      "title": "Early May bank holiday",
+      "date": "2017-05-01",
+      "is_active": "1"
+    }, {
+      "id": "13",
+      "title": "Spring bank holiday",
+      "date": "2017-05-29",
+      "is_active": "1"
+    }, {
+      "id": "14",
+      "title": "Summer bank holiday",
+      "date": "2017-08-28",
+      "is_active": "1"
+    }, {
+      "id": "15",
+      "title": "Christmas day",
+      "date": "2017-12-25",
+      "is_active": "1"
+    }, {
+      "id": "16",
+      "title": "Boxing day",
+      "date": "2017-12-26",
+      "is_active": "1"
+    }]
+  };
+  return {
+    all: function () {
+      return all_data;
+    }
+  };
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/apis/public-holiday-api_test.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/apis/public-holiday-api_test.js
@@ -1,0 +1,69 @@
+define([
+  'mocks/data/public-holiday-data',
+  'common/moment',
+  'leave-absences/shared/apis/public-holiday-api',
+], function (mockData, moment) {
+  'use strict'
+
+  describe("PublicHolidayAPI", function () {
+    var PublicHolidayAPI, $httpBackend;
+
+    beforeEach(module('leave-absences.apis'));
+
+    beforeEach(inject(function (_PublicHolidayAPI_, _$httpBackend_) {
+      PublicHolidayAPI = _PublicHolidayAPI_;
+      $httpBackend = _$httpBackend_;
+    }));
+
+    it("has expected interface", function () {
+      expect(Object.keys(PublicHolidayAPI)).toContain("all");
+    });
+
+    describe("all()", function () {
+      var promise, totalPublicHolidays, dateFormat = 'YYYY-MM-DD';
+
+      beforeEach(function () {
+        $httpBackend.whenGET(/action=get&entity=PublicHoliday/)
+          .respond(mockData.all());
+      })
+
+      beforeEach(function () {
+        totalPublicHolidays = mockData.all().values.length;
+        promise = PublicHolidayAPI.all();
+      });
+
+      afterEach(function () {
+        //enforce flush to make calls to httpBackend
+        $httpBackend.flush();
+      });
+
+      it("returns all public holidays", function () {
+        promise.then(function (result) {
+          expect(result.length).toEqual(totalPublicHolidays);
+        });
+      });
+
+      it("returns public holiday with all attributes keys", function () {
+        promise.then(function (result) {
+          var firstPublicHoliday = result[0];
+
+          expect(firstPublicHoliday.id).toBeDefined();
+          expect(firstPublicHoliday.title).toBeDefined();
+          expect(firstPublicHoliday.date).toBeDefined();
+          expect(firstPublicHoliday.is_active).toBeDefined();
+        });
+      });
+
+      it("returns public holiday with all attributes values", function () {
+        promise.then(function (result) {
+          var firstPublicHoliday = result[0];
+
+          expect(firstPublicHoliday.id).toEqual(jasmine.any(String));
+          expect(firstPublicHoliday.title).toEqual(jasmine.any(String));
+          expect(moment(firstPublicHoliday.date, dateFormat, true).isValid()).toBe(true);
+          expect(firstPublicHoliday.is_active).toEqual(jasmine.any(String));
+        });
+      });
+    });
+  });
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/instances/public-holiday-instance_test.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/instances/public-holiday-instance_test.js
@@ -1,0 +1,37 @@
+define([
+  'mocks/data/public-holiday-data',
+  'leave-absences/shared/models/instances/public-holiday-instance',
+], function (mockData) {
+  'use strict'
+
+  describe('PublicHolidayInstance', function () {
+    var PublicHolidayInstance, ModelInstance;
+
+    beforeEach(module('leave-absences.models.instances'));
+
+    beforeEach(inject(function (_PublicHolidayInstance_, _ModelInstance_) {
+      PublicHolidayInstance = _PublicHolidayInstance_;
+      ModelInstance = _ModelInstance_;
+    }));
+
+    it('inherits from ModelInstance', function () {
+      expect(_.functions(PublicHolidayInstance)).toEqual(jasmine.arrayContaining(_.functions(ModelInstance)));
+    });
+
+    describe('init()', function () {
+      var instance;
+      var attributes = mockData.all().values[0];
+
+      beforeEach(function () {
+        instance = PublicHolidayInstance.init(attributes, true);
+      });
+
+      it('has expected data', function () {
+        expect(instance.id).toBe(attributes.id);
+        expect(instance.title).toEqual(attributes.title);
+        expect(instance.date).toEqual(attributes.date);
+        expect(instance.is_active).toEqual(attributes.is_active);
+      });
+    });
+  });
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/public-holiday-model_test.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/public-holiday-model_test.js
@@ -1,0 +1,112 @@
+define([
+  'leave-absences/shared/models/public-holiday-model',
+  'mocks/apis/public-holiday-api-mock',
+  'common/mocks/services/hr-settings-mock',
+], function () {
+  'use strict'
+
+  describe('PublicHoliday', function () {
+    var $provide, PublicHoliday, PublicHolidayAPI, $rootScope;
+
+    beforeEach(module('leave-absences.models', 'leave-absences.mocks', 'common.mocks',
+      function (_$provide_) {
+        $provide = _$provide_;
+      }));
+
+    beforeEach(inject(function (_PublicHolidayAPIMock_, _HR_settingsMock_) {
+      $provide.value('PublicHolidayAPI', _PublicHolidayAPIMock_);
+      $provide.value('HR_settings', _HR_settingsMock_);
+    }));
+
+    beforeEach(inject(function (_PublicHoliday_, _PublicHolidayAPI_, _$rootScope_) {
+      PublicHoliday = _PublicHoliday_;
+      PublicHolidayAPI = _PublicHolidayAPI_;
+      $rootScope = _$rootScope_;
+
+      spyOn(PublicHolidayAPI, 'all').and.callThrough();
+    }));
+
+    it('has expected interface', function () {
+      expect(Object.keys(PublicHoliday)).toEqual(['all', 'isPublicHoliday']);
+    });
+
+    describe('all()', function () {
+      var promise;
+
+      beforeEach(function () {
+        promise = PublicHoliday.all();
+      });
+
+      afterEach(function () {
+        //to excute the promise force an digest
+        $rootScope.$apply();
+      });
+
+      it('calls equivalent API method', function () {
+        promise.then(function (response) {
+          expect(PublicHolidayAPI.all).toHaveBeenCalled();
+        });
+      });
+
+      it('returns model instances', function () {
+        promise.then(function (response) {
+          expect(response.every(function (modelInstance) {
+            return 'init' in modelInstance;
+          })).toBe(true);
+        });
+      });
+    });
+
+    describe('isPublicHoliday()', function () {
+      describe('when given date is public holiday', function () {
+        var promise, testDate = '2016-01-01';
+
+        beforeEach(function () {
+          promise = PublicHoliday.isPublicHoliday(testDate);
+        });
+
+        afterEach(function () {
+          //to excute the promise force an digest
+          $rootScope.$apply();
+        });
+
+        it('calls equivalent API method', function () {
+          promise.then(function (response) {
+            expect(PublicHolidayAPI.all).toHaveBeenCalled();
+          });
+        });
+
+        it('returns true', function () {
+          promise.then(function (response) {
+            expect(response).toBe(true);
+          });
+        });
+      });
+
+      describe('when given date is not a public holiday', function () {
+        var promise, testDate = '2016-01-02';
+
+        beforeEach(function () {
+          promise = PublicHoliday.isPublicHoliday(testDate);
+        });
+
+        afterEach(function () {
+          //to excute the promise force an digest
+          $rootScope.$apply();
+        });
+
+        it('calls equivalent API method', function () {
+          promise.then(function (response) {
+            expect(PublicHolidayAPI.all).toHaveBeenCalled();
+          });
+        });
+
+        it('returns false', function () {
+          promise.then(function (response) {
+            expect(response).toBe(false);
+          });
+        });
+      });
+    });
+  });
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/public-holiday-model_test.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/public-holiday-model_test.js
@@ -95,12 +95,6 @@ define([
           $rootScope.$apply();
         });
 
-        it('calls equivalent API method', function () {
-          promise.then(function (response) {
-            expect(PublicHolidayAPI.all).toHaveBeenCalled();
-          });
-        });
-
         it('returns false', function () {
           promise.then(function (response) {
             expect(response).toBe(false);


### PR DESCRIPTION
# PublicHoliday 
Implementation for publicholiday api end points as per ticket [PCHR-1275](https://compucorp.atlassian.net/browse/PCHR-1275).

## API
`PublicHolidayAPI` will get all the publicholidays from backends.

## Model
`PublicHoliday` contains the publicholiday data and is wrapper over the API. It also has method `isPublicHoliday` to check if given date is public holiday or not.

## Instance 
`PublicHolidayInstance` is the publicholiday instance with helper method to get publicholiday data.

## Source Code location
It is located under `civihr/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular`.

The implementation is located under shared folder. 

The test cases are in tests folder. 

## Sample PublicHoliday
A sample absence is presented below 

```json
{
  "is_error": 0,
  "version": 3,
  "count": 16,
  "values": [{
    "id": "1",
    "title": "New Year's Day",
    "date": "2016-01-01",
    "is_active": "1"
  }, {
    "id": "2",
    "title": "Good Friday",
    "date": "2016-03-25",
    "is_active": "1"
  }, {
    "id": "3",
    "title": "Easter Monday",
    "date": "2016-03-28",
    "is_active": "1"
  }, {
    "id": "4",
    "title": "Early May bank holiday",
    "date": "2016-05-02",
    "is_active": "1"
  }, {
    "id": "5",
    "title": "Spring bank holiday",
    "date": "2016-05-30",
    "is_active": "1"
  }, {
    "id": "6",
    "title": "Summer bank holiday",
    "date": "2016-08-29",
    "is_active": "1"
  }, {
    "id": "7",
    "title": "Boxing Day",
    "date": "2016-12-26",
    "is_active": "1"
  }, {
    "id": "8",
    "title": "Christmas Day (substitue day)",
    "date": "2016-12-27",
    "is_active": "1"
  }, {
    "id": "9",
    "title": "New Year's Day (substitute day)",
    "date": "2017-01-02",
    "is_active": "1"
  }, {
    "id": "10",
    "title": "Good Friday",
    "date": "2017-04-14",
    "is_active": "1"
  }, {
    "id": "11",
    "title": "Easter Monday",
    "date": "2017-04-17",
    "is_active": "1"
  }, {
    "id": "12",
    "title": "Early May bank holiday",
    "date": "2017-05-01",
    "is_active": "1"
  }, {
    "id": "13",
    "title": "Spring bank holiday",
    "date": "2017-05-29",
    "is_active": "1"
  }, {
    "id": "14",
    "title": "Summer bank holiday",
    "date": "2017-08-28",
    "is_active": "1"
  }, {
    "id": "15",
    "title": "Christmas day",
    "date": "2017-12-25",
    "is_active": "1"
  }, {
    "id": "16",
    "title": "Boxing day",
    "date": "2017-12-26",
    "is_active": "1"
  }]
}
```