### PR TITLE
PCHR-1829: Improve Leave Request validation

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -65,6 +65,38 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
       );
     }
 
+    if (empty($params['contact_id'])) {
+      throw new InvalidLeaveRequestException(
+        'Leave Request should have a contact',
+        'leave_request_empty_contact_id',
+        'contact_id'
+      );
+    }
+
+    if (empty($params['type_id'])) {
+      throw new InvalidLeaveRequestException(
+        'Leave Request should have an Absence Type',
+        'leave_request_empty_type_id',
+        'type_id'
+      );
+    }
+
+    if (empty($params['status_id'])) {
+      throw new InvalidLeaveRequestException(
+        'The Leave Request status should not be empty',
+        'leave_request_empty_status_id',
+        'status_id'
+      );
+    }
+
+    if (!empty($params['to_date']) && empty($params['to_date_type'])) {
+      throw new InvalidLeaveRequestException(
+        'The type of To Date should not be empty',
+        'leave_request_empty_to_date_type',
+        'to_date_type'
+      );
+    }
+
     if (!empty($params['to_date'])) {
       self::validateStartDateNotGreaterThanEndDate($params);
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -57,6 +57,47 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
    */
   private static function validateParams($params) {
+    self::validateMandatory($params);
+    self::validateToDateType($params);
+    if (!empty($params['to_date'])) {
+      self::validateStartDateNotGreaterThanEndDate($params);
+    }
+
+    self::validateAbsencePeriod($params);
+    self::validateNoOverlappingLeaveRequests($params);
+    self::validateBalanceChange($params);
+    self::validateWorkingDay($params);
+    self::validateLeaveDatesDoesNotOverlapContracts($params);
+  }
+
+  /**
+   * This method validates that the to_date_type field must be present when to_date field is not empty
+   *
+   * @param array $params
+   *   The params array received by the create method
+   *
+   * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
+   */
+  private static function validateToDateType($params) {
+    if (!empty($params['to_date']) && empty($params['to_date_type'])) {
+      throw new InvalidLeaveRequestException(
+        'The type of To Date should not be empty',
+        'leave_request_empty_to_date_type',
+        'to_date_type'
+      );
+    }
+  }
+
+  /**
+   * A method for validating the mandatory fields in the params
+   * passed to the Leave Request create method
+   *
+   * @param array $params
+   *   The params array received by the create method
+   *
+   * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
+   */
+  private static function validateMandatory($params) {
     if (empty($params['from_date'])) {
       throw new InvalidLeaveRequestException(
         'Leave Requests should have a start date',
@@ -88,24 +129,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
         'status_id'
       );
     }
-
-    if (!empty($params['to_date']) && empty($params['to_date_type'])) {
-      throw new InvalidLeaveRequestException(
-        'The type of To Date should not be empty',
-        'leave_request_empty_to_date_type',
-        'to_date_type'
-      );
-    }
-
-    if (!empty($params['to_date'])) {
-      self::validateStartDateNotGreaterThanEndDate($params);
-    }
-
-    self::validateAbsencePeriod($params);
-    self::validateNoOverlappingLeaveRequests($params);
-    self::validateBalanceChange($params);
-    self::validateWorkingDay($params);
-    self::validateLeaveDatesDoesNotOverlapContracts($params);
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -708,6 +708,65 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
   /**
    * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
+   * @expectedExceptionMessage Leave Request should have a contact
+   */
+  public function testALeaveRequestShouldNotBeCreatedWithoutContactID() {
+    $fromDate = new DateTime('+4 days');
+    LeaveRequest::create([
+      'type_id' => $this->absenceType->id,
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => 1
+    ]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
+   * @expectedExceptionMessage Leave Request should have an Absence Type
+   */
+  public function testALeaveRequestShouldNotBeCreatedWithoutTypeID() {
+    $fromDate = new DateTime('+4 days');
+    LeaveRequest::create([
+      'status_id' => 1,
+      'contact_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => 1
+    ]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
+   * @expectedExceptionMessage The Leave Request status should not be empty
+   */
+  public function testALeaveRequestShouldNotBeCreatedWithoutStatusID() {
+    $fromDate = new DateTime('+4 days');
+    LeaveRequest::create([
+      'type_id' => $this->absenceType->id,
+      'contact_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => 1
+    ]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
+   * @expectedExceptionMessage The type of To Date should not be empty
+   */
+  public function testALeaveRequestShouldNotBeCreatedWhenToDateIsNotEmptyAndToDateTypeIsEmpty() {
+    $toDate= new DateTime('+4 days');
+    $fromDate = new DateTime();
+    LeaveRequest::create([
+      'type_id' => $this->absenceType->id,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => 1,
+      'to_date' => $toDate->format('YmdHis'),
+    ]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
    * @expectedExceptionMessage Leave Request start date cannot be greater than the end date
    */
   public function testALeaveRequestEndDateShouldNotBeGreaterThanStartDate() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -1443,7 +1443,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
   /**
    * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
-   * @expectedExceptionMessage The Leave request dates is not contained within a valid absence period
+   * @expectedExceptionMessage The Leave request dates are not contained within a valid absence period
    */
   public function testLeaveRequestCanNotBeCreatedWhenTheDatesOverlapTwoAbsencePeriods() {
     $contact = ContactFabricator::fabricate();


### PR DESCRIPTION
In this PR, four additional validations are added to the LeaveRequest create BAO method.
They include:

- Check for empty contact_id
- Check for empty type_id
- Check for empty status_id
- Check to ensure that the to_date_type field should be mandatory if to_date is not empty