### PR TITLE
PCHR-1850: Extend LeaveRequest.getFull API to include the TOIL Request balance changes

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -3,9 +3,7 @@
 use CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement as LeavePeriodEntitlement;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
-use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
 use CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern as ContactWorkPattern;
-use CRM_HRLeaveAndAbsences_BAO_WorkDay as WorkDay;
 
 class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsences_DAO_LeaveBalanceChange {
 
@@ -340,6 +338,23 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
     }
 
     return $balance;
+  }
+
+  /**
+   * Returns the LeaveBalanceChange amount for the TOIL request ID
+   * Also note that a TOIL Request creates a single LeaveBalanceChange record.
+   *
+   * @param int $toilRequestID
+   *
+   * @return float
+   */
+  public static function getAmountForTOILRequest($toilRequestID) {
+    $balanceChange = new self();
+    $balanceChange->source_id = $toilRequestID;
+    $balanceChange->source_type = self::SOURCE_TOIL_REQUEST;
+    $balanceChange->find(true);
+
+    return $balanceChange->amount;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -11,7 +11,8 @@ use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange as LeaveBalanceCha
 use CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern as WorkPatternFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest as PublicHolidayLeaveRequestFabricator;
-
+use CRM_HRLeaveAndAbsences_Test_Fabricator_TOILRequest as TOILRequestFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
 /**
  * Class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest
  *
@@ -1037,6 +1038,24 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   private function deleteDefaultWorkPattern() {
     $workPatternTable = WorkPattern::getTableName();
     CRM_Core_DAO::executeQuery("DELETE FROM {$workPatternTable} WHERE is_default = 1");
+  }
+
+  public function testGetBalanceChangeForToilLeaveRequest() {
+
+    $toilRequest = TOILRequestFabricator::fabricateWithoutValidation([
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('+1 days'),
+      'to_date' => CRM_Utils_Date::processDate('+2 days'),
+      'to_date_type' => 1,
+      'from_date_type' => 1,
+      'toil_to_accrue' => 2,
+      'duration' => 120,
+      'expiry_date' => CRM_Utils_Date::processDate('+100 days')
+    ]);
+
+    $this->assertEquals(2, LeaveBalanceChange::getAmountForTOILRequest($toilRequest->id));
   }
 }
 


### PR DESCRIPTION
This PR updates the LeaveRequest.getFull() API to include the balance_change for TOIL leave request.
Currently, the API does not return the balance changes for TOIL requests because the balance change for a TOIL leave request is created differently from that of a normal leave request.
This PR takes this difference into consideration and makes changes that will allow balance changes for TOIL requests to returned in the LeaveRequest.getFull() API endpoint
