### PR TITLE
PCHR-1832: Modify SicknessRequest.get API to return associated LeaveRequest data

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/SicknessRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/SicknessRequest.php
@@ -36,13 +36,27 @@ function civicrm_api3_sickness_request_delete($params) {
 
 /**
  * SicknessRequest.get API
+ * This API also returns the associated LeaveRequest data along with the SicknessRequest.
  *
  * @param array $params
+ *
  * @return array API result descriptor
+ *
  * @throws API_Exception
  */
 function civicrm_api3_sickness_request_get($params) {
-  return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  $getLeaveRequest = function (&$item) {
+    $leaveRequest = CRM_HRLeaveAndAbsences_BAO_LeaveRequest::findById($item['leave_request_id']);
+    $leaveRequestFieldValues = $leaveRequest->toArray();
+    $item = array_merge($leaveRequestFieldValues, $item);
+  };
+
+  $result = _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  if ($result['count'] > 0) {
+    array_walk($result['values'], $getLeaveRequest);
+  }
+
+  return $result;
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/SicknessRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/SicknessRequestTest.php
@@ -71,4 +71,73 @@ class SicknessRequestTest extends BaseHeadlessTest {
     ];
     $this->assertArraySubset($expectedResult, $result);
   }
+
+  public function testSicknessRequestGetShouldReturnAssociatedLeaveRequestData() {
+    $fromDate = new DateTime("2016-11-14");
+    $toDate = new DateTime("2016-11-17");
+
+    $fromDate2 = new DateTime("2016-11-20");
+    $toDate2 = new DateTime("2016-11-30");
+
+    $fromType = $this->leaveRequestDayTypes['All Day']['id'];
+    $toType = $this->leaveRequestDayTypes['All Day']['id'];
+
+    $sicknessReasons = array_flip(SicknessRequest::buildOptions('reason'));
+
+    $sicknessRequest1 = SicknessRequest::create([
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => $fromType,
+      'to_date' => $toDate->format('YmdHis'),
+      'to_date_type' => $toType,
+      'reason' => $sicknessReasons['Appointment'],
+      'required_documents' => $this->requiredDocumentOptions['Self certification form required']['value'],
+    ], false);
+
+    $sicknessRequest2 = SicknessRequest::create([
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate2->format('YmdHis'),
+      'from_date_type' => $fromType,
+      'to_date' => $toDate2->format('YmdHis'),
+      'to_date_type' => $toType,
+      'reason' => $sicknessReasons['Accident'],
+      'required_documents' => $this->requiredDocumentOptions['Self certification form required']['value']. ',' . $this->requiredDocumentOptions['Back to work interview required']['value'],
+    ], false);
+
+    $expectedResult = [
+      [
+        'id' => $sicknessRequest1->id,
+        'type_id' => 1,
+        'contact_id' => 1,
+        'status_id' => 1,
+        'from_date' => $fromDate->format('Y-m-d'),
+        'from_date_type' => $fromType,
+        'to_date' => $toDate->format('Y-m-d'),
+        'to_date_type' => $toType,
+        'leave_request_id' => $sicknessRequest1->leave_request_id,
+        'reason' => $sicknessRequest1->reason,
+        'required_documents' => $sicknessRequest1->required_documents
+      ],
+      [
+        'id' => $sicknessRequest2->id,
+        'type_id' => 1,
+        'contact_id' => 1,
+        'status_id' => 1,
+        'from_date' => $fromDate2->format('Y-m-d'),
+        'from_date_type' => $fromType,
+        'to_date' => $toDate2->format('Y-m-d'),
+        'to_date_type' => $toType,
+        'leave_request_id' => $sicknessRequest2->leave_request_id,
+        'reason' => $sicknessRequest2->reason,
+        'required_documents' => $sicknessRequest2->required_documents
+      ]
+    ];
+
+    $result = civicrm_api3('SicknessRequest', 'get', ['contact_id'=> 1, 'sequential' => 1]);
+    $this->assertEquals($expectedResult, $result['values']);
+  }
 }


### PR DESCRIPTION
In this PR, some modifications were made to SicknessRequest.get API endpoint.
When calling the SicknessRequest.get API, it now returns all the fields from the Sickness Requests plus the fields from the Leave Request linked through SicknessRequest.leave_request_id.

Given a Sickness Request with:

| id | leave_request_id |reason | required_documents|
| ------------- | ------------- | ------------- | ------------- |
|1|3|2|3,2,1|

And the related Leave Request (a few fields omitted for simplicity):

| id | from_date | from_date_type | contact_id| status_id | type_id |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
|3|2016-01-01|1|2|2|3|

A call to:
```php
$result = civicrm_api3('SicknessRequest', 'get', array(
  'sequential' => 1,
));
```
Result:
```json
{
  "is_error": 0,
  "version": 3,
  "count": 1,
  "values": [
    {
      "id": "1",
      "type_id": "3",
      "contact_id": "2",
      "status_id": "2",
      "from_date": "2016-01-01",
      "from_date_type": "1",
      "to_date": "",
      "to_date_type": "",
      "leave_request_id": "3",
      "reason": "2",
      "required_documents": "3,2,1"
    }
  ]
}
```