### PR TITLE
PCHR-1369: Allow custom fields to be filtered out on LeaveRequest.getFull

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
@@ -188,16 +188,20 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
       $leaveRequestBao = new LeaveRequest();
       $leaveRequestBao->copyValues($leaveRequest);
 
-      $balanceChange = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequestBao);
-      $results[$i]['balance_change'] = $balanceChange;
+      if($this->shouldReturnBalanceChange()) {
+        $balanceChange = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequestBao);
+        $results[$i]['balance_change'] = $balanceChange;
+      }
 
-      $dates = $leaveRequestBao->getDates();
-      $results[$i]['dates'] = [];
-      foreach($dates as $date) {
-        $results[$i]['dates'][] = [
-          'id' => $date->id,
-          'date' => $date->date
-        ];
+      if($this->shouldReturnDates()) {
+        $dates = $leaveRequestBao->getDates();
+        $results[$i]['dates'] = [];
+        foreach($dates as $date) {
+          $results[$i]['dates'][] = [
+            'id' => $date->id,
+            'date' => $date->date
+          ];
+        }
       }
     }
   }
@@ -215,6 +219,41 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
    */
   private function addGroupBy(CRM_Utils_SQL_Select $query) {
     $query->groupBy(['a.id']);
+  }
+
+  /**
+   * Returns if the balance_change field should be included on the returned results
+   *
+   * @return bool
+   */
+  private function shouldReturnBalanceChange() {
+    return $this->shouldReturnField('balance_change');
+  }
+
+  /**
+   * Returns if the dates field should be included on the returned results
+   *
+   * @return bool
+   */
+  private function shouldReturnDates() {
+    return $this->shouldReturnField('dates');
+  }
+
+  /**
+   * Returns, based on the "return" param, if the given field should be returned
+   * on the results.
+   *
+   * If "return" is empty, it means all the fields should be returned. Otherwise,
+   * a field will be returned only if "return" is not empty and it includes the
+   * field.
+   *
+   * @param string $field
+   *
+   * @return bool
+   */
+  private function shouldReturnField($field) {
+    return empty($this->params['return']) ||
+           (is_array($this->params['return']) && in_array($field, $this->params['return']));
   }
 
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -540,6 +540,156 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals('2016-02-23', $result['values'][$leaveRequest2->id]['dates'][3]['date']);
   }
 
+  public function testGetFullShouldNotIncludeTheBalanceChangeIfTheReturnOptionIsNotEmptyAndDoesntIncludeIt() {
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
+
+    HRJobContractFabricator::fabricate(
+      [ 'contact_id' => 1 ],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => '2016-10-01'
+      ]
+    );
+
+    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => 1,
+      'type_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
+      'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
+      'status_id' => $leaveRequestStatuses['Admin Approved']
+    ], true);
+
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => 1,
+      'type_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
+      'to_date' =>  CRM_Utils_Date::processDate('2016-02-20'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
+      'status_id' => $leaveRequestStatuses['Admin Approved']
+    ], true);
+
+    $result = civicrm_api3('LeaveRequest', 'getFull', [
+      'sequential' => 1,
+      'return' => ['id', 'dates']]
+    );
+
+    $expectedValues = [
+      [
+        'id' => $leaveRequest1->id,
+        'dates' => $this->createLeaveRequestDatesArray($leaveRequest1)
+      ],
+      [
+        'id' => $leaveRequest2->id,
+        'dates' => $this->createLeaveRequestDatesArray($leaveRequest2)
+      ]
+    ];
+
+    $this->assertEquals($expectedValues, $result['values']);
+  }
+
+  public function testGetFullShouldNotIncludeTheDatesIfTheReturnOptionIsNotEmptyAndDoesntIncludeIt() {
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
+
+    HRJobContractFabricator::fabricate(
+      [ 'contact_id' => 1 ],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => '2016-10-01'
+      ]
+    );
+
+    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => 1,
+      'type_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
+      'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
+      'status_id' => $leaveRequestStatuses['Admin Approved']
+    ], true);
+
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => 1,
+      'type_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
+      'to_date' =>  CRM_Utils_Date::processDate('2016-02-20'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
+      'status_id' => $leaveRequestStatuses['Admin Approved']
+    ], true);
+
+    $result = civicrm_api3('LeaveRequest', 'getFull', [
+      'sequential' => 1,
+      'return' => ['id', 'balance_change']]
+    );
+
+    $expectedValues = [
+      [
+        'id' => $leaveRequest1->id,
+        'balance_change' => -1
+      ],
+      [
+        'id' => $leaveRequest2->id,
+        'balance_change' => -1
+      ]
+    ];
+
+    $this->assertEquals($expectedValues, $result['values']);
+  }
+
+  public function testGetFullShouldNotIncludeTheBalanceChangeAndDatesIfTheReturnOptionIsNotEmptyAndDoesntIncludeThem() {
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
+
+    HRJobContractFabricator::fabricate(
+      [ 'contact_id' => 1 ],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => '2016-10-01'
+      ]
+    );
+
+    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => 1,
+      'type_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
+      'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
+      'status_id' => $leaveRequestStatuses['Admin Approved']
+    ], true);
+
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => 1,
+      'type_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
+      'to_date' =>  CRM_Utils_Date::processDate('2016-02-20'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
+      'status_id' => $leaveRequestStatuses['Admin Approved']
+    ], true);
+
+    $result = civicrm_api3('LeaveRequest', 'getFull', [
+        'sequential' => 1,
+        'return' => ['id', 'type_id']]
+    );
+
+    $expectedValues = [
+      [
+        'id' => $leaveRequest1->id,
+        'type_id' => 1
+      ],
+      [
+        'id' => $leaveRequest2->id,
+        'type_id' => 1
+      ]
+    ];
+
+    $this->assertEquals($expectedValues, $result['values']);
+  }
+
   public function testGetDoesNotReturnALeaveRequestNotOverlappingAContractEvenIfItMatchesTheDatesParams() {
     $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
 
@@ -1442,5 +1592,17 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $result = civicrm_api3('LeaveRequest', 'get', ['managed_by' => $manager['id']]);
 
     $this->assertEquals(0, $result['count']);
+  }
+
+  private function createLeaveRequestDatesArray(LeaveRequest $leaveRequest) {
+    $dates = [];
+    foreach ($leaveRequest->getDates() as $date) {
+      $dates[] = [
+        'id'   => $date->id,
+        'date' => $date->date
+      ];
+    }
+
+    return $dates;
   }
 }


### PR DESCRIPTION
### Problem

The passing an array of fields to be returned to the `LeaveRequest.getFull` API, the `balance_change` and `dates` fields would always be included, even if they were not present on the list of fields to be returned.

This happens because both `balance_change` and `dates` are not actual fields on of the LeaveRequest, but fields added manually to the API results, after they were fetched from the database.

## Solution

The LeaveRequestSelect class was updated to take into consideration if the `return` param passed to the API and, if it's not empty and doesn't includes `balance_change` and/or `dates`, they won't be includes on the results