### PR TITLE
PCHR-1819: Fix SMTP Error on Absence Request Save and Approve

### DIFF
--- a/hrabsence/CRM/HRAbsence/Form/AbsenceRequest.php
+++ b/hrabsence/CRM/HRAbsence/Form/AbsenceRequest.php
@@ -615,6 +615,7 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
       if (array_key_exists('_qf_AbsenceRequest_done_cancelabsence', $this->_submitValues)) {
         $this->updateActivitiesStatus('Cancelled');
         $statusMsg = ts('Absence(s) have been Cancelled');
+        self::sendAbsenceMail($this->_mailprm, $this->_sendTemplateParams);
       }
       elseif (array_key_exists('_qf_AbsenceRequest_done_cancel', $this->_submitValues)) {
         $session->pushUserContext(CRM_Utils_System::url('civicrm/absences', "reset=1&cid={$this->_targetContactID}", false, 'hrabsence/list'));
@@ -769,8 +770,8 @@ class CRM_HRAbsence_Form_AbsenceRequest extends CRM_Core_Form {
         $sendTemplateParams['from'] = $loggedUserEmail;
         $sendTemplateParams['tplParams']['approval'] = TRUE;
         break;
-      case $editAction && array_key_exists('_qf_AbsenceRequest_done_cancelabsence', $this->_submitValues):
-        $sendTemplateParams['from'] = $targetContactEmail;
+      case array_key_exists('_qf_AbsenceRequest_done_cancelabsence', $this->_submitValues):
+        $sendTemplateParams['from'] = $loggedUserEmail;
         $sendTemplateParams['tplParams']['cancel'] = $sendMail = TRUE;
         break;
       case $editAction && array_key_exists('_qf_AbsenceRequest_done_approve', $this->_submitValues):


### PR DESCRIPTION
## Problem
When you added absences in Absences/New absence or when Approving or Rejecting an absence, an smtp error message was thrown: code: 501, response: 5.5.2 MAIL FROM syntax error.

As it turned out, there was a check when building the from address, validating if the target contact for the leave request had a manager.  If it didn't have a manager, the from address was being left empty, causing the error.

## Solution
Refactored code into more manageable chunks, including a function built specifically to set the from address and making sure a from address was always being set.