### PR TITLE
PCHR-1683: Update TOIL Requests according to changes in Absence Type settings

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -48,6 +48,12 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
   ];
 
   /**
+   * The absence type object before it gets updated.
+   * @var CRM_HRLeaveAndAbsences_BAO_AbsenceType
+   */
+  public $oldAbsenceType;
+
+  /**
    * Create a new AbsenceType based on array-data
    *
    * @param array $params key-value pairs
@@ -75,6 +81,11 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
     $mustUpdatePublicHolidaysLeaveRequests = self::mustUpdatePublicHolidayLeaveRequests($params);
 
     $instance = new $className();
+
+    if ($hook == 'edit') {
+      $instance->loadOldAbsenceType($params['id']);
+    }
+
     $instance->copyValues($params);
     $transaction = new CRM_Core_Transaction();
     $instance->save();
@@ -581,5 +592,15 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    */
   private function toilNeverExpires() {
     return !$this->accrual_expiration_unit || !$this->accrual_expiration_duration;
+  }
+
+  /**
+   * Load an absence type object and assign to the oldAbsenceType variable
+   *
+   * @param int $id
+   *   The Id of the absence type
+   */
+  private function loadOldAbsenceType($id) {
+    $this->oldAbsenceType = self::findById($id);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/AbsenceType.php
@@ -1,0 +1,31 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
+use CRM_HRLeaveAndAbsences_BAO_TOILRequest as TOILRequest;
+
+class CRM_HRLeaveAndAbsences_Service_AbsenceType {
+
+  /**
+   * Actions that occurs when an AbsenceType is updated
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_AbsenceType $absenceType
+   */
+  public function postUpdateActions(AbsenceType $absenceType) {
+    $oldAbsenceType = $absenceType->oldAbsenceType;
+    if ($oldAbsenceType->allow_accruals_request == true && $absenceType->allow_accruals_request == false) {
+      $this->onToilDisable($absenceType);
+    }
+  }
+
+  /**
+   * The set of actions/updates that occurs when TOIL is disabled for an AbsenceType.
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_AbsenceType $absenceType
+   */
+  private function onToilDisable(AbsenceType $absenceType) {
+    $currentPeriod = AbsencePeriod::getCurrentPeriod();
+    $startDate = new DateTime($currentPeriod->start_date);
+    TOILRequest::deleteAllForAbsenceType($absenceType->id, $startDate, null, true);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_HRLeaveAndAbsences_Factory_PublicHolidayLeaveRequestService as PublicHolidayLeaveRequestServiceFactory;
+use CRM_HRLeaveAndAbsences_Service_AbsenceType as AbsenceTypeService;
 
 require_once 'hrleaveandabsences.civix.php';
 
@@ -480,5 +481,23 @@ function _hrleaveandabsences_civicrm_post_hrjobdetails($op, $objectId, &$objectR
       $service = PublicHolidayLeaveRequestServiceFactory::create();
       $service->updateAllInTheFutureForContract($revision['jobcontract_id']);
     } catch(Exception $e) {}
+  }
+}
+
+/**
+ * Function which will be called when hook_civicrm_post is executed for the
+ * AbsenceType entity
+ *
+ * @param string $op
+ * @param int $objectId
+ * @param object $objectRef
+ */
+function _hrleaveandabsences_civicrm_post_absencetype($op, $objectId, &$objectRef) {
+  if(in_array($op, ['edit'])) {
+
+    try {
+      $absenceTypeService = new AbsenceTypeService();
+      $absenceTypeService->postUpdateActions($objectRef);
+    } catch (Exception $e) {}
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/AbsenceTypeTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod as AbsencePeriodFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_TOILRequest as TOILRequestFabricator;
+use CRM_HRLeaveAndAbsences_Service_AbsenceType as AbsenceTypeService;
+use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
+use CRM_HRLeaveAndAbsences_BAO_TOILRequest as TOILRequest;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_Service_AbsenceTypeTest extends BaseHeadlessTest {
+
+  public function testPostUpdateActionDeletesTOILRequestsWhenTOILGetsDisabled() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'max_leave_accrual' => 1,
+    ]);
+
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-1 days'),
+      'end_date' => CRM_Utils_Date::processDate('+ 300days'),
+    ]);
+
+    TOILRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceType->id,
+      'contact_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('+3 days'),
+      'to_date' => CRM_Utils_Date::processDate('+3 days'),
+      'toil_to_accrue' => 2,
+      'duration' => 120,
+      'expiry_date' => CRM_Utils_Date::processDate('+100 days')
+    ]);
+
+    $toilRequest2 = TOILRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceType->id,
+      'contact_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-03-10'),
+      'to_date' => CRM_Utils_Date::processDate('2016-03-10'),
+      'toil_to_accrue' => 2,
+      'duration' => 120,
+      'expiry_date' => CRM_Utils_Date::processDate('2016-12-10')
+    ]);
+
+    //assert the records exist first before updating absence type
+    $balanceChanges = new LeaveBalanceChange();
+    $balanceChanges->find();
+    $this->assertEquals($balanceChanges->N, 2);
+
+    $leaveRequest = new LeaveRequest();
+    $leaveRequest->find();
+    $this->assertEquals($leaveRequest->N, 2);
+
+    $leaveRequestDate = new LeaveRequestDate();
+    $leaveRequestDate->find();
+    $this->assertEquals($leaveRequestDate->N, 2);
+
+    $toilRequest = new ToilRequest();
+    $toilRequest->find();
+    $this->assertEquals($toilRequest->N, 2);
+
+    //disable TOIL
+    $updatedAbsenceType = AbsenceType::create([
+      'id' => $absenceType->id,
+      'allow_accruals_request' => false,
+      'color' => '#000000'
+    ]);
+
+    $absenceTypeService = new AbsenceTypeService();
+    $absenceTypeService->postUpdateActions($updatedAbsenceType);
+
+    //confirm the balance change for the expired TOIL balance was not deleted
+    $balanceChanges = new LeaveBalanceChange();
+    $balanceChanges->find();
+    $this->assertEquals($balanceChanges->N, 1);
+    $balanceChanges->fetch();
+    $this->assertEquals($balanceChanges->source_id, $toilRequest2->id);
+
+    //confirm the leave request for the expired TOIL balance was not deleted
+    $leaveRequest = new LeaveRequest();
+    $leaveRequest->find();
+    $this->assertEquals($leaveRequest->N, 1);
+    $leaveRequest->fetch();
+    $this->assertEquals($leaveRequest->id, $toilRequest2->leave_request_id);
+
+    //confirm the leave request dates for the expired TOIL balance was not deleted
+    $leaveRequestDate = new LeaveRequestDate();
+    $leaveRequestDate->find();
+    $this->assertEquals($leaveRequestDate->N, 1);
+    $leaveRequestDate->fetch();
+    $this->assertEquals($leaveRequestDate->date, '2016-03-10');
+
+    //confirm the TOIL Request for the expired TOIL balance was not deleted
+    $toilRequest = new ToilRequest();
+    $toilRequest->find();
+    $this->assertEquals($toilRequest->N, 1);
+    $toilRequest->fetch();
+    $this->assertEquals($toilRequest->id, $toilRequest2->id);
+  }
+}


### PR DESCRIPTION
This PR takes care of updates/changes to TOIL requests when the TOIL accrual settings for an Absence Type is updated.

The following situations were taken care of in this PR:

- A test was added to verify that when an admin decreases the max number of days that can be accrued for an Absence Type, for open TOIL Request, the system "protects" itself and will not allow the request to be approved if the request amount is more than the new max.

- When an admin disables TOIL for an Absence Type, for all non-expired TOIL Requests, the TOIL requests + leave requests + balance changes + leave request dates associated with the TOIL is deleted

For situations when increase the TOIL expiry duration for an Absence Type is increase or decreased,
nothing is done because there's no way to distinguish between manually and automatically calculated TOIL expiry date.