### PR TITLE
PCHR-1852: Install CiviCRM views integration module after civihr installation

### DIFF
--- a/bin/drush-install.sh
+++ b/bin/drush-install.sh
@@ -85,3 +85,5 @@ if [ "$WITH_HR_SAMPLE" == "1" ]; then
   set +ex
 fi
 
+# Enable CiviCRM views integration after civihr is completely get installed
+drush -y en civicrm_views_integration


### PR DESCRIPTION
This installs (CiviCRM views integration module) by default when installing civihr . This module is part of civihr employee portal and it is added in this PR : https://github.com/compucorp/civihr-employee-portal/pull/258