### PR TITLE
PCHR-1414: Make "Not Applicable" Payscale a Valid Value to Import

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/SelectValues.php
+++ b/hrjobcontract/CRM/Hrjobcontract/SelectValues.php
@@ -170,11 +170,20 @@ class CRM_Hrjobcontract_SelectValues {
     $query = "SELECT id,pay_scale,pay_grade,currency,amount,periodicity from civicrm_hrpay_scale ".
              " WHERE is_active=1";
     $options = array();
+    
     $result = CRM_Core_DAO::executeQuery($query);
     while ($result->fetch()) {
-      $label = $result->pay_scale." - ".$result->pay_grade." - ".$result->currency." ".$result->amount." per ".$result->periodicity;
+      $label = $result->pay_scale;
+      if (!empty($result->pay_grade)) {
+        $label .= ' - ' . 
+          $result->pay_grade . ' - ' . 
+          $result->currency . ' ' . 
+          $result->amount . ' per ' . 
+          $result->periodicity;
+      }      
       $options[] =  array( 'id'=>$result->id, 'label'=> $label);
     }
+    
     return $options;
   }
 


### PR DESCRIPTION
When importing job contracts, using "Not Applicable" as a pay scale resulted in an error.  This was because the label for all Pay Scales was expected to be of the form:
"<pay_scale> - <pay_grade> - <currency> <amount> per <periodicity>"

This meant the valid value to import a "Not Applicable" pay scale was, literally:
"Not Applicable - - per "

Fixed by building the expected label in CRM_Hrjobcontract_SelectValues::buildPayScales(), checking if pay_grade is empty, mirroring how the label is built on CRM_Hrjobcontract_BAO_Query::buildAdvancedSearchPaneForm().