### PR TITLE
PCHR-1831: Modify TOILRequest.get API to return associated LeaveRequest data

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/TOILRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/TOILRequest.php
@@ -36,13 +36,27 @@ function civicrm_api3_t_o_i_l_request_delete($params) {
 
 /**
  * TOILRequest.get API
+ * This API also returns the associated LeaveRequest data along with the TOILRequest.
  *
  * @param array $params
+ *
  * @return array API result descriptor
+ *
  * @throws API_Exception
  */
 function civicrm_api3_t_o_i_l_request_get($params) {
-  return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  $getLeaveRequest = function (&$item) {
+    $leaveRequest = CRM_HRLeaveAndAbsences_BAO_LeaveRequest::findById($item['leave_request_id']);
+    $leaveRequestFieldValues = $leaveRequest->toArray();
+    $item = array_merge($leaveRequestFieldValues, $item);
+  };
+
+  $result = _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  if ($result['count'] > 0) {
+    array_walk($result['values'], $getLeaveRequest);
+  }
+
+  return $result;
 }
 
 /**


### PR DESCRIPTION
In this PR, some modifications were made to TOILRequest.get API endpoint.
When calling the TOILRequest.get API, it now returns all the fields from the TOIL Requests plus the fields from the Leave Request linked through TOILRequest.leave_request_id.

Given a TOIL Request with:

| id | leave_request_id | duration |
| ------------- | ------------- | ------------- | 
|1|3|240|

And the related Leave Request (a few fields omitted for simplicity):

| id | from_date | from_date_type | contact_id| status_id | type_id |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
|3|2016-01-01|1|2|2|3|

A call to:
```php
$result = civicrm_api3('TOILRequest', 'get', array(
  'sequential' => 1,
));
```

Result:
```json
{
  "is_error": 0,
  "version": 3,
  "count": 1,
  "values": [
    {
      "id": "1",
      "type_id": "3",
      "contact_id": "2",
      "status_id": "2",
      "from_date": "2016-01-01",
      "from_date_type": "1",
      "to_date": "",
      "to_date_type": "",
      "leave_request_id": "3",
      "duration": "240",
    }
  ]
}
```