### PR TITLE
PCHR-1845: Add the LeavePeriodEntitlement.getEntitlement API endpoint

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/ContactWorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/ContactWorkPattern.php
@@ -17,7 +17,7 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_ContactWorkPattern extends Sequenti
     return [
       'contact_id' => 1,
       'pattern_id' => 1,
-      'effective_date' => CRM_Utils_Date::processDate(date('Y-01-01')),
+      'effective_date' => CRM_Utils_Date::processDate(date('2010-01-01')),
     ];
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeavePeriodEntitlement.php
@@ -184,7 +184,7 @@ function _civicrm_api3_leave_period_entitlement_getentitlement_spec(&$spec) {
  * [
  *   'is_error' => 0,
  *   'version' => 3,
- *   'count' => 1,
+ *   'count' => 2,
  *   'values' => [
  *     [
  *       'id' => 1, // LeavePeriodEntitlement.id

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/ContactWorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/ContactWorkPatternTest.php
@@ -136,21 +136,21 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest extends BaseHeadlessTest
   public function testGetWorkPatternForContact() {
     //create a contact with valid contract and a Work pattern assigned
     $contact = ContactFabricator::fabricate();
-    $periodStartDate = date('2016-01-01');
+    $periodStartDate = new DateTime('2016-01-01');
 
-    HRJobContractFabricator::fabricate([
-      'contact_id' => $contact['id']
-    ],
-    [
-      'period_start_date' => $periodStartDate,
-    ]);
+    HRJobContractFabricator::fabricate(
+      [ 'contact_id' => $contact['id'] ],
+      [ 'period_start_date' => $periodStartDate->format('Y-m-d') ]
+    );
+
     $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
     ContactWorkPatternFabricator::fabricate([
       'contact_id' => $contact['id'],
-      'pattern_id' => $workPattern->id
+      'pattern_id' => $workPattern->id,
+      'effective_date' => $periodStartDate->format('YmdHis')
     ]);
-    $date = new DateTime('2016-01-20');
 
+    $date = new DateTime('2016-01-20');
     $returnedWorkPattern = ContactWorkPattern::getWorkPattern($contact['id'], $date);
     $this->assertEquals($workPattern->id, $returnedWorkPattern->id);
   }
@@ -160,15 +160,13 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest extends BaseHeadlessTest
     $contact = ContactFabricator::fabricate();
     $periodStartDate = date('2016-01-01');
 
-    HRJobContractFabricator::fabricate([
-      'contact_id' => $contact['id']
-    ],
-    [
-      'period_start_date' => $periodStartDate,
-    ]);
-    $defaultWorkPattern = WorkPatternFabricator::fabricate(['is_default' => 1]);
-    $date = new DateTime('2016-01-20');
+    HRJobContractFabricator::fabricate(
+      [ 'contact_id' => $contact['id'] ],
+      [ 'period_start_date' => $periodStartDate ]);
 
+    $defaultWorkPattern = WorkPatternFabricator::fabricate(['is_default' => 1]);
+
+    $date = new DateTime('2016-01-20');
     $returnedWorkPattern = ContactWorkPattern::getWorkPattern($contact['id'], $date);
     $this->assertEquals($defaultWorkPattern->id, $returnedWorkPattern->id);
   }
@@ -371,20 +369,20 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest extends BaseHeadlessTest
 
   public function testGetWorkDayTypeForWorkPatternWithMultipleWeeks() {
     $contact = ContactFabricator::fabricate();
-    $periodStartDate = '2016-01-01';
+    $periodStartDate = new DateTime('2016-01-01');
 
-    HRJobContractFabricator::fabricate([
-      'contact_id' => $contact['id']
-    ],
-    [
-      'period_start_date' => $periodStartDate,
-    ]);
+    HRJobContractFabricator::fabricate(
+      [ 'contact_id' => $contact['id'] ],
+      [ 'period_start_date' => $periodStartDate->format('Y-m-d') ]);
+
     // Week 1 weekdays: monday, wednesday and friday
     // Week 2 weekdays: tuesday and thursday
     $workPattern = WorkPatternFabricator::fabricateWithTwoWeeksAnd31AndHalfHours();
+
     ContactWorkPatternFabricator::fabricate([
       'contact_id' => $contact['id'],
-      'pattern_id' => $workPattern->id
+      'pattern_id' => $workPattern->id,
+      'effective_date' => $periodStartDate->format('YmdHis')
     ]);
 
     //A sunday which is weekend on week 1

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -112,7 +112,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
   public function testBalanceForEntitlementCanSumOnlyTheBalanceChangesForLeaveRequestWithSpecificStatuses() {
     $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
-    $entitlement = $this->createLeavePeriodEntitlementMockForBalanceTests();
+    $entitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
+      new DateTime('-10 days'),
+      new DateTime('+10 days')
+    );
 
     // This is the initial entitlement and, since it has no
     // source_id, it will always be included in the balance SUM

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -475,23 +475,24 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
   public function testCalculateBalanceChangeForALeaveRequestForAContactWithMultipleWeeks() {
     $contact = ContactFabricator::fabricate();
-    $periodStartDate = date('Y-01-01');
+    $periodStartDate = new DateTime('2016-01-01');
     $title = 'Job Title';
 
-    HRJobContractFabricator::fabricate([
-      'contact_id' => $contact['id']
-    ],
-    [
-      'period_start_date' => $periodStartDate,
-      'title' => $title
-    ]);
+    HRJobContractFabricator::fabricate(
+      [ 'contact_id' => $contact['id'] ],
+      [
+        'period_start_date' => $periodStartDate->format('Y-m-d'),
+        'title' => $title
+      ]
+    );
 
     // Week 1 weekdays: monday, wednesday and friday
     // Week 2 weekdays: tuesday and thursday
     $pattern = WorkPatternFabricator::fabricateWithTwoWeeksAnd31AndHalfHours();
     ContactWorkPatternFabricator::fabricate([
       'contact_id' => $contact['id'],
-      'pattern_id' => $pattern->id
+      'pattern_id' => $pattern->id,
+      'effective_date' => $periodStartDate->format('YmdHis')
     ]);
 
     $fromDate = new DateTime('2016-07-31');

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
@@ -40,7 +40,10 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
   }
 
   public function testCanDeleteAPublicHolidayLeaveRequestForASingleContact() {
-    $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests();
+    $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
+      new DateTime('2016-01-01'),
+      new DateTime('2016-12-31')
+    );
     $periodEntitlement->contact_id = 2;
     $periodEntitlement->type_id = $this->absenceType->id;
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeavePeriodEntitlementTest.php
@@ -139,8 +139,16 @@ class api_v3_LeavePeriodEntitlementTest extends BaseHeadlessTest {
    * @expectedException CiviCRM_API3_Exception
    * @expectedExceptionMessage You must include either the id of a specific entitlement, or both the contact and period id
    */
-  public function testGetEntitlementWhenEntitlementIdAndPeriodIdArePassed() {
+  public function testGetEntitlementWhenEntitlementIdAndContactIdArePassed() {
     civicrm_api3('LeavePeriodEntitlement', 'getEntitlement', ['entitlement_id'=> 1, 'contact_id'=>1]);
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage You must include either the id of a specific entitlement, or both the contact and period id
+   */
+  public function testGetEntitlementWhenEntitlementIdAndPeriodIdArePassed() {
+    civicrm_api3('LeavePeriodEntitlement', 'getEntitlement', ['entitlement_id'=> 1, 'period_id'=>1]);
   }
 
   public function testGetEntitlementCanReturnTheEntitlementsForAContactInAPeriod() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeavePeriodEntitlementTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeavePeriodEntitlement as LeavePeriodEntitlementFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod as AbsencePeriodFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
 
 /**
  * Class api_v3_LeavePeriodEntitlementTest
@@ -9,6 +11,8 @@ use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod as AbsencePeriodFabrica
  * @group headless
  */
 class api_v3_LeavePeriodEntitlementTest extends BaseHeadlessTest {
+
+  use CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait;
 
   /**
    * @expectedException CiviCRM_API3_Exception
@@ -38,7 +42,7 @@ class api_v3_LeavePeriodEntitlementTest extends BaseHeadlessTest {
    * @expectedException CiviCRM_API3_Exception
    * @expectedExceptionMessage You must include either the id of a specific entitlement, or both the contact and period id
    */
-  public function testGetRemainderWhenEntitlentIdAndPeriodIdArePassed() {
+  public function testGetRemainderWhenEntitlementIdAndPeriodIdArePassed() {
     civicrm_api3('LeavePeriodEntitlement', 'getremainder', ['entitlement_id'=> 1, 'contact_id'=>1]);
   }
 
@@ -75,7 +79,7 @@ class api_v3_LeavePeriodEntitlementTest extends BaseHeadlessTest {
    * @expectedException CiviCRM_API3_Exception
    * @expectedExceptionMessage You must include either the id of a specific entitlement, or both the contact and period id
    */
-  public function testGetBreakdownWhenEntitlentIdAndPeriodIdArePassed() {
+  public function testGetBreakdownWhenEntitlementIdAndPeriodIdArePassed() {
     civicrm_api3('LeavePeriodEntitlement', 'getbreakdown', ['entitlement_id' => 1, 'contact_id' => 1]);
   }
 
@@ -105,5 +109,252 @@ class api_v3_LeavePeriodEntitlementTest extends BaseHeadlessTest {
       ]
     ];
     $this->assertEquals($expectedResult, $result);
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage You must include either the id of a specific entitlement, or both the contact and period id
+   */
+  public function testGetEntitlementDoesNotAcceptContactIdWithoutPeriodId() {
+    civicrm_api3('LeavePeriodEntitlement', 'getEntitlement', ['contact_id' => 1]);
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage You must include either the id of a specific entitlement, or both the contact and period id
+   */
+  public function testGetEntitlementDoesNotAcceptPeriodIdWithoutContactId() {
+    civicrm_api3('LeavePeriodEntitlement', 'getEntitlement', ['period_id' => 1]);
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage You must include either the id of a specific entitlement, or both the contact and period id
+   */
+  public function testGetEntitlementWhenAllParametersArePassed() {
+    civicrm_api3('LeavePeriodEntitlement', 'getEntitlement', ['entitlement_id'=> 1, 'period_id' => 1, 'contact_id'=>1]);
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage You must include either the id of a specific entitlement, or both the contact and period id
+   */
+  public function testGetEntitlementWhenEntitlementIdAndPeriodIdArePassed() {
+    civicrm_api3('LeavePeriodEntitlement', 'getEntitlement', ['entitlement_id'=> 1, 'contact_id'=>1]);
+  }
+
+  public function testGetEntitlementCanReturnTheEntitlementsForAContactInAPeriod() {
+    $contact = ContactFabricator::fabricate();
+
+    $type1 = AbsenceTypeFabricator::fabricate();
+    $type2 = AbsenceTypeFabricator::fabricate();
+    $type3 = AbsenceTypeFabricator::fabricate();
+
+    $period1 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31')
+    ]);
+
+    $period2 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2017-12-31')
+    ]);
+
+    $periodEntitlement1 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'type_id' => $type1->id,
+      'period_id' => $period1->id
+    ]);
+
+    $periodEntitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'type_id' => $type2->id,
+      'period_id' => $period1->id
+    ]);
+
+    $periodEntitlement3 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'type_id' => $type2->id,
+      'period_id' => $period2->id
+    ]);
+
+    $periodEntitlement4 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'type_id' => $type3->id,
+      'period_id' => $period2->id
+    ]);
+
+    $result = civicrm_api3('LeavePeriodEntitlement', 'getEntitlement', [
+      'contact_id' => $contact['id'],
+      'period_id' => $period1->id
+    ]);
+
+    //For the period 1, the contact only has entitlements for Types 1 and 2
+    $expected = [
+      'is_error' => 0,
+      'version' => 3,
+      'count' => 2,
+      'values' => [
+        [
+          'id' => $periodEntitlement1->id,
+          'entitlement' => 0,
+        ],
+        [
+          'id' => $periodEntitlement2->id,
+          'entitlement' => 0,
+        ]
+      ]
+    ];
+
+    $this->assertEquals($expected, $result);
+
+    $result = civicrm_api3('LeavePeriodEntitlement', 'getEntitlement', [
+      'contact_id' => $contact['id'],
+      'period_id' => $period2->id
+    ]);
+
+    //For the period 1, the contact only has entitlements for Types 2 and 3
+    $expected = [
+      'is_error' => 0,
+      'version' => 3,
+      'count' => 2,
+      'values' => [
+        [
+          'id' => $periodEntitlement3->id,
+          'entitlement' => 0,
+        ],
+        [
+          'id' => $periodEntitlement4->id,
+          'entitlement' => 0,
+        ]
+      ]
+    ];
+
+    $this->assertEquals($expected, $result);
+  }
+
+  public function testGetEntitlementCanReturnTheEntitlementsForASpecificLeavePeriodEntitlement() {
+    $contact = ContactFabricator::fabricate();
+
+    $type1 = AbsenceTypeFabricator::fabricate();
+    $type2 = AbsenceTypeFabricator::fabricate();
+
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31')
+    ]);
+
+    $periodEntitlement1 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'type_id' => $type1->id,
+      'period_id' => $period->id
+    ]);
+
+    $periodEntitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'type_id' => $type2->id,
+      'period_id' => $period->id
+    ]);
+
+    $result = civicrm_api3('LeavePeriodEntitlement', 'getEntitlement', [
+      'entitlement_id' => $periodEntitlement1->id,
+    ]);
+
+    $expected = [
+      'is_error' => 0,
+      'version' => 3,
+      'count' => 1,
+      'values' => [
+        [
+          'id' => $periodEntitlement1->id,
+          'entitlement' => 0,
+        ]
+      ]
+    ];
+
+    $this->assertEquals($expected, $result);
+
+    $result = civicrm_api3('LeavePeriodEntitlement', 'getEntitlement', [
+      'entitlement_id' => $periodEntitlement2->id,
+    ]);
+
+    $expected = [
+      'is_error' => 0,
+      'version' => 3,
+      'count' => 1,
+      'values' => [
+        [
+          'id' => $periodEntitlement2->id,
+          'entitlement' => 0,
+        ]
+      ]
+    ];
+
+    $this->assertEquals($expected, $result);
+  }
+
+  public function testGetEntitlementCanReturnTheEntitlementsForLeavePeriodEntitlements() {
+    $contact = ContactFabricator::fabricate();
+
+    $type1 = AbsenceTypeFabricator::fabricate();
+    $type2 = AbsenceTypeFabricator::fabricate();
+
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31')
+    ]);
+
+    $periodEntitlement1 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'type_id' => $type1->id,
+      'period_id' => $period->id
+    ]);
+
+    $periodEntitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'type_id' => $type2->id,
+      'period_id' => $period->id
+    ]);
+
+    $this->createLeaveBalanceChange($periodEntitlement1->id, 20);
+    $this->createPublicHolidayBalanceChange($periodEntitlement1->id, 5);
+
+    $result = civicrm_api3('LeavePeriodEntitlement', 'getEntitlement', [
+      'entitlement_id' => $periodEntitlement1->id,
+    ]);
+
+    $expected = [
+      'is_error' => 0,
+      'version' => 3,
+      'count' => 1,
+      'values' => [
+        [
+          'id' => $periodEntitlement1->id,
+          'entitlement' => 25,
+        ]
+      ]
+    ];
+
+    $this->assertEquals($expected, $result);
+
+    $this->createOverriddenBalanceChange($periodEntitlement2->id, 50);
+
+    $result = civicrm_api3('LeavePeriodEntitlement', 'getEntitlement', [
+      'entitlement_id' => $periodEntitlement2->id,
+    ]);
+
+    $expected = [
+      'is_error' => 0,
+      'version' => 3,
+      'count' => 1,
+      'values' => [
+        [
+          'id' => $periodEntitlement2->id,
+          'entitlement' => 50,
+        ]
+      ]
+    ];
+
+    $this->assertEquals($expected, $result);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/TOILRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/TOILRequestTest.php
@@ -446,7 +446,7 @@ class api_v3_TOILRequestTest extends BaseHeadlessTest {
       'expired_balance_change_id' => $toilRequestBalanceChange->id,
       'type_id' => $this->getBalanceChangeTypeValue('Debit')
     ]);
-define( 'CIVICRM_DEBUG_LOG_QUERY', 1 );
+
     $result = civicrm_api3('TOILRequest', 'get', ['expired' => true]);
     // Even with the balance change, it should still return nothing because 0
     // means nothing has expired


### PR DESCRIPTION
This PR introduces the `LeavePeriodEntitlement.getEntitlement` API endpoint. It's a "complement" to `LeavePeriodEntitlement.getRemainder` and `LeavePeriodEntitlement.getBreakdown`, as it returns a list of LeavePeriodEntitlements IDs and its entitlement (the number of days available to be taken as leave at the start of the period).

The API supports 3 params:
* **entitlement_id** _Optional_. The id of a specific entitlement
* **contact_id** _Optional_. The contact we want to get the remainder of the entitlements
* **period_id** _Optional_. The period we want to get the remainder of entitlements

When calling the API, one should pass either only the entitlement_id or both the contact_id and period_id.

### Examples
Getting the entitlement for a single LeavePeriodEntitlement
```php
civicrm_api3('LeavePeriodEntitlement', 'getEntitlement', ['entitlement_id' => 1]);
```

The response will be 
```javascript
{
    "is_error": 0,
    "version": 3,
    "count": 1,
    "values": [
        {
            "id": "1",
            "entitlement": 31
        }
    ]
}
```

Getting the entitlement for all the LeavePeriodEntitlements of a Contact during an AbsencePeriod:
```php
civicrm_api3('LeavePeriodEntitlement', 'getEntitlement', ['contact_id' => 1, 'period_id' => 1]);
```

The response will be 
```javascript
{
    "is_error": 0,
    "version": 3,
    "count": 2,
    "values": [
        {
            "id": "1",
            "entitlement": 31
        },
        {
            "id": "2",
            "entitlement": 2
        }
    ]
}
```

### About the implementation
Different from the other APIs, this was all implemented inside the API function. The reasons for this choice are:
- The LeavePeriodEntitlment already has a instance method named `getEntitlement()` (which, by the way, is used by this new endpoint).
- All the code inside the function is very "API specific". It has some validation only to the API params and the remaining code is just a loop to build the results array.
- Putting the code in a separated class would lead to some tests duplication. We would need to test the method on this other class and also to duplicated some of these on the API tests, in order to make sure the API would call the right method and return the expected value.

### What else is included in this PR?
This PR also includes fixes for some tests related to `ContactWorkPatterns`. It was caused by a poorly choose default effective date on the `ContactWorkPattern` Fabricator. Please check the commit message of https://github.com/civicrm/civihr/commit/6e145298f40a490a0bf94246e8594118a95566c3 for more details