### PR TITLE
PCHR-1811: Add the LeaveRequest.isManagedBy() API endpoint

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveManager.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveManager.php
@@ -9,24 +9,23 @@
 class CRM_HRLeaveAndAbsences_Service_LeaveManager {
 
   /**
-   * Checks if the current logged in user is the Leave Manager for the Contact
-   * with the given ID.
+   * Checks contact given by $contactID is managed by the contact given by
+   * $managerID.
    *
    * In order to do this, we check if there's a Relationship between both
    * contacts, where contact A ($contactID) "has Leave Approved By" contact B
-   * (the logged in), and that if the Relationship is active on the current date.
+   * ($managerID), and that if the Relationship is active on the current date.
    *
    * Note about implementation: Due to the impossibility of making complex
    * queries using the CiviCRM API (r.start_date IS NULL OR r.start_date <=
    * CURDATE()), this method uses a SQL query to check the relationship.
    *
    * @param int $contactID
+   * @param int $managerID
    *
    * @return bool
    */
-  public function currentUserIsLeaveManagerOf($contactID) {
-    $currentUserID = CRM_Core_Session::getLoggedInContactID();
-
+  public function isContactManagedBy($contactID, $managerID) {
     $relationshipTable = CRM_Contact_BAO_Relationship::getTableName();
     $relationshipTypeTable = CRM_Contact_BAO_RelationshipType::getTableName();
 
@@ -44,13 +43,29 @@ class CRM_HRLeaveAndAbsences_Service_LeaveManager {
 
     $params = [
       1 => [$contactID, 'Integer'],
-      2 => [$currentUserID, 'Integer'],
+      2 => [$managerID, 'Integer'],
       3 => [date('Y-m-d'), 'String']
     ];
 
     $result = CRM_Core_DAO::executeQuery($query, $params);
 
     return $result->N > 0;
+  }
+
+  /**
+   * Checks if the current logged in user is the Leave Manager for the Contact
+   * with the given ID.
+   *
+   * @see CRM_HRLeaveAndAbsences_Service_LeaveManager::isContactManagedBy()
+   *
+   * @param int $contactID
+   *
+   * @return bool
+   */
+  public function currentUserIsLeaveManagerOf($contactID) {
+    $currentUserID = CRM_Core_Session::getLoggedInContactID();
+
+    return $this->isContactManagedBy($contactID, $currentUserID);
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -323,3 +323,57 @@ function civicrm_api3_leave_request_isvalid($params) {
 
   return civicrm_api3_create_success($result);
 }
+
+/**
+ * LeaveRequest.isManagedBy API spec
+ *
+ * @param array $spec
+ */
+function _civicrm_api3_leave_request_ismanagedby_spec(&$spec) {
+  $spec['leave_request_id'] = [
+    'name' => 'leave_request_id',
+    'type' => CRM_Utils_Type::T_INT,
+    'title' => 'Leave Request',
+    'description' => 'The Leave Request to check if the contact is the manager of',
+    'api.required' => 1
+  ];
+
+  $spec['contact_id'] = [
+    'name' => 'contact_id',
+    'type' => CRM_Utils_Type::T_INT,
+    'title' => 'Contact',
+    'description' => 'The contact to check if the Leave Request is managed by',
+    'api.required' => 1,
+    'FKClassName'  => 'CRM_Contact_DAO_Contact',
+    'FKApiName'    => 'Contact',
+  ];
+}
+
+/**
+ * LeaveRequest.isManagedBy API
+ *
+ * Uses the LeaveManager service in order to check if the contact of the given
+ * Leave Request is managed by the contact with the given contact_id.
+ *
+ * @see CRM_HRLeaveAndAbsences_Service_LeaveManager::isContactManagedBy()
+ *
+ * @param array $params
+ *
+ * @return array
+ */
+function civicrm_api3_leave_request_ismanagedby($params) {
+  $leaveRequest = CRM_HRLeaveAndAbsences_BAO_LeaveRequest::findById($params['leave_request_id']);
+  $leaveManagerService = new CRM_HRLeaveAndAbsences_Service_LeaveManager();
+
+  $result = civicrm_api3_create_success($leaveManagerService->isContactManagedBy(
+    $leaveRequest->contact_id,
+    $params['contact_id'])
+  );
+
+  // When isContactManagedBy returns false, civicrm_api3_create_success will
+  // consider no value was returned and will set count to 0. So we manually
+  // set it to 1 here.
+  $result['count'] = 1;
+
+  return $result;
+}


### PR DESCRIPTION
This is a new API endpoint that can be used to check if a given Contact is the manager of the contact of a given Leave Request.

It has two mandatory params:
- *contact_id*: The contact to check if the Leave Request is managed by 
- *leave_request_id*: The Leave Request to check if the contact is the manager of

### Usage:
```php
civicrm_api3('LeaveRequest', 'isManagedBy', ['contact_id' => 1, 'leave_request_id' => 1]);
```

If Contact with ID 1 is the manager of the contact for the the LeaveRequest with ID 1, this will be the response:
```json
{
    "is_error": 0,
    "version": 3,
    "count": 1,
    "values": true
}
```

Otherwise, the response will be:
```json
{
    "is_error": 0,
    "version": 3,
    "count": 1,
    "values": false
}
```