### PR TITLE
PCHR-1840: Create Sickness Request isValid AP

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/SicknessRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/SicknessRequest.php
@@ -44,3 +44,26 @@ function civicrm_api3_sickness_request_delete($params) {
 function civicrm_api3_sickness_request_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
+
+/**
+ * SicknessRequest.isValid API
+ * This API runs the validation on the SicknessRequest BAO create method
+ * without a call to the SicknessRequest create itself.
+ *
+ * @param array $params
+ *  An array of params passed to the API
+ *
+ * @return array
+ */
+function civicrm_api3_sickness_request_isvalid($params) {
+  $result = [];
+
+  try {
+    CRM_HRLeaveAndAbsences_BAO_SicknessRequest::validateParams($params);
+  }
+  catch (CRM_HRLeaveAndAbsences_Exception_InvalidSicknessRequestException $e) {
+    $result[$e->getField()] = [$e->getExceptionCode()];
+  }
+
+  return civicrm_api3_create_success($result);
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/SicknessRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/SicknessRequestTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_SicknessRequest as SicknessRequest;
+
+/**
+ * Class api_v3_TOILRequestTest
+ *
+ * @group headless
+ */
+class SicknessRequestTest extends BaseHeadlessTest {
+
+  use CRM_HRLeaveAndAbsences_SicknessRequestHelpersTrait;
+  use CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait;
+
+  public function setUp() {
+    CRM_Core_DAO::executeQuery("SET foreign_key_checks = 0;");
+    $this->requiredDocumentOptions = $this->requiredDocumentOptionsBuilder();
+    $this->leaveRequestDayTypes = $this->leaveRequestDayTypeOptionsBuilder();
+  }
+
+  public function testSicknessRequestIsValidReturnsErrorWhenReasonIsEmpty() {
+    $fromDate = new DateTime("2016-11-14");
+    $fromType = $this->leaveRequestDayTypes['All Day']['id'];
+    $requiredDocuments = $this->requiredDocumentOptions['Self certification form required']['value'];
+
+    $result = civicrm_api3('SicknessRequest', 'isvalid', [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => $fromType,
+      'required_documents' => $requiredDocuments
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 1,
+      'values' => [
+        'reason' => ['sickness_request_empty_reason']
+      ]
+    ];
+    $this->assertArraySubset($expectedResult, $result);
+  }
+
+  public function testSicknessRequestIsValidShouldNotReturnErrorWhenValidationsPass() {
+    $contactID = 1;
+    $fromDate = new DateTime("2016-11-14");
+    $toDate = new DateTime("2016-11-17");
+    $fromType = $this->leaveRequestDayTypes['All Day']['id'];
+    $toType = $this->leaveRequestDayTypes['All Day']['id'];
+    $requiredDocuments = $this->requiredDocumentOptions['Self certification form required']['value'];
+
+    $sicknessReasons = array_flip(SicknessRequest::buildOptions('reason'));
+
+    $result = civicrm_api3('SicknessRequest', 'isvalid', [
+      'type_id' => 1,
+      'contact_id' => $contactID,
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => $fromType,
+      'to_date' => $toDate->format('YmdHis'),
+      'to_date_type' => $toType,
+      'reason' => $sicknessReasons['Appointment'],
+      'required_documents' => $requiredDocuments
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 0,
+      'values' => []
+    ];
+    $this->assertArraySubset($expectedResult, $result);
+  }
+}


### PR DESCRIPTION
This PR creates the Sickness Request isValid API. The API uses the validateParams() method of the SicknessRequest BAO but does not make a call to SicknessRequest BAO create method.

The Response of the API includes the field associated the error and also the error/Exception code for the exception.

Here are some sample request and responses for the API endpoint:

_reason field is empty_

```php
$result = civicrm_api3('SicknessRequest', 'isvalid', array(
  'type_id' => 1,
  'contact_id' => 1,
  'status_id' => 1,
  'from_date' => '2016-11-14',
  'from_date_type' => 1
  'required_documents' => 1,
));
```

Response: 
```json
{
  "is_error": 0,
  "version": 3,
  "count": 1,
  "values": {
    "reason": [
      "sickness_request_empty_reason"
    ]
  }
}
```

When all validations pass the response is:

```json
{
  "is_error": 0,
  "version": 3,
  "count": 0,
  "values": {}
}
```