### PR TITLE
PCHR-1790: Fix for updating Activity Types with Absence Types

### DIFF
--- a/hrabsence/CRM/HRAbsence/BAO/HRAbsenceType.php
+++ b/hrabsence/CRM/HRAbsence/BAO/HRAbsenceType.php
@@ -44,66 +44,26 @@ class CRM_HRAbsence_BAO_HRAbsenceType extends CRM_HRAbsence_DAO_HRAbsenceType {
     $activityTypesResult = civicrm_api3('activity_type', 'get', array());
     if (CRM_Utils_Array::value('allow_debits', $params)) {
       if (empty($params['debit_activity_type_id'])) {
-        $weight = count($activityTypesResult["values"]);
-        $debitActivityLabel = $params['title'];
-        $debitActivityTypeId = array_search($debitActivityLabel, $activityTypesResult["values"]);
+        $debitActivityTypeId = array_search($params['title'], $activityTypesResult["values"]);
         if (!$debitActivityTypeId) {
-          $weight = $weight + 1;
-          $paramsCreate = array(
-            'weight' => $weight,
-            'label' => $debitActivityLabel,
-            'filter' => 1,
-            'is_active' => 1,
-            'is_optgroup' => 0,
-            'is_default' => 0,
-            'grouping' => 'Timesheet',
-          );
-          $resultCreateActivityType = civicrm_api3('activity_type', 'create', $paramsCreate);
+          $resultCreateActivityType = self::createActivityType($activityTypesResult, $params, true);
           $debitActivityTypeId = $resultCreateActivityType['values'][$resultCreateActivityType["id"]]['value'];
         }
         $params["debit_activity_type_id"] = $debitActivityTypeId;
       } else {
-        $optionValue = civicrm_api3('OptionValue', 'get', array(
-          'sequential' => 1,
-          'option_group_id' => "activity_type",
-          'value' => $params['debit_activity_type_id'],
-        ));
-        civicrm_api3('OptionValue', 'create', array(
-          'id' => $optionValue['id'],
-          'label' => $params['title'],
-        ));
+        self::updateOptionValue($params, true);
       }
     }
     if (CRM_Utils_Array::value('allow_credits', $params)){
       if (empty($params['credit_activity_type_id'])) {
-        $weight = count($activityTypesResult["values"]);
-        $creditActivityLabel = ts('%1 (Credit)', array(1 => $params["title"]));
-        $creditActivityTypeId = array_search($creditActivityLabel, $activityTypesResult["values"]);
+        $creditActivityTypeId = array_search(ts('%1 (Credit)', array(1 => $params["title"])), $activityTypesResult["values"]);
         if (!$creditActivityTypeId) {
-          $weight = $weight + 1;
-          $paramsCreate = array(
-            'weight' => $weight,
-            'label' => $creditActivityLabel,
-            'filter' => 1,
-            'is_active' => 1,
-            'is_optgroup' => 0,
-            'is_default' => 0,
-            'grouping' => 'Timesheet',
-          );
-          $resultCreateActivityType = civicrm_api3('activity_type', 'create', $paramsCreate);
+          $resultCreateActivityType = self::createActivityType($activityTypesResult, $params, false);
           $creditActivityTypeId = $resultCreateActivityType['values'][$resultCreateActivityType["id"]]['value'];
-          $params["credit_activity_type_id"] = $creditActivityTypeId;
         }
+        $params["credit_activity_type_id"] = $creditActivityTypeId;
       } else {
-        $optionValue = civicrm_api3('OptionValue', 'get', array(
-          'sequential' => 1,
-          'option_group_id' => "activity_type",
-          'value' => $params['credit_activity_type_id'],
-        ));
-        civicrm_api3('OptionValue', 'create', array(
-          'id' => $optionValue['id'],
-          'label' => ts('%1 (Credit)', array(1 => $params["title"]))
-        ));
+        self::updateOptionValue($params, false);
       }
     }
     CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
@@ -114,6 +74,65 @@ class CRM_HRAbsence_BAO_HRAbsenceType extends CRM_HRAbsence_DAO_HRAbsenceType {
     CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
 
     return $instance;
+  }
+
+  /**
+   * Creates Activity Types based on $params and $activityTypes
+   *
+   * @param array $activityTypes
+   * @param array $params
+   * @param boolean $isDebit 'true' for 'debit' and 'false' for 'credit'
+   *
+   * @return array Created Activity Type as array
+   */
+  private static function createActivityType($activityTypes, $params, $isDebit) {
+    $weight = count($activityTypes["values"]);
+    if ($isDebit) {
+      $valueId = $params['debit_activity_type_id'];
+      $valueLabel = $params['title'];
+    } else {
+      $valueId = $params['credit_activity_type_id'];
+      $valueLabel = ts('%1 (Credit)', array(1 => $params["title"]));
+    }
+
+    $paramsCreate = array(
+      'weight' => ($weight+1),
+      'label' => $valueLabel,
+      'filter' => 1,
+      'is_active' => 1,
+      'is_optgroup' => 0,
+      'is_default' => 0,
+      'grouping' => 'Timesheet'
+    );
+
+    return civicrm_api3('activity_type', 'create', $paramsCreate);
+  }
+
+  /**
+   * Updates Option Value based on $params
+   *
+   * @param array $params
+   * @param boolean $isDebit 'true' for 'debit' and 'false' for 'credit'
+   */
+  private static function updateOptionValue($params, $isDebit) {
+    if ($isDebit) {
+      $valueId = $params['debit_activity_type_id'];
+      $valueLabel = $params['title'];
+    } else {
+      $valueId = $params['credit_activity_type_id'];
+      $valueLabel = ts('%1 (Credit)', array(1 => $params["title"]));
+    }
+
+    $optionValue = civicrm_api3('OptionValue', 'get', array(
+      'sequential' => 1,
+      'option_group_id' => "activity_type",
+      'value' => $valueId
+    ));
+
+    civicrm_api3('OptionValue', 'create', array(
+      'id' => $optionValue['id'],
+      'label' => $valueLabel
+    ));
   }
 
   /**


### PR DESCRIPTION
### Issue:
As for HRAbsenece Module, when updating the Absence Type didn't update its associated Activity Type. As a result, this issue arrises, as in absence navigation menu, filter dropdown and tables in entitlements, calendar, statistics in my absence page are displaying title or label from Activity Types. 

### Solution: 
**hrabsence/CRM/HRAbsence/BAO/HRAbsenceType.php's create function** has been modified to add Activity Type Update functionality when Absence Type is updated. Which solves the issue.