### PR TITLE
PCHR-1787: Fix Search by Contract Type in Advanced Search

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/BAO/Query.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/Query.php
@@ -118,7 +118,7 @@ class CRM_Hrjobcontract_BAO_Query extends CRM_Contact_BAO_Query_Interface {
         $display = $options = $value;
         if (is_array($value) && count($value) >= 1) {
           $op      = 'IN';
-          $options = "('" . implode("','", $value) . "')";
+          $options = array_map('trim', $value);
           $display = implode(' ' . ts('or') . ' ', $value);
         }
         $query->_qill[$grouping][]  = ts('%1 %2', array(1 => $fields[$name]['title'], 2 => $op)) . ' ' . $display;
@@ -131,7 +131,7 @@ class CRM_Hrjobcontract_BAO_Query extends CRM_Contact_BAO_Query_Interface {
         $display = $options = $value;
         if (is_array($value) && count($value) >= 1) {
           $op      = 'IN';
-          $options = "('" . implode("','", $value) . "')";
+          $options = array_map('trim', $value);
           $display = implode(' ' . ts('or') . ' ', $value);
         }
         $query->_qill[$grouping][]  = ts('%1 %2', array(1 => $fields[$name]['title'], 2 => $op)) . ' ' . $display;


### PR DESCRIPTION
## Problem
Advanced search by contract type field was not searchable, and always resulted in an empty set of results when selecting several contract types.  Array of values selected by user for search was being imploded into a string of the form ('value1', 'value2', ... 'valuen') and then passed to CRM_Contact_BAO_Query::buildClause(), which caused the value to be treated as a single string, and the clause to be built as: IN ("(\'value1\', \'value2\', ... , \'valuen\')").

## Solution
Fixed by passing value as an array to CRM_Contact_BAO_Query::buildClause(), which takes care of building the clause and quoting string values appropriately.  Found the same problem when searching by pension_is_enrolled, so fixed that one too.