### PR TITLE
PCHR-1835: Add the LeaveManager Service

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveManager.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveManager.php
@@ -1,0 +1,49 @@
+<?php
+
+class CRM_HRLeaveAndAbsences_Service_LeaveManager {
+
+  /**
+   * Checks if the current logged in user is the Leave Manager for the Contact
+   * with the given ID.
+   *
+   * In order to do this, we check if there's a Relationship between both
+   * contacts, where contact A ($contactID) "has Leave Approved By" contact B
+   * (the logged in), and that if the Relationship is active on the current date.
+   *
+   * Note about implementation: Due to the impossibility of making complex
+   * queries using the CiviCRM API (r.start_date IS NULL OR r.start_date <=
+   * CURDATE()), this method uses a SQL query to check the relationship.
+   *
+   * @param int $contactID
+   *
+   * @return bool
+   */
+  public function currentUserIsLeaveManagerOf($contactID) {
+    $currentUserID = CRM_Core_Session::getLoggedInContactID();
+
+    $relationshipTable = CRM_Contact_BAO_Relationship::getTableName();
+    $relationshipTypeTable = CRM_Contact_BAO_RelationshipType::getTableName();
+
+    $query = "SELECT r.id 
+                FROM {$relationshipTable} r
+                INNER JOIN {$relationshipTypeTable} rt ON rt.id = r.relationship_type_id
+              WHERE r.is_active = 1 AND 
+                    rt.is_active = 1 AND 
+                    rt.name_a_b = 'has Leave Approved By' AND
+                    r.contact_id_a = %1 AND
+                    r.contact_id_b = %2 AND
+                    (r.start_date IS NULL OR r.start_date <= %3) AND 
+                    (r.end_date IS NULL OR r.end_date >= %3)
+              ";
+
+    $params = [
+      1 => [$contactID, 'Integer'],
+      2 => [$currentUserID, 'Integer'],
+      3 => [date('Y-m-d'), 'String']
+    ];
+
+    $result = CRM_Core_DAO::executeQuery($query, $params);
+
+    return $result->N > 0;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveManager.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveManager.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * This service contains some methods to deal with who is the manager of Leave
+ * Requests. Examples, checking if a contact is the "Leave Approver" of another
+ * contact of if a contact has permission to administer things under Leave and
+ * Absences.
+ */
 class CRM_HRLeaveAndAbsences_Service_LeaveManager {
 
   /**
@@ -45,5 +51,15 @@ class CRM_HRLeaveAndAbsences_Service_LeaveManager {
     $result = CRM_Core_DAO::executeQuery($query, $params);
 
     return $result->N > 0;
+  }
+
+  /**
+   * Checks if the current logged user is a L&A admin. An admin is a user with
+   * the "administer leave and absences" permission.
+   *
+   * @return bool
+   */
+  public function currentUserIsAdmin() {
+    return CRM_Core_Permission::check('administer leave and absences');
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveManagerTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveManagerTest.php
@@ -61,6 +61,18 @@ class CRM_HRLeaveAndAbsences_Service_LeaveManagerTest extends BaseHeadlessTest {
     $this->assertFalse($this->leaveManagerService->currentUserIsLeaveManagerOf($staffMember['id']));
   }
 
+  public function testCurrentUserIsAdmin() {
+    // First we need to make sure no permission is set. Note that if
+    // permissions is null, CRM_Core_Permission always returns true, so we must
+    // manually set to an empty array
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
+
+    $this->assertFalse($this->leaveManagerService->currentUserIsAdmin());
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer leave and absences'];
+
+    $this->assertTrue($this->leaveManagerService->currentUserIsAdmin());
+  }
+
   private function setContactAsLeaveApproverOf($leaveApprover, $contact, $startDate = null, $endDate = null, $isActive = true) {
     $relationshipType = $this->getLeaveApproverRelationshipType();
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveManagerTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveManagerTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
+use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
+
+/**
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_Service_LeaveManagerTest extends BaseHeadlessTest {
+
+  private $leaveManagerService;
+
+  private $loggedInContact;
+
+  public function setUp() {
+    $this->loggedInContact = ContactFabricator::fabricate();
+    $this->registerCurrentLoggedInContactInSession();
+    $this->leaveManagerService = new LeaveManagerService();
+  }
+
+  public function tearDown() {
+    $this->unregisterCurrentLoggedInContactFromSession();
+  }
+
+  public function testCurrentUserIsLeaveManagerOf() {
+    $staffMember = ContactFabricator::fabricate();
+
+    $this->assertFalse($this->leaveManagerService->currentUserIsLeaveManagerOf($staffMember['id']));
+
+    $this->setContactAsLeaveApproverOf($this->loggedInContact, $staffMember);
+
+    $this->assertTrue($this->leaveManagerService->currentUserIsLeaveManagerOf($staffMember['id']));
+  }
+
+  public function testCurrentUserIsLeaveManagerOfWhenTheresNoActiveRelationshipForTheCurrentDate() {
+    $staffMember = ContactFabricator::fabricate();
+
+    $this->assertFalse($this->leaveManagerService->currentUserIsLeaveManagerOf($staffMember['id']));
+
+    // Set a relationship in the past
+    $startDate = new DateTime('-10 days');
+    $endDate = new DateTime('-1 day');
+    $this->setContactAsLeaveApproverOf($this->loggedInContact, $staffMember, $startDate->format('Y-m-d'), $endDate->format('Y-m-d'));
+
+    $this->assertFalse($this->leaveManagerService->currentUserIsLeaveManagerOf($staffMember['id']));
+
+    // Set a relationship in the future
+    $startDate = new DateTime('+1 day');
+    $this->setContactAsLeaveApproverOf($this->loggedInContact, $staffMember, $startDate->format('Y-m-d'));
+
+    $this->assertFalse($this->leaveManagerService->currentUserIsLeaveManagerOf($staffMember['id']));
+  }
+
+  public function testCurrentUserIsLeaveManagerOfWhenTheCurrentRelationshipIsNotActive() {
+    $staffMember = ContactFabricator::fabricate();
+
+    $this->assertFalse($this->leaveManagerService->currentUserIsLeaveManagerOf($staffMember['id']));
+    
+    $this->setContactAsLeaveApproverOf($this->loggedInContact, $staffMember, null, null, false);
+
+    $this->assertFalse($this->leaveManagerService->currentUserIsLeaveManagerOf($staffMember['id']));
+  }
+
+  private function setContactAsLeaveApproverOf($leaveApprover, $contact, $startDate = null, $endDate = null, $isActive = true) {
+    $relationshipType = $this->getLeaveApproverRelationshipType();
+
+    civicrm_api3('Relationship', 'create', array(
+      'sequential' => 1,
+      'contact_id_a' => $contact['id'],
+      'contact_id_b' => $leaveApprover['id'],
+      'relationship_type_id' => $relationshipType['id'],
+      'start_date' => $startDate,
+      'end_date' => $endDate,
+      'is_active' => $isActive
+    ));
+  }
+
+  private function getLeaveApproverRelationshipType() {
+    $result = civicrm_api3('RelationshipType', 'get', [
+      'name_a_b' => 'has Leave Approved by',
+    ]);
+
+    if(empty($result['values'])) {
+      return $this->createLeaveApproverRelationshipType();
+    }
+
+    return array_shift($result['values']);
+  }
+
+  private function createLeaveApproverRelationshipType() {
+    $result = civicrm_api3('RelationshipType', 'create', array(
+      'sequential'     => 1,
+      'name_a_b'       => 'has Leave Approved by',
+      'name_b_a'       => 'is Leave Approver of',
+      'contact_type_a' => 'Individual',
+      'contact_type_b' => 'Individual',
+    ));
+
+    return $result['values'][0];
+  }
+
+  private function registerCurrentLoggedInContactInSession() {
+    $session = CRM_Core_Session::singleton();
+    $session->set('userID', $this->loggedInContact['id']);
+  }
+
+  private function unregisterCurrentLoggedInContactFromSession() {
+    $session = CRM_Core_Session::singleton();
+    $session->set('userID', null);
+  }
+}


### PR DESCRIPTION
This service encapsulates the logic to deal with who is the Leave Approver of an Admin of Leave and Absences. It has two methods:

### currentUserIsLeaveManagerOf()
It accepts a contactID and checks if the current logged in user is his/her Leave Approver. This is done by checking if there is an active "has Leave Approved by/is Leave Approver of" relationship between the two contacts.

### currentUserIsAdmin()
It just checks if the current logged in user has the "administer leave and absences" permission