### PR TITLE
PCHR-1123: Group balance changes by type on LeavePeriodEntitlement.getBreakdown

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
@@ -192,9 +192,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
 
       self::saveBroughtForwardBalanceChange($calculation, $periodEntitlement);
       self::savePublicHolidaysBalanceChanges($calculation, $periodEntitlement);
-
       self::saveLeaveBalanceChange($calculation, $periodEntitlement, $overriddenEntitlement);
-
 
       $transaction->commit();
     } catch(\Exception $ex) {
@@ -344,7 +342,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
           'contact_id'     => $periodEntitlement->contact_id,
           'status_id'      => $leaveRequestStatuses['Admin Approved'],
           'from_date'      => CRM_Utils_Date::processDate($publicHoliday->date),
-          'from_date_type' => $leaveRequestDateTypes['All Day']
+          'to_date'        => CRM_Utils_Date::processDate($publicHoliday->date),
+          'from_date'      => CRM_Utils_Date::processDate($publicHoliday->date),
+          'from_date_type' => $leaveRequestDateTypes['All Day'],
+          'to_date_type'   => $leaveRequestDateTypes['All Day']
         ]);
 
         $requestDate  = LeaveRequestDate::getDatesForLeaveRequest($leaveRequest->id)[0];

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
@@ -914,27 +914,18 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
 
   public function testGetBreakdown() {
     $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate();
-    $this->createExpiredBroughtForwardBalanceChange($periodEntitlement->id, 9, 5);
+
     $this->createExpiredBroughtForwardBalanceChange($periodEntitlement->id, 8, 3);
     $this->createLeaveBalanceChange($periodEntitlement->id, 10);
 
-    $params = ['entitlement_id' => $periodEntitlement->id];
-    $result = LeavePeriodEntitlement::getBreakdown($params);
-    $this->assertCount(1, $result);
+    $result = LeavePeriodEntitlement::getBreakdown([
+      'entitlement_id' => $periodEntitlement->id
+    ]);
 
     $expectedResult = [
       [
-        'id' => "$periodEntitlement->id",
+        'id' => $periodEntitlement->id,
         'breakdown' => [
-          [
-            'amount' => '9.00',
-            'expiry_date' => null,
-            'type' => [
-              'id' => $this->getBalanceChangeTypeValue('Brought Forward'),
-              'value' => 'brought_forward',
-              'label' => 'Brought Forward'
-            ]
-          ],
           [
             'amount' => '8.00',
             'expiry_date' => null,
@@ -953,27 +944,31 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
               'label' => 'Leave'
             ]
           ]
-        ],
-      ],
+        ]
+      ]
     ];
+
     $this->assertEquals($expectedResult, $result);
   }
 
   public function testGetBreakdownWithExpiredSetToTrue() {
     $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate();
+
     $expiredByNoOfDays = 2;
-    $this->createExpiredBroughtForwardBalanceChange($periodEntitlement->id, 9, 5, $expiredByNoOfDays);
     $this->createExpiredBroughtForwardBalanceChange($periodEntitlement->id, 8, 3, $expiredByNoOfDays);
     $this->createLeaveBalanceChange($periodEntitlement->id, 10);
 
-    $params = ['entitlement_id' => $periodEntitlement->id, 'expired' => true];
-    $result = LeavePeriodEntitlement::getBreakdown($params);
+    $result = LeavePeriodEntitlement::getBreakdown([
+      'entitlement_id' => $periodEntitlement->id,
+      'expired'        => true
+    ]);
+
     $expectedResult = [
       [
-        'id' => "$periodEntitlement->id",
+        'id' => $periodEntitlement->id,
         'breakdown' => [
           [
-            'amount' => '-5.00',
+            'amount' => '-3.00', //only the expired amount will be returned
             'expiry_date' => date('Y-m-d', strtotime("-{$expiredByNoOfDays} day")),
             'type' => [
               'id' => $this->getBalanceChangeTypeValue('Brought Forward'),
@@ -981,24 +976,18 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
               'label' => 'Brought Forward'
             ]
           ],
-          [
-            'amount' => '-3.00',
-            'expiry_date' => date('Y-m-d', strtotime("-{$expiredByNoOfDays} day")),
-            'type' => [
-              'id' => $this->getBalanceChangeTypeValue('Brought Forward'),
-              'value' => 'brought_forward',
-              'label' => 'Brought Forward'
-            ]
-          ]
         ],
       ],
     ];
+
     $this->assertEquals($expectedResult, $result);
   }
 
   public function testGetBreakdownWithContactAndPeriodId() {
     $contactId = 1;
+
     $absencePeriod = AbsencePeriodFabricator::fabricate();
+
     $periodEntitlement1 = LeavePeriodEntitlementFabricator::fabricate([
       'contact_id' => $contactId,
       'period_id' => $absencePeriod->id
@@ -1010,33 +999,23 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
       'type_id' => 2
     ]);
 
-    $this->createExpiredBroughtForwardBalanceChange($periodEntitlement1->id, 9, 5);
-    $this->createExpiredBroughtForwardBalanceChange($periodEntitlement1->id, 8, 3);
+    $this->createBroughtForwardBalanceChange($periodEntitlement1->id, 8);
     $this->createLeaveBalanceChange($periodEntitlement1->id, 10);
 
-    $this->createExpiredBroughtForwardBalanceChange($periodEntitlement2->id, 5, 5);
-    $this->createExpiredBroughtForwardBalanceChange($periodEntitlement2->id, 3, 3);
+    $this->createBroughtForwardBalanceChange($periodEntitlement2->id, 5);
     $this->createLeaveBalanceChange($periodEntitlement2->id, 2);
 
-    $params = ['contact_id' => $contactId, 'period_id' => $absencePeriod->id];
-
-    $result = LeavePeriodEntitlement::getBreakdown($params);
+    $result = LeavePeriodEntitlement::getBreakdown([
+      'contact_id' => $contactId,
+      'period_id'  => $absencePeriod->id
+    ]);
 
     $expectedResult = [
       [
-        'id' => "$periodEntitlement1->id",
+        'id' => $periodEntitlement1->id,
         'breakdown' => [
           [
-            'amount' => '9.00',
-            'expiry_date' => null,
-            'type' => [
-              'id' => $this->getBalanceChangeTypeValue('Brought Forward'),
-              'value' => 'brought_forward',
-              'label' => 'Brought Forward'
-            ]
-          ],
-          [
-            'amount' => '8.00',
+            'amount' => '8',
             'expiry_date' => null,
             'type' => [
               'id' => $this->getBalanceChangeTypeValue('Brought Forward'),
@@ -1056,19 +1035,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
         ],
       ],
       [
-        'id' => "$periodEntitlement2->id",
+        'id' => $periodEntitlement2->id,
         'breakdown' => [
           [
-            'amount' => '5.00',
-            'expiry_date' => null,
-            'type' => [
-              'id' => $this->getBalanceChangeTypeValue('Brought Forward'),
-              'value' => 'brought_forward',
-              'label' => 'Brought Forward'
-            ]
-          ],
-          [
-            'amount' => '3.00',
+            'amount' => '5',
             'expiry_date' => null,
             'type' => [
               'id' => $this->getBalanceChangeTypeValue('Brought Forward'),
@@ -1088,12 +1058,15 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
         ],
       ]
     ];
+
     $this->assertEquals($expectedResult, $result);
   }
 
   public function testGetBreakdownWithContactAndPeriodIdAndExpiredSetToTrue() {
     $contactId = 1;
+
     $absencePeriod = AbsencePeriodFabricator::fabricate();
+
     $periodEntitlement1 = LeavePeriodEntitlementFabricator::fabricate([
       'contact_id' => $contactId,
       'period_id' => $absencePeriod->id
@@ -1104,23 +1077,20 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
       'period_id' => $absencePeriod->id,
       'type_id' => 2
     ]);
+
     $expiredByNoOfDays = 2;
     $this->createExpiredBroughtForwardBalanceChange($periodEntitlement1->id, 9, 5, $expiredByNoOfDays);
-    $this->createExpiredBroughtForwardBalanceChange($periodEntitlement1->id, 8, 3, $expiredByNoOfDays);
     $this->createLeaveBalanceChange($periodEntitlement1->id, 10);
 
     $this->createExpiredBroughtForwardBalanceChange($periodEntitlement2->id, 5, 3, $expiredByNoOfDays);
-    $this->createExpiredBroughtForwardBalanceChange($periodEntitlement2->id, 3, 2, $expiredByNoOfDays);
     $this->createLeaveBalanceChange($periodEntitlement2->id, 2);
-
-    $params = ['contact_id' => $contactId, 'period_id' => $absencePeriod->id, 'expired' => true];
 
     $expectedResult = [
       [
         'id' => "$periodEntitlement1->id",
         'breakdown' => [
           [
-            'amount' => '-5.00',
+            'amount' => '-5',
             'expiry_date' => date('Y-m-d', strtotime("-{$expiredByNoOfDays} day")),
             'type' => [
               'id' => $this->getBalanceChangeTypeValue('Brought Forward'),
@@ -1128,22 +1098,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
               'label' => 'Brought Forward'
             ]
           ],
-          [
-            'amount' => '-3.00',
-            'expiry_date' => date('Y-m-d', strtotime("-{$expiredByNoOfDays} day")),
-            'type' => [
-              'id' => $this->getBalanceChangeTypeValue('Brought Forward'),
-              'value' => 'brought_forward',
-              'label' => 'Brought Forward'
-            ]
-          ]
         ],
       ],
       [
         'id' => "$periodEntitlement2->id",
         'breakdown' => [
           [
-            'amount' => '-3.00',
+            'amount' => '-3',
             'expiry_date' => date('Y-m-d', strtotime("-{$expiredByNoOfDays} day")),
             'type' => [
               'id' => $this->getBalanceChangeTypeValue('Brought Forward'),
@@ -1151,22 +1112,126 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
               'label' => 'Brought Forward'
             ]
           ],
+        ],
+      ]
+    ];
+
+    $result = LeavePeriodEntitlement::getBreakdown([
+      'contact_id' => $contactId,
+      'period_id'  => $absencePeriod->id,
+      'expired'    => true
+    ]);
+
+    $this->assertEquals($expectedResult, $result);
+  }
+
+  public function testGetBreakdownWillGroupTogetherBalanceChangesOfTheSameType() {
+    $contactId = 1;
+    $absencePeriod = AbsencePeriodFabricator::fabricate();
+
+    $periodEntitlement1 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contactId,
+      'period_id' => $absencePeriod->id
+    ]);
+
+    $periodEntitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contactId,
+      'period_id' => $absencePeriod->id,
+      'type_id' => 2
+    ]);
+
+    $this->createLeaveBalanceChange($periodEntitlement1->id, 5);
+    $this->createLeaveBalanceChange($periodEntitlement1->id, 10);
+
+    $this->createPublicHolidayBalanceChange($periodEntitlement2->id, 4);
+    $this->createPublicHolidayBalanceChange($periodEntitlement2->id, 5);
+    $this->createLeaveBalanceChange($periodEntitlement2->id, 13);
+
+    $expectedResult = [
+      [
+        'id' => $periodEntitlement1->id,
+        'breakdown' => [
           [
-            'amount' => '-2.00',
-            'expiry_date' => date('Y-m-d', strtotime("-{$expiredByNoOfDays} day")),
+            'amount' => 15, // 10 + 5
+            'expiry_date' => null,
             'type' => [
-              'id' => $this->getBalanceChangeTypeValue('Brought Forward'),
-              'value' => 'brought_forward',
-              'label' => 'Brought Forward'
+              'id' => $this->getBalanceChangeTypeValue('Leave'),
+              'value' => 'leave',
+              'label' => 'Leave'
+            ]
+          ]
+        ],
+      ],
+      [
+        'id' => $periodEntitlement2->id,
+        'breakdown' => [
+          [
+            'amount' => 9, // 4 + 5
+            'expiry_date' => null,
+            'type' => [
+              'id' => $this->getBalanceChangeTypeValue('Public Holiday'),
+              'value' => 'public_holiday',
+              'label' => 'Public Holiday'
+            ]
+          ],
+          [
+            'amount' => 13,
+            'expiry_date' => null,
+            'type' => [
+              'id' => $this->getBalanceChangeTypeValue('Leave'),
+              'value' => 'leave',
+              'label' => 'Leave'
+            ]
+          ],
+        ],
+      ]
+    ];
+
+    $result = LeavePeriodEntitlement::getBreakdown([
+      'contact_id' => $contactId,
+      'period_id'  => $absencePeriod->id
+    ]);
+
+    $this->assertEquals($expectedResult, $result);
+  }
+
+  public function testGetBreakdownWillGroupTogetherOverriddenBalanceChangeWithLeave() {
+    $contactId = 1;
+    $absencePeriod = AbsencePeriodFabricator::fabricate();
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contactId,
+      'period_id' => $absencePeriod->id
+    ]);
+
+    $this->createOverriddenBalanceChange($periodEntitlement->id, 5);
+    $this->createLeaveBalanceChange($periodEntitlement->id, 10);
+
+    $expectedResult = [
+      [
+        'id' => "$periodEntitlement->id",
+        'breakdown' => [
+          [
+            'amount' => 15, // 10 from leave + 5 from overridden
+            'expiry_date' => null,
+            'type' => [
+              'id' => $this->getBalanceChangeTypeValue('Leave'),
+              'value' => 'leave',
+              'label' => 'Leave'
             ]
           ]
         ],
       ]
     ];
-    $result = LeavePeriodEntitlement::getBreakdown($params);
+
+    $result = LeavePeriodEntitlement::getBreakdown([
+      'contact_id' => $contactId,
+      'period_id'  => $absencePeriod->id
+    ]);
+
     $this->assertEquals($expectedResult, $result);
   }
-  
+
   /**
    * Some tests on this class use the HRJobDetails API which uses the
    * HRJobContractRevision API that depends on the the global $user.

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
@@ -861,7 +861,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
     $this->assertEquals(10, $result[0]['remainder']['current']);
   }
 
-  public function testgetBreakdownBalanceChangesShouldIncludeOnlyNonExpiredBalancesWhenFalseIsPassed() {
+  public function testGetBreakdownBalanceChangesShouldIncludeOnlyNonExpiredBalancesWhenFalseIsPassed() {
     $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate();
     $this->createLeaveBalanceChange($periodEntitlement->id, 10);
     $this->createExpiredBroughtForwardBalanceChange($periodEntitlement->id, 9, 5);
@@ -890,7 +890,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
     $this->assertEquals('entitlement', $breakdowns[2]->source_type);
   }
 
-  public function testgetBreakdownBalanceChangesShouldIncludeOnlyExpiredBalancesWhenTrueIsPassed() {
+  public function testGetBreakdownBalanceChangesShouldIncludeOnlyExpiredBalancesWhenTrueIsPassed() {
     $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate();
     $this->createLeaveBalanceChange($periodEntitlement->id, 10);
     $this->createExpiredBroughtForwardBalanceChange($periodEntitlement->id, 9, 5);
@@ -912,7 +912,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
     $this->assertEquals('entitlement', $breakdowns[1]->source_type);
   }
 
-  public function testGetLeavePeriodEntitlementBreakdown() {
+  public function testGetBreakdown() {
     $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate();
     $this->createExpiredBroughtForwardBalanceChange($periodEntitlement->id, 9, 5);
     $this->createExpiredBroughtForwardBalanceChange($periodEntitlement->id, 8, 3);
@@ -959,7 +959,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
     $this->assertEquals($expectedResult, $result);
   }
 
-  public function testGetLeavePeriodEntitlementBreakdownWithExpiredSetToTrue() {
+  public function testGetBreakdownWithExpiredSetToTrue() {
     $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate();
     $expiredByNoOfDays = 2;
     $this->createExpiredBroughtForwardBalanceChange($periodEntitlement->id, 9, 5, $expiredByNoOfDays);
@@ -996,7 +996,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
     $this->assertEquals($expectedResult, $result);
   }
 
-  public function testGetLeavePeriodEntitlementBreakdownWithContactAndPeriodId() {
+  public function testGetBreakdownWithContactAndPeriodId() {
     $contactId = 1;
     $absencePeriod = AbsencePeriodFabricator::fabricate();
     $periodEntitlement1 = LeavePeriodEntitlementFabricator::fabricate([
@@ -1091,7 +1091,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
     $this->assertEquals($expectedResult, $result);
   }
 
-  public function testGetLeavePeriodEntitlementBreakdownWithContactAndPeriodIdAndExpiredSetToTrue() {
+  public function testGetBreakdownWithContactAndPeriodIdAndExpiredSetToTrue() {
     $contactId = 1;
     $absencePeriod = AbsencePeriodFabricator::fabricate();
     $periodEntitlement1 = LeavePeriodEntitlementFabricator::fabricate([
@@ -1166,6 +1166,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
     $result = LeavePeriodEntitlement::getBreakdown($params);
     $this->assertEquals($expectedResult, $result);
   }
+  
   /**
    * Some tests on this class use the HRJobDetails API which uses the
    * HRJobContractRevision API that depends on the the global $user.

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
@@ -70,6 +70,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'from_date' => CRM_Utils_Date::processDate($publicHoliday->date),
+      'to_date' => CRM_Utils_Date::processDate($publicHoliday->date),
       'contact_id' => $this->contract['contact_id'],
       'type_id' => $this->absenceType->id,
       'status_id' => 1

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/SicknessRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/SicknessRequestTest.php
@@ -271,6 +271,8 @@ class SicknessRequestTest extends BaseHeadlessTest {
       'status_id' => $this->leaveRequestStatuses['Approved']['value'],
       'from_date' => $startDate->format('Y-m-d'),
       'from_date_type' => $this->leaveRequestDayTypes['All Day']['value'],
+      'to_date' => $startDate->format('Y-m-d'),
+      'to_date_type' => $this->leaveRequestDayTypes['All Day']['value'],
       'reason' => $this->sicknessRequestReasons['Accident']['value'],
       'sequential' => 1
     ]);
@@ -281,9 +283,9 @@ class SicknessRequestTest extends BaseHeadlessTest {
       'status_id' => $this->leaveRequestStatuses['Approved']['value'],
       'from_date' => $startDate->format('Y-m-d'),
       'from_date_type' => $this->leaveRequestDayTypes['All Day']['value'],
-      'to_date' => '',
+      'to_date' => $startDate->format('Y-m-d'),
+      'to_date_type' => $this->leaveRequestDayTypes['All Day']['value'],
       'reason' => $this->sicknessRequestReasons['Accident']['value'],
-      'to_date_type' => '',
     ];
 
     $this->assertArraySubset($expectedValues, $result['values'][0]);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/TOILRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/TOILRequestTest.php
@@ -299,7 +299,9 @@ class api_v3_TOILRequestTest extends BaseHeadlessTest {
       'type_id' => $type->id,
       'status_id' => $this->getLeaveRequestStatuses()['Approved']['value'],
       'from_date' => $startDate->format('Y-m-d'),
+      'to_date' => $startDate->format('Y-m-d'),
       'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
       'toil_to_accrue' => 3,
       'duration' => 60,
       'sequential' => 1
@@ -311,8 +313,8 @@ class api_v3_TOILRequestTest extends BaseHeadlessTest {
       'status_id' => $this->getLeaveRequestStatuses()['Approved']['value'],
       'from_date' => $startDate->format('Y-m-d'),
       'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
-      'to_date' => '',
-      'to_date_type' => '',
+      'to_date' => $startDate->format('Y-m-d'),
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
       'duration' => 60
     ];
 
@@ -334,7 +336,8 @@ class api_v3_TOILRequestTest extends BaseHeadlessTest {
     $toilRequest1 = TOILRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact['id'],
       'type_id' => $type->id,
-      'from_date' => '20160101',
+      'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'duration' => 10,
       'expiry_date' => '20160110'
     ]);
@@ -357,6 +360,7 @@ class api_v3_TOILRequestTest extends BaseHeadlessTest {
       'contact_id' => $contact['id'],
       'type_id' => $type->id,
       'from_date' => $nextMonday->format('Ymd'),
+      'to_date' => $nextMonday->format('Ymd'),
       'duration' => 10,
       'expiry_date' => $nextMonday->modify('+5 days')->format('Ymd')
     ]);
@@ -380,9 +384,10 @@ class api_v3_TOILRequestTest extends BaseHeadlessTest {
     $toilRequest1 = TOILRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact['id'],
       'type_id' => $type->id,
-      'from_date' => '20160101',
+      'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'duration' => 10,
-      'expiry_date' => '20160110'
+      'expiry_date' => CRM_Utils_Date::processDate('2016-01-10')
     ]);
 
     $toilRequestBalanceChange = $this->findToilRequestBalanceChange($toilRequest1->id);
@@ -403,6 +408,7 @@ class api_v3_TOILRequestTest extends BaseHeadlessTest {
       'contact_id' => $contact['id'],
       'type_id' => $type->id,
       'from_date' => $nextMonday->format('Ymd'),
+      'to_date' => $nextMonday->format('Ymd'),
       'duration' => 10,
       'expiry_date' => $nextMonday->modify('+5 days')->format('Ymd')
     ]);
@@ -425,7 +431,8 @@ class api_v3_TOILRequestTest extends BaseHeadlessTest {
     $toilRequest1 = TOILRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact['id'],
       'type_id' => $type->id,
-      'from_date' => '20160101',
+      'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'duration' => 10,
       'expiry_date' => '20160110'
     ]);


### PR DESCRIPTION
In cases when a LeavePeriodEntitlement has more than one LeaveBalanceChange with the same type_id, the `getBreakdown()`  method should return them as a single entry, where the amount will be the sum of the amounts of the grouped items.

So, say you have 2 balance changes of type "Leave", one with 5 days and another with 2 days. The returned date will be this single entry:

```json
{
      "amount": 7,
      "expiry_date": null,
      "type": {
      "id": 1,
        "value": "leave",
        "label": "Leave"
      }
}
```

There's a special handling for Balance Changes of type "Overridden". They will be grouped together with balance changes of type "Leave". The reason is that "Overridden" days are the same thing as Leave. The "Overridden" type is just used internally for the system to be able to know that the original calculated number of days for "Leave" was manually overidden during the entitlement calculation.

Say the calculated entitlement was 10 days, but then it was overridden to 15. This will create 2 balance changes:
- type: "Leave", amount: 10 (the calculated amount)
- type: "Overridden", amount: 5 (the difference between the calculated amount and the overridden value)

LeavePeriodEntitlement.getBreakdown will group both together and the returned data will be:
```json
{
      "amount": 15,
      "expiry_date": null,
      "type": {
      "id": 1,
        "value": "leave",
        "label": "Leave"
      }
}
``` 