### PR TITLE
PCHR-1839: Improve Sickness Request validation

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/SicknessRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/SicknessRequest.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use CRM_HRLeaveAndAbsences_Exception_InvalidSicknessRequestException as InvalidSicknessRequestException;
 
 class CRM_HRLeaveAndAbsences_BAO_SicknessRequest extends CRM_HRLeaveAndAbsences_DAO_SicknessRequest {
 
@@ -8,6 +9,8 @@ class CRM_HRLeaveAndAbsences_BAO_SicknessRequest extends CRM_HRLeaveAndAbsences_
    * Create a new SicknessRequest based on array-data
    *
    * @param array $params key-value pairs
+   * @param boolean $validate
+   *   Whether to allow validation or not
    *
    * @return CRM_HRLeaveAndAbsences_BAO_SicknessRequest|NULL
    **/
@@ -15,6 +18,10 @@ class CRM_HRLeaveAndAbsences_BAO_SicknessRequest extends CRM_HRLeaveAndAbsences_
     $entityName = 'SicknessRequest';
     $hook = empty($params['id']) ? 'create' : 'edit';
     CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
+
+    if ($validate) {
+      self::validateParams($params);
+    }
     $instance = new self();
 
     if ($hook == 'edit') {
@@ -39,5 +46,36 @@ class CRM_HRLeaveAndAbsences_BAO_SicknessRequest extends CRM_HRLeaveAndAbsences_
     CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
 
     return $instance;
+  }
+
+  /**
+   * A method for validating the params passed to the SicknessRequest create method
+   *
+   * @param array $params
+   *   The params array received by the create method
+   *
+   * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidSicknessRequestException
+   */
+  public static function validateParams($params) {
+    self::validateMandatory($params);
+  }
+
+  /**
+   * A method for validating the mandatory fields in the params
+   * passed to the SicknessRequest create method
+   *
+   * @param array $params
+   *   The params array received by the create method
+   *
+   * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidSicknessRequestException
+   */
+  private static function validateMandatory($params) {
+    if (empty($params['reason'])) {
+      throw new InvalidSicknessRequestException(
+        'Sickness Requests should have a reason',
+        'sickness_request_empty_reason',
+        'reason'
+      );
+    }
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Exception/InvalidSicknessRequestException.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Exception/InvalidSicknessRequestException.php
@@ -1,0 +1,2 @@
+<?php
+class CRM_HRLeaveAndAbsences_Exception_InvalidSicknessRequestException extends CRM_HRLeaveAndAbsences_Exception_EntityValidationException  {}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/SicknessRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/SicknessRequestTest.php
@@ -121,4 +121,42 @@ class CRM_HRLeaveAndAbsences_BAO_SicknessRequestTest extends BaseHeadlessTest {
     $this->assertEquals($requiredDocuments1, $sicknessRequest1->required_documents);
     $this->assertEquals($requiredDocuments2, $sicknessRequest2->required_documents);
   }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidSicknessRequestException
+   * @expectedExceptionMessage Sickness Requests should have a reason
+   */
+  public function testValidateSicknessRequestWhenReasonIsEmpty() {
+    $fromDate = new DateTime("2016-11-14");
+    $fromType = $this->leaveRequestDayTypes['All Day']['id'];
+    $requiredDocuments = $this->requiredDocumentOptions['Self certification form required']['value'];
+
+    SicknessRequest::validateParams([
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => $fromType,
+      'required_documents' => $requiredDocuments
+    ]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidSicknessRequestException
+   * @expectedExceptionMessage Sickness Requests should have a reason
+   */
+  public function testValidateParamsIsCalledOnCreate() {
+    $fromDate = new DateTime("2016-11-14");
+    $fromType = $this->leaveRequestDayTypes['All Day']['id'];
+    $requiredDocuments = $this->requiredDocumentOptions['Self certification form required']['value'];
+
+    SicknessRequest::create([
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => $fromType,
+      'required_documents' => $requiredDocuments
+    ], true);
+  }
 }


### PR DESCRIPTION
In this PR, an additional validation is added to the SicknessRequest create BAO method rather than relying on a database level exception to validate.

It includes:
Check for empty reason field
