### PR TITLE
PCHR-1757: Set calendar view criteria and collection to match filter model

### DIFF
--- a/hrabsence/js/app.js
+++ b/hrabsence/js/app.js
@@ -36,8 +36,8 @@ CRM.HRAbsenceApp.module('Main', function(Main, HRAbsenceApp, Backbone, Marionett
     },
     showCalendar: function() {
       HRAbsenceApp.contentRegion.show(new HRAbsenceApp.Calendar.CalendarView({
-        criteria: calendarAbsenceCriteria,
-        collection: calendarAbsenceCollection
+        criteria: absenceCriteria,
+        collection: absenceCollection
       }));
     },
     showStatistics: function() {


### PR DESCRIPTION
# Calendar is inactive 

![absence-cal](https://cloud.githubusercontent.com/assets/5742538/21433055/94fd733a-c86e-11e6-8d32-3b03dbbd22c1.gif)

The filter view of the Marionette app can only use one model entity; the list view of the app had criteria and collection that correspond to the model of the filter view, hence the list view updates based on the changes made in the filter view. 

_Setting filter model_
```
    HRAbsenceApp.filterRegion.show(new HRAbsenceApp.Filter.FilterView({
      model: absenceCriteria
    }));
```

_Setting list view criteria and region_
```
      HRAbsenceApp.contentRegion.show(CRM.av = new HRAbsenceApp.List.ListView({
        criteria: absenceCriteria,
        collection: absenceCollection,
        entitlementCollection: entitlementCollection,
        absenceTypeCollection: absenceTypeCollection
      }));
```

However, the calendar view's criteria and collection seem not match the filter view's model so changes in the filter didn't reflect in the calendar.

_Before the commit_
```
      HRAbsenceApp.contentRegion.show(new HRAbsenceApp.Calendar.CalendarView({
        criteria: calendarAbsenceCriteria,
        collection: calendarAbsenceCollection
      }));
```

## Instantiation of criteria and collection

calendarAbsenceCriteria and calendarAbsenceCollection has the same instantiation with absenceCriteria except for an extra option **status_id** that is arbitrary and seems not to have any relationship with calendar/view.js and hrabsence-calendar-template.tpl

```
    absenceCriteria = new HRAbsenceApp.Models.AbsenceCriteria({
      target_contact_id: CRM.absenceApp.contactId,
      options: {'absence-range': 1}
    });
    calendarAbsenceCriteria = new HRAbsenceApp.Models.AbsenceCriteria({
      target_contact_id: CRM.absenceApp.contactId,
      options: {'absence-range': 1},
      status_id:{'NOT IN':[3, 9]} //3: Cancelled, 9: Rejected
    });
```
# Calendar is active

Setting the calendar view criteria and collection to match the model of the filter view updated the calendar any time a change occurred.

![1757](https://cloud.githubusercontent.com/assets/5742538/21433095/c4f51c46-c86e-11e6-908c-700fa534138d.gif)
