### PR TITLE
PCHR-1762: Create TOIL Request isValid API

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/TOILRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/TOILRequest.php
@@ -83,7 +83,11 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequest extends CRM_HRLeaveAndAbsences_DAO_
   private static function validateTOILAmountIsValid($params) {
     $toilAmountOptions = self::toilAmountOptions();
     if (!in_array($params['toil_to_accrue'], $toilAmountOptions)) {
-      throw new InvalidTOILRequestException("The TOIL amount is not valid");
+      throw new InvalidTOILRequestException(
+        'The TOIL amount is not valid',
+        'toil_request_toil_amount_is_invalid',
+        'toil_to_accrue'
+      );
     }
   }
 
@@ -101,7 +105,9 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequest extends CRM_HRLeaveAndAbsences_DAO_
     $unlimitedAccrual = empty($absenceType->max_leave_accrual) && $absenceType->max_leave_accrual != 0;
     if ($params['toil_to_accrue'] > $absenceType->max_leave_accrual && !$unlimitedAccrual) {
       throw new InvalidTOILRequestException(
-        "The TOIL amount requested for is greater than the maximum for this Absence Type"
+        'The TOIL amount requested for is greater than the maximum for this Absence Type',
+        'toil_request_toil_amount_more_than_maximum_for_absence_type',
+        'toil_to_accrue'
       );
     }
   }
@@ -129,7 +135,9 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequest extends CRM_HRLeaveAndAbsences_DAO_
 
     if ($leaveDatesHasPastDates && !$absenceType->allow_accrue_in_the_past) {
       throw new InvalidTOILRequestException(
-        "You cannot request TOIL for past days"
+        "You cannot request TOIL for past days",
+        'toil_request_toil_cannot_be_requested_for_past_days',
+        'from_date'
       );
     }
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Exception/EntityValidationException.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Exception/EntityValidationException.php
@@ -6,7 +6,7 @@
 class CRM_HRLeaveAndAbsences_Exception_EntityValidationException extends Exception {
   /**
    * @var string
-   *   The DAO field associated with the thrown exception
+   *   The field associated with the thrown exception
    */
   private $field;
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Exception/InvalidTOILRequestException.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Exception/InvalidTOILRequestException.php
@@ -1,2 +1,2 @@
 <?php
-class CRM_HRLeaveAndAbsences_Exception_InvalidTOILRequestException extends Exception {}
+class CRM_HRLeaveAndAbsences_Exception_InvalidTOILRequestException extends CRM_HRLeaveAndAbsences_Exception_EntityValidationException  {}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/TOILRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/TOILRequest.php
@@ -44,3 +44,26 @@ function civicrm_api3_t_o_i_l_request_delete($params) {
 function civicrm_api3_t_o_i_l_request_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
+
+/**
+ * TOILRequest.isValid API
+ * This API runs the validation on the TOILRequest BAO create method
+ * without a call to the TOILRequest create itself.
+ *
+ * @param array $params
+ *  An array of params passed to the API
+ *
+ * @return array
+ */
+function civicrm_api3_t_o_i_l_request_isvalid($params) {
+  $result = [];
+
+  try {
+    CRM_HRLeaveAndAbsences_BAO_TOILRequest::validateParams($params);
+  }
+  catch (CRM_HRLeaveAndAbsences_Exception_InvalidTOILRequestException $e) {
+    $result[$e->getField()] = [$e->getExceptionCode()];
+  }
+
+  return civicrm_api3_create_success($result);
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/TOILRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/TOILRequestTest.php
@@ -1,0 +1,126 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
+
+/**
+ * Class api_v3_TOILRequestTest
+ *
+ * @group headless
+ */
+class api_v3_TOILRequestTest extends BaseHeadlessTest {
+
+  use CRM_HRLeaveAndAbsences_TOILRequestHelpersTrait;
+
+  public function setUp() {
+    CRM_Core_DAO::executeQuery("SET foreign_key_checks = 0;");
+
+    $this->toilAmounts = $this->toilAmountOptions();
+  }
+
+  public function testTOILRequestIsValidShouldReturnErrorWhenToilAmountIsNotValid() {
+    $result = civicrm_api3('TOILRequest', 'isvalid', [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => '2016-11-14',
+      'toil_to_accrue' => 200,
+      'duration' => 120
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 1,
+      'values' => [
+        'toil_to_accrue' => ['toil_request_toil_amount_is_invalid']
+      ]
+    ];
+    $this->assertArraySubset($expectedResult, $result);
+  }
+
+  public function testTOILRequestIsValidShouldReturnErrorWhenToilAmountIsGreaterThanMaximumAllowed() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'title' => 'Title 1',
+      'allow_accruals_request' => true,
+      'max_leave_accrual' => 1,
+      'is_active' => 1,
+    ]);
+
+    $result = civicrm_api3('TOILRequest', 'isvalid', [
+      'type_id' => $absenceType->id,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => '2016-11-14',
+      'to_date' => '2016-11-18',
+      'toil_to_accrue' => $this->toilAmounts['2 Days']['value'],
+      'duration' => 120
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 1,
+      'values' => [
+        'toil_to_accrue' => ['toil_request_toil_amount_more_than_maximum_for_absence_type']
+      ]
+    ];
+    $this->assertArraySubset($expectedResult, $result);
+  }
+
+  public function testTOILRequestIsValidShouldReturnErrorWhenTOILRequestIsMadeWithPastDatesAndAbsenceTypeDoesNotAllowPastDates() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'title' => 'Title 1',
+      'allow_accruals_request' => true,
+      'max_leave_accrual' => 4,
+      'is_active' => 1,
+      'allow_accrue_in_the_past' => false
+    ]);
+
+    $result = civicrm_api3('TOILRequest', 'isvalid', [
+      'type_id' => $absenceType->id,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => '2016-11-14',
+      'to_date' => '2016-11-18',
+      'toil_to_accrue' => $this->toilAmounts['2 Days']['value'],
+      'duration' => 120
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 1,
+      'values' => [
+        'from_date' => ['toil_request_toil_cannot_be_requested_for_past_days']
+      ]
+    ];
+    $this->assertArraySubset($expectedResult, $result);
+  }
+
+  public function testTOILRequestIsValidShouldNotReturnErrorWhenValidationsPass() {
+
+    $fromDate = new DateTime();
+    $toDate = new DateTime('+3 days');
+
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'title' => 'Title 1',
+      'allow_accruals_request' => true,
+      'max_leave_accrual' => 4,
+      'is_active' => 1,
+    ]);
+
+    $result = civicrm_api3('TOILRequest', 'isvalid', [
+      'type_id' => $absenceType->id,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'to_date' => $toDate->format('YmdHis'),
+      'toil_to_accrue' => $this->toilAmounts['2 Days']['value'],
+      'duration' => 120
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 0,
+      'values' => []
+    ];
+    $this->assertArraySubset($expectedResult, $result);
+  }
+}


### PR DESCRIPTION
This PR creates the TOILRequest isValid API. The API uses the validateParams() method of the TOILRequest BAO but does not make a call to TOILRequest BAO create method.

The Response of the API includes the field associated the error and also the error/Exception code for the exception.

Here are some sample request and responses for the API endpoint:

_The TOIL amount is not valid_

```php
$result = civicrm_api3('TOILRequest', 'isvalid', array(
  'type_id' => 1,
  'contact_id' => 1,
  'status_id' => 1,
  'from_date' => '2016-11-14',
  'toil_to_accrue' => 200,
  'duration' => 120
));
```

Response: 
```json
{
  "is_error": 0,
  "version": 3,
  "count": 1,
  "values": {
    "toil_to_accrue": [
      "toil_request_toil_amount_is_invalid"
    ]
  }
}
```

When all validations pass the response is:

```json
{
  "is_error": 0,
  "version": 3,
  "count": 0,
  "values": {}
}
```