### PR TITLE
PCHR-1644: Delete Leave Entitlements on Absence Type Deletion

### DIFF
--- a/hrabsence/CRM/HRAbsence/Test/Fabricator/HRAbsenceType.php
+++ b/hrabsence/CRM/HRAbsence/Test/Fabricator/HRAbsenceType.php
@@ -1,12 +1,24 @@
 <?php
 
 class CRM_HRAbsence_Test_Fabricator_HRAbsenceType {
-
+  /**
+   * Array of default parameters
+   * @var array 
+   */
   private static $defaultParams = [
     'is_active' => 1,
   ];
-
-  public static function fabricate($params = []) {
+  
+  /**
+   * Helper method that builds parameters array combining given parameters with
+   * default parameters.
+   * 
+   * @param arry $params
+   *   Given array of parameters
+   * @return array
+   *   Result of merging default parameters with given parameters
+   */
+  private static function buildParamsArray($params) {
     if(empty($params['title'])) {
       $params['title'] = 'Absence Type ' . microtime();
     }
@@ -15,9 +27,33 @@ class CRM_HRAbsence_Test_Fabricator_HRAbsenceType {
       $params['name'] = 'Absence Type ' . microtime();
     }
 
-    $params = array_merge(self::$defaultParams, $params);
-
-    return CRM_HRAbsence_BAO_HRAbsenceType::create($params);
+    return array_merge(self::$defaultParams, $params);
+  }
+  
+  /**
+   * Absence Type fabricator method, uses BAO directly
+   * 
+   * @param array $params
+   *   Parameters to be passed to BAO to create absence type
+   * @return CRM_HRAbsence_BAO_HRAbsenceType
+   */
+  public static function fabricate($params = []) {
+    return CRM_HRAbsence_BAO_HRAbsenceType::create(self::buildParamsArray($params));
+  }
+  
+  /**
+   * Absence Type fabricator method that uses API and returns values of created
+   * record.
+   * 
+   * @param array $params
+   *   Parameters to be passed to API call to create absence type
+   * @return array
+   *   Values of created absence type
+   */
+  public static function fabricateUsingAPI($params = []) {
+    $params['sequential'] = 1;
+    $result = civicrm_api3('HRAbsenceType', 'create', self::buildParamsArray($params));
+    return array_shift($result['values']);
   }
 
 }

--- a/hrabsence/tests/phpunit/CRM/HRAbsence/BAO/HRAbsenceTypeTest.php
+++ b/hrabsence/tests/phpunit/CRM/HRAbsence/BAO/HRAbsenceTypeTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
+use CRM_HRAbsence_Test_Fabricator_HRAbsenceType as AbsenceTypeFabricator;
+use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
+use CRM_Hrjobcontract_Test_Fabricator_HRJobLeave as HRJobLeaveFabricator;
+use CRM_HRCore_Test_Fabricator_Activity as ActivityFabricator;
+
+/**
+ * Class CRM_HRAbsence_BAO_HRAbsenceTypeTest
+ * 
+ * @group headless
+ */
+class CRM_HRAbsence_BAO_HRAbsenceTypeTest extends PHPUnit_Framework_TestCase 
+  implements HeadlessInterface, TransactionalInterface {
+  
+  protected $absenceType;
+  protected $contact;
+  protected $jobContract;
+  protected $leave;
+  
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->install('uk.co.compucorp.civicrm.hrcore')
+      ->install('org.civicrm.hrjobcontract')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+  
+  /**
+   * Creates absence type, contact, contract and leave entitlement to be used in
+   * tests.
+   */
+  protected function setUp() {
+    $this->absenceType = AbsenceTypeFabricator::fabricateUsingAPI();
+
+    $this->contact = ContactFabricator::fabricate();
+
+    $this->jobContract = HRJobContractFabricator::fabricate(
+      ['contact_id' => $this->contact['id']], 
+      ['period_start_date' => '2015-01-01']
+    );
+
+    $this->leave = HRJobLeaveFabricator::fabricate([
+      'jobcontract_id' => $this->jobContract['id'],
+      'leave_type' => $this->absenceType['id']
+    ]);
+  }
+  
+  /**
+   * @expectedException CRM_Core_Exception
+   */
+  public function testDoesNotAllowAbsenceTypeInUseByLeaveRequestToBeDeleted() {
+    $activityParam = [
+      'source_contact_id' => $this->contact['id'],
+      'target_contact_id' => $this->contact['id'],
+      'assignee_contact_id' => $this->contact['id'],
+      'activity_type_id' => $this->absenceType['debit_activity_type_id'],
+    ];
+    ActivityFabricator::fabricate($activityParam);
+    
+    CRM_HRAbsence_BAO_HRAbsenceType::del($this->absenceType['id']);
+  }
+  
+  public function testIfDeletionOfAbsenceTypeDeletesAssociatedEntitlements() {
+    $this->assertEquals(1, $this->countEntitlementsForAbsenceType());
+
+    CRM_HRAbsence_BAO_HRAbsenceType::del($this->absenceType['id']);
+
+    $this->assertEquals(0, $this->countEntitlementsForAbsenceType());
+  }
+  
+  private function countEntitlementsForAbsenceType() {
+    $result = civicrm_api3('HRJobLeave', 'get', [
+      'sequential' => 1,
+      'id' => $this->leave['id'],
+      'jobcontract_id' => $this->jobContract['id'],
+    ]);
+    
+    return $result['count'];
+  }
+}


### PR DESCRIPTION
On absence type deletion, leave entitlements associated to deleted absence types were being kept in the dtabase, breaking the leave entitlement interface for contract revisions.  Also, though front end validates if an absence type is being used in existing leave requests to allow/disallow deletion, this could be circumvented if you clicked on the delete link for the absence type, created a leave request for that absence type on another screen, and then confirmed deletion of absence type.

Implemented functionality to delete leave entitlements associated to Absence Type being deleted. Also, added validation to check if Absence Type being deleted is used on existing leave requests.

Added tests to verify use of deletion method in absence type BAO throws an exception when deleting absence types used in existing leave requests, and to check succesful deletion of absence type deletes associated entitlements also.