### PR TITLE
PCHR-1681: Save LeaveRequest balance changes as a negative number

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChange.php
@@ -21,7 +21,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange {
           LeaveBalanceChange::create([
             'source_id' => $date->id,
             'source_type' => LeaveBalanceChange::SOURCE_LEAVE_REQUEST_DAY,
-            'amount' => $balanceChange['amount'],
+            'amount' => $balanceChange['amount'] * -1,
             'type_id' => $balanceChangeTypes['debit']
           ]);
         }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChangeTest.php
@@ -27,14 +27,14 @@ class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChangeTest extends BaseHeadless
 
     $leaveRequestDateTypes = array_flip(LeaveRequest::buildOptions('from_date_type', 'validate'));
 
-    // a 7 days leave request, from monday to sunday
+    // a 9 days leave request, from friday to saturday of the next week
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => 1,
       'contact_id' => $contact['id'],
       'status_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'from_date_type' => $leaveRequestDateTypes['all_day'],
-      'to_date' => CRM_Utils_Date::processDate('2016-01-07'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-09'),
       'to_date_type' => $leaveRequestDateTypes['all_day'],
     ]);
 
@@ -42,14 +42,15 @@ class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChangeTest extends BaseHeadless
     $service->createForLeaveRequest($leaveRequest);
 
     $balance = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
-    // Since the 40 hours work pattern was used, and it this is a week long
-    // leave request, the balance will be 5 (for the 5 working days)
-    $this->assertEquals(5, $balance);
+    // Since the 40 hours work pattern was used and there are 3 weekend days on the
+    // leave period (2 saturdays and 1 sunday), the balance change will be -6
+    // (the working days of all the 9 days requested)
+    $this->assertEquals(-6, $balance);
 
     $balanceChanges = LeaveBalanceChange::getBreakdownForLeaveRequest($leaveRequest);
-    // Even though the balance is 5, we must have 7 balance changes, one for
+    // Even though the balance is -6, we must have 9 balance changes, one for
     // each date
-    $this->assertCount(7, $balanceChanges);
+    $this->assertCount(9, $balanceChanges);
   }
 
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -35,16 +35,16 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
       'type_id' => 1,
       'contact_id' => $contact['id'],
       'status_id' => 1,
-      'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
       'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
-      'to_date' => CRM_Utils_Date::processDate('2016-01-07'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-10'),
       'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
     ], false);
 
     $balance = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
     // Since the 40 hours work pattern was used, and it this is a week long
-    // leave request, the balance will be 5 (for the 5 working days)
-    $this->assertEquals(5, $balance);
+    // leave request, the balance will be -5 (for the 5 working days)
+    $this->assertEquals(-5, $balance);
 
     $balanceChanges = LeaveBalanceChange::getBreakdownForLeaveRequest($leaveRequest);
     // Even though the balance is 5, we must have 7 balance changes, one for
@@ -64,6 +64,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequestService = new LeaveRequestService(new LeaveBalanceChangeService());
 
+    // a 7 days leave request, from friday to thursday
     $params = [
       'type_id' => 1,
       'contact_id' => $contact['id'],
@@ -74,13 +75,12 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
       'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
     ];
 
-    // a 7 days leave request, from monday to sunday
     $leaveRequest = $leaveRequestService->create($params, false);
 
     $balance = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
     // Since the 40 hours work pattern was used, and it this is a week long
     // leave request, the balance will be 5 (for the 5 working days)
-    $this->assertEquals(5, $balance);
+    $this->assertEquals(-5, $balance);
 
     $balanceChanges = LeaveBalanceChange::getBreakdownForLeaveRequest($leaveRequest);
     // Even though the balance is 5, we must have 7 balance changes, one for
@@ -94,7 +94,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
 
     $balance = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
     // 5 from before + 2 (from the 2 new working days)
-    $this->assertEquals(7, $balance);
+    $this->assertEquals(-7, $balance);
 
     $balanceChanges = LeaveBalanceChange::getBreakdownForLeaveRequest($leaveRequest);
     // 7 from before + 4 from the new period

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/SicknessRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/SicknessRequestTest.php
@@ -38,14 +38,14 @@ class CRM_HRLeaveAndAbsences_Service_SicknessRequestTest extends BaseHeadlessTes
 
     $sicknessReasons = array_flip(SicknessRequest::buildOptions('reason', 'validate'));
 
-    // a 7 days request, from friday to thursday
+    // a 9 days request, from thursday to friday next week
     $sicknessRequest = $service->create([
       'type_id' => 1,
       'contact_id' => $contact['id'],
       'status_id' => 1,
-      'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'from_date' => CRM_Utils_Date::processDate('2016-02-11'),
       'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
-      'to_date' => CRM_Utils_Date::processDate('2016-01-07'),
+      'to_date' => CRM_Utils_Date::processDate('2016-02-19'),
       'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
       'reason' => $sicknessReasons['accident']
     ], false);
@@ -53,14 +53,14 @@ class CRM_HRLeaveAndAbsences_Service_SicknessRequestTest extends BaseHeadlessTes
     $leaveRequest = LeaveRequest::findById($sicknessRequest->leave_request_id);
 
     $balance = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
-    // Since the 40 hours work pattern was used, and it this is a week long
-    // leave request, the balance will be 5 (for the 5 working days)
-    $this->assertEquals(5, $balance);
+    // Since the 40 hours work pattern was used and there are 7 working days during
+    // the 9 days period of the requests, the balance will be -7
+    $this->assertEquals(-7, $balance);
 
     $balanceChanges = LeaveBalanceChange::getBreakdownForLeaveRequest($leaveRequest);
-    // Even though the balance is 5, we must have 7 balance changes, one for
+    // Even though the balance is -7, we must have 9 balance changes, one for
     // each date
-    $this->assertCount(7, $balanceChanges);
+    $this->assertCount(9, $balanceChanges);
   }
 
   public function testCreateDoesNotDuplicateLeaveBalanceChangesOnUpdate() {
@@ -92,18 +92,18 @@ class CRM_HRLeaveAndAbsences_Service_SicknessRequestTest extends BaseHeadlessTes
       'reason' => $sicknessReasons['accident']
     ];
 
-    // a 7 days leave request, from monday to sunday
+    // a 7 days leave request, from friday to thursday
     $sicknessRequest = $service->create($params, false);
 
     $leaveRequest = LeaveRequest::findById($sicknessRequest->leave_request_id);
 
     $balance = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
     // Since the 40 hours work pattern was used, and it this is a week long
-    // leave request, the balance will be 5 (for the 5 working days)
-    $this->assertEquals(5, $balance);
+    // leave request, the balance will be -5 (for the 5 working days)
+    $this->assertEquals(-5, $balance);
 
     $balanceChanges = LeaveBalanceChange::getBreakdownForLeaveRequest($leaveRequest);
-    // Even though the balance is 5, we must have 7 balance changes, one for
+    // Even though the balance is -5, we must have 7 balance changes, one for
     // each date
     $this->assertCount(7, $balanceChanges);
 
@@ -116,8 +116,8 @@ class CRM_HRLeaveAndAbsences_Service_SicknessRequestTest extends BaseHeadlessTes
     $this->assertEquals($leaveRequest->id, $sicknessRequest->leave_request_id);
 
     $balance = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
-    // 5 from before + 2 (from the 2 new working days)
-    $this->assertEquals(7, $balance);
+    // -5 from before - 2 (from the 2 new working days)
+    $this->assertEquals(-7, $balance);
 
     $balanceChanges = LeaveBalanceChange::getBreakdownForLeaveRequest($leaveRequest);
     // 7 from before + 4 from the new period


### PR DESCRIPTION
LeaveRequest always deduct days from the entitlement, so their balance changes should always have a negative number as the amount.

The associated tests were updated to reflected this. They were also updated in order to add some more "randomness" (they were all using the same dates and balance changes, so I picked some different dates in order to generate some differente balance changes in the end)