### PR TITLE
PCHR-1828: Add details for LeaveRequest validation errors

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -59,7 +59,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
   private static function validateParams($params) {
     if (empty($params['from_date'])) {
       throw new InvalidLeaveRequestException(
-        "Leave Requests should have a start date"
+        'Leave Requests should have a start date',
+        'leave_request_empty_from_date',
+        'from_date'
       );
     }
 
@@ -92,7 +94,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     //either there was an overlap or the absence period does not simply exist.
     if (!$period) {
       throw new InvalidLeaveRequestException(
-        "The Leave request dates is not contained within a valid absence period"
+        'The Leave request dates are not contained within a valid absence period',
+        'leave_request_not_within_absence_period',
+        'from_date'
       );
     }
   }
@@ -120,7 +124,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
 
     if ($contract['count'] > 1) {
       throw new InvalidLeaveRequestException(
-        "The Leave request dates must not have dates in more than one contract period"
+        'The Leave request dates must not have dates in more than one contract period',
+        'leave_request_overlapping_multiple_contracts',
+        'from_date'
       );
     }
   }
@@ -147,7 +153,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
 
     if(!$absenceType->allow_overuse && $leaveRequestBalance > $currentBalance) {
       throw new InvalidLeaveRequestException(
-        "Balance change for the leave request cannot be greater than the remaining balance of the period"
+        'Balance change for the leave request cannot be greater than the remaining balance of the period',
+        'leave_request_balance_change_greater_than_remaining_balance',
+        'type_id'
       );
     }
   }
@@ -192,7 +200,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     $leaveRequestBalance = self::calculateBalanceChangeFromCreateParams($params);
     if ($leaveRequestBalance == 0) {
       throw new InvalidLeaveRequestException(
-        "Leave Request must have at least one working day to be created"
+        'Leave Request must have at least one working day to be created',
+        'leave_request_doesnt_have_working_day',
+        'from_date'
       );
     }
   }
@@ -228,7 +238,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
 
     if ($overlappingLeaveRequests) {
       throw new InvalidLeaveRequestException(
-        "This Leave request has dates that overlapps with an existing leave request"
+        'This Leave request has dates that overlaps with an existing leave request',
+        'leave_request_overlaps_another_leave_request',
+        'from_date'
       );
     }
   }
@@ -248,7 +260,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
 
       if ($fromDate > $toDate) {
         throw new InvalidLeaveRequestException(
-          "Leave Request start date cannot be greater than the end date"
+          'Leave Request start date cannot be greater than the end date',
+          'leave_request_from_date_greater_than_end_date',
+          'from_date'
         );
       }
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Exception/EntityValidationException.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Exception/EntityValidationException.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Exception_EntityValidationException
+ */
+class CRM_HRLeaveAndAbsences_Exception_EntityValidationException extends Exception {
+  /**
+   * @var string
+   *   The DAO field associated with the thrown exception
+   */
+  private $field;
+
+  /**
+   * @var string
+   *   The Exception code associated with the thrown exception
+   */
+  private $exceptionCode;
+
+  /**
+   * CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException constructor.
+   *
+   * @param string $message
+   * @param string $code
+   * @param string $field
+   *   The DAO field associated with the thrown exception
+   */
+  public function __construct($message, $code, $field) {
+    $this->field = $field;
+    $this->exceptionCode = $code;
+
+    parent::__construct($message);
+  }
+
+  /**
+   * Getter function for the field property
+   *
+   * @return string
+   */
+  public function getField() {
+    return $this->field;
+  }
+
+  /**
+   * Getter function for the exceptionCode property
+   *
+   * @return string
+   */
+  public function getExceptionCode() {
+    return $this->exceptionCode;
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Exception/InvalidLeaveRequestException.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Exception/InvalidLeaveRequestException.php
@@ -1,2 +1,2 @@
 <?php
-class CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException extends Exception {}
+class CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException extends CRM_HRLeaveAndAbsences_Exception_EntityValidationException  {}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -986,7 +986,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
   /**
    * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
-   * @expectedExceptionMessage This Leave request has dates that overlapps with an existing leave request
+   * @expectedExceptionMessage This Leave request has dates that overlaps with an existing leave request
    */
   public function testALeaveRequestShouldNotBeCreatedWhenThereAreOverlappingLeaveRequests() {
     $contactID = 1;
@@ -1356,7 +1356,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
   /**
    * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
-   * @expectedExceptionMessage The Leave request dates is not contained within a valid absence period
+   * @expectedExceptionMessage The Leave request dates are not contained within a valid absence period
    */
   public function testLeaveRequestCanNotBeCreatedWhenTheDatesAreNotContainedInValidAbsencePeriod() {
     $contact = ContactFabricator::fabricate();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -298,7 +298,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ]);
 
     //This leave request is before the contract start date and will not be returned
-    LeaveRequestFabricator::fabricate([
+    LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2015-12-30'),
@@ -307,7 +307,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ], true);
 
     //This will be returned as it is after the contract start date
-    $leaveRequest2 = LeaveRequestFabricator::fabricate([
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2017-12-30'),
@@ -332,7 +332,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ]);
 
     //This leave request is before the contract start date and will not be returned
-    LeaveRequestFabricator::fabricate([
+    LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2015-12-30'),
@@ -341,7 +341,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ], true);
 
     // This will be returned
-    $leaveRequest2 = LeaveRequestFabricator::fabricate([
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-01-02'),
@@ -350,7 +350,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ], true);
 
     // This will be returned
-    $leaveRequest3 = LeaveRequestFabricator::fabricate([
+    $leaveRequest3 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-09-07'),
@@ -359,7 +359,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ], true);
 
     //This will not be returned as it is after the contract start date
-    LeaveRequestFabricator::fabricate([
+    LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2017-12-30'),
@@ -384,7 +384,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ]);
 
     //This leave request is before the contract start date and will not be returned
-    LeaveRequestFabricator::fabricate([
+    LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2015-12-30'),
@@ -392,7 +392,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ], true);
 
     // This will be returned as it's after the contract start date
-    $leaveRequest2 = LeaveRequestFabricator::fabricate([
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2017-09-02'),
@@ -400,7 +400,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ], true);
 
     // This will be returned as it's after the contract start date as well
-    $leaveRequest3 = LeaveRequestFabricator::fabricate([
+    $leaveRequest3 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2018-01-02'),
@@ -425,7 +425,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ]);
 
     //This leave request is before the contract start date and will not be returned
-    LeaveRequestFabricator::fabricate([
+    LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2015-12-30'),
@@ -433,7 +433,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ], true);
 
     // This will be returned
-    $leaveRequest2 = LeaveRequestFabricator::fabricate([
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
@@ -441,7 +441,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ], true);
 
     // This will be returned
-    $leaveRequest3 = LeaveRequestFabricator::fabricate([
+    $leaveRequest3 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
@@ -449,7 +449,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ], true);
 
     //This will not be returned as it is after the contract start date
-    LeaveRequestFabricator::fabricate([
+    LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2017-12-30'),
@@ -474,7 +474,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     );
 
     // This will be returned. The balance change will be -1
-    $leaveRequest1 = LeaveRequestFabricator::fabricate([
+    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
@@ -482,7 +482,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ], true);
 
     // This will be returned. The balance change will be -4
-    $leaveRequest2 = LeaveRequestFabricator::fabricate([
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
@@ -518,7 +518,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     //This leave request matches the date params, but not the contract dates,
     //so it will not be returned
-    LeaveRequestFabricator::fabricate([
+    LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2015-12-30'),


### PR DESCRIPTION
In this PR, the exceptions thrown during the Leave Request validation is updated to include more details. Besides the error message, it now  contains the field where the error was found and the Exception/Error code code.

A new exception class CRM_HRLeaveAndAbsences_Exception_EntityValidationExceptionhas been added which has two private fields: field and exceptionCode. The InvalidLeaveRequestException class is the only class that extends this class for now.

The following Error messages and Exception/Error codes were implemented

| Error Message | Error Code |
| ------------- | ------------- |
|Leave Requests should have a start date|leave_request_empty_from_date|
|Leave Request start date cannot be greater than the end date|leave_request_from_date_greater_than_end_date|
|The Leave request dates is not contained within a valid absence period|leave_request_not_within_absence_period|
|The Leave request dates must not have dates in more than one contract period|leave_request_overlapping_multiple_contracts|
|Balance change for the leave request cannot be greater than the remaining balance of the period|leave_request_balance_change_greater_than_remaining_balance|
|Leave Request must have at least one working day to be created|leave_request_doesnt_have_working_day|
|This Leave request has dates that overlapps with an existing leave request|leave_request_overlaps_another_leave_request|