### PR TITLE
PCHR-1677: Fix bug in overlapping leave request validation when a leave request is updated

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -289,6 +289,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
       $leaveRequestStatusFilter
     );
 
+    //if its an update and the only overlapping leave request is the leave request being updated itself
+    if (!empty($params['id'])) {
+      if(count($overlappingLeaveRequests) == 1 &&  $overlappingLeaveRequests[0]->id == $params['id']){
+        return;
+      }
+    }
+
     if ($overlappingLeaveRequests) {
       throw new InvalidLeaveRequestException(
         'This Leave request has dates that overlaps with an existing leave request',


### PR DESCRIPTION
This PR solves the bug encountered when a Leave Request is updated and the dates overlap with the originally created leave request. To solve this, when a leave request is updated and the the overlapping leave request validation runs, If the leave request being updated is the only one returned as an overlapping leave request, an exception is not thrown.