### PR TITLE
PCHR-1844: Set Leave Request to_date to be same as  from_date for single day leave requests

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -59,31 +59,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    */
   public static function validateParams($params) {
     self::validateMandatory($params);
-    self::validateToDateType($params);
     self::validateStartDateNotGreaterThanEndDate($params);
     self::validateAbsencePeriod($params);
     self::validateNoOverlappingLeaveRequests($params);
     self::validateBalanceChange($params);
     self::validateWorkingDay($params);
     self::validateLeaveDatesDoesNotOverlapContracts($params);
-  }
-
-  /**
-   * This method validates that the to_date_type field must be present when to_date field is not empty
-   *
-   * @param array $params
-   *   The params array received by the create method
-   *
-   * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
-   */
-  private static function validateToDateType($params) {
-    if (!empty($params['to_date']) && empty($params['to_date_type'])) {
-      throw new InvalidLeaveRequestException(
-        'The type of To Date should not be empty',
-        'leave_request_empty_to_date_type',
-        'to_date_type'
-      );
-    }
   }
 
   /**
@@ -104,11 +85,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
       );
     }
 
-    if (empty($params['to_date'])) {
+    if (empty($params['from_date_type'])) {
       throw new InvalidLeaveRequestException(
-        'Leave Requests should have an end date',
-        'leave_request_empty_to_date',
-        'to_date'
+        'The type of From Date should not be empty',
+        'leave_request_empty_from_date_type',
+        'from_date_type'
       );
     }
 
@@ -133,6 +114,22 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
         'The Leave Request status should not be empty',
         'leave_request_empty_status_id',
         'status_id'
+      );
+    }
+
+    if (empty($params['to_date'])) {
+      throw new InvalidLeaveRequestException(
+        'Leave Requests should have an end date',
+        'leave_request_empty_to_date',
+        'to_date'
+      );
+    }
+
+    if (empty($params['to_date_type'])) {
+      throw new InvalidLeaveRequestException(
+        'The type of To Date should not be empty',
+        'leave_request_empty_to_date_type',
+        'to_date_type'
       );
     }
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -26,13 +26,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
 
     CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
 
-    //For single day leave requests
-    $hasFromDateAndFromDateType = !empty($params['from_date']) && !empty($params['from_date_type']);
-    $doesNotHaveToDateAndToDateType = empty($params['to_date']) && empty($params['to_date_type']);
-    if ($hasFromDateAndFromDateType && $doesNotHaveToDateAndToDateType){
-      $params['to_date'] = $params['from_date'];
-      $params['to_date_type'] = $params['from_date_type'];
-    }
     if($validate){
       self::validateParams($params);
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/TOILRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/TOILRequest.php
@@ -28,7 +28,7 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequest extends CRM_HRLeaveAndAbsences_DAO_
     $instance = new self();
     //set from_date_type and to_date_type to be full day by default
     $dateTypeOptions = array_flip(LeaveRequest::buildOptions('from_date_type'));
-    $param['from_date_type'] = $dateTypeOptions['All Day'];
+    $params['from_date_type'] = $dateTypeOptions['All Day'];
     if(!empty($params['to_date'])){
       $params['to_date_type'] = $dateTypeOptions['All Day'];
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/LeaveRequest.php
@@ -117,7 +117,7 @@ class CRM_HRLeaveAndAbsences_DAO_LeaveRequest extends CRM_Core_DAO
    */
   public $from_date_type;
   /**
-   * The date the leave request ends. If null, it means is starts and ends at the same date
+   * The date the leave request ends
    *
    * @var date
    */
@@ -214,7 +214,8 @@ class CRM_HRLeaveAndAbsences_DAO_LeaveRequest extends CRM_Core_DAO
           'name' => 'to_date',
           'type' => CRM_Utils_Type::T_DATE,
           'title' => ts('To Date') ,
-          'description' => 'The date the leave request ends. If null, it means is starts and ends at the same date',
+          'description' => 'The date the leave request ends',
+          'required' => true,
         ) ,
         'to_date_type' => array(
           'name' => 'to_date_type',

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/LeaveRequest.php
@@ -222,6 +222,7 @@ class CRM_HRLeaveAndAbsences_DAO_LeaveRequest extends CRM_Core_DAO
           'type' => CRM_Utils_Type::T_INT,
           'title' => ts('To Date Type') ,
           'description' => 'One of the values of the Leave Request Day Type option group',
+          'required' => true,
           'pseudoconstant' => array(
             'optionGroupName' => 'hrleaveandabsences_leave_request_day_type',
             'optionEditPath' => 'civicrm/admin/options/hrleaveandabsences_leave_request_day_type',

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -145,7 +145,9 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
       'type_id'        => $absenceType->id,
       'status_id'      => $leaveRequestStatuses['Admin Approved'],
       'from_date'      => CRM_Utils_Date::processDate($publicHoliday->date),
-      'from_date_type' => $leaveRequestDayTypes['All Day']
+      'from_date_type' => $leaveRequestDayTypes['All Day'],
+      'to_date' => CRM_Utils_Date::processDate($publicHoliday->date),
+      'to_date_type' => $leaveRequestDayTypes['All Day']
     ], false);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
@@ -329,9 +329,9 @@ CREATE TABLE `civicrm_hrleaveandabsences_leave_request` (
      `contact_id` int unsigned NOT NULL   COMMENT 'FK to Contact',
      `status_id` int unsigned NOT NULL   COMMENT 'One of the values of the Leave Request Status option group',
      `from_date` date NOT NULL   COMMENT 'The date the leave request starts.',
-     `from_date_type` int unsigned    COMMENT 'One of the values of the Leave Request Day Type option group',
+     `from_date_type` int unsigned NOT NULL   COMMENT 'One of the values of the Leave Request Day Type option group',
      `to_date` date NOT NULL   COMMENT 'The date the leave request ends',
-     `to_date_type` int unsigned    COMMENT 'One of the values of the Leave Request Day Type option group',
+     `to_date_type` int unsigned NOT NULL   COMMENT 'One of the values of the Leave Request Day Type option group',
     PRIMARY KEY ( `id` ),
     CONSTRAINT FK_civicrm_hrlaa_leave_request_type_id FOREIGN KEY (`type_id`) REFERENCES `civicrm_hrleaveandabsences_absence_type`(`id`) ON DELETE CASCADE,
     CONSTRAINT FK_civicrm_hrlaa_leave_request_contact_id FOREIGN KEY (`contact_id`) REFERENCES `civicrm_contact`(`id`) ON DELETE CASCADE

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
@@ -330,7 +330,7 @@ CREATE TABLE `civicrm_hrleaveandabsences_leave_request` (
      `status_id` int unsigned NOT NULL   COMMENT 'One of the values of the Leave Request Status option group',
      `from_date` date NOT NULL   COMMENT 'The date the leave request starts.',
      `from_date_type` int unsigned    COMMENT 'One of the values of the Leave Request Day Type option group',
-     `to_date` date    COMMENT 'The date the leave request ends. If null, it means is starts and ends at the same date',
+     `to_date` date NOT NULL   COMMENT 'The date the leave request ends',
      `to_date_type` int unsigned    COMMENT 'One of the values of the Leave Request Day Type option group',
     PRIMARY KEY ( `id` ),
     CONSTRAINT FK_civicrm_hrlaa_leave_request_type_id FOREIGN KEY (`type_id`) REFERENCES `civicrm_hrleaveandabsences_absence_type`(`id`) ON DELETE CASCADE,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -736,6 +736,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'contact_id' => 2,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
       'status_id' => 1
     ]);
 
@@ -759,6 +762,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'contact_id' => $leaveRequest->contact_id,
       'type_id' => $leaveRequest->type_id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
       'status_id' => 1
     ], true);
 
@@ -775,6 +781,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
   public function testGetExistingBalanceChangeForALeaveRequestDateShouldReturnNullIfThereIsNoRecordLinkedToALeaveRequestWithTheGivenContact() {
     $date = new DateTime('2017-01-01');
+    $leaveDate = $date->format('YmdHis');
 
     $leaveRequest = new LeaveRequest();
     $leaveRequest->contact_id = 2;
@@ -783,7 +790,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => $leaveRequest->type_id,
-      'from_date' => $date->format('YmdHis'),
+      'from_date' => $leaveDate,
+      'to_date' => $leaveDate,
+      'from_date_type' => 1,
+      'to_date_type' => 1,
       'status_id' => 1
     ], true);
 
@@ -799,6 +809,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
   public function testGetExistingBalanceChangeForALeaveRequestDateShouldReturnARecordIfItIsLinkedToALeaveRequestForTheSameContactTypeAndDate() {
     $date = new DateTime('2017-01-01');
+    $leaveDate = $date->format('YmdHis');
 
     $leaveRequest = new LeaveRequest();
     $leaveRequest->contact_id = 2;
@@ -807,7 +818,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $leaveRequest->contact_id,
       'type_id' => $leaveRequest->type_id,
-      'from_date' => $date->format('YmdHis'),
+      'from_date' => $leaveDate,
+      'to_date' => $leaveDate,
+      'from_date_type' => 1,
+      'to_date_type' =>1,
       'status_id' => 1
     ], true);
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -49,15 +49,19 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     CRM_Core_DAO::executeQuery("SET foreign_key_checks = 1;");
   }
 
-  public function testALeaveRequestWithOnlyTheStartDateShouldCreateOnlyOneLeaveRequestDate()
+  public function testALeaveRequestWithSameStartAndEndDateShouldCreateOnlyOneLeaveRequestDate()
   {
     $fromDate = new DateTime();
+    $date = $fromDate->format('YmdHis');
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => 1,
       'contact_id' => 1,
       'status_id' => 1, //The status is not important here. We just need a value to be stored in the DB
-      'from_date' => $fromDate->format('YmdHis'),
-      'from_date_type' => 1 //The type is not important here. We just need a value to be stored in the DB
+      'from_date' => $date,
+      'from_date_type' => 1,
+      'to_date' => $date,
+      'to_date_type' => 1,
+
     ]);
 
     $dates = $leaveRequest->getDates();
@@ -90,12 +94,15 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   public function testUpdatingALeaveRequestShouldNotDuplicateTheLeaveRequestDates()
   {
     $fromDate = new DateTime();
+    $date = $fromDate->format('YmdHis');
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => 1,
       'contact_id' => 1,
       'status_id' => 1,
-      'from_date' => $fromDate->format('YmdHis'),
-      'from_date_type' => 1
+      'from_date' => $date,
+      'from_date_type' => 1,
+      'to_date' => $date,
+      'to_date_type' => 1
     ]);
 
     $dates = $leaveRequest->getDates();
@@ -768,7 +775,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
    * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
    * @expectedExceptionMessage The type of To Date should not be empty
    */
-  public function testALeaveRequestShouldNotBeCreatedWhenToDateIsNotEmptyAndToDateTypeIsEmpty() {
+  public function testALeaveRequestShouldNotBeCreatedWithoutToDateType() {
     $toDate= new DateTime('+4 days');
     $fromDate = new DateTime();
     LeaveRequest::create([
@@ -778,6 +785,23 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'from_date' => $fromDate->format('YmdHis'),
       'from_date_type' => 1,
       'to_date' => $toDate->format('YmdHis'),
+    ]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
+   * @expectedExceptionMessage The type of From Date should not be empty
+   */
+  public function testALeaveRequestShouldNotBeCreatedWithoutFromDateType() {
+    $toDate= new DateTime('+4 days');
+    $fromDate = new DateTime();
+    LeaveRequest::create([
+      'type_id' => $this->absenceType->id,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'to_date' => $toDate->format('YmdHis'),
+      'to_date_type' => 1,
     ]);
   }
 
@@ -1419,13 +1443,16 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     //there's a public holiday on the leave request day
     $fromDate = new DateTime('2016-11-16');
     $fromType = $this->leaveRequestDayTypes['All Day']['id'];
+    $date = $fromDate->format('YmdHis');
 
     LeaveRequest::create([
       'type_id' => $absenceType->id,
       'contact_id' => $contact['id'],
       'status_id' => 1,
-      'from_date' => $fromDate->format('Ymd'),
+      'from_date' => $date,
       'from_date_type' => $fromType,
+      'to_date' => $date,
+      'to_date_type' => $fromType
     ]);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -708,6 +708,22 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
   /**
    * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
+   * @expectedExceptionMessage Leave Requests should have an end date
+   */
+  public function testALeaveRequestShouldNotBeCreatedWithoutAnEndDate() {
+    $fromDate = new DateTime('+4 days');
+    LeaveRequest::create([
+      'type_id' => $this->absenceType->id,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate->format('YmdHis'),
+      'from_date_type' => 1,
+      'to_date_type' => 1
+    ]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
    * @expectedExceptionMessage Leave Request should have a contact
    */
   public function testALeaveRequestShouldNotBeCreatedWithoutContactID() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/TOILRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/TOILRequestTest.php
@@ -183,6 +183,8 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequestTest extends BaseHeadlessTest {
       'status_id' => 1,
       'from_date' => $fromDate->format('YmdHis'),
       'to_date' => $toDate->format('YmdHis'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
       'toil_to_accrue' => $this->toilAmounts['2 Days']['value'],
       'duration' => 120
     ], false);
@@ -220,6 +222,8 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequestTest extends BaseHeadlessTest {
       'status_id' => 1,
       'from_date' => $fromDate->format('YmdHis'),
       'to_date' => $toDate->format('YmdHis'),
+      'to_date_type' => 1,
+      'from_date_type' => 1,
       'toil_to_accrue' => $this->toilAmounts['2 Days']['value'],
       'duration' => 120
     ], false);
@@ -232,6 +236,8 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequestTest extends BaseHeadlessTest {
       'status_id' => 1,
       'from_date' => $fromDate->format('YmdHis'),
       'to_date' => $toDate2->format('YmdHis'),
+      'to_date_type' => 1,
+      'from_date_type' => 1,
       'toil_to_accrue' => $this->toilAmounts['2 Days']['value'],
       'duration' => 80
     ], false);
@@ -275,6 +281,8 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequestTest extends BaseHeadlessTest {
       'status_id' => 1,
       'from_date' => $fromDate->format('YmdHis'),
       'to_date' => $toDate->format('YmdHis'),
+      'to_date_type' => 1,
+      'from_date_type' => 1,
       'toil_to_accrue' => $this->toilAmounts['2 Days']['value'],
       'duration' => 120
     ], false);
@@ -310,6 +318,8 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequestTest extends BaseHeadlessTest {
       'status_id' => 1,
       'from_date' => $fromDate->format('YmdHis'),
       'to_date' => $toDate->format('YmdHis'),
+      'to_date_type' => 1,
+      'from_date_type' => 1,
       'toil_to_accrue' => $this->toilAmounts['2 Days']['value'],
       'duration' => 120
     ], false);
@@ -322,6 +332,8 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequestTest extends BaseHeadlessTest {
       'status_id' => 1,
       'from_date' => $fromDate->format('YmdHis'),
       'to_date' => $toDate2->format('YmdHis'),
+      'to_date_type' => 1,
+      'from_date_type' => 1,
       'toil_to_accrue' => $this->toilAmounts['3 Days']['value'],
       'duration' => 80
     ], false);
@@ -354,6 +366,8 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequestTest extends BaseHeadlessTest {
       'status_id' => 1,
       'from_date' => $fromDate->format('YmdHis'),
       'to_date' => $toDate->format('YmdHis'),
+      'to_date_type' => 1,
+      'from_date_type' => 1,
       'toil_to_accrue' => $this->toilAmounts['2 Days']['value'],
       'duration' => 120
     ], false);
@@ -387,6 +401,8 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequestTest extends BaseHeadlessTest {
       'status_id' => 1,
       'from_date' => $fromDate->format('YmdHis'),
       'to_date' => $toDate->format('YmdHis'),
+      'to_date_type' => 1,
+      'from_date_type' => 1,
       'toil_to_accrue' => $this->toilAmounts['2 Days']['value'],
       'duration' => 120
     ], false);
@@ -418,6 +434,9 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequestTest extends BaseHeadlessTest {
       'contact_id' => 1,
       'status_id' => 1,
       'from_date' => date('YmdHis'),
+      'to_date' => date('YmdHis'),
+      'to_date_type' => 1,
+      'from_date_type' => 1,
       'toil_to_accrue' => $this->toilAmounts['2 Days']['value'],
       'duration' => 300,
       'expiry_date' => $expiryDate->format('Ymd')

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -78,6 +78,9 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'contact_id' => $contactID,
       'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'to_date_type' => 1,
+      'from_date_type' => 1,
       'status_id' => 1
     ], true);
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -397,6 +397,9 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2015-12-30'),
+      'to_date' => CRM_Utils_Date::processDate('2015-12-30'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
       'status_id' => $leaveRequestStatuses['Cancelled']
     ], true);
 
@@ -405,6 +408,9 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2017-09-02'),
+      'to_date' => CRM_Utils_Date::processDate('2017-09-02'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
       'status_id' => $leaveRequestStatuses['Admin Approved']
     ], true);
 
@@ -413,6 +419,9 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2018-01-02'),
+      'to_date' => CRM_Utils_Date::processDate('2018-01-02'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
       'status_id' => $leaveRequestStatuses['Admin Approved']
     ], true);
 
@@ -438,6 +447,9 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2015-12-30'),
+      'to_date' => CRM_Utils_Date::processDate('2015-12-30'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
       'status_id' => $leaveRequestStatuses['Cancelled']
     ], true);
 
@@ -446,6 +458,9 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
+      'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
       'status_id' => $leaveRequestStatuses['Admin Approved']
     ], true);
 
@@ -454,6 +469,9 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
+      'to_date' => CRM_Utils_Date::processDate('2016-02-20'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
       'status_id' => $leaveRequestStatuses['Admin Approved']
     ], true);
 
@@ -462,6 +480,9 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2017-12-30'),
+      'to_date' => CRM_Utils_Date::processDate('2017-12-30'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
       'status_id' => $leaveRequestStatuses['Rejected']
     ], true);
 
@@ -487,6 +508,9 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
+      'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
       'status_id' => $leaveRequestStatuses['Admin Approved']
     ], true);
 
@@ -496,6 +520,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-02-23'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
       'status_id' => $leaveRequestStatuses['Admin Approved']
     ], true);
 
@@ -531,6 +557,9 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => 1,
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2015-12-30'),
+      'to_date' =>  CRM_Utils_Date::processDate('2015-12-30'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
       'status_id' => $leaveRequestStatuses['Cancelled']
     ], true);
 
@@ -1270,30 +1299,45 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $staffMember1['id'],
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'from_date_type' => 1,
+      'to_date_type' => 1
     ], true);
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember1['id'],
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-02-01'),
+      'to_date' => CRM_Utils_Date::processDate('2016-02-01'),
+      'from_date_type' => 1,
+      'to_date_type' => 1
     ], true);
 
     $leaveRequest3 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember2['id'],
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-01-05'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-05'),
+      'from_date_type' => 1,
+      'to_date_type' => 1
     ], true);
 
     $leaveRequest4 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember3['id'],
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-03-13'),
+      'to_date' => CRM_Utils_Date::processDate('2016-03-13'),
+      'from_date_type' => 1,
+      'to_date_type' => 1
     ], true);
 
     $leaveRequest5 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember4['id'],
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-10-23'),
+      'to_date' => CRM_Utils_Date::processDate('2016-10-23'),
+      'from_date_type' => 1,
+      'to_date_type' => 1
     ], true);
 
     $result = civicrm_api3('LeaveRequest', 'get');
@@ -1344,6 +1388,9 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $staffMember['id'],
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'from_date_type' => 1,
+      'to_date_type' => 1
     ], true);
 
     $result = civicrm_api3('LeaveRequest', 'get');
@@ -1381,6 +1428,9 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $staffMember['id'],
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'from_date_type' => 1,
+      'to_date_type' => 1
     ], true);
 
     $result = civicrm_api3('LeaveRequest', 'get');

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
@@ -119,11 +119,13 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
     }
 
     $fromDate = "'{$fromDate}'";
-    $toDate = $toDate ? "'{$toDate}'" : 'NULL';
+    $toDate = $toDate ? "'{$toDate}'" : $fromDate;
+    $leaveRequestDateTypes = array_flip(LeaveRequest::buildOptions('from_date_type', 'validate'));
+    $dateType = $leaveRequestDateTypes['all_day'];
 
     $query = "
-      INSERT INTO {$leaveRequestTable}(type_id, contact_id, status_id, from_date, to_date)
-      VALUES({$typeID}, {$contactID}, {$status}, {$fromDate}, {$toDate})
+      INSERT INTO {$leaveRequestTable}(type_id, contact_id, status_id, from_date, to_date, from_date_type, to_date_type)
+      VALUES({$typeID}, {$contactID}, {$status}, {$fromDate}, {$toDate}, {$dateType}, {$dateType} )
     ";
 
     CRM_Core_DAO::executeQuery($query);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/LeaveRequest.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/LeaveRequest.xml
@@ -83,7 +83,8 @@
   <field>
     <name>to_date</name>
     <type>date</type>
-    <comment>The date the leave request ends. If null, it means is starts and ends at the same date</comment>
+    <required>true</required>
+    <comment>The date the leave request ends</comment>
     <add>4.4</add>
   </field>
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/LeaveRequest.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/LeaveRequest.xml
@@ -91,6 +91,7 @@
   <field>
     <name>to_date_type</name>
     <type>int unsigned</type>
+    <required>true</required>
     <comment>One of the values of the Leave Request Day Type option group</comment>
     <add>4.4</add>
     <pseudoconstant>


### PR DESCRIPTION
This PR updates the LeaveRequest DAO to_date field to be a required field.
The reason for this is that currently, a call to : 
```php
civicrm_api3('LeaveRequest', 'get', array(
  'sequential' => 1,
  'from_date' => array('>=' => "2016-01-01"),
  'to_date' => array('<=' => "2016-12-31"),
));
```
will not include Single day Leave Requests. This is because currently the to_date field for single day leave request is null. 
So in this PR, for single day leave requests, the to_date field is set to be same value as the from_date field.