### PR TITLE
PCHR-1869: Modify Comment Entity Get and Delete API endpoints

### DIFF
--- a/uk.co.compucorp.civicrm.hrcomments/CRM/HRComments/API/Query/CommentSelect.php
+++ b/uk.co.compucorp.civicrm.hrcomments/CRM/HRComments/API/Query/CommentSelect.php
@@ -1,0 +1,81 @@
+<?php
+
+use Civi\API\SelectQuery;
+use CRM_HRComments_BAO_Comment as Comment;
+
+/**
+ * This class is basically a wrapper around Civi\API\SelectQuery.
+ */
+class CRM_HRComments_API_Query_CommentSelect {
+
+  /**
+   * @var array
+   *   An array of params passed to an API endpoint
+   */
+  private $params;
+
+  /**
+   * @var \Civi\API\SelectQuery
+   *  The SelectQuery instance wrapped by this class
+   */
+  private $query;
+
+  public function __construct($params) {
+    $this->params = $params;
+    $this->buildCustomQuery();
+  }
+
+  /**
+   * Build the custom query.
+   */
+  private function buildCustomQuery() {
+    $customQuery = CRM_Utils_SQL_Select::from(Comment::getTableName() . ' as a');
+
+    $this->addWhere($customQuery);
+    $this->filterReturnFields();
+    $this->query = new SelectQuery(Comment::class, $this->params, false);
+    $this->query->merge($customQuery);
+  }
+
+  /**
+   * Add the conditions to the query.
+   *
+   * This where it is ensured that only non soft-deleted comments are returned
+   *
+   * @param \CRM_Utils_SQL_Select $customQuery
+   */
+  private function addWhere(CRM_Utils_SQL_Select $customQuery) {
+    $conditions[] = 'a.is_deleted = 0';
+    $customQuery->where($conditions);
+  }
+
+  /**
+   * Executes the query
+   *
+   * @return array
+   */
+  public function run() {
+    $results = $this->query->run();
+    return $results;
+  }
+
+  /**
+   * This function allows some fields to be filtered out of the query results.
+   * Currently only the is_deleted field is filtered out
+   */
+  private function filterReturnFields() {
+    if (empty($this->params['return'])) {
+      $allFields = array_keys(Comment::fields());
+      $key = array_search('is_deleted', $allFields);
+      unset($allFields[$key]);
+      $this->params['return'] = $allFields;
+    }
+
+    if (!empty($this->params['return'])) {
+      if (in_array('is_deleted', $this->params['return'])){
+        $key = array_search('is_deleted', $this->params['return']);
+        unset($this->params['return'][$key]);
+      }
+    }
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcomments/CRM/HRComments/Test/Fabricator/Comment.php
+++ b/uk.co.compucorp.civicrm.hrcomments/CRM/HRComments/Test/Fabricator/Comment.php
@@ -1,0 +1,20 @@
+<?php
+
+use CRM_HRComments_BAO_Comment as Comment;
+
+class CRM_HRComments_Test_Fabricator_Comment {
+
+  public static function fabricate($params) {
+    $params = self::mergeDefaultParams($params);
+
+    return Comment::create($params);
+  }
+
+  private static function mergeDefaultParams($params) {
+    $defaultParams = [
+      'text' => 'This is some random comment',
+      'entity_name' => 'DefaultEntity',
+    ];
+    return array_merge($defaultParams, $params);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcomments/api/v3/Comment.php
+++ b/uk.co.compucorp.civicrm.hrcomments/api/v3/Comment.php
@@ -20,7 +20,15 @@ function _civicrm_api3_comment_create_spec(&$spec) {
  * @throws API_Exception
  */
 function civicrm_api3_comment_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  $results =  _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+
+  if($results['count'] > 0){
+    array_walk($results['values'], function (&$item) {
+      unset($item['is_deleted']);
+    });
+  }
+
+  return $results;
 }
 
 /**
@@ -31,16 +39,23 @@ function civicrm_api3_comment_create($params) {
  * @throws API_Exception
  */
 function civicrm_api3_comment_delete($params) {
-  return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  civicrm_api3_verify_mandatory($params, NULL, ['id']);
+  CRM_HRComments_BAO_Comment::softDelete($params['id']);
 }
 
 /**
  * Comment.get API
+ * This API returns comments that are not deleted
+ * i.e comments with is_deleted flag false.
  *
  * @param array $params
+ *
  * @return array API result descriptor
+ *
  * @throws API_Exception
  */
 function civicrm_api3_comment_get($params) {
-  return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  $query = new CRM_HRComments_API_Query_CommentSelect($params);
+  return civicrm_api3_create_success($query->run(), $params, '', 'get');
 }
+

--- a/uk.co.compucorp.civicrm.hrcomments/tests/phpunit/api/v3/CommentTest.php
+++ b/uk.co.compucorp.civicrm.hrcomments/tests/phpunit/api/v3/CommentTest.php
@@ -1,0 +1,192 @@
+<?php
+
+use CRM_HRComments_Test_Fabricator_Comment as CommentFabricator;
+use CRM_HRComments_BAO_Comment as Comment;
+
+/**
+ * Class api_v3_CommentTest
+ *
+ * @group headless
+ */
+class api_v3_CommentTest extends BaseHeadlessTest  {
+
+  public function setUp() {
+    CRM_Core_DAO::executeQuery("SET foreign_key_checks = 0;");
+  }
+
+  public function tearDown() {
+    CRM_Core_DAO::executeQuery("SET foreign_key_checks = 1;");
+  }
+
+  public function testDeleteDoesNotDeleteCommentsFromCommentsTableButSetsIsDeletedFlagToOne() {
+    $comment1 = CommentFabricator::fabricate([
+      'entity_id' => 1,
+      'contact_id' => 1,
+    ]);
+
+    $comment2 = CommentFabricator::fabricate([
+      'entity_id' => 2,
+      'contact_id' => 2,
+    ]);
+
+    //soft delete the first comment
+    civicrm_api3('Comment', 'delete', [
+      'id' => $comment1->id,
+    ]);
+
+    $comment = new Comment();
+    $comment->find();
+    $this->assertEquals($comment->N, 2);
+
+    $comment->fetch();
+    $this->assertEquals($comment->id, $comment1->id);
+    $this->assertEquals(1, $comment->is_deleted);
+
+    $comment->fetch();
+    $this->assertEquals($comment->id, $comment2->id);
+    $this->assertEquals(0, $comment->is_deleted);
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage Unable to find a CRM_HRComments_BAO_Comment with id 2.
+   */
+  public function testDeleteThrowsExceptionWhenCommentIdDoesNotExist() {
+    //soft delete the first comment
+    civicrm_api3('Comment', 'delete', [
+      'id' => 2,
+    ]);
+  }
+
+  public function testGetDoesNotIncludeSoftDeletedCommentsAndIsDeletedColumn() {
+    $entityName = 'LeaveRequest';
+    $comment1 = CommentFabricator::fabricate([
+      'entity_id' => 1,
+      'entity_name' => $entityName,
+      'contact_id' => 1,
+    ]);
+
+    $comment2 = CommentFabricator::fabricate([
+      'entity_id' => 2,
+      'entity_name' => $entityName,
+      'contact_id' => 1,
+    ]);
+
+    $comment3 = CommentFabricator::fabricate([
+      'entity_id' => 3,
+      'entity_name' => $entityName,
+      'contact_id' => 1,
+    ]);
+
+    //soft delete the second comment
+    civicrm_api3('Comment', 'delete', [
+      'id' => $comment2->id,
+    ]);
+
+    $result = civicrm_api3('Comment', 'get', [
+      'entity_name' => $entityName,
+      'contact_id' => 1,
+      'sequential' => 1,
+    ]);
+
+    $comment1Date  = new DateTime($comment1->created_at);
+    $comment1FormattedDate = $comment1Date->format('Y-m-d H:i:s');
+
+    $comment3Date  = new DateTime($comment3->created_at);
+    $comment3FormattedDate = $comment3Date->format('Y-m-d H:i:s');
+    $expectedValues = [
+      [
+        'id' => $comment1->id,
+        'entity_name' => $comment1->entity_name,
+        'entity_id' => $comment1->entity_id,
+        'text' => $comment1->text,
+        'contact_id' => $comment1->contact_id,
+        'created_at' => $comment1FormattedDate,
+      ],
+      [
+        'id' => $comment3->id,
+        'entity_name' => $comment3->entity_name,
+        'entity_id' => $comment3->entity_id,
+        'text' => $comment3->text,
+        'contact_id' => $comment3->contact_id,
+        'created_at' => $comment3FormattedDate,
+      ],
+    ];
+
+    $this->assertEquals($expectedValues, $result['values']);
+  }
+
+  public function testGetDoesNotIncludeSoftDeletedCommentsAndIsDeletedColumnWhenReturnArrayIncludesIsDeleted() {
+    $entityName = 'LeaveRequest';
+    $comment1 = CommentFabricator::fabricate([
+      'entity_id' => 1,
+      'entity_name' => $entityName,
+      'contact_id' => 1,
+    ]);
+
+    $comment2 = CommentFabricator::fabricate([
+      'entity_id' => 2,
+      'entity_name' => $entityName,
+      'contact_id' => 1,
+    ]);
+
+    $comment3 = CommentFabricator::fabricate([
+      'entity_id' => 3,
+      'entity_name' => $entityName,
+      'contact_id' => 1,
+    ]);
+
+    //soft delete the second comment
+    civicrm_api3('Comment', 'delete', [
+      'id' => $comment2->id,
+    ]);
+
+    $result = civicrm_api3('Comment', 'get', [
+      'entity_name' => $entityName,
+      'contact_id' => 1,
+      'sequential' => 1,
+      'return' => ['id', 'entity_name', 'entity_id', 'is_deleted']
+    ]);
+
+    $expectedValues = [
+      [
+        'id' => $comment1->id,
+        'entity_name' => $comment1->entity_name,
+        'entity_id' => $comment1->entity_id,
+      ],
+      [
+        'id' => $comment3->id,
+        'entity_name' => $comment3->entity_name,
+        'entity_id' => $comment3->entity_id,
+      ],
+    ];
+
+    $this->assertEquals($expectedValues, $result['values']);
+  }
+
+  public function testCreateDoesNotReturnIsDeletedFieldInReturnedResults() {
+    $results = civicrm_api3('Comment', 'create', [
+      'entity_id' => 1,
+      'entity_name' => 'LeaveRequest',
+      'text' => 'This is a sample comment',
+      'contact_id' => 1,
+      'sequential' => 1,
+    ]);
+
+    $comment = new Comment();
+    $comment->find(true);
+    $date = new DateTime($comment->created_at);
+
+    $expectedValues = [
+      [
+        'id' => $comment->id,
+        'entity_name' => $comment->entity_name,
+        'entity_id' => $comment->entity_id,
+        'text' => $comment->text,
+        'contact_id' => $comment->contact_id,
+        'created_at' => $date->format('YmdHis')
+      ],
+    ];
+    $this->assertEquals($expectedValues, $results['values']);
+  }
+}


### PR DESCRIPTION
This PR modifies the default Get and Delete API endpoints of the Comment entity. The Get endpoint is modified to return only non deleted comments.
The Delete endpoint is modified to only soft delete comments by setting the is_deleted column of the comment to 1.

Given a Comment table

| id | entity_id | entity_name | contact_id| text | created_at | is_deleted |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |------------- |
|1|1|LeaveRequest|2|Randon Comment 1 |2017-01-17 12:51:13|0|
|2|1|LeaveRequest|2|Random Comment 2|2017-01-18 12:51:13|0|
|3|1|LeaveRequest|2|Random Comment 2|2017-01-19 12:51:13|1|

A call to
```php
$result = civicrm_api3('Comment', 'get', []);
```
Will return only non deleted values 
```json
{
  "is_error": 0,
  "version": 3,
  "count": 2,
  "values": [
    {
      "id": "1",
      "entity_name": "LeaveRequest",
      "entity_id": "1",
      "text": "Randon Comment 1",
      "contact_id": "2",
      "created_at": "2017-01-17 12:51:13",
      "is_deleted": "0"
    },
    {
      "id": "2",
      "entity_name": "LeaveRequest",
      "entity_id": "1",
      "text": "Randon Comment 2",
      "contact_id": "2",
      "created_at": "2017-01-18 12:51:13",
      "is_deleted": "0"
    }
  ]
}
```