### PR TITLE
PCHR-1770: Extend TOILRequest.get API to filter expired requests

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/TOILRequestSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/TOILRequestSelect.php
@@ -1,0 +1,104 @@
+<?php
+
+use Civi\API\SelectQuery;
+use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
+use CRM_HRLeaveAndAbsences_BAO_TOILRequest as TOILRequest;
+
+/**
+ * This class is basically a wrapper around Civi\API\SelectQuery.
+ *
+ * It's supposed to work just like SelectQuery, but it will automatically join
+ * the TOILRequest with its LeaveBalanceChange, allowing us to filter the results
+ * based on balance change details, like returning only expired requests.
+ */
+class CRM_HRLeaveAndAbsences_API_Query_TOILRequestSelect {
+
+  /**
+   * @var array
+   *   An array of params passed to an API endpoint
+   */
+  private $params;
+
+  /**
+   * @var \Civi\API\SelectQuery
+   *  The SelectQuery instance wrapped by this class
+   */
+  private $query;
+
+  public function __construct($params) {
+    $this->params = $params;
+    $this->buildCustomQuery();
+  }
+
+  /**
+   * Build the custom query, joining TOILRequests with LeaveBalanceChanges
+   */
+  private function buildCustomQuery() {
+    $customQuery = CRM_Utils_SQL_Select::from(TOILRequest::getTableName() . ' as a');
+
+    $this->addJoins($customQuery);
+    $this->addWhere($customQuery);
+    $this->addGroupBy($customQuery);
+
+    $this->query = new SelectQuery(TOILRequest::class, $this->params, false);
+    $this->query->merge($customQuery);
+  }
+
+  /**
+   * Add the conditions to the query.
+   *
+   * If the $params array has the "expired" flag set, the conditions will make
+   * sure only expired TOILRequests will be returned
+   *
+   * @param \CRM_Utils_SQL_Select $customQuery
+   */
+  private function addWhere(CRM_Utils_SQL_Select $customQuery) {
+    $whereClauses = [];
+
+    if(!empty($this->params['expired'])) {
+      $whereClauses[] = "lbc.expiry_date < '" . date('Y-m-d') . "'";
+      $whereClauses[] = 'lbc.expired_balance_change_id Is NOT NULL';
+      $whereClauses[] = 'lbc.amount < 0';
+    }
+
+    $customQuery->where($whereClauses);
+  }
+
+  /**
+   * Add the joins required to join the TOILRequest with its LeaveBalanceChanges.
+   *
+   * @param \CRM_Utils_SQL_Select $query
+   */
+  private function addJoins(CRM_Utils_SQL_Select $query) {
+    $query->join(null, [
+      'INNER JOIN ' . LeaveBalanceChange::getTableName() . " lbc 
+        ON lbc.source_id = a.id AND lbc.source_type = '" . LeaveBalanceChange::SOURCE_TOIL_REQUEST . "'",
+    ]);
+  }
+
+  /**
+   * Executes the query
+   *
+   * @return array
+   */
+  public function run() {
+    return $this->query->run();
+  }
+
+  /**
+   * Add a GROUP BY to the query, group the results
+   *
+   * Since we join with Leave Balance Change, we might
+   * end up with multiple records for the same TOIL Request. The reason is that,
+   * once expired, the TOIL Request will be linked to 2 balance changes (the
+   * original one and the expired one). The API infrastructure is smart enough
+   * to remove those duplicates once the records are fetched, but this would
+   * cause problems with the LIMIT option, as it would be added to the query
+   * and the duplicated records would also be included on the limit.
+   *
+   * @param \CRM_Utils_SQL_Select $query
+   */
+  private function addGroupBy(CRM_Utils_SQL_Select $query) {
+    $query->groupBy(['a.id']);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/TOILRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/TOILRequest.php
@@ -67,9 +67,36 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequest extends CRM_HRLeaveAndAbsences_DAO_
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidTOILRequestException
    */
   public static function validateParams($params) {
+    self::validateMandatoryFields($params);
     self::validateTOILAmountIsValid($params);
     self::validateValidTOILAmountNotGreaterThanMaximum($params);
     self::validateValidTOILPastDaysRequest($params);
+  }
+
+  /**
+   * Validates if all the mandatory fields are present
+   *
+   * @param array $params
+   *   The params array received by the create method
+   *
+   * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidTOILRequestException
+   */
+  private static function validateMandatoryFields($params) {
+    if(empty($params['duration'])) {
+      throw new InvalidTOILRequestException(
+        'The TOIL duration cannot be empty',
+        'toil_request_duration_is_empty',
+        'duration'
+      );
+    }
+
+    if(empty($params['toil_to_accrue'])) {
+      throw new InvalidTOILRequestException(
+        'The TOIL amount cannot be empty',
+        'toil_request_toil_to_accrue_is_empty',
+        'toil_to_accrue'
+      );
+    }
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/TOILRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/TOILRequest.php
@@ -52,7 +52,8 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequest extends CRM_HRLeaveAndAbsences_DAO_
       $instance->save();
     }
 
-    $instance->saveBalanceChange($leaveRequest, $params['toil_to_accrue']);
+    $expiryDate = !empty($params['expiry_date']) ? new DateTime($params['expiry_date']) : null;
+    $instance->saveBalanceChange($leaveRequest, $params['toil_to_accrue'], $expiryDate);
     CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
 
     return $instance;
@@ -176,23 +177,22 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequest extends CRM_HRLeaveAndAbsences_DAO_
    *   The Leave Request created by this TOIL Request
    * @param float $toilToAccrue
    *   The amount of TOIL to be accrued.
+   * @param \DateTime $expiryDate
+   *   The date the LeaveBalanceChange will expire
    */
-  private function saveBalanceChange(LeaveRequest $leaveRequest, $toilToAccrue) {
+  private function saveBalanceChange(LeaveRequest $leaveRequest, $toilToAccrue, DateTime $expiryDate = null) {
     $this->deleteBalanceChange();
 
     $balanceChangeTypes = array_flip(LeaveBalanceChange::buildOptions('type_id'));
-    $absenceType = AbsenceType::findById($leaveRequest->type_id);
-    $toilExpiry =  $absenceType->calculateToilExpiryDate(new DateTime());
-    $expiryDate = null;
-
-    if ($toilExpiry instanceof DateTime) {
-      $expiryDate = CRM_Utils_Date::processDate($toilExpiry->format('Y-m-d'));
+    if($expiryDate === null) {
+      $absenceType = AbsenceType::findById($leaveRequest->type_id);
+      $expiryDate =  $absenceType->calculateToilExpiryDate(new DateTime());
     }
 
     LeaveBalanceChange::create([
       'type_id' => $balanceChangeTypes['Credit'],
       'amount' => $toilToAccrue,
-      'expiry_date' => $expiryDate,
+      'expiry_date' => $expiryDate ? $expiryDate->format('Ymd') : null,
       'source_id' => $this->id,
       'source_type' => LeaveBalanceChange::SOURCE_TOIL_REQUEST
     ]);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/TOILRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/TOILRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use CRM_HRLeaveAndAbsences_BAO_TOILRequest as TOILRequest;
+
+class CRM_HRLeaveAndAbsences_Test_Fabricator_TOILRequest {
+
+  private static $leaveRequestStatuses;
+  private static $toilAmounts;
+
+  public static function fabricate($params) {
+    $params = self::mergeDefaultParams($params);
+
+    return TOILRequest::create($params);
+  }
+
+  /**
+   * Creates a new Sickness Request without running any validation
+   *
+   * @param array $params
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_SicknessRequest
+   */
+  public static function fabricateWithoutValidation($params = []) {
+    $params = self::mergeDefaultParams($params);
+
+    return TOILRequest::create($params, false);
+  }
+
+  private static function mergeDefaultParams($params) {
+    $defaultParams = [
+      'status_id' => self::getStatusValue('Approved'),
+      'toil_to_accrue' => self::getToilToAccrueValue('1 Day')
+    ];
+
+    return array_merge($defaultParams, $params);
+  }
+
+  private static function getStatusValue($statusLabel) {
+    if(is_null(self::$leaveRequestStatuses)) {
+      self::$leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
+    }
+
+    return self::$leaveRequestStatuses[$statusLabel];
+  }
+
+  private static function getToilToAccrueValue($reasonLabel) {
+    if(is_null(self::$toilAmounts)) {
+      $result = civicrm_api3('OptionValue', 'get', ['option_group_id' => 'hrleaveandabsences_toil_amounts']);
+      foreach($result['values'] as $value) {
+        self::$toilAmounts[$value['label']] = $value['value'];
+      }
+    }
+
+    return self::$toilAmounts[$reasonLabel];
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/SicknessRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/SicknessRequest.php
@@ -23,8 +23,8 @@ function _civicrm_api3_sickness_request_create_spec(&$spec) {
     'type'         => CRM_Utils_Type::T_INT,
     'description'  => 'FK to Contact',
     'api.required' => TRUE,
-    'FKClassName'  => 'CRM_HRLeaveAndAbsences_DAO_LeaveRequest',
-    'FKApiName'    => 'LeaveRequest',
+    'FKClassName'  => 'CRM_Contact_DAO_Contact',
+    'FKApiName'    => 'Contact',
   ];
 
   $spec['status_id'] = array(

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/TOILRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/TOILRequest.php
@@ -79,6 +79,14 @@ function _civicrm_api3_t_o_i_l_request_create_spec(&$spec) {
   $spec['leave_request_id'] = [
     'api.required' => 0
   ];
+
+  $spec['expiry_date'] = [
+    'name' => 'expiry_date',
+    'type' => CRM_Utils_Type::T_DATE,
+    'title' => ts('Expiry Date'),
+    'description' => 'The date when the accrued TOIL will expire, if not used',
+    'api.required' => false
+  ];
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/TOILRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/TOILRequest.php
@@ -9,7 +9,76 @@
  * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
  */
 function _civicrm_api3_t_o_i_l_request_create_spec(&$spec) {
-  // $spec['some_parameter']['api.required'] = 1;
+  $spec['type_id'] = [
+    'name'         => 'type_id',
+    'type'         => CRM_Utils_Type::T_INT,
+    'description'  => 'FK to AbsenceType',
+    'api.required' => TRUE,
+    'FKClassName'  => 'CRM_HRLeaveAndAbsences_DAO_AbsenceType',
+    'FKApiName'    => 'AbsenceType',
+  ];
+
+  $spec['contact_id'] = [
+    'name'         => 'contact_id',
+    'type'         => CRM_Utils_Type::T_INT,
+    'description'  => 'FK to Contact',
+    'api.required' => TRUE,
+    'FKClassName'  => 'CRM_Contact_DAO_Contact',
+    'FKApiName'    => 'Contact',
+  ];
+
+  $spec['status_id'] = array(
+    'name'           => 'status_id',
+    'type'           => CRM_Utils_Type::T_INT,
+    'description'    => 'One of the values of the Leave Request Status option group',
+    'api.required'   => TRUE,
+    'pseudoconstant' => [
+      'optionGroupName' => 'hrleaveandabsences_leave_request_status',
+      'optionEditPath'  => 'civicrm/admin/options/hrleaveandabsences_leave_request_status'
+    ]
+  );
+
+  $spec['from_date'] = [
+    'name'         => 'from_date',
+    'type'         => CRM_Utils_Type::T_DATE,
+    'title'        => ts('From Date'),
+    'description'  => 'The date the leave request starts.',
+    'api.required' => TRUE,
+  ];
+
+  $spec['from_date_type'] = [
+    'name'           => 'from_date_type',
+    'type'           => CRM_Utils_Type::T_INT,
+    'title'          => ts('From Date Type'),
+    'description'    => 'One of the values of the Leave Request Day Type option group',
+    'api.required'   => TRUE,
+    'pseudoconstant' => [
+      'optionGroupName' => 'hrleaveandabsences_leave_request_day_type',
+      'optionEditPath'  => 'civicrm/admin/options/hrleaveandabsences_leave_request_day_type',
+    ]
+  ];
+
+  $spec['to_date'] = [
+    'name'        => 'to_date',
+    'type'        => CRM_Utils_Type::T_DATE,
+    'title'       => ts('To Date'),
+    'description' => 'The date the leave request ends. If null, it means is starts and ends at the same date',
+  ];
+
+  $spec['to_date_type'] = [
+    'name'           => 'to_date_type',
+    'type'           => CRM_Utils_Type::T_INT,
+    'title'          => ts('To Date Type'),
+    'description'    => 'One of the values of the Leave Request Day Type option group',
+    'pseudoconstant' => [
+      'optionGroupName' => 'hrleaveandabsences_leave_request_day_type',
+      'optionEditPath'  => 'civicrm/admin/options/hrleaveandabsences_leave_request_day_type',
+    ]
+  ];
+
+  $spec['leave_request_id'] = [
+    'api.required' => 0
+  ];
 }
 
 /**
@@ -20,7 +89,12 @@ function _civicrm_api3_t_o_i_l_request_create_spec(&$spec) {
  * @throws API_Exception
  */
 function civicrm_api3_t_o_i_l_request_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  if ($result['count'] > 0) {
+    array_walk($result['values'], '_civicrm_api3_t_o_i_l_request_merge_with_leave_request');
+  }
+
+  return $result;
 }
 
 /**
@@ -45,15 +119,9 @@ function civicrm_api3_t_o_i_l_request_delete($params) {
  * @throws API_Exception
  */
 function civicrm_api3_t_o_i_l_request_get($params) {
-  $getLeaveRequest = function (&$item) {
-    $leaveRequest = CRM_HRLeaveAndAbsences_BAO_LeaveRequest::findById($item['leave_request_id']);
-    $leaveRequestFieldValues = $leaveRequest->toArray();
-    $item = array_merge($leaveRequestFieldValues, $item);
-  };
-
   $result = _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
   if ($result['count'] > 0) {
-    array_walk($result['values'], $getLeaveRequest);
+    array_walk($result['values'], '_civicrm_api3_t_o_i_l_request_merge_with_leave_request');
   }
 
   return $result;
@@ -80,4 +148,16 @@ function civicrm_api3_t_o_i_l_request_isvalid($params) {
   }
 
   return civicrm_api3_create_success($result);
+}
+
+/**
+ * Helper method to fetch the LeaveRequest associated with a TOILRequest and
+ * merge it into a TOILRequest array returned by the API
+ *
+ * @param array $item
+ */
+function _civicrm_api3_t_o_i_l_request_merge_with_leave_request(&$item) {
+  $leaveRequest = CRM_HRLeaveAndAbsences_BAO_LeaveRequest::findById($item['leave_request_id']);
+  $leaveRequestFieldValues = $leaveRequest->toArray();
+  $item = array_merge($leaveRequestFieldValues, $item);
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/TOILRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/TOILRequest.php
@@ -116,6 +116,16 @@ function civicrm_api3_t_o_i_l_request_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
 
+function _civicrm_api3_t_o_i_l_request_get_spec(&$spec) {
+  $spec['expired'] = [
+    'name'         => 'expired',
+    'type'         => CRM_Utils_Type::T_BOOLEAN,
+    'title'        => ts('Expired?'),
+    'description'  => ts('When true, only expired TOIL Requests will be returned. Otherwise, only the non-expired ones will be returned'),
+    'api.required' => FALSE
+  ];
+}
+
 /**
  * TOILRequest.get API
  * This API also returns the associated LeaveRequest data along with the TOILRequest.
@@ -127,7 +137,9 @@ function civicrm_api3_t_o_i_l_request_delete($params) {
  * @throws API_Exception
  */
 function civicrm_api3_t_o_i_l_request_get($params) {
-  $result = _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  $query = new CRM_HRLeaveAndAbsences_API_Query_TOILRequestSelect($params);
+  $result = civicrm_api3_create_success($query->run(), $params, '', 'get');
+
   if ($result['count'] > 0) {
     array_walk($result['values'], '_civicrm_api3_t_o_i_l_request_merge_with_leave_request');
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
@@ -307,7 +307,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
   }
 
   public function testTheLeaveRequestBalanceShouldOnlyIncludeDaysDeductedByApprovedLeaveRequests() {
-    $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests();
+    $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
+      new DateTime(),
+      new DateTime('+8 days')
+    );
 
     // None of these will be included in the Leave Request balance
     $this->createLeaveBalanceChange($periodEntitlement->id, 6);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/SicknessRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/SicknessRequestTest.php
@@ -16,7 +16,7 @@ class CRM_HRLeaveAndAbsences_BAO_SicknessRequestTest extends BaseHeadlessTest {
   public function setUp() {
     CRM_Core_DAO::executeQuery("SET foreign_key_checks = 0;");
 
-    $this->requiredDocumentOptions = $this->requiredDocumentOptionsBuilder();
+    $this->requiredDocumentOptions = $this->getSicknessRequestRequiredDocumentsOptions();
     $this->leaveRequestDayTypes = $this->getLeaveRequestDayTypes();
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/TOILRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/TOILRequestTest.php
@@ -337,7 +337,7 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequestTest extends BaseHeadlessTest {
     $this->assertEquals($this->toilAmounts['3 Days']['value'], $toilBalanceChange->amount);
   }
 
-  public function testCreateTOILRequestBalanceChangeWhenTOILHasNoExpiry() {
+  public function testCreateTOILRequestBalanceChangeWhenNoExpiryDateIsGivenAndAbsenceTypeSaysTOILNeverExpires() {
     $fromDate = new DateTime();
     $toDate = new DateTime('+3 days');
 
@@ -368,7 +368,7 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequestTest extends BaseHeadlessTest {
     $this->assertNull($toilBalanceChange->expiry_date);
   }
 
-  public function testCreateTOILRequestBalanceChangeWhenTOILHasExpiryDate() {
+  public function testCreateTOILRequestBalanceChangeWhenNoExpiryDateIsGivenAndAbsenceTypeHasTOILExpiryDuration() {
     $fromDate = new DateTime();
     $toDate = new DateTime('+3 days');
 
@@ -399,5 +399,38 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequestTest extends BaseHeadlessTest {
     $toilBalanceChange->find(true);
 
     $this->assertEquals($toilBalanceChange->expiry_date, $expectedExpiryDate->format('Y-m-d'));
+  }
+
+  public function testCreateTOILRequestBalanceChangeWhenATOILExpiryDateIsGiven() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'title' => 'Title 1',
+      'max_leave_accrual' => 10,
+      'allow_accruals_request' => true,
+      'accrual_expiration_duration' => 10,
+      'accrual_expiration_unit' => AbsenceType::EXPIRATION_UNIT_DAYS,
+      'is_active' => 1,
+    ]);
+
+    $expiryDate = new DateTime('+100 days');
+
+    $toilRequest = TOILRequest::create([
+      'type_id' => $absenceType->id,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => date('YmdHis'),
+      'toil_to_accrue' => $this->toilAmounts['2 Days']['value'],
+      'duration' => 300,
+      'expiry_date' => $expiryDate->format('Ymd')
+    ], false);
+
+    $toilBalanceChange = new LeaveBalanceChange();
+    $toilBalanceChange->source_id = $toilRequest->id;
+    $toilBalanceChange->source_type = LeaveBalanceChange::SOURCE_TOIL_REQUEST;
+    $toilBalanceChange->find(true);
+
+    // The settings on the AbsenceType says TOIL Requests should expire in 10 days,
+    // but the expiry date passed to create was 100 days, so that should be the
+    // date used
+    $this->assertEquals($expiryDate->format('Y-m-d'), $toilBalanceChange->expiry_date);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/TOILRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/TOILRequestTest.php
@@ -23,6 +23,64 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequestTest extends BaseHeadlessTest {
 
   /**
    * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidTOILRequestException
+   * @expectedExceptionMessage The TOIL duration cannot be empty
+   */
+  public function testValidateTOILRequestWhenDurationIsNotPresent() {
+    TOILRequest::validateParams([
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => '2016-11-14',
+      'toil_to_accrue' => 1,
+    ]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidTOILRequestException
+   * @expectedExceptionMessage The TOIL duration cannot be empty
+   */
+  public function testValidateTOILRequestWhenDurationIsEmpty() {
+    TOILRequest::validateParams([
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => '2016-11-14',
+      'toil_to_accrue' => 1,
+      'duration' => null
+    ]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidTOILRequestException
+   * @expectedExceptionMessage The TOIL amount cannot be empty
+   */
+  public function testValidateTOILRequestWhenToilAmountIsNotPresent() {
+    TOILRequest::validateParams([
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => '2016-11-14',
+      'duration' => 120
+    ]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidTOILRequestException
+   * @expectedExceptionMessage The TOIL amount cannot be empty
+   */
+  public function testValidateTOILRequestWhenToilAmountIsEmpty() {
+    TOILRequest::validateParams([
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => '2016-11-14',
+      'duration' => 120,
+      'toil_to_accrue' => null
+    ]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidTOILRequestException
    * @expectedExceptionMessage The TOIL amount is not valid
    */
   public function testValidateTOILRequestWhenToilAmountIsNotValid() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/TOILRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/TOILRequestTest.php
@@ -5,7 +5,9 @@ use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
 use CRM_HRLeaveAndAbsences_BAO_TOILRequest as TOILRequest;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod as AbsencePeriodFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange as LeaveBalanceChangeFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeavePeriodEntitlement as LeavePeriodEntitlementFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_TOILRequest as TOILRequestFabricator;
 
 /**
  * Class api_v3_TOILRequestTest
@@ -317,5 +319,137 @@ class api_v3_TOILRequestTest extends BaseHeadlessTest {
     $this->assertArraySubset($expectedValues, $result['values'][0]);
     $this->assertNotEmpty($result['values'][0]['id']);
     $this->assertNotEmpty($result['values'][0]['leave_request_id']);
+  }
+
+  public function testGetWithoutTheExpiredParamReturnsAllTOILRequests() {
+    $contact = ContactFabricator::fabricate();
+
+    $type = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'max_leave_accrual' => 10
+    ]);
+
+    // This request has expired, but will be included on
+    // the response since the "expired" flag is not set
+    $toilRequest1 = TOILRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contact['id'],
+      'type_id' => $type->id,
+      'from_date' => '20160101',
+      'duration' => 10,
+      'expiry_date' => '20160110'
+    ]);
+
+    $toilRequestBalanceChange = $this->findToilRequestBalanceChange($toilRequest1->id);
+    LeaveBalanceChangeFabricator::fabricate([
+      'source_id' => $toilRequestBalanceChange->source_id,
+      'source_type' => $toilRequestBalanceChange->source_type,
+      'amount' => $toilRequestBalanceChange->amount * -1,
+      'expiry_date' => CRM_Utils_Date::processDate($toilRequestBalanceChange->expiry_date),
+      'expired_balance_change_id' => $toilRequestBalanceChange->id,
+      'type_id' => $this->getBalanceChangeTypeValue('Debit')
+    ]);
+
+    $nextMonday = new DateTime('next monday');
+
+    // This is not expired yet and it will be included on
+    // the response
+    $toilRequest2 = TOILRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contact['id'],
+      'type_id' => $type->id,
+      'from_date' => $nextMonday->format('Ymd'),
+      'duration' => 10,
+      'expiry_date' => $nextMonday->modify('+5 days')->format('Ymd')
+    ]);
+
+    $result = civicrm_api3('TOILRequest', 'get');
+    $this->assertEquals(2, $result['count']);
+    $this->assertNotEmpty($result['values'][$toilRequest1->id]);
+    $this->assertNotEmpty($result['values'][$toilRequest2->id]);
+  }
+
+  public function testGetWitTheExpiredParamReturnsOnlyExpiredRequests() {
+    $contact = ContactFabricator::fabricate();
+
+    $type = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'max_leave_accrual' => 10
+    ]);
+
+    // This request has expired, and it will be included in
+    // the response
+    $toilRequest1 = TOILRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contact['id'],
+      'type_id' => $type->id,
+      'from_date' => '20160101',
+      'duration' => 10,
+      'expiry_date' => '20160110'
+    ]);
+
+    $toilRequestBalanceChange = $this->findToilRequestBalanceChange($toilRequest1->id);
+    LeaveBalanceChangeFabricator::fabricate([
+      'source_id' => $toilRequestBalanceChange->source_id,
+      'source_type' => $toilRequestBalanceChange->source_type,
+      'amount' => $toilRequestBalanceChange->amount * -1,
+      'expiry_date' => CRM_Utils_Date::processDate($toilRequestBalanceChange->expiry_date),
+      'expired_balance_change_id' => $toilRequestBalanceChange->id,
+      'type_id' => $this->getBalanceChangeTypeValue('Debit')
+    ]);
+
+    $nextMonday = new DateTime('next monday');
+
+    // This is not expired yet and it will not be included on
+    // the response
+    $toilRequest2 = TOILRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contact['id'],
+      'type_id' => $type->id,
+      'from_date' => $nextMonday->format('Ymd'),
+      'duration' => 10,
+      'expiry_date' => $nextMonday->modify('+5 days')->format('Ymd')
+    ]);
+
+    $result = civicrm_api3('TOILRequest', 'get', ['expired' => true]);
+    $this->assertEquals(1, $result['count']);
+    $this->assertNotEmpty($result['values'][$toilRequest1->id]);
+  }
+
+  public function testGetWitTheExpiredParamDoesNotReturnsARequestWithAnExpiryDateInThePastButWithoutAnExpiredAmount() {
+    $contact = ContactFabricator::fabricate();
+
+    $type = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'max_leave_accrual' => 10
+    ]);
+
+    // This request has expired, and it will be included in
+    // the response
+    $toilRequest1 = TOILRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contact['id'],
+      'type_id' => $type->id,
+      'from_date' => '20160101',
+      'duration' => 10,
+      'expiry_date' => '20160110'
+    ]);
+
+    $result = civicrm_api3('TOILRequest', 'get', ['expired' => true]);
+    // The expiry date is in the past and the expired leave balance change was
+    // not created yet. Nothing will be returned
+    $this->assertEquals(0, $result['count']);
+
+    $toilRequestBalanceChange = $this->findToilRequestBalanceChange($toilRequest1->id);
+    // Now we create the expired balance change, but the amount will be 0, meaning
+    // that, in practice, nothing has expired and all the accrued days were used
+    LeaveBalanceChangeFabricator::fabricate([
+      'source_id' => $toilRequestBalanceChange->source_id,
+      'source_type' => $toilRequestBalanceChange->source_type,
+      'amount' => 0,
+      'expiry_date' => CRM_Utils_Date::processDate($toilRequestBalanceChange->expiry_date),
+      'expired_balance_change_id' => $toilRequestBalanceChange->id,
+      'type_id' => $this->getBalanceChangeTypeValue('Debit')
+    ]);
+define( 'CIVICRM_DEBUG_LOG_QUERY', 1 );
+    $result = civicrm_api3('TOILRequest', 'get', ['expired' => true]);
+    // Even with the balance change, it should still return nothing because 0
+    // means nothing has expired
+    $this->assertEquals(0, $result['count']);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/TOILRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/TOILRequestTest.php
@@ -198,4 +198,63 @@ class api_v3_TOILRequestTest extends BaseHeadlessTest {
     $result = civicrm_api3('TOILRequest', 'get', ['contact_id'=> 1, 'sequential' => 1]);
     $this->assertEquals($expectedResult, $result['values']);
   }
+
+  public function testTOILRequestIsValidShouldReturnErrorWhenDurationIsEmptyOrNotPresent() {
+    $result = civicrm_api3('TOILRequest', 'isValid', [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => '2016-11-14',
+      'toil_to_accrue' => 200,
+      'duration' => null
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 1,
+      'values' => [
+        'duration' => ['toil_request_duration_is_empty']
+      ]
+    ];
+
+    $this->assertArraySubset($expectedResult, $result);
+
+    $result = civicrm_api3('TOILRequest', 'isValid', [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => '2016-11-14',
+      'toil_to_accrue' => 200,
+    ]);
+    $this->assertArraySubset($expectedResult, $result);
+  }
+
+  public function testTOILRequestIsValidShouldReturnErrorWhenToilToAccrueIsEmptyOrNotPresent() {
+    $result = civicrm_api3('TOILRequest', 'isValid', [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => '2016-11-14',
+      'toil_to_accrue' => '',
+      'duration' => 10,
+    ]);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'count' => 1,
+      'values' => [
+        'toil_to_accrue' => ['toil_request_toil_to_accrue_is_empty']
+      ]
+    ];
+    $this->assertArraySubset($expectedResult, $result);
+
+    $result = civicrm_api3('TOILRequest', 'isValid', [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => '2016-11-14',
+      'duration' => 10
+    ]);
+    $this->assertArraySubset($expectedResult, $result);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
@@ -8,7 +8,7 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
 
   private $balanceChangeTypes = [];
 
-  private function getBalanceChangeTypeValue($type) {
+  public function getBalanceChangeTypeValue($type) {
     if(empty($this->balanceChangeTypes)) {
       $this->balanceChangeTypes = array_flip(LeaveBalanceChange::buildOptions('type_id'));
     }
@@ -162,5 +162,26 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
     $dao = CRM_Core_DAO::executeQuery("SELECT id FROM {$tableName} ORDER BY id DESC LIMIT 1");
     $dao->fetch();
     return (int)$dao->id;
+  }
+
+  /**
+   * Finds a LeaveBalanceChange associated with the TOILRequest with the given ID
+   *
+   * @param int $toilRequestID
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange|null
+   */
+  public function findToilRequestBalanceChange($toilRequestID) {
+    $balanceChange = new LeaveBalanceChange();
+    $balanceChange->source_id = $toilRequestID;
+    $balanceChange->source_type = LeaveBalanceChange::SOURCE_TOIL_REQUEST;
+
+    if($balanceChange->find()) {
+      $balanceChange->fetch();
+
+      return $balanceChange;
+    }
+
+    return null;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestHelpersTrait.php
@@ -5,6 +5,7 @@ use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 trait CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait {
 
   protected $leaveRequestDayTypes = [];
+  protected $leaveRequestStatuses = [];
 
   protected function getLeaveRequestDayTypes() {
     if(empty($this->leaveRequestDayTypes)) {
@@ -21,5 +22,22 @@ trait CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait {
     }
 
     return $this->leaveRequestDayTypes;
+  }
+
+  protected function getLeaveRequestStatuses() {
+    if(empty($this->leaveRequestStatuses)) {
+      $leaveRequestStatusOptions = LeaveRequest::buildOptions('status_id');
+      foreach($leaveRequestStatusOptions  as $key => $label) {
+        $name = CRM_Core_Pseudoconstant::getName(LeaveRequest::class, 'status_id', $key);
+        $this->leaveRequestStatuses[$label] = [
+          'id' => $key,
+          'value' => $key,
+          'name' => $name,
+          'label' => $label
+        ];
+      }
+    }
+
+    return $this->leaveRequestStatuses;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/SicknessRequestHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/SicknessRequestHelpersTrait.php
@@ -4,23 +4,47 @@
 trait CRM_HRLeaveAndAbsences_SicknessRequestHelpersTrait {
 
   protected $requiredDocumentOptions = [];
+  protected $sicknessRequestReasons = [];
 
-  protected function requiredDocumentOptionsBuilder() {
+  protected function getSicknessRequestRequiredDocumentsOptions() {
+    if(empty($this->requiredDocumentOptions)) {
+      $result = civicrm_api3('OptionValue', 'get', [
+        'option_group_id' => 'hrleaveandabsences_leave_request_required_document',
+      ]);
 
-    $result = civicrm_api3('OptionValue', 'get', [
-      'option_group_id' => 'hrleaveandabsences_leave_request_required_document',
-    ]);
-    $requiredDocumentOptions = [];
+      foreach ($result['values'] as $requiredDocument) {
+        $option = [
+          'id' => $requiredDocument['id'],
+          'value' => $requiredDocument['value'],
+          'name' => $requiredDocument['name'],
+          'label' => $requiredDocument['label']
+        ];
 
-    foreach ($result['values'] as $requiredDocument) {
-      $option = [
-        'id' => $requiredDocument['id'],
-        'value' => $requiredDocument['value'],
-        'name' => $requiredDocument['name'],
-        'label' => $requiredDocument['label']
-      ];
-      $requiredDocumentOptions[$requiredDocument['label']] = $option;
+        $this->requiredDocumentOptions[$requiredDocument['label']] = $option;
+      }
     }
-    return $requiredDocumentOptions;
+
+    return $this->requiredDocumentOptions;
+  }
+
+  protected function getSicknessRequestReasons() {
+    if(empty($this->sicknessRequestReasons)) {
+      $result = civicrm_api3('OptionValue', 'get', [
+        'option_group_id' => 'hrleaveandabsences_sickness_reason',
+      ]);
+
+      foreach ($result['values'] as $requiredDocument) {
+        $option = [
+          'id' => $requiredDocument['id'],
+          'value' => $requiredDocument['value'],
+          'name' => $requiredDocument['name'],
+          'label' => $requiredDocument['label']
+        ];
+
+        $this->sicknessRequestReasons[$requiredDocument['label']] = $option;
+      }
+    }
+
+    return $this->sicknessRequestReasons;
   }
 }


### PR DESCRIPTION
This PR adds the "expired" filter to the TOILRequest.get API. When this filter is set, only expired TOILRequests will be returned, otherwise all will be returned.

Example usage:
```php
civicrm_api3('TOILRequest', 'get', ['expired' => true]);
```

The `TOILRequestSelect` was introduced to make this filter work. It wraps the `Civi\API\SelectQuery` class in order to join the TOILRequest with its LeaveBalanceChanges and be able to check if it's expired or not.

### What else changed?

While working on this ticket, I found a few problems with TOILRequest and SicknessRequest apis and BAOs. They were all fixed:
- The spec for the contact_id field of the SicknessRequest.create API had the wrong class name. 
- The TOILRequest BAO was missing the validation of mandatory fields (duration and toil_to_accrue)
- The TOILRequest BAO did not support receiving an expiry date to set it on the LeaveBalanceChange]
- The TOILRequest.create API was nothing returning all of the LeaveRequest fields on the response
- The LeavePeriodEntitlement BAO tests had some bugs which would make them fail close to the end of the year