### PR TITLE
PCHR-1788: Fix Advanced Search When Using Multiple Select Fields

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/BAO/Query.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/Query.php
@@ -286,7 +286,14 @@ class CRM_Hrjobcontract_BAO_Query extends CRM_Contact_BAO_Query_Interface {
           return;
         }
         $whereTable = $fields[$name];
-        $value      = trim($value);
+
+        if (is_array($value)) {
+          $value = array_map('trim', $value);
+          $quoteValue = "('" . implode("', '", $value) . "')";
+        } else {
+          $value = trim($value);
+        }
+
         $dataType   = "String";
 
         if (in_array($name, array(


### PR DESCRIPTION
Use of Normal Place of Work, Notice Period from Employer (Unit) and Notice Period from Employee (Unit)  fields in advanced search was causing a DB error.  As it turned out, use of multiple select fields was sending the values selected by the user in an array. Trim was being used on the value, assuming it was always a string, converting the array into null, and breaking the query. 

Added check to verify if value to build query is an array and calling trim on each value of it instead.