### PR TITLE
PCHR-1761: Create Leave Request isValid API

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -56,7 +56,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    *
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
    */
-  private static function validateParams($params) {
+  public static function validateParams($params) {
     self::validateMandatory($params);
     self::validateToDateType($params);
     if (!empty($params['to_date'])) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -258,3 +258,26 @@ function _civicrm_api3_leave_request_get_statuses_from_params($params) {
 
   return $params['statuses']['IN'];
 }
+
+/**
+ * LeaveRequest.isValid API
+ * This API runs the validation on the LeaveRequest BAO create method
+ * without a call to the LeaveRequest create itself.
+ *
+ * @param array $params
+ *  An array of params passed to the API
+ *
+ * @return array
+ */
+function civicrm_api3_leave_request_isvalid($params) {
+  $result = [];
+
+  try {
+    CRM_HRLeaveAndAbsences_BAO_LeaveRequest::validateParams($params);
+  }
+  catch (CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException $e) {
+    $result[$e->getField()] = [$e->getExceptionCode()];
+  }
+
+  return civicrm_api3_create_success($result);
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -698,7 +698,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
    * @expectedExceptionMessage Leave Requests should have a start date
    */
   public function testALeaveRequestShouldNotBeCreatedWithoutAStartDate() {
-    LeaveRequest::create([
+    LeaveRequest::validateParams([
       'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
@@ -712,7 +712,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
    */
   public function testALeaveRequestShouldNotBeCreatedWithoutContactID() {
     $fromDate = new DateTime('+4 days');
-    LeaveRequest::create([
+    LeaveRequest::validateParams([
       'type_id' => $this->absenceType->id,
       'status_id' => 1,
       'from_date' => $fromDate->format('YmdHis'),
@@ -726,7 +726,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
    */
   public function testALeaveRequestShouldNotBeCreatedWithoutTypeID() {
     $fromDate = new DateTime('+4 days');
-    LeaveRequest::create([
+    LeaveRequest::validateParams([
       'status_id' => 1,
       'contact_id' => 1,
       'from_date' => $fromDate->format('YmdHis'),
@@ -740,7 +740,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
    */
   public function testALeaveRequestShouldNotBeCreatedWithoutStatusID() {
     $fromDate = new DateTime('+4 days');
-    LeaveRequest::create([
+    LeaveRequest::validateParams([
       'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'from_date' => $fromDate->format('YmdHis'),
@@ -755,7 +755,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   public function testALeaveRequestShouldNotBeCreatedWhenToDateIsNotEmptyAndToDateTypeIsEmpty() {
     $toDate= new DateTime('+4 days');
     $fromDate = new DateTime();
-    LeaveRequest::create([
+    LeaveRequest::validateParams([
       'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
@@ -772,7 +772,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   public function testALeaveRequestEndDateShouldNotBeGreaterThanStartDate() {
     $fromDate = new DateTime('+4 days');
     $toDate = new DateTime();
-    LeaveRequest::create([
+    LeaveRequest::validateParams([
       'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
@@ -1085,7 +1085,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromDate = new DateTime('2016-11-03');
     $toDate = new DateTime('2016-11-05');
 
-    LeaveRequest::create([
+    LeaveRequest::validateParams([
       'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
@@ -1237,7 +1237,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     //four working days which will create a balance change of 4
 
-    LeaveRequest::create([
+    LeaveRequest::validateParams([
       'type_id' => $absenceType->id,
       'contact_id' => $contact['id'],
       'status_id' => 1,
@@ -1347,7 +1347,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromType = $this->leaveRequestDayTypes['All Day']['id'];
     $toType = $this->leaveRequestDayTypes['All Day']['id'];
 
-    LeaveRequest::create([
+    LeaveRequest::validateParams([
       'type_id' => $absenceType->id,
       'contact_id' => $contact['id'],
       'status_id' => 1,
@@ -1404,7 +1404,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromDate = new DateTime("2016-11-16");
     $fromType = $this->leaveRequestDayTypes['All Day']['id'];
 
-    LeaveRequest::create([
+    LeaveRequest::validateParams([
       'type_id' => $absenceType->id,
       'contact_id' => $contact['id'],
       'status_id' => 1,
@@ -1430,7 +1430,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromType = $this->leaveRequestDayTypes['All Day']['id'];
     $toType = $this->leaveRequestDayTypes['All Day']['id'];
 
-    LeaveRequest::create([
+    LeaveRequest::validateParams([
       'type_id' => 1,
       'contact_id' => $contact['id'],
       'status_id' => 1,
@@ -1462,7 +1462,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromType = $this->leaveRequestDayTypes['All Day']['id'];
     $toType = $this->leaveRequestDayTypes['All Day']['id'];
 
-    LeaveRequest::create([
+    LeaveRequest::validateParams([
       'type_id' => 1,
       'contact_id' => $contact['id'],
       'status_id' => 1,
@@ -1529,7 +1529,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromType = $this->leaveRequestDayTypes['All Day']['id'];
     $toType = $this->leaveRequestDayTypes['All Day']['id'];
 
-    LeaveRequest::create([
+    LeaveRequest::validateParams([
       'type_id' => $absenceType->id,
       'contact_id' => $contact['id'],
       'status_id' => 1,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -698,7 +698,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
    * @expectedExceptionMessage Leave Requests should have a start date
    */
   public function testALeaveRequestShouldNotBeCreatedWithoutAStartDate() {
-    LeaveRequest::validateParams([
+    LeaveRequest::create([
       'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
@@ -712,7 +712,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
    */
   public function testALeaveRequestShouldNotBeCreatedWithoutContactID() {
     $fromDate = new DateTime('+4 days');
-    LeaveRequest::validateParams([
+    LeaveRequest::create([
       'type_id' => $this->absenceType->id,
       'status_id' => 1,
       'from_date' => $fromDate->format('YmdHis'),
@@ -726,7 +726,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
    */
   public function testALeaveRequestShouldNotBeCreatedWithoutTypeID() {
     $fromDate = new DateTime('+4 days');
-    LeaveRequest::validateParams([
+    LeaveRequest::create([
       'status_id' => 1,
       'contact_id' => 1,
       'from_date' => $fromDate->format('YmdHis'),
@@ -740,7 +740,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
    */
   public function testALeaveRequestShouldNotBeCreatedWithoutStatusID() {
     $fromDate = new DateTime('+4 days');
-    LeaveRequest::validateParams([
+    LeaveRequest::create([
       'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'from_date' => $fromDate->format('YmdHis'),
@@ -755,7 +755,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   public function testALeaveRequestShouldNotBeCreatedWhenToDateIsNotEmptyAndToDateTypeIsEmpty() {
     $toDate= new DateTime('+4 days');
     $fromDate = new DateTime();
-    LeaveRequest::validateParams([
+    LeaveRequest::create([
       'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
@@ -772,7 +772,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   public function testALeaveRequestEndDateShouldNotBeGreaterThanStartDate() {
     $fromDate = new DateTime('+4 days');
     $toDate = new DateTime();
-    LeaveRequest::validateParams([
+    LeaveRequest::create([
       'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
@@ -1085,7 +1085,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromDate = new DateTime('2016-11-03');
     $toDate = new DateTime('2016-11-05');
 
-    LeaveRequest::validateParams([
+    LeaveRequest::create([
       'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
@@ -1237,7 +1237,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     //four working days which will create a balance change of 4
 
-    LeaveRequest::validateParams([
+    LeaveRequest::create([
       'type_id' => $absenceType->id,
       'contact_id' => $contact['id'],
       'status_id' => 1,
@@ -1347,7 +1347,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromType = $this->leaveRequestDayTypes['All Day']['id'];
     $toType = $this->leaveRequestDayTypes['All Day']['id'];
 
-    LeaveRequest::validateParams([
+    LeaveRequest::create([
       'type_id' => $absenceType->id,
       'contact_id' => $contact['id'],
       'status_id' => 1,
@@ -1404,7 +1404,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromDate = new DateTime("2016-11-16");
     $fromType = $this->leaveRequestDayTypes['All Day']['id'];
 
-    LeaveRequest::validateParams([
+    LeaveRequest::create([
       'type_id' => $absenceType->id,
       'contact_id' => $contact['id'],
       'status_id' => 1,
@@ -1430,7 +1430,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromType = $this->leaveRequestDayTypes['All Day']['id'];
     $toType = $this->leaveRequestDayTypes['All Day']['id'];
 
-    LeaveRequest::validateParams([
+    LeaveRequest::create([
       'type_id' => 1,
       'contact_id' => $contact['id'],
       'status_id' => 1,
@@ -1462,7 +1462,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromType = $this->leaveRequestDayTypes['All Day']['id'];
     $toType = $this->leaveRequestDayTypes['All Day']['id'];
 
-    LeaveRequest::validateParams([
+    LeaveRequest::create([
       'type_id' => 1,
       'contact_id' => $contact['id'],
       'status_id' => 1,
@@ -1529,7 +1529,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromType = $this->leaveRequestDayTypes['All Day']['id'];
     $toType = $this->leaveRequestDayTypes['All Day']['id'];
 
-    LeaveRequest::validateParams([
+    LeaveRequest::create([
       'type_id' => $absenceType->id,
       'contact_id' => $contact['id'],
       'status_id' => 1,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -704,7 +704,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals($expectedResultsBreakdown, $result['values']);
   }
 
-  public function testLeaveRequestIsValidWithoutAStartDate() {
+  public function testLeaveRequestIsValidShouldReturnErrorWhenStartDateIsEmpty() {
     $result = civicrm_api3('LeaveRequest', 'isvalid', [
       'type_id' => 1,
       'contact_id' => 1,
@@ -722,7 +722,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertArraySubset($expectedResult, $result);
   }
 
-  public function testLeaveRequestIsValidWithoutContactID() {
+  public function testLeaveRequestIsValidShouldReturnErrorWhenContactIDIsEmpty() {
     $fromDate = new DateTime('+4 days');
     $result = civicrm_api3('LeaveRequest', 'isvalid', [
       'type_id' => 1,
@@ -741,7 +741,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertArraySubset($expectedResult, $result);
   }
 
-  public function testLeaveRequestIsValidWithoutTypeID() {
+  public function testLeaveRequestIsValidShouldReturnErrorWhenTypeIDIsEmpty() {
     $fromDate = new DateTime('+4 days');
     $result = civicrm_api3('LeaveRequest', 'isvalid', [
       'status_id' => 1,
@@ -760,7 +760,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertArraySubset($expectedResult, $result);
   }
 
-  public function testLeaveRequestIsValidWithoutStatusID() {
+  public function testLeaveRequestIsValidShouldReturnErrorWhenStatusIDIsEmpty() {
     $fromDate = new DateTime('+4 days');
     $result = civicrm_api3('LeaveRequest', 'isvalid', [
       'type_id' => 1,
@@ -779,7 +779,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertArraySubset($expectedResult, $result);
   }
 
-  public function testLeaveRequestIsValidWhenToDateIsNotEmptyAndToDateTypeIsEmpty() {
+  public function testLeaveRequestIsValidShouldReturnErrorWhenToDateIsNotEmptyAndToDateTypeIsEmpty() {
     $toDate= new DateTime('+4 days');
     $fromDate = new DateTime();
     $result = civicrm_api3('LeaveRequest', 'isvalid', [
@@ -801,7 +801,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertArraySubset($expectedResult, $result);
   }
 
-  public function testLeaveRequestIsValidWhenEndDateIsGreaterThanStartDate() {
+  public function testLeaveRequestIsValidShouldReturnErrorWhenEndDateIsGreaterThanStartDate() {
     $fromDate = new DateTime('+4 days');
     $toDate = new DateTime();
     $result = civicrm_api3('LeaveRequest', 'isvalid', [
@@ -824,7 +824,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertArraySubset($expectedResult, $result);
   }
 
-  public function testLeaveRequestIsValidWhenThereAreOverlappingLeaveRequests() {
+  public function testLeaveRequestIsValidShouldReturnErrorWhenThereAreOverlappingLeaveRequests() {
     $contactID = 1;
     $fromDate1 = new DateTime('2016-11-02');
     $toDate1 = new DateTime('2016-11-04');
@@ -882,7 +882,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertArraySubset($expectedResult, $result);
   }
 
-  public function testLeaveRequestIsValidWhenBalanceChangeGreaterThanPeriodEntitlementBalanceChangeWhenAllowOveruseFalse() {
+  public function testLeaveRequestIsValidShouldReturnErrorWhenBalanceChangeGreaterThanPeriodEntitlementBalanceChangeAndAllowOveruseFalse() {
     $contact = ContactFabricator::fabricate();
     $period = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
@@ -942,7 +942,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertArraySubset($expectedResult, $result);
   }
 
-  public function testLeaveRequestIsValidWhenLeaveRequestHasNoWorkingDay() {
+  public function testLeaveRequestIsValidShouldReturnErrorWhenLeaveRequestHasNoWorkingDay() {
     $contact = ContactFabricator::fabricate();
     $period = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
@@ -1002,7 +1002,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertArraySubset($expectedResult, $result);
   }
 
-  public function testLeaveRequestIsValidWhenTheDatesAreNotContainedInValidAbsencePeriod() {
+  public function testLeaveRequestIsValidShouldReturnErrorWhenTheDatesAreNotContainedInValidAbsencePeriod() {
     $contact = ContactFabricator::fabricate();
     AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
@@ -1035,7 +1035,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertArraySubset($expectedResult, $result);
   }
 
-  public function testLeaveRequestIsValidWhenTheDatesOverlapMoreThanOneContract() {
+  public function testLeaveRequestIsValidShouldReturnErrorWhenTheDatesOverlapMoreThanOneContract() {
     $contact = ContactFabricator::fabricate();
     $period = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
@@ -1107,7 +1107,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertArraySubset($expectedResult, $result);
   }
 
-  public function testLeaveRequestIsValidWhenValidationsPassed() {
+  public function testLeaveRequestIsValidShouldNotReturnErrorWhenValidationsPass() {
     $contactID = 1;
 
     $period = AbsencePeriodFabricator::fabricate([

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -20,6 +20,12 @@ use CRM_HRLeaveAndAbsences_Test_Fabricator_ContactWorkPattern as ContactWorkPatt
 class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
   use CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait;
+  use CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait;
+
+  /**
+   * @var CRM_HRLeaveAndAbsences_BAO_AbsenceType
+   */
+  private $absenceType;
 
   public function setUp() {
     // In order to make tests simpler, we disable the foreign key checks,
@@ -32,6 +38,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $tableName = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getTableName();
     CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
     $this->leaveRequestDayTypes = $this->leaveRequestDayTypeOptionsBuilder();
+    $this->absenceType = AbsenceTypeFabricator::fabricate();
   }
 
   /**
@@ -695,5 +702,450 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'to_type' => $toType
     ]);
     $this->assertEquals($expectedResultsBreakdown, $result['values']);
+  }
+
+  public function testLeaveRequestIsValidWithoutAStartDate() {
+    $result = civicrm_api3('LeaveRequest', 'isvalid', [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date_type' => 1
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 1,
+      'values' => [
+        'from_date' => ['leave_request_empty_from_date']
+      ]
+    ];
+    $this->assertArraySubset($expectedResult, $result);
+  }
+
+  public function testLeaveRequestIsValidWithoutContactID() {
+    $fromDate = new DateTime('+4 days');
+    $result = civicrm_api3('LeaveRequest', 'isvalid', [
+      'type_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => 1
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 1,
+      'values' => [
+        'contact_id' => ['leave_request_empty_contact_id']
+      ]
+    ];
+    $this->assertArraySubset($expectedResult, $result);
+  }
+
+  public function testLeaveRequestIsValidWithoutTypeID() {
+    $fromDate = new DateTime('+4 days');
+    $result = civicrm_api3('LeaveRequest', 'isvalid', [
+      'status_id' => 1,
+      'contact_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => 1
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 1,
+      'values' => [
+        'type_id' => ['leave_request_empty_type_id']
+      ]
+    ];
+    $this->assertArraySubset($expectedResult, $result);
+  }
+
+  public function testLeaveRequestIsValidWithoutStatusID() {
+    $fromDate = new DateTime('+4 days');
+    $result = civicrm_api3('LeaveRequest', 'isvalid', [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => 1
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 1,
+      'values' => [
+        'status_id' => ['leave_request_empty_status_id']
+      ]
+    ];
+    $this->assertArraySubset($expectedResult, $result);
+  }
+
+  public function testLeaveRequestIsValidWhenToDateIsNotEmptyAndToDateTypeIsEmpty() {
+    $toDate= new DateTime('+4 days');
+    $fromDate = new DateTime();
+    $result = civicrm_api3('LeaveRequest', 'isvalid', [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => 1,
+      'to_date' => $toDate->format('YmdHis'),
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 1,
+      'values' => [
+        'to_date_type' => ['leave_request_empty_to_date_type']
+      ]
+    ];
+    $this->assertArraySubset($expectedResult, $result);
+  }
+
+  public function testLeaveRequestIsValidWhenEndDateIsGreaterThanStartDate() {
+    $fromDate = new DateTime('+4 days');
+    $toDate = new DateTime();
+    $result = civicrm_api3('LeaveRequest', 'isvalid', [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => 1,
+      'to_date' => $toDate->format('YmdHis'),
+      'to_date_type' => 1
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 1,
+      'values' => [
+        'from_date' => ['leave_request_from_date_greater_than_end_date']
+      ]
+    ];
+    $this->assertArraySubset($expectedResult, $result);
+  }
+
+  public function testLeaveRequestIsValidWhenThereAreOverlappingLeaveRequests() {
+    $contactID = 1;
+    $fromDate1 = new DateTime('2016-11-02');
+    $toDate1 = new DateTime('2016-11-04');
+
+    $fromDate2 = new DateTime('2016-11-05');
+    $toDate2 = new DateTime('2016-11-10');
+
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $this->absenceType->id,
+      'contact_id' => $contactID,
+      'status_id' => $leaveRequestStatuses['Waiting Approval'],
+      'from_date' => $fromDate1->format('YmdHis'),
+      'from_date_type' => 1,
+      'to_date' => $toDate1->format('YmdHis'),
+      'to_date_type' => 1
+    ], true);
+
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $this->absenceType->id,
+      'contact_id' => $contactID,
+      'status_id' => $leaveRequestStatuses['Rejected'],
+      'from_date' => $fromDate2->format('YmdHis'),
+      'from_date_type' => 1,
+      'to_date' => $toDate2->format('YmdHis'),
+      'to_date_type' => 1
+    ], true);
+
+    //from date and to date have date in both leave request
+    $fromDate = new DateTime('2016-11-03');
+    $toDate = new DateTime('2016-11-05');
+
+    $result = civicrm_api3('LeaveRequest', 'isvalid', [
+      'type_id' => $this->absenceType->id,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => 1,
+      'to_date' => $toDate->format('YmdHis'),
+      'to_date_type' => 1
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 1,
+      'values' => [
+        'from_date' => ['leave_request_overlaps_another_leave_request']
+      ]
+    ];
+    $this->assertArraySubset($expectedResult, $result);
+  }
+
+  public function testLeaveRequestIsValidWhenBalanceChangeGreaterThanPeriodEntitlementBalanceChangeWhenAllowOveruseFalse() {
+    $contact = ContactFabricator::fabricate();
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'title' => 'Type 1',
+      'allow_overuse' => 0
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceType->id,
+      'contact_id' => $contact['id'],
+      'period_id' => $period->id
+    ]);
+
+    $this->createLeaveBalanceChange($periodEntitlement->id, 3);
+    $periodStartDate = date('2016-01-01');
+    $title = 'Job Title';
+
+    HRJobContractFabricator::fabricate([
+      'contact_id' => $contact['id']
+    ],
+    [
+      'period_start_date' => $periodStartDate,
+      'title' => $title
+    ]);
+    $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'pattern_id' => $workPattern->id
+    ]);
+
+    $fromDate = new DateTime("2016-11-14");
+    $toDate = new DateTime("2016-11-17");
+    $fromType = $this->leaveRequestDayTypes['All Day']['id'];
+    $toType = $this->leaveRequestDayTypes['All Day']['id'];
+
+    $result = civicrm_api3('LeaveRequest', 'isvalid', [
+      'type_id' => $absenceType->id,
+      'contact_id' => $contact['id'],
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => $fromType,
+      'to_date' => $toDate->format('YmdHis'),
+      'to_date_type' => $toType
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 1,
+      'values' => [
+        'type_id' => ['leave_request_balance_change_greater_than_remaining_balance']
+      ]
+    ];
+    $this->assertArraySubset($expectedResult, $result);
+  }
+
+  public function testLeaveRequestIsValidWhenLeaveRequestHasNoWorkingDay() {
+    $contact = ContactFabricator::fabricate();
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'title' => 'Type 1',
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceType->id,
+      'contact_id' => $contact['id'],
+      'period_id' => $period->id
+    ]);
+
+    $this->createLeaveBalanceChange($periodEntitlement->id, 3);
+    $periodStartDate = date('2016-01-01');
+    $title = 'Job Title';
+
+    HRJobContractFabricator::fabricate([
+      'contact_id' => $contact['id']
+    ],
+    [
+      'period_start_date' => $periodStartDate,
+      'title' => $title
+    ]);
+    $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'pattern_id' => $workPattern->id
+    ]);
+
+    //both days are on weekends
+    $fromDate = new DateTime("2016-11-12");
+    $toDate = new DateTime("2016-11-13");
+    $fromType = $this->leaveRequestDayTypes['All Day']['id'];
+    $toType = $this->leaveRequestDayTypes['All Day']['id'];
+
+    $result = civicrm_api3('LeaveRequest', 'isvalid', [
+      'type_id' => $absenceType->id,
+      'contact_id' => $contact['id'],
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => $fromType,
+      'to_date' => $toDate->format('YmdHis'),
+      'to_date_type' => $toType
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 1,
+      'values' => [
+        'from_date' => ['leave_request_doesnt_have_working_day']
+      ]
+    ];
+    $this->assertArraySubset($expectedResult, $result);
+  }
+
+  public function testLeaveRequestIsValidWhenTheDatesAreNotContainedInValidAbsencePeriod() {
+    $contact = ContactFabricator::fabricate();
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    //the dates are outside of the absence period dates
+    $fromDate = new DateTime("2015-11-12");
+    $toDate = new DateTime("2015-11-13");
+    $fromType = $this->leaveRequestDayTypes['All Day']['id'];
+    $toType = $this->leaveRequestDayTypes['All Day']['id'];
+
+    $result = civicrm_api3('LeaveRequest', 'isvalid', [
+      'type_id' => 1,
+      'contact_id' => $contact['id'],
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => $fromType,
+      'to_date' => $toDate->format('YmdHis'),
+      'to_date_type' => $toType
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 1,
+      'values' => [
+        'from_date' => ['leave_request_not_within_absence_period']
+      ]
+    ];
+    $this->assertArraySubset($expectedResult, $result);
+  }
+
+  public function testLeaveRequestIsValidWhenTheDatesOverlapMoreThanOneContract() {
+    $contact = ContactFabricator::fabricate();
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'title' => 'Type 1',
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceType->id,
+      'contact_id' => $contact['id'],
+      'period_id' => $period->id
+    ]);
+
+    $this->createLeaveBalanceChange($periodEntitlement->id, 30);
+    $periodStartDate1 = date('2016-01-01');
+    $periodEndDate1 = date('2016-06-30');
+
+    $periodStartDate2 = date('2016-07-01');
+    $periodEndDate2 = date('2016-12-31');
+
+    HRJobContractFabricator::fabricate([
+      'contact_id' => $contact['id']
+    ],
+    [
+      'period_start_date' => $periodStartDate1,
+      'period_end_date' => $periodEndDate1
+    ]);
+
+    HRJobContractFabricator::fabricate([
+      'contact_id' => $contact['id']
+    ],
+    [
+      'period_start_date' => $periodStartDate2,
+      'period_end_date' => $periodEndDate2
+    ]);
+
+    $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'pattern_id' => $workPattern->id
+    ]);
+
+    //The from date and to date overlaps the two job contracts
+    $fromDate = new DateTime("2016-06-25");
+    $toDate = new DateTime("2016-07-13");
+    $fromType = $this->leaveRequestDayTypes['All Day']['id'];
+    $toType = $this->leaveRequestDayTypes['All Day']['id'];
+
+    $result = civicrm_api3('LeaveRequest', 'isvalid', [
+      'type_id' => $absenceType->id,
+      'contact_id' => $contact['id'],
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => $fromType,
+      'to_date' => $toDate->format('YmdHis'),
+      'to_date_type' => $toType
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 1,
+      'values' => [
+        'from_date' => ['leave_request_overlapping_multiple_contracts']
+      ]
+    ];
+    $this->assertArraySubset($expectedResult, $result);
+  }
+
+  public function testLeaveRequestIsValidWhenValidationsPassed() {
+    $contactID = 1;
+
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $this->absenceType->id,
+      'contact_id' => $contactID,
+      'period_id' => $period->id
+    ]);
+
+    $this->createLeaveBalanceChange($periodEntitlement->id, 20);
+
+    $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $contactID,
+      'pattern_id' => $workPattern->id
+    ]);
+
+    $fromDate = new DateTime('2016-11-05');
+    $toDate = new DateTime('2016-11-11');
+    $result = civicrm_api3('LeaveRequest', 'isvalid', [
+      'type_id' => $this->absenceType->id,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => 1,
+      'to_date' => $toDate->format('YmdHis'),
+      'to_date_type' => 1
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 0,
+      'values' => []
+    ];
+    $this->assertArraySubset($expectedResult, $result);
   }
 }


### PR DESCRIPTION
This PR creates the LeaveRequest isValid API. The API uses the validateParams() method of the LeaveRequest BAO but does not make a call to LeaveRequest BAO create method.

The Response of the API includes the DAO field associated the error and also the error/Exception code for the exception.

Here are some sample request and responses for the API endpoint: 
_When from_date field is not present_
```php
$result = civicrm_api3('LeaveRequest', 'isvalid', array(
  'sequential' => 1,
  'contact_id' => 1,
  'status_id' => 1,
));
```
Response: 
```json
{
  "is_error": 0,
  "version": 3,
  "count": 1,
  "values": {
    "from_date": [
      "leave_request_empty_from_date"
    ]
  }
}
```
_When the absence type field is not included in the payload_
```php
$result = civicrm_api3('LeaveRequest', 'isvalid', array(
  'sequential' => 1,
  'contact_id' => 1,
  'status_id' => 1,
  'from_date' => "2016-12-10",
  'from_date_type' => 1,
));
```
Response: 
```json
{
  "is_error": 0,
  "version": 3,
  "count": 1,
  "values": {
    "type_id": [
      "leave_request_empty_type_id"
    ]
  }
}
```
When all validations pass the response is:

```json
{
  "is_error": 0,
  "version": 3,
  "count": 0,
  "values": {}
}
```
