### PR TITLE
PCHR-1798: Add the managed_by param to the LeaveRequest.get API

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Test/Fabricator/Relationship.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Test/Fabricator/Relationship.php
@@ -1,0 +1,19 @@
+<?php
+
+class CRM_HRCore_Test_Fabricator_Relationship {
+
+  private static $defaultParams = [
+    'is_active' => 1,
+    'start_date' => null,
+    'end_date' => null,
+  ];
+
+  public static function fabricate($params = []) {
+    $params = array_merge(self::$defaultParams, $params);
+
+    $result = civicrm_api3('Relationship', 'create', $params);
+
+    return array_shift($result['values']);
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -73,16 +73,31 @@ function _civicrm_api3_leave_request_get_spec(&$spec) {
     'type' => CRM_Utils_Type::T_BOOLEAN,
     'api.required' => 0,
   ];
+
+  $spec['managed_by'] = [
+    'name' => 'managed_by',
+    'title' => 'Include only Leave Requests for contacts managed by the contact with the given ID',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 0,
+    'FKClassName'  => 'CRM_Contact_DAO_Contact',
+    'FKApiName'    => 'Contact',
+  ];
+
 }
 
 /**
  * LeaveRequest.get API
  *
- * This API accepts a special param, named public_holiday. It does not map
- * directly to one of the LeaveRequests fields, but it can be used to make the
- * response include only Public Holiday Leave Requests. When it's not present,
- * or if it's false, the API will return all Leave Requests, except the Public
- * Holiday ones.
+ * This API accepts some special params:
+ *
+ * - public_holiday: It does not map directly to one of the LeaveRequests
+ * fields, but it can be used to make the response include only Public Holiday
+ * Leave Requests. When it's not present, or if it's false, the API will return
+ * all Leave Requests, except the Public Holiday ones.
+ *
+ * - managed_by: It's another filter which doesn't map directly to one of
+ * the LeaveRequests fields. It accepts a contact ID and, when present, will
+ * only return LeaveRequests of contacts managed by given contact ID.
  *
  * @param array $params
  *

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveManagerTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveManagerTest.php
@@ -8,6 +8,8 @@ use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
  */
 class CRM_HRLeaveAndAbsences_Service_LeaveManagerTest extends BaseHeadlessTest {
 
+  use CRM_HRLeaveAndAbsences_LeaveManagerHelpersTrait;
+
   private $leaveManagerService;
 
   private $loggedInContact;
@@ -71,44 +73,6 @@ class CRM_HRLeaveAndAbsences_Service_LeaveManagerTest extends BaseHeadlessTest {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer leave and absences'];
 
     $this->assertTrue($this->leaveManagerService->currentUserIsAdmin());
-  }
-
-  private function setContactAsLeaveApproverOf($leaveApprover, $contact, $startDate = null, $endDate = null, $isActive = true) {
-    $relationshipType = $this->getLeaveApproverRelationshipType();
-
-    civicrm_api3('Relationship', 'create', array(
-      'sequential' => 1,
-      'contact_id_a' => $contact['id'],
-      'contact_id_b' => $leaveApprover['id'],
-      'relationship_type_id' => $relationshipType['id'],
-      'start_date' => $startDate,
-      'end_date' => $endDate,
-      'is_active' => $isActive
-    ));
-  }
-
-  private function getLeaveApproverRelationshipType() {
-    $result = civicrm_api3('RelationshipType', 'get', [
-      'name_a_b' => 'has Leave Approved by',
-    ]);
-
-    if(empty($result['values'])) {
-      return $this->createLeaveApproverRelationshipType();
-    }
-
-    return array_shift($result['values']);
-  }
-
-  private function createLeaveApproverRelationshipType() {
-    $result = civicrm_api3('RelationshipType', 'create', array(
-      'sequential'     => 1,
-      'name_a_b'       => 'has Leave Approved by',
-      'name_b_a'       => 'is Leave Approver of',
-      'contact_type_a' => 'Individual',
-      'contact_type_b' => 'Individual',
-    ));
-
-    return $result['values'][0];
   }
 
   private function registerCurrentLoggedInContactInSession() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
@@ -12,6 +12,7 @@ require_once 'helpers/LeaveRequestHelpersTrait.php';
 require_once 'helpers/SicknessRequestHelpersTrait.php';
 require_once 'helpers/WorkPatternHelpersTrait.php';
 require_once 'helpers/TOILRequestHelpersTrait.php';
+require_once 'helpers/LeaveManagerHelpersTrait.php';
 
 /**
  * Call the "cv" command.

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveManagerHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveManagerHelpersTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+trait CRM_HRLeaveAndAbsences_LeaveManagerHelpersTrait {
+
+  public function setContactAsLeaveApproverOf($leaveApprover, $contact, $startDate = null, $endDate = null, $isActive = true) {
+    $relationshipType = $this->getLeaveApproverRelationshipType();
+
+    civicrm_api3('Relationship', 'create', array(
+      'sequential' => 1,
+      'contact_id_a' => $contact['id'],
+      'contact_id_b' => $leaveApprover['id'],
+      'relationship_type_id' => $relationshipType['id'],
+      'start_date' => $startDate,
+      'end_date' => $endDate,
+      'is_active' => $isActive
+    ));
+  }
+
+  private function getLeaveApproverRelationshipType() {
+    $result = civicrm_api3('RelationshipType', 'get', [
+      'name_a_b' => 'has Leave Approved by',
+    ]);
+
+    if(empty($result['values'])) {
+      return $this->createLeaveApproverRelationshipType();
+    }
+
+    return array_shift($result['values']);
+  }
+
+  private function createLeaveApproverRelationshipType() {
+    $result = civicrm_api3('RelationshipType', 'create', array(
+      'sequential'     => 1,
+      'name_a_b'       => 'has Leave Approved by',
+      'name_b_a'       => 'is Leave Approver of',
+      'contact_type_a' => 'individual',
+      'contact_type_b' => 'individual',
+    ));
+
+    return $result['values'][0];
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveManagerHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveManagerHelpersTrait.php
@@ -1,19 +1,20 @@
 <?php
 
+use CRM_HRCore_Test_Fabricator_Relationship as RelationshipFabricator;
+
 trait CRM_HRLeaveAndAbsences_LeaveManagerHelpersTrait {
 
   public function setContactAsLeaveApproverOf($leaveApprover, $contact, $startDate = null, $endDate = null, $isActive = true) {
     $relationshipType = $this->getLeaveApproverRelationshipType();
 
-    civicrm_api3('Relationship', 'create', array(
-      'sequential' => 1,
+    RelationshipFabricator::fabricate([
       'contact_id_a' => $contact['id'],
       'contact_id_b' => $leaveApprover['id'],
       'relationship_type_id' => $relationshipType['id'],
       'start_date' => $startDate,
       'end_date' => $endDate,
       'is_active' => $isActive
-    ));
+    ]);
   }
 
   private function getLeaveApproverRelationshipType() {


### PR DESCRIPTION
This PR introduces the `managed_by` param for the `LeaveRequest.get` API. It accepts a Contact ID and, when present, it will make the API return only the Leave Requests of contacts managed by Contact with the given ID.

To know which contact is the manager of another contact, we use the "has Leave Approved by/is Leave Approver of" relationship. When the `managed_by` param is present, the LeaveRequestSelect class will add JOINs to the civicrm_relationship and civicrm_relationship_type.

The query also considers if the relationship is active today. That is, if the `start_date` and `end_date` are null or overlap the current date and if `is_active` is true

### Example usage
Say you have a manager with ID 1 and you have two contacts, with IDs 2 and 3. The manager is the Leave Approver only for the Contact with ID 2.

If you call:
```php
civicrm_api3('LeaveRequest', 'get');
```

It will return all the Leave Request for both contacts. 

Now, if you call:
```php
civicrm_api3('LeaveRequest', 'get', ['managed_by' => 1]);
```

Only the LeaveRequests for Contact ID 2 will be returned.



