### PR TITLE
PCHR-1666: Standalone Basic Installation script for CiviHR.

### DIFF
--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -286,9 +286,9 @@ function _amp_install_cms() {
   else
     amp create -f --root="$CMS_ROOT" --name="$amp_name" --prefix=CMS_ --output-file="$amp_vars_file_path" --perm="$CMS_DB_PERM"
   fi
-  echo $amp_vars_file_path;exit
   source "$amp_vars_file_path"
-  rm -f "$amp_vars_file_path"
+
+  #rm -f "$amp_vars_file_path"
 }
 
 function _amp_install_civi() {
@@ -580,11 +580,18 @@ function civihr_parse() {
       #   
       #   ;;
 
-      --type)
-        SITE_TYPE="$1"
+      --dbuser)
+        DB_USER="$1"
         shift
         ;;
-
+      --dbpass)
+        DB_PASS="$1"
+        shift
+        ;;
+      --dbport)
+        DB_PORT="$1"
+        shift
+        ;;
       --url)
         CMS_URL="$1"
         shift
@@ -598,17 +605,14 @@ function civihr_parse() {
     esac
   done
 
-#[ -z "$CACHE_DIR" ]          && CACHE_DIR="$TMPDIR/git-cache"
 [ -z "$WEB_ROOT" ]           && WEB_ROOT="$BLDDIR/$SITE_NAME"
 [ -z "$CMS_ROOT" ]           && CMS_ROOT="$WEB_ROOT"
 [ -z "$CIVI_SITE_KEY" ]      && CIVI_SITE_KEY=$(civihr_makepasswd 16)
 [ -z "$ADMIN_PASS" ]         && ADMIN_PASS=$(civihr_makepasswd 12)
 [ -z "$DEMO_PASS" ]          && DEMO_PASS=$(civihr_makepasswd 12)
-[ -z "$SITE_TYPE" ]          && SITE_TYPE="$SITE_NAME"
 [ -z "$CMS_TITLE" ]          && CMS_TITLE="$SITE_NAME"
 [ -z "$CMS_HOSTNAME" ]       && CMS_HOSTNAME=$(php -r '$p = parse_url($argv[1]); echo $p["host"];' "$CMS_URL")
 [ -z "$CMS_PORT" ]           && CMS_PORT=$(php -r '$p = parse_url($argv[1]); echo $p["port"];' "$CMS_URL")
-[ -z "$SITE_CONFIG_DIR" ]    && SITE_CONFIG_DIR="$PRJDIR/app/config/$SITE_TYPE"
 [ -z "$SITE_TOKEN" ]         && SITE_TOKEN=$(civihr_makepasswd 16)
 
 }
@@ -777,7 +781,7 @@ EOSQL
 ###############################################################################
 ## Run the download scripts if necessary
 function civihr_app_download() {
-  civihr_assertvars civihr_app_download WEB_ROOT PRJDIR SITE_NAME SITE_TYPE TMPDIR #CACHE_DIR
+  civihr_assertvars civihr_app_download WEB_ROOT PRJDIR SITE_NAME TMPDIR #CACHE_DIR
 
   echo "[[Download $SITE_NAME ( in '$WEB_ROOT')]]"
 
@@ -799,7 +803,7 @@ function civihr_app_download() {
 ###############################################################################
 ## Runs the installation process for CMS, CiviCRM and CiviHR.
 function civihr_app_install() {
-  civihr_assertvars civihr_app_install WEB_ROOT  SITE_NAME SITE_ID SITE_TYPE
+  civihr_assertvars civihr_app_install WEB_ROOT  SITE_NAME SITE_ID
 
   echo "[[Install $SITE_NAME ( in '$WEB_ROOT')]]"
 

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -71,13 +71,12 @@ CMS_URL=
 CMS_ROOT=
 
 ## DB credentials for CMS
-## (suggested: autogenerate via 'amp create -f --root="$WEB_ROOT" --prefix=CMS_ --url="$CMS_URL"')
 CMS_DB_DSN=
 CMS_DB_ARGS=
-CMS_DB_HOST=
+CMS_DB_HOST=127.0.0.1
 CMS_DB_NAME=
 CMS_DB_PASS=
-CMS_DB_PORT=
+CMS_DB_PORT=3306
 CMS_DB_USER=
 CMS_DB_PERM=admin
 
@@ -85,13 +84,12 @@ CMS_DB_PERM=admin
 CIVI_CORE=
 
 ## DB credentials for Civi
-## (suggested: autogenerate via 'amp create -f --root="$WEB_ROOT" --name=civi --prefix=CIVI_ --skip-url')
 CIVI_DB_DSN=
 CIVI_DB_ARGS=
-CIVI_DB_HOST=
+CIVI_DB_HOST=127.0.0.1
 CIVI_DB_NAME=
 CIVI_DB_PASS=
-CIVI_DB_PORT=
+CIVI_DB_PORT=3306
 CIVI_DB_USER=
 CIVI_DB_PERM=super
 
@@ -205,6 +203,18 @@ function civihr_mkdir() {
 }
 
 ###############################################################################
+## Creates host and port to a single string
+function civihr_build_hostport() {
+  local host=$1
+  local port=$2
+  if [ -z "$port" ]; then
+    echo "$host"
+  else
+    echo "$host:$port"
+  fi
+}
+
+###############################################################################
 ## Appends the civibuild settings directives to a file
 ## usage: civihr_inject_settings <php-file> <settings-dir-name>
 ## example: civihr_inject_settings "/var/www/build/drupal/sites/foo/civicrm.settings.php" "civicrm.settings.d"
@@ -264,46 +274,42 @@ EOF
 }
 
 ###############################################################################
-## Setup HTTP and MySQL services
-## This outputs several variables: CMS_URL, CMS_DB_*, CIVI_DB_*, and TEST_DB_*
-function amp_install() {
-  _amp_install_cms
-  _amp_install_civi
+## Setup MySQL services
+function database_install() {
+  _database_install_cms
+  _database_install_civi
 }
 
-function _amp_install_cms() {
-  echo "[[Setup MySQL and HTTP for CMS]]"
+function _database_install_cms() {
+
+  echo "[[Setup MySQL for CMS]]"
   civihr_assertvars _amp_install_cms CMS_ROOT SITE_NAME SITE_ID TMPDIR
+  
+  mysql -u$DB_USER -p$DB_PASS -e "create database $CMSdbName" >/dev/null 2>&1 || { echo "[[Please provide CMS database name ( i.e --crmdb ) or Check if its already exists.]]";exit 1;  }
 
-  civihr_maketempfile
+  [ -z "$CMS_DB_USER" ]           && CMS_DB_USER="$DB_USER"
+  [ -z "$CMS_DB_PASS" ]           && CMS_DB_PASS="$DB_PASS"
+  [ -z "$CMS_DB_NAME" ]           && CMS_DB_NAME="$CMSdbName"
 
-  local amp_vars_file_path=$(php $TMPDIR/mktemp.php ampvar)
-  local amp_name="cms$SITE_ID"
-  [ "$SITE_ID" == "default" ] && amp_name=cms
-
-  if [ -n "$CMS_URL" ]; then
-    amp create -f --root="$CMS_ROOT" --name="$amp_name" --prefix=CMS_ --url="$CMS_URL" --output-file="$amp_vars_file_path" --perm="$CMS_DB_PERM"
-  else
-    amp create -f --root="$CMS_ROOT" --name="$amp_name" --prefix=CMS_ --output-file="$amp_vars_file_path" --perm="$CMS_DB_PERM"
-  fi
-  source "$amp_vars_file_path"
-
-  #rm -f "$amp_vars_file_path"
+  CMS_DB_HOSTPORT=$(civihr_build_hostport "$CMS_DB_HOST" "$CMS_DB_PORT")
+  [ -z "$CMS_DB_DSN" ]           && CMS_DB_DSN="mysql://${DB_USER}:${DB_PASS}@${CMS_DB_HOSTPORT}/${CMSdbName}?new_link=true"
 }
 
-function _amp_install_civi() {
+function _database_install_civi() {
+
   echo "[[Setup MySQL for Civi]]"
   civihr_assertvars _amp_install_civi CMS_ROOT SITE_NAME SITE_ID TMPDIR
 
-  local amp_vars_file_path=$(php $TMPDIR/mktemp.php ampvar)
-  local amp_name="civi$SITE_ID"
-  [ "$SITE_ID" == "default" ] && amp_name=civi
+  mysql -u$DB_USER -p$DB_PASS -e "create database $CIVIdbName" >/dev/null 2>&1 || { echo "[[Please provide CRM database name ( i.e --crmdb ) or Check if its already exists.]]";exit 1;  }
 
-  amp create -f --root="$CMS_ROOT" --name="$amp_name" --prefix=CIVI_ --skip-url --output-file="$amp_vars_file_path" --perm="$CIVI_DB_PERM"
+  [ -z "$CIVI_DB_USER" ]           && CIVI_DB_USER="$DB_USER"
+  [ -z "$CIVI_DB_PASS" ]           && CIVI_DB_PASS="$DB_PASS"
+  [ -z "$CIVI_DB_NAME" ]           && CIVI_DB_NAME="$CIVIdbName"
 
-  source "$amp_vars_file_path"
-  rm -f "$amp_vars_file_path"
+  CIVI_DB_HOSTPORT=$(civihr_build_hostport "$CIVI_DB_HOST" "$CIVI_DB_PORT")
+  [ -z "$CIVI_DB_DSN" ]           && CIVI_DB_DSN="mysql://${DB_USER}:${DB_PASS}@${CIVI_DB_HOSTPORT}/${CIVIdbName}?new_link=true"
 }
+
 
 ###############################################################################
 ## Generate config files and setup database
@@ -313,30 +319,24 @@ function civicrm_install() {
     echo "Failed to locate valid civi root: $CIVI_CORE"
     exit 1
   fi
-
   ## Create CiviCRM data dirs
-  amp datadir "$CIVI_FILES" "$CIVI_TEMPLATEC"
+  civihr_mkdir "$CIVI_FILES" "$CIVI_TEMPLATEC"
   if [ -n "$CIVI_EXT_DIR" ]; then
-    amp datadir "$CIVI_EXT_DIR"
+    civihr_mkdir "$CIVI_EXT_DIR"
   fi
 
   ## Create CiviCRM config files
   civicrm_make_settings_php
   civicrm_make_setup_conf
-  
 
   pushd "$CIVI_CORE" >> /dev/null
-    ## Does this build include development support (eg git or tarball-based)?
-    if [ -e "xml" -a -e "bin/setup.sh" ]; then
-      env SITE_ID="$SITE_ID" bash ./bin/setup.sh
-    elif [ -e "sql/civicrm.mysql" -a -e "sql/civicrm_generated.mysql" ]; then
-      cat sql/civicrm.mysql sql/civicrm_generated.mysql | eval mysql $CIVI_DB_ARGS
+    if [ -e "sql/civicrm.mysql" -a -e "sql/civicrm_generated.mysql" ]; then
+      cat sql/civicrm.mysql sql/civicrm_generated.mysql | mysql -u$CIVI_DB_USER -p$CIVI_DB_PASS $CIVI_DB_NAME
     else
       echo "Failed to locate civi SQL files"
     fi
   popd >> /dev/null
-
-  eval mysql $CIVI_DB_ARGS <<EOSQL
+  eval mysql -u$CIVI_DB_USER -p$CIVI_DB_PASS $CIVI_DB_NAME <<EOSQL
     UPDATE civicrm_domain SET name = '$CIVI_DOMAIN_NAME';
     SELECT @option_group_id := id
       FROM civicrm_option_group n
@@ -348,17 +348,7 @@ function civicrm_install() {
 EOSQL
 }
 
-###############################################################################
-## Creates host and port to a single string
-function civihr_build_hostport() {
-  local host=$1
-  local port=$2
-  if [ -z "$port" ]; then
-    echo "$host"
-  else
-    echo "$host:$port"
-  fi
-}
+
 
 ###############################################################################
 ## Generate a "civicrm.settings.php" file
@@ -416,26 +406,19 @@ function civicrm_make_setup_conf() {
   civihr_assertvars civicrm_make_setup_conf PRJDIR CMS_ROOT CIVI_CORE CIVI_UF CIVI_DB_NAME CIVI_DB_USER CIVI_DB_PASS
 
   cat > "$CIVI_CORE/bin/setup.conf" << EOF
-    ## INFRA-114
     PRJDIR="$PRJDIR"
     CMS_ROOT="$CMS_ROOT"
-    SITE_ID="\${SITE_ID:-$SITE_ID}"
-    AMP_NAME=civi\${SITE_ID}
-    [ "\$SITE_ID" == "default" ] && AMP_NAME=civi
-    eval \`\$PRJDIR/bin/amp export --root="\$CMS_ROOT" -N\${AMP_NAME}\`
-    DBNAME="\$AMP_DB_NAME"
-    DBUSER="\$AMP_DB_USER"
-    DBPASS="\$AMP_DB_PASS"
-    DBHOST="\$AMP_DB_HOST"
-    DBPORT="\$AMP_DB_PORT"
-    ##
+    DBNAME="$CIVI_DB_NAME"
+    DBUSER="$CIVI_DB_USER"
+    DBPASS="$CIVI_DB_PASS"
+    DBHOST="$CIVI_DB_HOST"
+    DBPORT="$CIVI_DB_PORT"
     SVNROOT="$CIVI_CORE"
     CIVISOURCEDIR="$CIVI_CORE"
     SCHEMA=schema/Schema.xml
     DBARGS=""
-    PHP5PATH=
+    PHP5PATH=""
     DBLOAD="$DBLOAD"
-    # DBADD=
     GENCODE_CMS="$CIVI_UF"
 EOF
 }
@@ -454,6 +437,7 @@ function drupal7_install() {
   DRUPAL_SITE_DIR="$SITE_ID"
 
   CMS_DB_HOSTPORT=$(civihr_build_hostport "$CMS_DB_HOST" "$CMS_DB_PORT")
+
   pushd "$CMS_ROOT" >> /dev/null
     [ -f "sites/$DRUPAL_SITE_DIR/settings.php" ] && rm -f "sites/$DRUPAL_SITE_DIR/settings.php"
 
@@ -470,7 +454,7 @@ function drupal7_install() {
     chmod u-w "sites/$DRUPAL_SITE_DIR/settings.php"
 
     ## Setup extra directories
-    amp datadir "sites/${DRUPAL_SITE_DIR}/files"
+    civihr_mkdir "sites/${DRUPAL_SITE_DIR}/files"
     civihr_mkdir "sites/${DRUPAL_SITE_DIR}/modules"
   
   popd >> /dev/null
@@ -592,6 +576,17 @@ function civihr_parse() {
         DB_PORT="$1"
         shift
         ;;
+
+      --cmsdb)
+        CMSdbName="$1"
+        shift
+        ;;
+
+      --crmdb)
+        CIVIdbName="$1"
+        shift
+        ;;
+
       --url)
         CMS_URL="$1"
         shift
@@ -600,6 +595,7 @@ function civihr_parse() {
       *)
          if [ "${OPTION::1}" == "-" ]; then
            echo "Unrecognized option: $OPTION"
+           exit
          fi
         ;;
     esac
@@ -634,7 +630,8 @@ BLDDIR="$PRJDIR"
 
 export PATH="$PATH:$BINDIR"
 civihr_parse "$@"
-command -v drush >/dev/null 2>&1 || ( echo "[[Downloading dependencies.........]]" && curl -Lo "$TMPDIR/drush" "https://github.com/drush-ops/drush/releases/download/8.1.8/drush.phar"  && chmod +x "$TMPDIR/drush" && export PATH="$PATH:$TMPDIR" )
+
+command -v drush >/dev/null 2>&1 || ( echo "[[Downloading dependencies.........]]" && curl -Lo "$TMPDIR/drush" "https://github.com/drush-ops/drush/releases/download/8.1.8/drush.phar"  && chmod +x "$TMPDIR/drush" && export PATH="$PATH:$TMPDIR/drush" )
 
 ###############################################################################
 ## Runs download script - Download Drupal and CiviCRM
@@ -696,11 +693,7 @@ function disabled_unused_blocks() {
 ##
 # Installs CiviHR extensions
 function install_civihr() {
-  ## (no sample data as default)
   bash ${CIVI_CORE}/tools/extensions/civihr/bin/drush-install.sh ${CIVI_CORE}
-
-  ## (with sample data - if required)
-  # bash ${CIVI_CORE}/tools/extensions/civihr/bin/drush-install.sh --with-sample-data
 }
 
 ##
@@ -721,13 +714,16 @@ function setup_themes {
 function civihr_install_site(){
 
   ## Create virtual-host and databases
-  amp_install
+  database_install
 
   ## Grant access for the Drupal database user to access the Civi Database too
-eval mysql $CIVI_DB_ARGS <<EOSQL
+eval mysql -u$CIVI_DB_USER -p$CIVI_DB_PASS <<EOSQL
     GRANT ALL PRIVILEGES ON $CIVI_DB_NAME.* TO $CMS_DB_USER@'%';
 EOSQL
 
+## Grant access for the Drupal database user to access the Civi Database too
+#mysql -u$CIVI_DB_USER -p$CIVI_DB_PASS -e "GRANT ALL PRIVILEGES ON $CIVI_DB_NAME.* TO $CMS_DB_USER@'$CIVI_DB_HOSTPORT' IDENTIFIED BY '$CMS_DB_PASS'";
+  
   ## Setup Drupal (config files, database tables)
   drupal_install
 
@@ -746,6 +742,7 @@ EOSQL
     CIVI_EXT_DIR="${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}/ext"
     CIVI_EXT_URL="${CMS_URL}/sites/${DRUPAL_SITE_DIR}/ext"
   fi
+
 
   civicrm_install
 

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -110,57 +110,36 @@ CIVI_EXT_DIR=
 ## URL of the web-managed extension folder (required if CIVI_EXT_DIR is set)
 CIVI_EXT_URL=
 
-
-
 ###############################################################################
 ## Display usage message
 function civihr_app_usage() {
   APP=$(basename "$0")
 
-  php -r 'echo file_get_contents("php://stdin");' <<EOT
-
+  cat <<EOT
 Common Options :
   <site-name>        The name of the site-directory to build
-
-Syntax: $APP <site-name> [required-options]
+Syntax: $APP <site-name> [required-parameters]
 Description: Downloads and/or installs the application.
 
-Required options:
+Required parameters:
   --dbuser <mysql-username>     Username for mysql
-  --dbpass <mysql-password>     Password for mysql ( Optional )
   --cmsdb  <cms-database-name>  Database name for Drupal CMS installation
   --crmdb  <crm-database-name>  Database name for CiviCRM CRM installation
   --url    <url>                The public URL of the site
 
+Optional parameters:
+  --dbpass <mysql-password>     Password for mysql
 EOT
-  exit 99;
+  exit 99
 }
 
 
 ###############################################################################
 ## Creates random password.
-function civihr_makepasswd() {
-
-  cat > "$TMPDIR/mkpasswd.php" << EOF
-<?php
-    function createRandom(\$len, \$alphabet) {
-      \$alphabetSize = strlen(\$alphabet);
-      \$result = '';
-    for (\$i = 0; \$i < \$len; \$i++) {
-      \$result .= \$alphabet{rand(1, \$alphabetSize) - 1};
-    }
-    return \$result;
-  }
-  if (empty(\$argv[1])) {
-    \$len = 8;
-  } else {
-    \$len = \$argv[1];
-  }
-  print createRandom(\$len, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789');
-?>
-EOF
-# Calling temp make password php file.
-php "$TMPDIR/mkpasswd.php" "$1"
+function civihr_make_passwd() {
+  if [ -n "$1" ]; then
+    echo $(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w "$1" | head -n 1)
+  fi
 }
 
 ###############################################################################
@@ -590,10 +569,10 @@ function civihr_parse() {
 [ -z "$SITE_NAME" ]          && civihr_app_usage && exit 99
 [ -z "$WEB_ROOT" ]           && WEB_ROOT="$BLDDIR/$SITE_NAME"
 [ -z "$CMS_ROOT" ]           && CMS_ROOT="$WEB_ROOT"
-[ -z "$CIVI_SITE_KEY" ]      && CIVI_SITE_KEY=$(civihr_makepasswd 16)
-[ -z "$ADMIN_PASS" ]         && ADMIN_PASS=$(civihr_makepasswd 12)
+[ -z "$CIVI_SITE_KEY" ]      && CIVI_SITE_KEY=$(civihr_make_passwd 16)
+[ -z "$ADMIN_PASS" ]         && ADMIN_PASS=$(civihr_make_passwd 12)
 [ -z "$CMS_TITLE" ]          && CMS_TITLE="$SITE_NAME"
-[ -z "$SITE_TOKEN" ]         && SITE_TOKEN=$(civihr_makepasswd 16)
+[ -z "$SITE_TOKEN" ]         && SITE_TOKEN=$(civihr_make_passwd 16)
 
 }
 

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -1,6 +1,8 @@
 #!/bin/bash
+#
+# Setups CiviHR site using Drupal CMS and CiviCRM.
 
-###############################################################################
+##########################################################
 ## Global variables
 
 ## The location of the Project tree
@@ -110,43 +112,62 @@ CIVI_EXT_DIR=
 ## URL of the web-managed extension folder (required if CIVI_EXT_DIR is set)
 CIVI_EXT_URL=
 
-###############################################################################
-## Display usage message
+##########################################################
+# Displays usage message
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
 function civihr_app_usage() {
   APP=$(basename "$0")
 
   cat <<EOT
 Common Options :
   <site-name>        The name of the site-directory to build
-Syntax: $APP <site-name> [required-parameters]
+Syntax: $APP [site-name] [required-parameters]
 Description: Downloads and/or installs the application.
 
 Required parameters:
-  --dbuser <mysql-username>     Username for mysql
-  --cmsdb  <cms-database-name>  Database name for Drupal CMS installation
-  --crmdb  <crm-database-name>  Database name for CiviCRM CRM installation
-  --url    <url>                The public URL of the site
+  --dbuser [mysql-username]     Username for mysql
+  --cmsdb  [cms-database-name]  Database name for Drupal CMS installation
+  --crmdb  [crm-database-name]  Database name for CiviCRM CRM installation
+  --url    [url]                The public URL of the site
 
 Optional parameters:
-  --dbpass <mysql-password>     Password for mysql
+  --dbpass [mysql-password]     Password for mysql
 EOT
   exit 99
 }
 
 
-###############################################################################
-## Creates random password.
+##########################################################
+# Creates random password.
+# Arguments:
+#   Length of the string
+# Returns:
+#   Random alphanumeric password string
+# Usage:
+#   civihr_make_passwd 12
+##########################################################
 function civihr_make_passwd() {
   if [ -n "$1" ]; then
     echo $(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w "$1" | head -n 1)
   fi
 }
 
-###############################################################################
-## Assert that shell variables are defined. If not defined, exit with an error.
-##  If a variable missing, the application dies.
-function civihr_assertvars() {
-  _civihr_assertvars_back="$-"
+##########################################################
+# Assert that shell variables are defined. If not defined, exit with an error.
+# If a variable missing, the application dies.
+# Arguments:
+#   Global Variables
+# Returns:
+#   Value of the Global Variables.
+# Usage:
+#   civihr_assert_vars SITE_NAME
+##########################################################
+function civihr_assert_vars() {
+  _civihr_assert_vars_back="$-"
 
   set +x
   context="$1"
@@ -161,18 +182,25 @@ function civihr_assertvars() {
     shift
   done
 
-  set -${_civihr_assertvars_back} 
+  set -${_civihr_assert_vars_back} 
 }
 
-###############################################################################
-## Summarize the content of key environment variables
+##########################################################
+# Summarize the content of key environment variables.
+# Arguments:
+#   All the command line parameters i.e $@
+# Returns:
+#   Displays values for each of the parameter passed.
+# Usage:
+#   civihr_summary $@
+##########################################################
 function civihr_summary() {
   if [ -n "$1" ]; then
     echo "$1"
   fi
   shift
 
-  civihr_assertvars civihr_summary "$@"
+  civihr_assert_vars civihr_summary "$@"
   for var in "$@" ; do
     eval "val=\$$var"
     echo " - $var: $val"
@@ -180,18 +208,31 @@ function civihr_summary() {
 }
 
 
-###############################################################################
-## Creates and ensure parent directory exists.
-## civihr_makeparent <file>
-function civihr_makeparent() {
+##########################################################
+# Creates and ensure parent directory exists.
+# Arguments:
+#   File Name.
+# Returns:
+#   Creates Parent directory.
+# Usage:
+#   civihr_make_parent <file-name>
+##########################################################
+function civihr_make_parent() {
   parentdir=$(dirname "$1")
   if [ ! -d "$parentdir" ]; then
     mkdir -p "$parentdir"
   fi
 }
 
-###############################################################################
-## Checks whether directory exists, if not then create it.
+##########################################################
+# Checks whether directory exists, if not then create it.
+# Arguments:
+#   Folder Name.
+# Returns:
+#   Creates directory.
+# Usage:
+#   civihr_mkdir <directory-name>
+##########################################################
 function civihr_mkdir() {
   for a in "$@" ; do
     if [ ! -d "$a" ]; then
@@ -200,9 +241,16 @@ function civihr_mkdir() {
   done
 }
 
-###############################################################################
-## Creates host and port to a single string.
-function civihr_build_hostport() {
+##########################################################
+# Creates host and port to a single string.
+# Arguments:
+#   Folder Name.
+# Returns:
+#   Creates directory.
+# Usage:
+#   civihr_mkdir <directory-name>
+##########################################################
+function civihr_build_host_port() {
   local host=$1
   local port=$2
   if [ -z "$port" ]; then
@@ -212,30 +260,32 @@ function civihr_build_hostport() {
   fi
 }
 
-###############################################################################
-## Making Random temp files
-function civihr_maketempfile(){
- cat > "$TMPDIR/mktemp.php" << EOF
-<?php
-    \$prefix = empty(\$argv[1]) ? 'mktemp-' : \$argv[1];
-\$basedir = empty(\$argv[2]) ? sys_get_temp_dir() : \$argv[2];
-echo tempnam(\$basedir,  \$prefix);
-?>
-EOF
-}
-
-###############################################################################
-## Setup MySQL services
+##########################################################
+# Setup MySQL services
+# Arguments:
+#   None
+# Returns:
+#   None
+# Usage:
+#   database_install
+##########################################################
 function database_install() {
   _database_install_cms
   _database_install_civi
 }
 
-## Setting up Database for CMS i.e Drupal
+##########################################################
+# Creates empty Database for CMS.
+# Assign required values to Global Variables.
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
 function _database_install_cms() {
 
   echo "[[Setting up MySQL for CMS]]"
-  civihr_assertvars _database_install_cms CMS_ROOT SITE_NAME SITE_ID TMPDIR
+  civihr_assert_vars _database_install_cms CMS_ROOT SITE_NAME SITE_ID TMPDIR
   # Create database.
   mysql -u$DB_USER -p$DB_PASS -e "create database $CMSdbName" || { echo "[[Please fix above MySQL error.]]"; exit 1;  }
   # Assign values to global variables.
@@ -243,15 +293,22 @@ function _database_install_cms() {
   [ -z "$CMS_DB_PASS" ]           && CMS_DB_PASS="$DB_PASS"
   [ -z "$CMS_DB_NAME" ]           && CMS_DB_NAME="$CMSdbName"
 
-  CMS_DB_HOSTPORT=$(civihr_build_hostport "$CMS_DB_HOST" "$CMS_DB_PORT")
+  CMS_DB_HOSTPORT=$(civihr_build_host_port "$CMS_DB_HOST" "$CMS_DB_PORT")
   [ -z "$CMS_DB_DSN" ]           && CMS_DB_DSN="mysql://${DB_USER}:${DB_PASS}@${CMS_DB_HOSTPORT}/${CMSdbName}?new_link=true"
 }
 
-## Setting up Database for CRM i.e CiviHR
+##########################################################
+# Creates empty Database for CRM ie CiviHR.
+# Assign required values to Global Variables.
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
 function _database_install_civi() {
 
   echo "[[Setting up MySQL for CiviCRM]]"
-  civihr_assertvars _database_install_civi CMS_ROOT SITE_NAME SITE_ID TMPDIR
+  civihr_assert_vars _database_install_civi CMS_ROOT SITE_NAME SITE_ID TMPDIR
   # Create database.
   mysql -u$DB_USER -p$DB_PASS -e "create database $CIVIdbName" || { echo "[[Please fix above MySQL error.]]"; exit 1;  }
   # Assign values to global variables.
@@ -259,14 +316,19 @@ function _database_install_civi() {
   [ -z "$CIVI_DB_PASS" ]           && CIVI_DB_PASS="$DB_PASS"
   [ -z "$CIVI_DB_NAME" ]           && CIVI_DB_NAME="$CIVIdbName"
 
-  CIVI_DB_HOSTPORT=$(civihr_build_hostport "$CIVI_DB_HOST" "$CIVI_DB_PORT")
+  CIVI_DB_HOSTPORT=$(civihr_build_host_port "$CIVI_DB_HOST" "$CIVI_DB_PORT")
   [ -z "$CIVI_DB_DSN" ]           && CIVI_DB_DSN="mysql://${DB_USER}:${DB_PASS}@${CIVI_DB_HOSTPORT}/${CIVIdbName}?new_link=true"
 }
 
-###############################################################################
-## Generate config files and setup database
+##########################################################
+# Generate Configuration Files and Installs Civicrm.
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
 function civicrm_install() {
-  civihr_assertvars civicrm_install CIVI_CORE CIVI_FILES CIVI_TEMPLATEC CIVI_DOMAIN_NAME CIVI_DOMAIN_EMAIL
+  civihr_assert_vars civicrm_install CIVI_CORE CIVI_FILES CIVI_TEMPLATEC CIVI_DOMAIN_NAME CIVI_DOMAIN_EMAIL
   if [ ! -d "$CIVI_CORE/bin" -o ! -d "$CIVI_CORE/CRM" ]; then
     echo "Failed to locate valid civi root: $CIVI_CORE"
     exit 1
@@ -300,12 +362,17 @@ function civicrm_install() {
 EOSQL
 }
 
-###############################################################################
-## Generate Civicrm "civicrm.settings.php" file.
+##########################################################
+# Generates Civicrm "civicrm.settings.php" file.
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
 function civicrm_make_settings_php() {
-  civihr_assertvars civicrm_make_settings_php CIVI_SETTINGS CIVI_CORE CIVI_UF CIVI_TEMPLATEC CMS_URL CIVI_SITE_KEY
-  civihr_assertvars civicrm_make_settings_php CMS_DB_HOST CMS_DB_NAME CMS_DB_PASS CMS_DB_USER
-  civihr_assertvars civicrm_make_settings_php CIVI_DB_HOST CIVI_DB_NAME CIVI_DB_PASS CIVI_DB_USER
+  civihr_assert_vars civicrm_make_settings_php CIVI_SETTINGS CIVI_CORE CIVI_UF CIVI_TEMPLATEC CMS_URL CIVI_SITE_KEY
+  civihr_assert_vars civicrm_make_settings_php CMS_DB_HOST CMS_DB_NAME CMS_DB_PASS CMS_DB_USER
+  civihr_assert_vars civicrm_make_settings_php CIVI_DB_HOST CIVI_DB_NAME CIVI_DB_PASS CIVI_DB_USER
 
   local tpl
 
@@ -319,8 +386,8 @@ function civicrm_make_settings_php() {
     exit 96
   fi
 
-  CMS_DB_HOSTPORT=$(civihr_build_hostport "$CMS_DB_HOST" "$CMS_DB_PORT")
-  CIVI_DB_HOSTPORT=$(civihr_build_hostport "$CIVI_DB_HOST" "$CIVI_DB_PORT")
+  CMS_DB_HOSTPORT=$(civihr_build_host_port "$CMS_DB_HOST" "$CMS_DB_PORT")
+  CIVI_DB_HOSTPORT=$(civihr_build_host_port "$CIVI_DB_HOST" "$CIVI_DB_PORT")
 
   cat "$CIVI_CORE/$tpl" \
     | sed "s;%%baseURL%%;${CMS_URL};" \
@@ -346,13 +413,17 @@ function civicrm_make_settings_php() {
     \$civicrm_setting['URL Preferences']['extensionsURL'] = '$CIVI_EXT_URL';
 EOF
   fi
-  
 }
 
-###############################################################################
-## Generate Civicrm "setup.conf" file.
+##########################################################
+# Generate Civicrm "setup.conf" file.
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
 function civicrm_make_setup_conf() {
-  civihr_assertvars civicrm_make_setup_conf PRJDIR CMS_ROOT CIVI_CORE CIVI_UF CIVI_DB_NAME CIVI_DB_USER CIVI_DB_PASS
+  civihr_assert_vars civicrm_make_setup_conf PRJDIR CMS_ROOT CIVI_CORE CIVI_UF CIVI_DB_NAME CIVI_DB_USER CIVI_DB_PASS
 
   cat > "$CIVI_CORE/bin/setup.conf" << EOF
     PRJDIR="$PRJDIR"
@@ -372,20 +443,30 @@ function civicrm_make_setup_conf() {
 EOF
 }
 
-###############################################################################
-## Drupal -- Generate config files and setup database
+##########################################################
+# Calls Drupal installation process function.
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
 function drupal_install() {
   drupal7_install
 }
 
-###############################################################################
-## Drupal -- Generate config files and setup database
+##########################################################
+# Generate Configuration Files and Installs Drupal.
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
 function drupal7_install() {
-  civihr_assertvars drupal7_install CMS_ROOT SITE_ID CMS_TITLE CMS_DB_USER CMS_DB_PASS CMS_DB_HOST CMS_DB_NAME ADMIN_USER ADMIN_PASS CMS_URL
 
+  civihr_assert_vars drupal7_install CMS_ROOT SITE_ID CMS_TITLE CMS_DB_USER CMS_DB_PASS CMS_DB_HOST CMS_DB_NAME ADMIN_USER ADMIN_PASS CMS_URL
   DRUPAL_SITE_DIR="$SITE_ID"
 
-  CMS_DB_HOSTPORT=$(civihr_build_hostport "$CMS_DB_HOST" "$CMS_DB_PORT")
+  CMS_DB_HOSTPORT=$(civihr_build_host_port "$CMS_DB_HOST" "$CMS_DB_PORT")
 
   pushd "$CMS_ROOT" >> /dev/null
     [ -f "sites/$DRUPAL_SITE_DIR/settings.php" ] && rm -f "sites/$DRUPAL_SITE_DIR/settings.php"
@@ -408,9 +489,14 @@ function drupal7_install() {
   popd >> /dev/null
 }
 
-###############################################################################
-## Initialize (or update) a cached copy of a git repo in $CACHE_DIR
-## usage: git_cache_setup <url> <cache-dir>
+##########################################################
+# Initialize (or update) a cached copy of a git repo in $CACHE_DIR.
+# Arguments:
+#   URL - Git Repo URL address.
+#   Cache Directory.
+# Usage:
+#   git_cache_setup <url> <cache-dir>
+##########################################################
 function git_cache_setup() {
   local url="$1"
   local cachedir="$2"
@@ -425,13 +511,13 @@ function git_cache_setup() {
     fi
   fi
 
-  civihr_makeparent "$lock"
+  civihr_make_parent "$lock"
   if pidlockfile.php "$lock" $$ $CACHE_LOCK_WAIT ; then
     php -r 'echo time();' > "$lastrun"
     if [ ! -d "$cachedir" ]; then
       ## clone
       echo "[[Initialize cache dir: $cachedir]]"
-      civihr_makeparent "$cachedir"
+      civihr_make_parent "$cachedir"
       timeout.php $SCM_TIMEOUT git clone --mirror "$url" "$cachedir"
     else
       ## update
@@ -451,10 +537,12 @@ function git_cache_setup() {
   fi
 }
 
-###############################################################################
-## Fix the remote configurations of any git repos in <build-dir>, changing any
-## references to <cache-base-dir> to proper remotes
-## usage: git_cache_deref_remotes <cache-base-dir> <build-dir>
+##########################################################
+# Fix the remote configurations of any git repos in <build-dir>, changing any
+# references to <cache-base-dir> to proper remotes
+# Usage:
+#   git_cache_deref_remotes <cache-base-dir> <build-dir>
+##########################################################
 function git_cache_deref_remotes() {
   local _shellopt="$-"
   set +x
@@ -483,23 +571,16 @@ function git_cache_deref_remotes() {
   set -${_shellopt}
 }
 
-###############################################################################
-## Update core/default caches
-function default_cache_setup() {
-  if [ -z "$OFFLINE" ]; then
-    echo "[[Update caches]]"
-    civihr_assertvars default_cache_setup PRJDIR
-    git_cache_setup "https://github.com/civicrm/civihr.git" "$CACHE_DIR/civicrm/civihr.git"
-    git_cache_setup "https://github.com/civicrm/civicrm-core.git" "$CACHE_DIR/civicrm/civicrm-core.git"
-    git_cache_setup "https://github.com/civicrm/civicrm-drupal.git"  "$CACHE_DIR/civicrm/civicrm-drupal.git"
-    git_cache_setup "https://github.com/civicrm/civicrm-packages.git" "$CACHE_DIR/civicrm/civicrm-packages.git"
-    git_cache_setup "https://github.com/eileenmcnaughton/civicrm_developer.git" "$CACHE_DIR/eileenmcnaughton/civicrm_developer.git"
-  fi
-}
-
-###############################################################################
-## Parse options
-function civihr_parse() {
+##########################################################
+# Parse provided options and assign values according.
+# Arguments:
+#   All the command line parameters i.e $@
+# Returns:
+#   None
+# Usage:
+#   civihr_parse_options "$@"
+##########################################################
+function civihr_parse_options() {
 
   civihr_mkdir "$TMPDIR" "$BLDDIR"
 
@@ -576,25 +657,42 @@ function civihr_parse() {
 
 }
 
-function absdirname() {
+##########################################################
+# Determine the absolute path of the directory with the file
+# Arguments:
+#   Name of the shell script i.e $0
+# Returns:
+#   None
+# Usage:
+#   civihr_absdirname <file-path>
+##########################################################
+function civihr_absdirname() {
   pushd $(dirname "$0") >> /dev/null
     pwd
   popd >> /dev/null
 }
 
-BINDIR=$(absdirname "$0")
+BINDIR=$(civihr_absdirname "$0")
 PRJDIR=$(pwd)
 TMPDIR="$PRJDIR/temp"
 BLDDIR="$PRJDIR"
 
 export PATH="$PATH:$BINDIR"
-civihr_parse "$@"
+
+civihr_parse_options "$@"
 
 # Checking for Drush dependencies if not present downloading into temp.
 command -v drush >/dev/null 2>&1 || ( echo "[[Downloading dependencies.........]]" && curl -Lo "$TMPDIR/drush" "https://github.com/drush-ops/drush/releases/download/8.1.8/drush.phar" && chmod +x "$TMPDIR/drush" && export PATH="$TMPDIR:$PATH" )
 
-###############################################################################
-## Downloads Drupal,CiviCRM and CiviHR from remote drush.make file.
+##########################################################
+# Downloads Drupal,CiviCRM and CiviHR from remote drush.make file.
+# Arguments:
+#   None
+# Returns:
+#   None
+# Usage:
+#   civihr_setup_structure
+##########################################################
 function civihr_setup_structure() {
 
   [ -z "$CMS_VERSION" ] && CMS_VERSION=7.x
@@ -602,7 +700,7 @@ function civihr_setup_structure() {
   [ -z "$HR_VERSION" ] && HR_VERSION=master
 
   MAKEFILE="${TMPDIR}/${SITE_NAME}/${SITE_ID}.make"
-  civihr_makeparent "$MAKEFILE"
+  civihr_make_parent "$MAKEFILE"
   curl https://raw.githubusercontent.com/civicrm/civihr/PCHR-1666/bin/drush.make \
     | sed "s;%%CACHE_DIR%%;${CACHE_DIR};" \
     | sed "s;%%CIVI_VERSION%%;${CIVI_VERSION};" \
@@ -613,9 +711,14 @@ function civihr_setup_structure() {
   drush -y make --concurrency=5 --working-copy "$MAKEFILE" "$WEB_ROOT"
 }
 
-
+##########################################################
 # Creates the default CiviHR users
-function create_default_users() {
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
+function _civihr_create_default_users() {
   drush -y user-create --password="civihr_staff" --mail="civihr_staff@compucorp.co.uk" "civihr_staff"
   drush -y user-add-role civihr_staff "civihr_staff"
 
@@ -626,23 +729,38 @@ function create_default_users() {
   drush -y user-add-role civihr_admin "civihr_admin"
 }
 
-##
+##########################################################
 # Creates the "Personal" Location Type
-function create_personal_location_type() {
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
+function _civihr_create_personal_location_type() {
   drush cvapi LocationType.create sequential=1 name="Personal" display_name="Personal" vcard_name="PERSONAL" description="Place of Residence"
 }
 
-##
+##########################################################
 # Deletes the "Name and address profile"
-function delete_name_and_address_profile() {
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
+function _civihr_delete_name_and_address_profile() {
   PROFILE_ID=`[[ $(drush cvapi UFGroup.getsingle return="id" title="Name and address") =~ \[id\].+([1-9]) ]] && echo ${BASH_REMATCH[1]}`
 
   drush cvapi UFGroup.delete sequential=1 id="$PROFILE_ID"
 }
 
-##
+##########################################################
 # Disables the unused drupal blocks, leaving only the "main content" one active
-function disabled_unused_blocks() {
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
+function _civihr_disabled_unused_blocks() {
   for block in 'navigation' 'form' 'powered-by' 'help' 'navigation' 'login' \
     '2' '3' '5' '7'
   do
@@ -650,15 +768,25 @@ function disabled_unused_blocks() {
   done
 }
 
-##
+##########################################################
 # Installs CiviHR extensions
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
 function install_civihr() {
   bash ${CIVI_CORE}/tools/extensions/civihr/bin/drush-install.sh ${CIVI_CORE}
 }
 
-##
+##########################################################
 # Sets up the themes
-function setup_themes {
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
+function _civihr_setup_themes() {
   ## Drupal theme
   drush -y en civihr_default_theme
   drush -y vset theme_default civihr_default_theme
@@ -669,8 +797,13 @@ function setup_themes {
   drush -y vset civicrmtheme_theme_public seven
 }
 
-###############################################################################
-## Create config files and databases; fill the databases
+##########################################################
+# Create config files and databases; fill the databases
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
 function civihr_install_site(){
 
   ## Creating databases for Drupal and CIVICRM.
@@ -713,14 +846,14 @@ EOSQL
 
     install_civihr
 
-     drush -y en civicrmtheme civihr_employee_portal_features civihr_default_permissions
-     drush -y features-revert civihr_employee_portal_features
+    drush -y en civicrmtheme civihr_employee_portal_features civihr_default_permissions
+    drush -y features-revert civihr_employee_portal_features
 
-    setup_themes
-    create_default_users
-    disabled_unused_blocks
-    create_personal_location_type
-    delete_name_and_address_profile
+    _civihr_setup_themes
+    _civihr_create_default_users
+    _civihr_disabled_unused_blocks
+    _civihr_create_personal_location_type
+    _civihr_delete_name_and_address_profile
 
     ## Create My Details and My Emergency Contact forms
     drush refresh-node-export-files
@@ -731,10 +864,15 @@ EOSQL
 
 }
 
-###############################################################################
-## Downloads all the required repos for Drupal , CiviCRM and CiviHR.
+##########################################################
+# Downloads all the required repos for Drupal , CiviCRM and CiviHR.
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
 function civihr_app_download() {
-  civihr_assertvars civihr_app_download WEB_ROOT PRJDIR SITE_NAME TMPDIR
+  civihr_assert_vars civihr_app_download WEB_ROOT PRJDIR SITE_NAME TMPDIR
 
   echo "[[Download $SITE_NAME ( in '$WEB_ROOT')]]"
 
@@ -751,10 +889,15 @@ function civihr_app_download() {
   fi
 }
 
-###############################################################################
-## Runs the installation process for CMS, CiviCRM and CiviHR.
+##########################################################
+# Runs the installation process for CMS, CiviCRM and CiviHR.
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
 function civihr_app_install() {
-  civihr_assertvars civihr_app_install WEB_ROOT  SITE_NAME SITE_ID
+  civihr_assert_vars civihr_app_install WEB_ROOT  SITE_NAME SITE_ID
 
   echo "[[Install $SITE_NAME ( in '$WEB_ROOT')]]"
 
@@ -773,8 +916,13 @@ function civihr_app_install() {
   fi
 }
 
-###############################################################################
-## Displays CMS,DB and Site User Credentials.
+##########################################################
+# Displays CMS,DB and Site User Credentials.
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
 function civihr_app_show() {
 
     civihr_app_show_summary \
@@ -783,10 +931,15 @@ function civihr_app_show() {
       ADMIN_USER ADMIN_PASS
 }
 
-###############################################################################
-## Displays Site Summary
+##########################################################
+# Displays Site Summary
+# Arguments:
+#   None
+# Returns:
+#   None
+##########################################################
 function civihr_app_show_summary() {
-  civihr_assertvars civi_app_show_summary SITE_NAME TMPDIR "$@"
+  civihr_assert_vars civi_app_show_summary SITE_NAME TMPDIR "$@"
   civihr_summary "[[Show site summary ($SITE_NAME)]]" "$@"
   echo "[[General notes]]"
   echo " - You may need to restart httpd."

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -708,8 +708,9 @@ export PATH="$PATH:$BINDIR"
 civihr_parse_options "$@"
 
 # Checking for Drush dependencies if not present downloading into temp.
-command -v drush >/dev/null 2>&1 || ( echo "[[Downloading dependencies.........]]" && curl -Lo "$TMPDIR/drush" "https://github.com/drush-ops/drush/releases/download/8.1.8/drush.phar" && chmod +x "$TMPDIR/drush" && export PATH="$TMPDIR:$PATH" )
-
+command -v drush >/dev/null 2>&1 || ( echo "[[Downloading dependencies.........]]" && curl -Lo "$TMPDIR/drush" "https://github.com/drush-ops/drush/releases/download/8.1.8/drush.phar" && chmod +x "$TMPDIR/drush" )
+# Adding Drush to environment path.
+[[ -f "$TMPDIR/drush" ]] && export PATH="$TMPDIR:$PATH"
 ##########################################################
 # Downloads Drupal,CiviCRM and CiviHR from remote drush.make file.
 # Arguments:

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -138,6 +138,7 @@ Required parameters:
 
 Optional parameters:
   --dbpass [mysql-password]     Password for mysql
+  --webroot [root dir path]     The full path to the website root. If not given, the site will be installed in the current directory
   --force-drop                  Drop existing databases for --crmdb and --cmsdb options.
 EOT
   exit 99
@@ -651,6 +652,12 @@ function civihr_parse_options() {
         shift
         ;;
 
+      --webroot)
+        [ -z "$1" ] && echo "[[Missing value for option --webroot.]]" && civihr_app_usage && exit 1
+        WEB_ROOT="$1"
+        shift
+        ;;
+
       --force-drop)
         FORCE_DROP=1
         ;;
@@ -890,7 +897,7 @@ function civihr_app_download() {
       exit 97
     fi
   else
-    echo "Already downloaded ${SITE_NAME}"
+    echo "The $WEB_ROOT folder already exists" && exit
   fi
 }
 

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -1,0 +1,847 @@
+#!/bin/bash
+
+###############################################################################
+## Global variables
+
+## The location of the Project tree
+PRJDIR=
+
+## Location to store temp files, defaults (PRJDIR/tmp)
+TMPDIR=
+
+## Location that  points to sites that we build.
+BLDDIR=
+
+## Codename for the build instance.
+SITE_NAME=
+
+## Identifies site pointing ot default state.
+## (default: default)
+SITE_ID=default
+
+## Unique token for this site.
+## (default: random)
+SITE_TOKEN=
+
+## Root directory where the site's code will be installed
+## (default: BLDDIR/SITE_NAME)
+WEB_ROOT=
+
+## Root directory where we store cached copies of git repositories
+## (default: TMPDIR/git-cache)
+CACHE_DIR=
+
+## Time to wait before allowing updates to git/svn caches (seconds)
+CACHE_TTL=60
+
+## When updating a cache record, first attempt to lock it. Wait up to X seconds to acquire lock.
+CACHE_LOCK_WAIT=120
+
+## When checking out or updating git/svn, wait up to X seconds for process to complete
+SCM_TIMEOUT=3600
+
+## Whether the site has been previously installed
+IS_INSTALLED=
+
+## Default user accounts
+ADMIN_EMAIL="admin@example.com"
+ADMIN_PASS=
+ADMIN_USER="admin"
+DEMO_EMAIL="demo@example.com"
+DEMO_PASS="demo"
+DEMO_USER="demo"
+
+## Printable name of the site (default: $SITE_NAME)
+CMS_TITLE=
+
+## The Drupal version
+CMS_VERSION=
+
+## The CiviCRM API (default: randomly generated)
+CIVI_SITE_KEY=
+
+## The CiviCRM branch/version
+CIVI_VERSION=4.7.9
+
+## Public URL of the site
+CMS_URL=
+
+## Path to the base of the CMS
+## (default: WEB_ROOT)
+CMS_ROOT=
+
+## DB credentials for CMS
+## (suggested: autogenerate via 'amp create -f --root="$WEB_ROOT" --prefix=CMS_ --url="$CMS_URL"')
+CMS_DB_DSN=
+CMS_DB_ARGS=
+CMS_DB_HOST=
+CMS_DB_NAME=
+CMS_DB_PASS=
+CMS_DB_PORT=
+CMS_DB_USER=
+CMS_DB_PERM=admin
+
+## Path to the civicrm-core tree
+CIVI_CORE=
+
+## DB credentials for Civi
+## (suggested: autogenerate via 'amp create -f --root="$WEB_ROOT" --name=civi --prefix=CIVI_ --skip-url')
+CIVI_DB_DSN=
+CIVI_DB_ARGS=
+CIVI_DB_HOST=
+CIVI_DB_NAME=
+CIVI_DB_PASS=
+CIVI_DB_PORT=
+CIVI_DB_USER=
+CIVI_DB_PERM=super
+
+## Path to the civicrm.settings.php
+CIVI_SETTINGS=
+
+## Path to the civicrm files directory
+CIVI_FILES=
+
+## Path to the civicrm templates_c cache directory
+CIVI_TEMPLATEC=
+
+## Name of the CiviCRM UF (Drupal, Drupal6, Joomla, WordPress)
+CIVI_UF=
+
+## The name of the organization (for inclusion in footers, etc)
+CIVI_DOMAIN_NAME=
+
+## The default from email address
+CIVI_DOMAIN_EMAIL=
+
+## Path to the web-managed extension folder (optional)
+CIVI_EXT_DIR=
+
+## URL of the web-managed extension folder (required iff CIVI_EXT_DIR is set)
+CIVI_EXT_URL=
+
+###############################################################################
+## Creates random password.
+function civihr_makepasswd() {
+
+  cat > "$TMPDIR/mkpasswd.php" << EOF
+<?php
+    function createRandom(\$len, \$alphabet) {
+      \$alphabetSize = strlen(\$alphabet);
+      \$result = '';
+    for (\$i = 0; \$i < \$len; \$i++) {
+      \$result .= \$alphabet{rand(1, \$alphabetSize) - 1};
+    }
+    return \$result;
+  }
+  if (empty(\$argv[1])) {
+    \$len = 8;
+  } else {
+    \$len = \$argv[1];
+  }
+  print createRandom(\$len, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789');
+?>
+EOF
+# Calling temp make password php file.
+php "$TMPDIR/mkpasswd.php" $1
+}
+
+###############################################################################
+## Assert that shell variables are defined. If not defined, exit with an error.
+##  If a variable missing, the application dies.
+function civihr_assertvars() {
+  _civihr_assertvars_back="$-"
+
+  set +x
+  context="$1"
+  shift
+  while [ "$1" ]; do
+    var="$1"
+    eval "val=\$$var"
+    if [ -z "$val" ]; then
+      echo "missing variable: $var [in $context]"
+      exit 98
+    fi
+    shift
+  done
+
+  set -${_civihr_assertvars_back} 
+}
+
+###############################################################################
+## Summarize the content of key environment variables
+function civihr_summary() {
+  if [ -n "$1" ]; then
+    echo $1
+  fi
+  shift
+
+  civihr_assertvars civihr_summary "$@"
+  for var in "$@" ; do
+    eval "val=\$$var"
+    echo " - $var: $val"
+  done
+}
+
+
+###############################################################################
+## Creates and ensure parent directory exists.
+## civihr_makeparent <file>
+function civihr_makeparent() {
+  parentdir=$(dirname "$1")
+  if [ ! -d "$parentdir" ]; then
+    mkdir -p "$parentdir"
+  fi
+}
+
+###############################################################################
+## Checks whether directory exists, if not then create it.
+## civihr_mkdir <dir1> <dir2> ...
+function civihr_mkdir() {
+  for a in "$@" ; do
+    if [ ! -d "$a" ]; then
+      mkdir -p "$a"
+    fi
+  done
+}
+
+###############################################################################
+## Appends the civibuild settings directives to a file
+## usage: civihr_inject_settings <php-file> <settings-dir-name>
+## example: civihr_inject_settings "/var/www/build/drupal/sites/foo/civicrm.settings.php" "civicrm.settings.d"
+function civihr_inject_settings() {
+  local FILE="$1"
+  local NAME="$2"
+  civihr_assertvars civihr_inject_settings PRJDIR SITE_NAME SITE_ID SITE_TOKEN FILE NAME
+
+  ## Prepare temp file
+  local TMPFILE="${TMPDIR}/${SITE_NAME}/${SITE_ID}.settings.tmp"
+  civihr_makeparent "$TMPFILE"
+
+  cat > "$TMPFILE" << EOF
+<?php
+    #### If deployed via civibuild, include any "pre" scripts
+    global \$civibuild;
+    \$civibuild['PRJDIR'] = '$PRJDIR';
+    \$civibuild['SITE_NAME'] = '$SITE_NAME';
+    \$civibuild['SITE_ID'] = '$SITE_ID';
+    \$civibuild['SITE_TOKEN'] = '$SITE_TOKEN';
+    \$civibuild['WEB_ROOT'] = '$WEB_ROOT';
+    \$civibuild['CMS_ROOT'] = '$CMS_ROOT';
+
+    if (file_exists(\$civibuild['PRJDIR'].'/src/civibuild.settings.php')) {
+      require_once \$civibuild['PRJDIR'].'/src/civibuild.settings.php';
+      _civibuild_settings(__FILE__, '$NAME', \$civibuild, 'pre');
+    }
+
+EOF
+
+  # Don't know if FILE has good newlines, so prefix/postfix both have extras
+  sed 's/^<?php//' < "$FILE" >> "$TMPFILE"
+
+  cat >> "$TMPFILE" << EOF
+
+    #### If deployed via civibuild, include any "post" scripts
+    if (file_exists(\$civibuild['PRJDIR'].'/src/civibuild.settings.php')) {
+      require_once \$civibuild['PRJDIR'].'/src/civibuild.settings.php';
+      _civibuild_settings(__FILE__, '$NAME', \$civibuild, 'post');
+    }
+EOF
+
+  ## Replace main file with temp file
+  cat < "$TMPFILE" > "$FILE"
+}
+
+###############################################################################
+## Making Random temp files
+function civihr_maketempfile(){
+ cat > "$TMPDIR/mktemp.php" << EOF
+<?php
+    \$prefix = empty(\$argv[1]) ? 'mktemp-' : \$argv[1];
+\$basedir = empty(\$argv[2]) ? sys_get_temp_dir() : \$argv[2];
+echo tempnam(\$basedir,  \$prefix);
+?>
+EOF
+}
+
+###############################################################################
+## Setup HTTP and MySQL services
+## This outputs several variables: CMS_URL, CMS_DB_*, CIVI_DB_*, and TEST_DB_*
+function amp_install() {
+  _amp_install_cms
+  _amp_install_civi
+}
+
+function _amp_install_cms() {
+  echo "[[Setup MySQL and HTTP for CMS]]"
+  civihr_assertvars _amp_install_cms CMS_ROOT SITE_NAME SITE_ID TMPDIR
+
+  civihr_maketempfile
+
+  local amp_vars_file_path=$(php $TMPDIR/mktemp.php ampvar)
+  local amp_name="cms$SITE_ID"
+  [ "$SITE_ID" == "default" ] && amp_name=cms
+
+  if [ -n "$CMS_URL" ]; then
+    amp create -f --root="$CMS_ROOT" --name="$amp_name" --prefix=CMS_ --url="$CMS_URL" --output-file="$amp_vars_file_path" --perm="$CMS_DB_PERM"
+  else
+    amp create -f --root="$CMS_ROOT" --name="$amp_name" --prefix=CMS_ --output-file="$amp_vars_file_path" --perm="$CMS_DB_PERM"
+  fi
+  echo $amp_vars_file_path;exit
+  source "$amp_vars_file_path"
+  rm -f "$amp_vars_file_path"
+}
+
+function _amp_install_civi() {
+  echo "[[Setup MySQL for Civi]]"
+  civihr_assertvars _amp_install_civi CMS_ROOT SITE_NAME SITE_ID TMPDIR
+
+  local amp_vars_file_path=$(php $TMPDIR/mktemp.php ampvar)
+  local amp_name="civi$SITE_ID"
+  [ "$SITE_ID" == "default" ] && amp_name=civi
+
+  amp create -f --root="$CMS_ROOT" --name="$amp_name" --prefix=CIVI_ --skip-url --output-file="$amp_vars_file_path" --perm="$CIVI_DB_PERM"
+
+  source "$amp_vars_file_path"
+  rm -f "$amp_vars_file_path"
+}
+
+###############################################################################
+## Generate config files and setup database
+function civicrm_install() {
+  civihr_assertvars civicrm_install CIVI_CORE CIVI_FILES CIVI_TEMPLATEC CIVI_DOMAIN_NAME CIVI_DOMAIN_EMAIL
+  if [ ! -d "$CIVI_CORE/bin" -o ! -d "$CIVI_CORE/CRM" ]; then
+    echo "Failed to locate valid civi root: $CIVI_CORE"
+    exit 1
+  fi
+
+  ## Create CiviCRM data dirs
+  amp datadir "$CIVI_FILES" "$CIVI_TEMPLATEC"
+  if [ -n "$CIVI_EXT_DIR" ]; then
+    amp datadir "$CIVI_EXT_DIR"
+  fi
+
+  ## Create CiviCRM config files
+  civicrm_make_settings_php
+  civicrm_make_setup_conf
+  
+
+  pushd "$CIVI_CORE" >> /dev/null
+    ## Does this build include development support (eg git or tarball-based)?
+    if [ -e "xml" -a -e "bin/setup.sh" ]; then
+      env SITE_ID="$SITE_ID" bash ./bin/setup.sh
+    elif [ -e "sql/civicrm.mysql" -a -e "sql/civicrm_generated.mysql" ]; then
+      cat sql/civicrm.mysql sql/civicrm_generated.mysql | eval mysql $CIVI_DB_ARGS
+    else
+      echo "Failed to locate civi SQL files"
+    fi
+  popd >> /dev/null
+
+  eval mysql $CIVI_DB_ARGS <<EOSQL
+    UPDATE civicrm_domain SET name = '$CIVI_DOMAIN_NAME';
+    SELECT @option_group_id := id
+      FROM civicrm_option_group n
+      WHERE name = 'from_email_address';
+    UPDATE civicrm_option_value
+      SET label = '$CIVI_DOMAIN_EMAIL'
+      WHERE option_group_id = @option_group_id
+      AND value = '1';
+EOSQL
+}
+
+###############################################################################
+## Creates host and port to a single string
+function civihr_build_hostport() {
+  local host=$1
+  local port=$2
+  if [ -z "$port" ]; then
+    echo "$host"
+  else
+    echo "$host:$port"
+  fi
+}
+
+###############################################################################
+## Generate a "civicrm.settings.php" file
+function civicrm_make_settings_php() {
+  civihr_assertvars civicrm_make_settings_php CIVI_SETTINGS CIVI_CORE CIVI_UF CIVI_TEMPLATEC CMS_URL CIVI_SITE_KEY
+  civihr_assertvars civicrm_make_settings_php CMS_DB_HOST CMS_DB_NAME CMS_DB_PASS CMS_DB_USER
+  civihr_assertvars civicrm_make_settings_php CIVI_DB_HOST CIVI_DB_NAME CIVI_DB_PASS CIVI_DB_USER
+
+  local tpl
+
+  for tpl in templates/CRM/common/civicrm.settings.php.template templates/CRM/common/civicrm.settings.php.tpl ; do
+    if [ -f "$CIVI_CORE/$tpl" ]; then
+      break
+    fi
+  done
+  if [ ! -f "$CIVI_CORE/$tpl" ]; then
+    echo "Failed to locate template for civicrm.settings.php"
+    exit 96
+  fi
+
+  CMS_DB_HOSTPORT=$(civihr_build_hostport "$CMS_DB_HOST" "$CMS_DB_PORT")
+  CIVI_DB_HOSTPORT=$(civihr_build_hostport "$CIVI_DB_HOST" "$CIVI_DB_PORT")
+
+  cat "$CIVI_CORE/$tpl" \
+    | sed "s;%%baseURL%%;${CMS_URL};" \
+    | sed "s;%%cms%%;${CIVI_UF};" \
+    | sed "s;%%CMSdbHost%%;${CMS_DB_HOSTPORT};" \
+    | sed "s;%%CMSdbName%%;${CMS_DB_NAME};" \
+    | sed "s;%%CMSdbPass%%;${CMS_DB_PASS};" \
+    | sed "s;%%CMSdbUser%%;${CMS_DB_USER};" \
+    | sed "s;%%crmRoot%%;${CIVI_CORE}/;" \
+    | sed "s;%%dbHost%%;${CIVI_DB_HOSTPORT};" \
+    | sed "s;%%dbName%%;${CIVI_DB_NAME};" \
+    | sed "s;%%dbPass%%;${CIVI_DB_PASS};" \
+    | sed "s;%%dbUser%%;${CIVI_DB_USER};" \
+    | sed "s;%%siteKey%%;${CIVI_SITE_KEY};" \
+    | sed "s;%%templateCompileDir%%;${CIVI_TEMPLATEC};" \
+    > "$CIVI_SETTINGS"
+  echo >> "$CIVI_SETTINGS"
+
+  if [ -n "$CIVI_EXT_DIR" ]; then
+    cat >> "$CIVI_SETTINGS" << EOF
+    global \$civicrm_setting;
+    \$civicrm_setting['Directory Preferences']['extensionsDir'] = '$CIVI_EXT_DIR';
+    \$civicrm_setting['URL Preferences']['extensionsURL'] = '$CIVI_EXT_URL';
+EOF
+  fi
+
+  civihr_inject_settings "$CIVI_SETTINGS" "civicrm.settings.d"
+}
+
+###############################################################################
+## Generate a "setup.conf" file
+function civicrm_make_setup_conf() {
+  civihr_assertvars civicrm_make_setup_conf PRJDIR CMS_ROOT CIVI_CORE CIVI_UF CIVI_DB_NAME CIVI_DB_USER CIVI_DB_PASS
+
+  cat > "$CIVI_CORE/bin/setup.conf" << EOF
+    ## INFRA-114
+    PRJDIR="$PRJDIR"
+    CMS_ROOT="$CMS_ROOT"
+    SITE_ID="\${SITE_ID:-$SITE_ID}"
+    AMP_NAME=civi\${SITE_ID}
+    [ "\$SITE_ID" == "default" ] && AMP_NAME=civi
+    eval \`\$PRJDIR/bin/amp export --root="\$CMS_ROOT" -N\${AMP_NAME}\`
+    DBNAME="\$AMP_DB_NAME"
+    DBUSER="\$AMP_DB_USER"
+    DBPASS="\$AMP_DB_PASS"
+    DBHOST="\$AMP_DB_HOST"
+    DBPORT="\$AMP_DB_PORT"
+    ##
+    SVNROOT="$CIVI_CORE"
+    CIVISOURCEDIR="$CIVI_CORE"
+    SCHEMA=schema/Schema.xml
+    DBARGS=""
+    PHP5PATH=
+    DBLOAD="$DBLOAD"
+    # DBADD=
+    GENCODE_CMS="$CIVI_UF"
+EOF
+}
+
+###############################################################################
+## Drupal -- Generate config files and setup database
+function drupal_install() {
+  drupal7_install
+}
+
+###############################################################################
+## Drupal -- Generate config files and setup database
+function drupal7_install() {
+  civihr_assertvars drupal7_install CMS_ROOT SITE_ID CMS_TITLE CMS_DB_USER CMS_DB_PASS CMS_DB_HOST CMS_DB_NAME ADMIN_USER ADMIN_PASS CMS_URL
+
+  DRUPAL_SITE_DIR="$SITE_ID"
+
+  CMS_DB_HOSTPORT=$(civihr_build_hostport "$CMS_DB_HOST" "$CMS_DB_PORT")
+  pushd "$CMS_ROOT" >> /dev/null
+    [ -f "sites/$DRUPAL_SITE_DIR/settings.php" ] && rm -f "sites/$DRUPAL_SITE_DIR/settings.php"
+
+    drush site-install -y "$@" \
+      --db-url="mysql://${CMS_DB_USER}:${CMS_DB_PASS}@${CMS_DB_HOSTPORT}/${CMS_DB_NAME}" \
+      --account-name="$ADMIN_USER" \
+      --account-pass="$ADMIN_PASS" \
+      --account-mail="$ADMIN_EMAIL" \
+      --site-name="$CMS_TITLE" \
+      --sites-subdir="$DRUPAL_SITE_DIR"
+    chmod u+w "sites/$DRUPAL_SITE_DIR"
+    chmod u+w "sites/$DRUPAL_SITE_DIR/settings.php"
+    civihr_inject_settings "$CMS_ROOT/sites/$DRUPAL_SITE_DIR/settings.php" "drupal.settings.d"
+    chmod u-w "sites/$DRUPAL_SITE_DIR/settings.php"
+
+    ## Setup extra directories
+    amp datadir "sites/${DRUPAL_SITE_DIR}/files"
+    civihr_mkdir "sites/${DRUPAL_SITE_DIR}/modules"
+  
+  popd >> /dev/null
+}
+
+###############################################################################
+## Initialize (or update) a cached copy of a git repo in $CACHE_DIR
+## usage: git_cache_setup <url> <cache-dir>
+function git_cache_setup() {
+  local url="$1"
+  local cachedir="$2"
+  local lock="${cachedir}.lock"
+  local lastrun="${cachedir}.lastrun"
+  ## TODO: defensive programming: $cachedir should not end in "/"
+
+  if [ -d "$cachedir" -a -f "$lastrun" -a -z "$FORCE_DOWNLOAD" ]; then
+    if php -r 'exit($argv[1] + file_get_contents($argv[2]) < time() ? 1 : 0);' -- $CACHE_TTL "$lastrun" ; then
+      echo "SKIP: git_caccaches.shhe_setup '$url' $cachedir' (recently updated; ttl=$CACHE_TTL)"
+      return
+    fi
+  fi
+
+  civihr_makeparent "$lock"
+  if pidlockfile.php "$lock" $$ $CACHE_LOCK_WAIT ; then
+    php -r 'echo time();' > $lastrun
+    if [ ! -d "$cachedir" ]; then
+      ## clone
+      echo "[[Initialize cache dir: $cachedir]]"
+      civihr_makeparent "$cachedir"
+      timeout.php $SCM_TIMEOUT git clone --mirror "$url" "$cachedir"
+    else
+      ## update
+      if [ -z "$OFFLINE" ]; then
+        pushd "$cachedir" >> /dev/null
+          git remote set-url origin "$url"
+          timeout.php $SCM_TIMEOUT git fetch origin +refs/heads/*:refs/heads/* -u
+        popd >> /dev/null
+      else
+        echo "[[Offline mode. Skip cache update: $cachedir]]"
+      fi
+    fi
+
+    rm -f "$lock"
+  else
+    echo "ERROR: git_cache_setup '$url' '$cachdir': failed to acquire lock"
+  fi
+}
+
+###############################################################################
+## Fix the remote configurations of any git repos in <build-dir>, changing any
+## references to <cache-base-dir> to proper remotes
+## usage: git_cache_deref_remotes <cache-base-dir> <build-dir>
+function git_cache_deref_remotes() {
+  local _shellopt="$-"
+  set +x
+
+  local cachedir="$1"
+  local builddir="$2"
+  find "$builddir" -type d -name .git | while read gitdir; do
+    pushd "$gitdir" >> /dev/null
+      pushd ".." >> /dev/null
+        local origin_old=$(git config --get remote.origin.url)
+        if [[ $origin_old == ${cachedir}* || $origin_old == file://${cachedir}* || $origin_old == file:///${cachedir}*  ]]; then
+          local origin_path=$(echo "$origin_old" | sed 's;file://;;')
+          pushd "$origin_path" >> /dev/null
+            origin_new=$(git config --get remote.origin.url)
+          popd >> /dev/null
+          echo "Change origin in [$gitdir] from [$origin_old] to [$origin_new]"
+          git remote set-url origin "$origin_new"
+          git fetch origin
+        fi
+      popd >> /dev/null
+    popd >> /dev/null
+  done
+
+  set -${_shellopt}
+}
+
+###############################################################################
+## Update core/default caches
+function default_cache_setup() {
+  if [ -z "$OFFLINE" ]; then
+    echo "[[Update caches]]"
+    civihr_assertvars default_cache_setup PRJDIR
+    git_cache_setup "https://github.com/civicrm/civihr.git" "$CACHE_DIR/civicrm/civihr.git"
+    git_cache_setup "https://github.com/civicrm/civicrm-core.git" "$CACHE_DIR/civicrm/civicrm-core.git"
+    git_cache_setup "https://github.com/civicrm/civicrm-drupal.git"  "$CACHE_DIR/civicrm/civicrm-drupal.git"
+    git_cache_setup "https://github.com/civicrm/civicrm-packages.git" "$CACHE_DIR/civicrm/civicrm-packages.git"
+    git_cache_setup "https://github.com/eileenmcnaughton/civicrm_developer.git" "$CACHE_DIR/eileenmcnaughton/civicrm_developer.git"
+  fi
+}
+
+###############################################################################
+## Parse options
+declare -a ARGS=()
+function civihr_parse() {
+
+  civihr_mkdir "$TMPDIR" "$BLDDIR"
+  
+  [ -z "$SITE_NAME" ]          && SITE_NAME="$1"
+
+  while [ -n "$1" ] ; do
+    OPTION="$1"
+    shift
+    case "$OPTION" in
+      # -h|--help|-?)
+      #   
+      #   ;;
+
+      --type)
+        SITE_TYPE="$1"
+        shift
+        ;;
+
+      --url)
+        CMS_URL="$1"
+        shift
+        ;;
+
+      *)
+         if [ "${OPTION::1}" == "-" ]; then
+           echo "Unrecognized option: $OPTION"
+         fi
+        ;;
+    esac
+  done
+
+#[ -z "$CACHE_DIR" ]          && CACHE_DIR="$TMPDIR/git-cache"
+[ -z "$WEB_ROOT" ]           && WEB_ROOT="$BLDDIR/$SITE_NAME"
+[ -z "$CMS_ROOT" ]           && CMS_ROOT="$WEB_ROOT"
+[ -z "$CIVI_SITE_KEY" ]      && CIVI_SITE_KEY=$(civihr_makepasswd 16)
+[ -z "$ADMIN_PASS" ]         && ADMIN_PASS=$(civihr_makepasswd 12)
+[ -z "$DEMO_PASS" ]          && DEMO_PASS=$(civihr_makepasswd 12)
+[ -z "$SITE_TYPE" ]          && SITE_TYPE="$SITE_NAME"
+[ -z "$CMS_TITLE" ]          && CMS_TITLE="$SITE_NAME"
+[ -z "$CMS_HOSTNAME" ]       && CMS_HOSTNAME=$(php -r '$p = parse_url($argv[1]); echo $p["host"];' "$CMS_URL")
+[ -z "$CMS_PORT" ]           && CMS_PORT=$(php -r '$p = parse_url($argv[1]); echo $p["port"];' "$CMS_URL")
+[ -z "$SITE_CONFIG_DIR" ]    && SITE_CONFIG_DIR="$PRJDIR/app/config/$SITE_TYPE"
+[ -z "$SITE_TOKEN" ]         && SITE_TOKEN=$(civihr_makepasswd 16)
+
+}
+
+echo '******************************************';
+echo 'CiviHR Install script';
+echo '******************************************';
+
+function absdirname() {
+  pushd $(dirname $0) >> /dev/null
+    pwd
+  popd >> /dev/null
+}
+
+BINDIR=$(absdirname "$0")
+PRJDIR=`pwd`
+TMPDIR="$PRJDIR/temp"
+BLDDIR="$PRJDIR"
+
+export PATH="$PATH:$BINDIR"
+civihr_parse "$@"
+command -v drush >/dev/null 2>&1 || ( echo "[[Downloading dependencies.........]]" && curl -Lo "$TMPDIR/drush" "https://github.com/drush-ops/drush/releases/download/8.1.8/drush.phar"  && chmod +x "$TMPDIR/drush" && export PATH="$PATH:$TMPDIR" )
+
+###############################################################################
+## Runs download script - Download Drupal and CiviCRM
+function civihr_setup_structure() {
+
+  [ -z "$CMS_VERSION" ] && CMS_VERSION=7.x
+  [ -z "$CIVI_VERSION" ] && CIVI_VERSION=4.4
+  [ -z "$HR_VERSION" ] && HR_VERSION=master
+
+  MAKEFILE="${TMPDIR}/${SITE_NAME}/${SITE_ID}.make"
+  civihr_makeparent "$MAKEFILE"
+  curl https://raw.githubusercontent.com/compucorp/civihr-employee-portal/PCHR-1666-install-script/drush.make \
+    | sed "s;%%CACHE_DIR%%;${CACHE_DIR};" \
+    | sed "s;%%CIVI_VERSION%%;${CIVI_VERSION};" \
+    | sed "s;%%CMS_VERSION%%;${CMS_VERSION};" \
+    | sed "s;%%HR_VERSION%%;${HR_VERSION};" \
+    > "$MAKEFILE"
+
+  drush -y make --concurrency=5 --working-copy "$MAKEFILE" "$WEB_ROOT"
+}
+
+##
+# Creates the default CiviHR users
+function create_default_users() {
+  drush -y user-create --password="civihr_staff" --mail="civihr_staff@compucorp.co.uk" "civihr_staff"
+  drush -y user-add-role civihr_staff "civihr_staff"
+
+  drush -y user-create --password="civihr_manager" --mail="civihr_manager@compucorp.co.uk" "civihr_manager"
+  drush -y user-add-role civihr_manager "civihr_manager"
+
+  drush -y user-create --password="civihr_admin" --mail="civihr_admin@compucorp.co.uk" "civihr_admin"
+  drush -y user-add-role civihr_admin "civihr_admin"
+}
+
+##
+# Creates the "Personal" Location Type
+function create_personal_location_type() {
+  drush cvapi LocationType.create sequential=1 name="Personal" display_name="Personal" vcard_name="PERSONAL" description="Place of Residence"
+}
+
+##
+# Deletes the "Name and address profile"
+function delete_name_and_address_profile() {
+  PROFILE_ID=`[[ $(drush cvapi UFGroup.getsingle return="id" title="Name and address") =~ \[id\].+([1-9]) ]] && echo ${BASH_REMATCH[1]}`
+
+  drush cvapi UFGroup.delete sequential=1 id=$PROFILE_ID
+}
+
+##
+# Disables the unused drupal blocks, leaving only the "main content" one active
+function disabled_unused_blocks() {
+  for block in 'navigation' 'form' 'powered-by' 'help' 'navigation' 'login' \
+    '2' '3' '5' '7'
+  do
+    drush block-disable --delta="$block"
+  done
+}
+
+##
+# Installs CiviHR extensions
+function install_civihr() {
+  ## (no sample data as default)
+  bash ${CIVI_CORE}/tools/extensions/civihr/bin/drush-install.sh ${CIVI_CORE}
+
+  ## (with sample data - if required)
+  # bash ${CIVI_CORE}/tools/extensions/civihr/bin/drush-install.sh --with-sample-data
+}
+
+##
+# Sets up the themes
+function setup_themes {
+  ## Drupal theme
+  drush -y en civihr_default_theme
+  drush -y vset theme_default civihr_default_theme
+
+  ## Civicrm and admin theme
+  drush -y vset admin_theme seven
+  drush -y vset civicrmtheme_theme_admin seven
+  drush -y vset civicrmtheme_theme_public seven
+}
+
+###############################################################################
+## Create config files and databases; fill the databases
+function civihr_install_site(){
+
+  ## Create virtual-host and databases
+  amp_install
+
+  ## Grant access for the Drupal database user to access the Civi Database too
+eval mysql $CIVI_DB_ARGS <<EOSQL
+    GRANT ALL PRIVILEGES ON $CIVI_DB_NAME.* TO $CMS_DB_USER@'%';
+EOSQL
+
+  ## Setup Drupal (config files, database tables)
+  drupal_install
+
+  ## Setup CiviCRM (config files, database tables)
+  DRUPAL_SITE_DIR="$SITE_ID"
+  CIVI_DOMAIN_NAME="Demonstrators Anonymous"
+  CIVI_DOMAIN_EMAIL="\"Demonstrators Anonymous\" <info@example.org>"
+  CIVI_CORE="${WEB_ROOT}/sites/all/modules/civicrm"
+  CIVI_SETTINGS="${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}/civicrm.settings.php"
+  CIVI_FILES="${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}/files/civicrm"
+  CIVI_TEMPLATEC="${CIVI_FILES}/templates_c"
+  CIVI_UF="Drupal"
+
+  ## civicrm-core v4.7+ sets default ext dir; for older versions, we'll set our own.
+  if [[ "$CIVI_VERSION" =~ ^4.[0123456](\.([0-9]|alpha|beta)+)?$ ]] ; then
+    CIVI_EXT_DIR="${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}/ext"
+    CIVI_EXT_URL="${CMS_URL}/sites/${DRUPAL_SITE_DIR}/ext"
+  fi
+
+  civicrm_install
+
+  ## Extra configuration
+  pushd "${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}" >> /dev/null
+
+    drush -y dl drush_extras drush_taxonomyinfo
+
+    drush -y updatedb
+    drush -y dis overlay shortcut color
+    drush -y en administerusersbyrole role_delegation subpermissions civicrm toolbar locale seven userprotect
+
+    install_civihr
+
+     drush -y en civicrmtheme civihr_employee_portal_features civihr_default_permissions
+     drush -y features-revert civihr_employee_portal_features
+
+    setup_themes
+    create_default_users
+    disabled_unused_blocks
+    create_personal_location_type
+    delete_name_and_address_profile
+
+    ## Create My Details and My Emergency Contact forms
+    drush refresh-node-export-files
+
+    ## Clear the cache
+    drush cc all
+  popd >> /dev/null
+
+}
+
+###############################################################################
+## Run the download scripts if necessary
+function civihr_app_download() {
+  civihr_assertvars civihr_app_download WEB_ROOT PRJDIR SITE_NAME SITE_TYPE TMPDIR #CACHE_DIR
+
+  echo "[[Download $SITE_NAME ( in '$WEB_ROOT')]]"
+
+  if [ ! -d "$WEB_ROOT" ]; then
+    IS_INSTALLED=
+    pushd "$PRJDIR" > /dev/null
+     # default_cache_setup
+      civihr_setup_structure
+     # git_cache_deref_remotes "$CACHE_DIR" "$WEB_ROOT"
+    if [ ! -d "$WEB_ROOT" ]; then
+      echo "Download failed to create directory"
+      exit 97
+    fi
+  else
+    echo "Already downloaded ${SITE_NAME}"
+  fi
+}
+
+###############################################################################
+## Runs the installation process for CMS, CiviCRM and CiviHR.
+function civihr_app_install() {
+  civihr_assertvars civihr_app_install WEB_ROOT  SITE_NAME SITE_ID SITE_TYPE
+
+  echo "[[Install $SITE_NAME ( in '$WEB_ROOT')]]"
+
+  if [ ! -d "$WEB_ROOT" ]; then
+    echo "Cannot install: missing root '$WEB_ROOT'"
+    exit 96
+  fi
+
+  if [ -z "$IS_INSTALLED" ]; then
+    pushd "$WEB_ROOT" > /dev/null
+      civihr_install_site
+    popd > /dev/null
+    IS_INSTALLED=1
+  else
+    echo "Already installed ${SITE_NAME}"
+  fi
+}
+
+###############################################################################
+## Displays CMS,DB and Site User Credentials.
+function civihr_app_show() {
+
+    civihr_app_show_summary \
+      CMS_ROOT CMS_URL CMS_DB_DSN \
+      CIVI_DB_DSN \
+      ADMIN_USER ADMIN_PASS DEMO_USER DEMO_PASS
+}
+
+###############################################################################
+## Displays Site Summary
+function civihr_app_show_summary() {
+  civihr_assertvars civi_app_show_summary SITE_NAME TMPDIR "$@"
+  civihr_summary "[[Show site summary ($SITE_NAME)]]" $@
+  echo "[[General notes]]"
+  echo " - You may need to restart httpd."
+  echo " - You may need to add the hostname and IP to /etc/hosts or DNS."
+  ## Removing unwanted temporary files.
+  if [ -d "$TMPDIR/$SITE_NAME" ]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+
+civihr_app_download
+civihr_app_install
+civihr_app_show

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -17,7 +17,7 @@ BLDDIR=
 # Codename for the build instance.
 SITE_NAME=
 
-# Identifies site pointing ot default state.
+# Identifies site pointing to default state.
 # (default: default)
 SITE_ID=default
 
@@ -28,10 +28,6 @@ SITE_TOKEN=
 # Root directory where the site's code will be installed
 # (default: BLDDIR/SITE_NAME)
 WEB_ROOT=
-
-# Root directory where we store cached copies of git repositories
-# (default: TMPDIR/git-cache)
-CACHE_DIR=
 
 # Time to wait before allowing updates to git/svn caches (seconds)
 CACHE_TTL=60
@@ -53,14 +49,8 @@ ADMIN_USER="admin"
 # Printable name of the site (default: $SITE_NAME)
 CMS_TITLE=
 
-# The Drupal version
-CMS_VERSION=
-
 # The CiviCRM API (default: randomly generated)
 CIVI_SITE_KEY=
-
-# The CiviCRM branch/version
-CIVI_VERSION=4.7.9
 
 # Public URL of the site
 CMS_URL=
@@ -102,7 +92,6 @@ CIVI_UF=
 
 # The name of the organization (for inclusion in footers, etc)
 CIVI_DOMAIN_NAME=
-
 
 # The default from email address
 CIVI_DOMAIN_EMAIL=
@@ -845,13 +834,6 @@ function civihr_install_site(){
   CIVI_FILES="${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}/files/civicrm"
   CIVI_TEMPLATEC="${CIVI_FILES}/templates_c"
   CIVI_UF="Drupal"
-
-
-  ## civicrm-core v4.7+ sets default ext dir; for older versions, we'll set our own.
-  if [[ "$CIVI_VERSION" =~ ^4.[0123456](\.([0-9]|alpha|beta)+)?$ ]] ; then
-    CIVI_EXT_DIR="${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}/ext"
-    CIVI_EXT_URL="${CMS_URL}/sites/${DRUPAL_SITE_DIR}/ext"
-  fi
 
   civicrm_install
 

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -784,7 +784,7 @@ function _civihr_delete_name_and_address_profile() {
 #   None
 ##########################################################
 function _civihr_disabled_unused_blocks() {
-  for block in 'navigation' 'form' 'powered-by' 'help' 'navigation' 'login' \
+  for block in 'navigation' 'form' 'powered-by' 'help' 'login' \
     '2' '3' '5' '7'
   do
     drush block-disable --delta="$block"
@@ -861,7 +861,7 @@ function civihr_install_site(){
 
     drush -y updatedb
     drush -y dis overlay shortcut color
-    drush -y en administerusersbyrole role_delegation subpermissions civicrm toolbar locale seven userprotect
+    drush -y en administerusersbyrole role_delegation subpermissions civicrm toolbar locale seven userprotect masquerade smtp
 
     install_civihr
 

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -118,17 +118,19 @@ function civihr_app_usage() {
   APP=$(basename "$0")
 
   php -r 'echo file_get_contents("php://stdin");' <<EOT
-Common options:
+
+Common Options :
   <site-name>        The name of the site-directory to build
 
-Syntax: $APP     <build-name> [options]
-Description: Download and/or install the application
+Syntax: $APP <site-name> [required-options]
+Description: Downloads and/or installs the application.
 
+Required options:
   --dbuser <mysql-username>     Username for mysql
   --dbpass <mysql-password>     Password for mysql
   --cmsdb  <cms-database-name>  Database name for Drupal CMS installation
   --crmdb  <crm-database-name>  Database name for CiviCRM CRM installation
-  --url <url>         The public URL of the site
+  --url    <url>                The public URL of the site
 EOT
   exit 99;
 }
@@ -252,10 +254,10 @@ function database_install() {
 ## Setting up Database for CMS i.e Drupal
 function _database_install_cms() {
 
-  echo "[[Setup MySQL for CMS]]"
+  echo "[[Setting up MySQL for CMS]]"
   civihr_assertvars _database_install_cms CMS_ROOT SITE_NAME SITE_ID TMPDIR
   # Create database.
-  mysql -u$DB_USER -p$DB_PASS -e "create database $CMSdbName" >/dev/null 2>&1 || { echo "[[Please provide CMS database name ( i.e --crmdb ) or Check if its already exists.]]";exit 1;  }
+  mysql -u$DB_USER -p$DB_PASS -e "create database $CMSdbName" || { echo "[[Please fix above MySQL error.]]"; exit 1;  }
   # Assign values to global variables.
   [ -z "$CMS_DB_USER" ]           && CMS_DB_USER="$DB_USER"
   [ -z "$CMS_DB_PASS" ]           && CMS_DB_PASS="$DB_PASS"
@@ -268,10 +270,10 @@ function _database_install_cms() {
 ## Setting up Database for CRM i.e CiviHR
 function _database_install_civi() {
 
-  echo "[[Setup MySQL for Civi]]"
+  echo "[[Setting up MySQL for CiviCRM]]"
   civihr_assertvars _database_install_civi CMS_ROOT SITE_NAME SITE_ID TMPDIR
   # Create database.
-  mysql -u$DB_USER -p$DB_PASS -e "create database $CIVIdbName" >/dev/null 2>&1 || { echo "[[Please provide CRM database name ( i.e --crmdb ) or Check if its already exists.]]";exit 1;  }
+  mysql -u$DB_USER -p$DB_PASS -e "create database $CIVIdbName" || { echo "[[Please fix above MySQL error.]]"; exit 1;  }
   # Assign values to global variables.
   [ -z "$CIVI_DB_USER" ]           && CIVI_DB_USER="$DB_USER"
   [ -z "$CIVI_DB_PASS" ]           && CIVI_DB_PASS="$DB_PASS"
@@ -520,8 +522,11 @@ function default_cache_setup() {
 function civihr_parse() {
 
   civihr_mkdir "$TMPDIR" "$BLDDIR"
+
+  # Checking for site-name parameter.
+  [ "${1::1}" == "-" ]  && echo "[[Please provide site-name]]" && civihr_app_usage && exit 1
   
-  [ -z "$SITE_NAME" ]          && SITE_NAME="$1"
+  [ -z "$SITE_NAME" ]  && SITE_NAME="$1"
 
   while [ -n "$1" ] ; do
     OPTION="$1"
@@ -532,10 +537,12 @@ function civihr_parse() {
         ;;
 
       --dbuser)
+        [ "${1::1}" == "-" ] && echo "[[Missing value for option --dbuser.]]" && civihr_app_usage && exit 1
         DB_USER="$1"
         shift
         ;;
       --dbpass)
+        [ "${1::1}" == "-" ] && echo "[[Missing value for option --dbpass.]]" && civihr_app_usage && exit 1
         DB_PASS="$1"
         shift
         ;;
@@ -545,11 +552,13 @@ function civihr_parse() {
         ;;
 
       --cmsdb)
+        [ "${1::1}" == "-" ] && echo "[[Missing value for option --cmsdb.]]" && civihr_app_usage && exit 1
         CMSdbName="$1"
         shift
         ;;
 
       --crmdb)
+        [ "${1::1}" == "-" ] && echo "[[Missing value for option --crmdb.]]" && civihr_app_usage && exit 1
         CIVIdbName="$1"
         shift
         ;;
@@ -561,7 +570,7 @@ function civihr_parse() {
 
       *)
          if [ "${OPTION::1}" == "-" ]; then
-           echo "Unrecognized option: $OPTION"
+           echo "[[Unrecognized option: $OPTION]]"
            civihr_app_usage
            exit
          fi
@@ -569,7 +578,11 @@ function civihr_parse() {
     esac
   done
 
-[ -z "$SITE_NAME" ] && civihr_app_usage
+# Checking for all required options/arguments.
+[ -z "$DB_USER" ] || [ -z "$DB_PASS" ] || [ -z "$CMSdbName" ] || [ -z "$CIVIdbName" ] || [ -z "$CMS_URL" ] && echo "[[Please provide missing options/agruments.]]" && civihr_app_usage && exit 99
+
+# Assigning values.
+[ -z "$SITE_NAME" ]          && civihr_app_usage && exit 99
 [ -z "$WEB_ROOT" ]           && WEB_ROOT="$BLDDIR/$SITE_NAME"
 [ -z "$CMS_ROOT" ]           && CMS_ROOT="$WEB_ROOT"
 [ -z "$CIVI_SITE_KEY" ]      && CIVI_SITE_KEY=$(civihr_makepasswd 16)
@@ -596,8 +609,7 @@ export PATH="$PATH:$BINDIR"
 civihr_parse "$@"
 
 # Checking for Drush dependencies if not present downloading into temp.
-command -v drush >/dev/null 2>&1 || ( echo "[[Downloading dependencies.........]]" && curl -Lo "$TMPDIR/drush" "https://github.com/drush-ops/drush/releases/download/8.1.8/drush.phar"  && chmod +x "$TMPDIR/drush" && export PATH="$PATH:$TMPDIR/drush" )
-
+command -v drush >/dev/null 2>&1 || ( echo "[[Downloading dependencies.........]]" && curl -Lo "$TMPDIR/drush" "https://github.com/drush-ops/drush/releases/download/8.1.8/drush.phar" && chmod +x "$TMPDIR/drush" && export PATH="$TMPDIR:$PATH" )
 
 ###############################################################################
 ## Downloads Drupal,CiviCRM and CiviHR from remote drush.make file.

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -713,10 +713,13 @@ export PATH="$PATH:$BINDIR"
 
 civihr_parse_options "$@"
 
+# Checking for Git dependencies.
+command -v git >/dev/null 2>&1 || { echo "Please download git to continue."; exit 1; }
 # Checking for Drush dependencies if not present downloading into temp.
 command -v drush >/dev/null 2>&1 || ( echo "[[Downloading dependencies.........]]" && curl -Lo "$TMPDIR/drush" "https://github.com/drush-ops/drush/releases/download/8.1.8/drush.phar" && chmod +x "$TMPDIR/drush" )
 # Adding Drush to environment path.
 [[ -f "$TMPDIR/drush" ]] && export PATH="$TMPDIR:$PATH"
+
 ##########################################################
 # Downloads Drupal,CiviCRM and CiviHR from remote drush.make file.
 # Arguments:

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -47,9 +47,6 @@ IS_INSTALLED=
 ADMIN_EMAIL="admin@example.com"
 ADMIN_PASS=
 ADMIN_USER="admin"
-DEMO_EMAIL="demo@example.com"
-DEMO_PASS="demo"
-DEMO_USER="demo"
 
 ## Printable name of the site (default: $SITE_NAME)
 CMS_TITLE=
@@ -102,7 +99,7 @@ CIVI_FILES=
 ## Path to the civicrm templates_c cache directory
 CIVI_TEMPLATEC=
 
-## Name of the CiviCRM UF (Drupal, Drupal6, Joomla, WordPress)
+## Name of the CiviCRM UF (Drupal)
 CIVI_UF=
 
 ## The name of the organization (for inclusion in footers, etc)
@@ -114,7 +111,7 @@ CIVI_DOMAIN_EMAIL=
 ## Path to the web-managed extension folder (optional)
 CIVI_EXT_DIR=
 
-## URL of the web-managed extension folder (required iff CIVI_EXT_DIR is set)
+## URL of the web-managed extension folder (required if CIVI_EXT_DIR is set)
 CIVI_EXT_URL=
 
 ###############################################################################
@@ -283,8 +280,8 @@ function database_install() {
 function _database_install_cms() {
 
   echo "[[Setup MySQL for CMS]]"
-  civihr_assertvars _amp_install_cms CMS_ROOT SITE_NAME SITE_ID TMPDIR
-  
+  civihr_assertvars _database_install_cms CMS_ROOT SITE_NAME SITE_ID TMPDIR
+
   mysql -u$DB_USER -p$DB_PASS -e "create database $CMSdbName" >/dev/null 2>&1 || { echo "[[Please provide CMS database name ( i.e --crmdb ) or Check if its already exists.]]";exit 1;  }
 
   [ -z "$CMS_DB_USER" ]           && CMS_DB_USER="$DB_USER"
@@ -298,7 +295,7 @@ function _database_install_cms() {
 function _database_install_civi() {
 
   echo "[[Setup MySQL for Civi]]"
-  civihr_assertvars _amp_install_civi CMS_ROOT SITE_NAME SITE_ID TMPDIR
+  civihr_assertvars _database_install_civi CMS_ROOT SITE_NAME SITE_ID TMPDIR
 
   mysql -u$DB_USER -p$DB_PASS -e "create database $CIVIdbName" >/dev/null 2>&1 || { echo "[[Please provide CRM database name ( i.e --crmdb ) or Check if its already exists.]]";exit 1;  }
 
@@ -605,7 +602,6 @@ function civihr_parse() {
 [ -z "$CMS_ROOT" ]           && CMS_ROOT="$WEB_ROOT"
 [ -z "$CIVI_SITE_KEY" ]      && CIVI_SITE_KEY=$(civihr_makepasswd 16)
 [ -z "$ADMIN_PASS" ]         && ADMIN_PASS=$(civihr_makepasswd 12)
-[ -z "$DEMO_PASS" ]          && DEMO_PASS=$(civihr_makepasswd 12)
 [ -z "$CMS_TITLE" ]          && CMS_TITLE="$SITE_NAME"
 [ -z "$CMS_HOSTNAME" ]       && CMS_HOSTNAME=$(php -r '$p = parse_url($argv[1]); echo $p["host"];' "$CMS_URL")
 [ -z "$CMS_PORT" ]           && CMS_PORT=$(php -r '$p = parse_url($argv[1]); echo $p["port"];' "$CMS_URL")
@@ -643,7 +639,7 @@ function civihr_setup_structure() {
 
   MAKEFILE="${TMPDIR}/${SITE_NAME}/${SITE_ID}.make"
   civihr_makeparent "$MAKEFILE"
-  curl https://raw.githubusercontent.com/compucorp/civihr-employee-portal/PCHR-1666-install-script/drush.make \
+  curl https://raw.githubusercontent.com/civicrm/civihr/PCHR-1666/bin/drush.make \
     | sed "s;%%CACHE_DIR%%;${CACHE_DIR};" \
     | sed "s;%%CIVI_VERSION%%;${CIVI_VERSION};" \
     | sed "s;%%CMS_VERSION%%;${CMS_VERSION};" \
@@ -826,7 +822,7 @@ function civihr_app_show() {
     civihr_app_show_summary \
       CMS_ROOT CMS_URL CMS_DB_DSN \
       CIVI_DB_DSN \
-      ADMIN_USER ADMIN_PASS DEMO_USER DEMO_PASS
+      ADMIN_USER ADMIN_PASS
 }
 
 ###############################################################################

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -190,7 +190,6 @@ function civihr_makeparent() {
 
 ###############################################################################
 ## Checks whether directory exists, if not then create it.
-## civihr_mkdir <dir1> <dir2> ...
 function civihr_mkdir() {
   for a in "$@" ; do
     if [ ! -d "$a" ]; then
@@ -200,7 +199,7 @@ function civihr_mkdir() {
 }
 
 ###############################################################################
-## Creates host and port to a single string
+## Creates host and port to a single string.
 function civihr_build_hostport() {
   local host=$1
   local port=$2
@@ -209,53 +208,6 @@ function civihr_build_hostport() {
   else
     echo "$host:$port"
   fi
-}
-
-###############################################################################
-## Appends the civibuild settings directives to a file
-## usage: civihr_inject_settings <php-file> <settings-dir-name>
-## example: civihr_inject_settings "/var/www/build/drupal/sites/foo/civicrm.settings.php" "civicrm.settings.d"
-function civihr_inject_settings() {
-  local FILE="$1"
-  local NAME="$2"
-  civihr_assertvars civihr_inject_settings PRJDIR SITE_NAME SITE_ID SITE_TOKEN FILE NAME
-
-  ## Prepare temp file
-  local TMPFILE="${TMPDIR}/${SITE_NAME}/${SITE_ID}.settings.tmp"
-  civihr_makeparent "$TMPFILE"
-
-  cat > "$TMPFILE" << EOF
-<?php
-    #### If deployed via civibuild, include any "pre" scripts
-    global \$civibuild;
-    \$civibuild['PRJDIR'] = '$PRJDIR';
-    \$civibuild['SITE_NAME'] = '$SITE_NAME';
-    \$civibuild['SITE_ID'] = '$SITE_ID';
-    \$civibuild['SITE_TOKEN'] = '$SITE_TOKEN';
-    \$civibuild['WEB_ROOT'] = '$WEB_ROOT';
-    \$civibuild['CMS_ROOT'] = '$CMS_ROOT';
-
-    if (file_exists(\$civibuild['PRJDIR'].'/src/civibuild.settings.php')) {
-      require_once \$civibuild['PRJDIR'].'/src/civibuild.settings.php';
-      _civibuild_settings(__FILE__, '$NAME', \$civibuild, 'pre');
-    }
-
-EOF
-
-  # Don't know if FILE has good newlines, so prefix/postfix both have extras
-  sed 's/^<?php//' < "$FILE" >> "$TMPFILE"
-
-  cat >> "$TMPFILE" << EOF
-
-    #### If deployed via civibuild, include any "post" scripts
-    if (file_exists(\$civibuild['PRJDIR'].'/src/civibuild.settings.php')) {
-      require_once \$civibuild['PRJDIR'].'/src/civibuild.settings.php';
-      _civibuild_settings(__FILE__, '$NAME', \$civibuild, 'post');
-    }
-EOF
-
-  ## Replace main file with temp file
-  cat < "$TMPFILE" > "$FILE"
 }
 
 ###############################################################################
@@ -393,8 +345,7 @@ function civicrm_make_settings_php() {
     \$civicrm_setting['URL Preferences']['extensionsURL'] = '$CIVI_EXT_URL';
 EOF
   fi
-
-  civihr_inject_settings "$CIVI_SETTINGS" "civicrm.settings.d"
+  
 }
 
 ###############################################################################
@@ -447,7 +398,6 @@ function drupal7_install() {
       --sites-subdir="$DRUPAL_SITE_DIR"
     chmod u+w "sites/$DRUPAL_SITE_DIR"
     chmod u+w "sites/$DRUPAL_SITE_DIR/settings.php"
-    civihr_inject_settings "$CMS_ROOT/sites/$DRUPAL_SITE_DIR/settings.php" "drupal.settings.d"
     chmod u-w "sites/$DRUPAL_SITE_DIR/settings.php"
 
     ## Setup extra directories
@@ -717,8 +667,7 @@ eval mysql -u$CIVI_DB_USER -p$CIVI_DB_PASS <<EOSQL
     GRANT ALL PRIVILEGES ON $CIVI_DB_NAME.* TO $CMS_DB_USER@'%';
 EOSQL
 
-## Grant access for the Drupal database user to access the Civi Database too
-#mysql -u$CIVI_DB_USER -p$CIVI_DB_PASS -e "GRANT ALL PRIVILEGES ON $CIVI_DB_NAME.* TO $CMS_DB_USER@'$CIVI_DB_HOSTPORT' IDENTIFIED BY '$CMS_DB_PASS'";
+  #mysql -u$CIVI_DB_USER -p$CIVI_DB_PASS -e "GRANT ALL PRIVILEGES ON $CIVI_DB_NAME.* TO $CMS_DB_USER@'$CIVI_DB_HOSTPORT' IDENTIFIED BY '$CMS_DB_PASS'";
   
   ## Setup Drupal (config files, database tables)
   drupal_install
@@ -781,9 +730,7 @@ function civihr_app_download() {
   if [ ! -d "$WEB_ROOT" ]; then
     IS_INSTALLED=
     pushd "$PRJDIR" > /dev/null
-     # default_cache_setup
       civihr_setup_structure
-     # git_cache_deref_remotes "$CACHE_DIR" "$WEB_ROOT"
     if [ ! -d "$WEB_ROOT" ]; then
       echo "Download failed to create directory"
       exit 97

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -69,26 +69,22 @@ CMS_ROOT=
 
 ## DB credentials for CMS
 CMS_DB_DSN=
-CMS_DB_ARGS=
 CMS_DB_HOST=127.0.0.1
 CMS_DB_NAME=
 CMS_DB_PASS=
 CMS_DB_PORT=3306
 CMS_DB_USER=
-CMS_DB_PERM=admin
 
 ## Path to the civicrm-core tree
 CIVI_CORE=
 
 ## DB credentials for Civi
 CIVI_DB_DSN=
-CIVI_DB_ARGS=
 CIVI_DB_HOST=127.0.0.1
 CIVI_DB_NAME=
 CIVI_DB_PASS=
 CIVI_DB_PORT=3306
 CIVI_DB_USER=
-CIVI_DB_PERM=super
 
 ## Path to the civicrm.settings.php
 CIVI_SETTINGS=
@@ -137,7 +133,7 @@ function civihr_makepasswd() {
 ?>
 EOF
 # Calling temp make password php file.
-php "$TMPDIR/mkpasswd.php" $1
+php "$TMPDIR/mkpasswd.php" "$1"
 }
 
 ###############################################################################
@@ -166,7 +162,7 @@ function civihr_assertvars() {
 ## Summarize the content of key environment variables
 function civihr_summary() {
   if [ -n "$1" ]; then
-    echo $1
+    echo "$1"
   fi
   shift
 
@@ -281,12 +277,12 @@ function civicrm_install() {
 
   pushd "$CIVI_CORE" >> /dev/null
     if [ -e "sql/civicrm.mysql" -a -e "sql/civicrm_generated.mysql" ]; then
-      cat sql/civicrm.mysql sql/civicrm_generated.mysql | mysql -u$CIVI_DB_USER -p$CIVI_DB_PASS $CIVI_DB_NAME
+      cat sql/civicrm.mysql sql/civicrm_generated.mysql | mysql -u"$CIVI_DB_USER" -p"$CIVI_DB_PASS" "$CIVI_DB_NAME"
     else
       echo "Failed to locate civi SQL files"
     fi
   popd >> /dev/null
-  eval mysql -u$CIVI_DB_USER -p$CIVI_DB_PASS $CIVI_DB_NAME <<EOSQL
+  eval mysql -u"$CIVI_DB_USER" -p"$CIVI_DB_PASS" "$CIVI_DB_NAME" <<EOSQL
     UPDATE civicrm_domain SET name = '$CIVI_DOMAIN_NAME';
     SELECT @option_group_id := id
       FROM civicrm_option_group n
@@ -417,7 +413,7 @@ function git_cache_setup() {
   ## TODO: defensive programming: $cachedir should not end in "/"
 
   if [ -d "$cachedir" -a -f "$lastrun" -a -z "$FORCE_DOWNLOAD" ]; then
-    if php -r 'exit($argv[1] + file_get_contents($argv[2]) < time() ? 1 : 0);' -- $CACHE_TTL "$lastrun" ; then
+    if php -r "exit($argv[1] + file_get_contents($argv[2]) < time() ? 1 : 0);" -- $CACHE_TTL "$lastrun" ; then
       echo "SKIP: git_caccaches.shhe_setup '$url' $cachedir' (recently updated; ttl=$CACHE_TTL)"
       return
     fi
@@ -425,7 +421,7 @@ function git_cache_setup() {
 
   civihr_makeparent "$lock"
   if pidlockfile.php "$lock" $$ $CACHE_LOCK_WAIT ; then
-    php -r 'echo time();' > $lastrun
+    php -r 'echo time();' > "$lastrun"
     if [ ! -d "$cachedir" ]; then
       ## clone
       echo "[[Initialize cache dir: $cachedir]]"
@@ -445,7 +441,7 @@ function git_cache_setup() {
 
     rm -f "$lock"
   else
-    echo "ERROR: git_cache_setup '$url' '$cachdir': failed to acquire lock"
+    echo "ERROR: git_cache_setup '$url' '$cachedir': failed to acquire lock"
   fi
 }
 
@@ -495,7 +491,6 @@ function default_cache_setup() {
 
 ###############################################################################
 ## Parse options
-declare -a ARGS=()
 function civihr_parse() {
 
   civihr_mkdir "$TMPDIR" "$BLDDIR"
@@ -563,13 +558,13 @@ echo 'CiviHR Install script';
 echo '******************************************';
 
 function absdirname() {
-  pushd $(dirname $0) >> /dev/null
+  pushd $(dirname "$0") >> /dev/null
     pwd
   popd >> /dev/null
 }
 
 BINDIR=$(absdirname "$0")
-PRJDIR=`pwd`
+PRJDIR=$(pwd)
 TMPDIR="$PRJDIR/temp"
 BLDDIR="$PRJDIR"
 
@@ -624,7 +619,7 @@ function create_personal_location_type() {
 function delete_name_and_address_profile() {
   PROFILE_ID=`[[ $(drush cvapi UFGroup.getsingle return="id" title="Name and address") =~ \[id\].+([1-9]) ]] && echo ${BASH_REMATCH[1]}`
 
-  drush cvapi UFGroup.delete sequential=1 id=$PROFILE_ID
+  drush cvapi UFGroup.delete sequential=1 id="$PROFILE_ID"
 }
 
 ##
@@ -664,11 +659,9 @@ function civihr_install_site(){
   database_install
 
   ## Grant access for the Drupal database user to access the Civi Database too.
-eval mysql -u$CIVI_DB_USER -p$CIVI_DB_PASS <<EOSQL
+eval mysql -u"$CIVI_DB_USER" -p"$CIVI_DB_PASS" <<EOSQL
     GRANT ALL PRIVILEGES ON $CIVI_DB_NAME.* TO $CMS_DB_USER@'%';
 EOSQL
-
-  #mysql -u$CIVI_DB_USER -p$CIVI_DB_PASS -e "GRANT ALL PRIVILEGES ON $CIVI_DB_NAME.* TO $CMS_DB_USER@'$CIVI_DB_HOSTPORT' IDENTIFIED BY '$CMS_DB_PASS'";
   
   ## Setup Drupal (config files, database tables)
   drupal_install
@@ -776,7 +769,7 @@ function civihr_app_show() {
 ## Displays Site Summary
 function civihr_app_show_summary() {
   civihr_assertvars civi_app_show_summary SITE_NAME TMPDIR "$@"
-  civihr_summary "[[Show site summary ($SITE_NAME)]]" $@
+  civihr_summary "[[Show site summary ($SITE_NAME)]]" "$@"
   echo "[[General notes]]"
   echo " - You may need to restart httpd."
   echo " - You may need to add the hostname and IP to /etc/hosts or DNS."

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -624,8 +624,9 @@ function civihr_parse_options() {
           echo -n "Enter Password for Mysql:"
           read -s DB_PASS
           echo
+        else
+          DB_PASS="$1"
         fi
-        DB_PASS="$1"
         [ -n "$DB_PASS" ] && PASS_PARAM="-p$DB_PASS"
         shift
         ;;

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -192,7 +192,7 @@ function civihr_assert_vars() {
     shift
   done
 
-  set -${_civihr_assert_vars_back} 
+  set -${_civihr_assert_vars_back}
 }
 
 ##########################################################
@@ -365,7 +365,7 @@ function civicrm_install() {
   pushd "$CIVI_CORE" >> /dev/null
     if [ -e "sql/civicrm.mysql" -a -e "sql/civicrm_generated.mysql" ]; then
       cat sql/civicrm.mysql sql/civicrm_generated.mysql | mysql -u$CIVI_DB_USER $PASS_PARAM $CIVI_DB_NAME
-      
+
     else
       echo "Failed to locate civi SQL files"
     fi
@@ -507,7 +507,7 @@ function drupal7_install() {
     ## Setup extra directories
     civihr_mkdir "sites/${DRUPAL_SITE_DIR}/files"
     civihr_mkdir "sites/${DRUPAL_SITE_DIR}/modules"
-  
+
   popd >> /dev/null
 }
 
@@ -608,7 +608,7 @@ function civihr_parse_options() {
 
   # Checking for site-name parameter.
   [ "${1::1}" == "-" ]  && echo "[[Please provide site-name]]" && civihr_app_usage && exit 1
-  
+
   [ -z "$SITE_NAME" ]  && SITE_NAME="$1"
 
   while [ -n "$1" ] ; do
@@ -628,11 +628,11 @@ function civihr_parse_options() {
       --dbpass)
         if [ -z "$1" ]; then
           echo -n "Enter Password for Mysql:"
-          read -s DB_PASS 
-          echo     
+          read -s DB_PASS
+          echo
         fi
         DB_PASS="$1"
-        [ -n "$DB_PASS" ] && PASS_PARAM="-p$DB_PASS" 
+        [ -n "$DB_PASS" ] && PASS_PARAM="-p$DB_PASS"
         shift
         ;;
 
@@ -721,7 +721,7 @@ command -v drush >/dev/null 2>&1 || ( echo "[[Downloading dependencies.........]
 [[ -f "$TMPDIR/drush" ]] && export PATH="$TMPDIR:$PATH"
 
 ##########################################################
-# Downloads Drupal,CiviCRM and CiviHR from remote drush.make file.
+# Downloads Drupal, CiviCRM and CiviHR from drush.make file.
 # Arguments:
 #   None
 # Returns:
@@ -730,20 +730,7 @@ command -v drush >/dev/null 2>&1 || ( echo "[[Downloading dependencies.........]
 #   civihr_setup_structure
 ##########################################################
 function civihr_setup_structure() {
-
-  [ -z "$CMS_VERSION" ] && CMS_VERSION=7.x
-  [ -z "$CIVI_VERSION" ] && CIVI_VERSION=4.4
-  [ -z "$HR_VERSION" ] && HR_VERSION=master
-
-  MAKEFILE="${TMPDIR}/${SITE_NAME}/${SITE_ID}.make"
-  civihr_make_parent "$MAKEFILE"
-  curl https://raw.githubusercontent.com/civicrm/civihr/PCHR-1666/bin/drush.make \
-    | sed "s;%%CACHE_DIR%%;${CACHE_DIR};" \
-    | sed "s;%%CIVI_VERSION%%;${CIVI_VERSION};" \
-    | sed "s;%%CMS_VERSION%%;${CMS_VERSION};" \
-    | sed "s;%%HR_VERSION%%;${HR_VERSION};" \
-    > "$MAKEFILE"
-
+  MAKEFILE="${BINDIR}/drush.make"
   drush -y make --concurrency=5 --working-copy "$MAKEFILE" "$WEB_ROOT"
 }
 

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -3,73 +3,73 @@
 # Setups CiviHR site using Drupal CMS and CiviCRM.
 
 ##########################################################
-## Global variables
+# Global variables
 
-## The location of the Project tree
+# The location of the Project tree
 PRJDIR=
 
-## Location to store temp files, defaults (PRJDIR/tmp)
+# Location to store temp files, defaults (PRJDIR/tmp)
 TMPDIR=
 
-## Location that  points to sites that we build.
+# Location that  points to sites that we build.
 BLDDIR=
 
-## Codename for the build instance.
+# Codename for the build instance.
 SITE_NAME=
 
-## Identifies site pointing ot default state.
-## (default: default)
+# Identifies site pointing ot default state.
+# (default: default)
 SITE_ID=default
 
-## Unique token for this site.
-## (default: random)
+# Unique token for this site.
+# (default: random)
 SITE_TOKEN=
 
-## Root directory where the site's code will be installed
-## (default: BLDDIR/SITE_NAME)
+# Root directory where the site's code will be installed
+# (default: BLDDIR/SITE_NAME)
 WEB_ROOT=
 
-## Root directory where we store cached copies of git repositories
-## (default: TMPDIR/git-cache)
+# Root directory where we store cached copies of git repositories
+# (default: TMPDIR/git-cache)
 CACHE_DIR=
 
-## Time to wait before allowing updates to git/svn caches (seconds)
+# Time to wait before allowing updates to git/svn caches (seconds)
 CACHE_TTL=60
 
-## When updating a cache record, first attempt to lock it. Wait up to X seconds to acquire lock.
+# When updating a cache record, first attempt to lock it. Wait up to X seconds to acquire lock.
 CACHE_LOCK_WAIT=120
 
-## When checking out or updating git/svn, wait up to X seconds for process to complete
+# When checking out or updating git/svn, wait up to X seconds for process to complete
 SCM_TIMEOUT=3600
 
-## Whether the site has been previously installed
+# Whether the site has been previously installed
 IS_INSTALLED=
 
-## Default user accounts
+# Default user accounts
 ADMIN_EMAIL="admin@example.com"
 ADMIN_PASS=
 ADMIN_USER="admin"
 
-## Printable name of the site (default: $SITE_NAME)
+# Printable name of the site (default: $SITE_NAME)
 CMS_TITLE=
 
-## The Drupal version
+# The Drupal version
 CMS_VERSION=
 
-## The CiviCRM API (default: randomly generated)
+# The CiviCRM API (default: randomly generated)
 CIVI_SITE_KEY=
 
-## The CiviCRM branch/version
+# The CiviCRM branch/version
 CIVI_VERSION=4.7.9
 
-## Public URL of the site
+# Public URL of the site
 CMS_URL=
 
-## Path to the base of the CMS
-## (default: WEB_ROOT)
+# Path to the base of the CMS
+# (default: WEB_ROOT)
 CMS_ROOT=
 
-## DB credentials for CMS
+# DB credentials for CMS
 CMS_DB_DSN=
 CMS_DB_HOST=127.0.0.1
 CMS_DB_NAME=
@@ -77,10 +77,10 @@ CMS_DB_PASS=
 CMS_DB_PORT=3306
 CMS_DB_USER=
 
-## Path to the civicrm-core tree
+# Path to the civicrm-core tree
 CIVI_CORE=
 
-## DB credentials for Civi
+# DB credentials for Civi
 CIVI_DB_DSN=
 CIVI_DB_HOST=127.0.0.1
 CIVI_DB_NAME=
@@ -88,29 +88,35 @@ CIVI_DB_PASS=
 CIVI_DB_PORT=3306
 CIVI_DB_USER=
 
-## Path to the civicrm.settings.php
+# Path to the civicrm.settings.php
 CIVI_SETTINGS=
 
-## Path to the civicrm files directory
+# Path to the civicrm files directory
 CIVI_FILES=
 
-## Path to the civicrm templates_c cache directory
+# Path to the civicrm templates_c cache directory
 CIVI_TEMPLATEC=
 
-## Name of the CiviCRM UF (Drupal)
+# Name of the CiviCRM UF (Drupal)
 CIVI_UF=
 
-## The name of the organization (for inclusion in footers, etc)
+# The name of the organization (for inclusion in footers, etc)
 CIVI_DOMAIN_NAME=
 
-## The default from email address
+# The default from email address
 CIVI_DOMAIN_EMAIL=
 
-## Path to the web-managed extension folder (optional)
+# Path to the web-managed extension folder (optional)
 CIVI_EXT_DIR=
 
-## URL of the web-managed extension folder (required if CIVI_EXT_DIR is set)
+# URL of the web-managed extension folder (required if CIVI_EXT_DIR is set)
 CIVI_EXT_URL=
+
+# Defines -p option for mysql.
+PASS_PARAM=
+
+# Defines username and password string for MySQL DSN.
+USER_PASS=
 
 ##########################################################
 # Displays usage message
@@ -136,6 +142,7 @@ Required parameters:
 
 Optional parameters:
   --dbpass [mysql-password]     Password for mysql
+  --force-drop                  Drop existing databases for --crmdb and --cmsdb options.
 EOT
   exit 99
 }
@@ -287,14 +294,16 @@ function _database_install_cms() {
   echo "[[Setting up MySQL for CMS]]"
   civihr_assert_vars _database_install_cms CMS_ROOT SITE_NAME SITE_ID TMPDIR
   # Create database.
-  mysql -u$DB_USER -p$DB_PASS -e "create database $CMSdbName" || { echo "[[Please fix above MySQL error.]]"; exit 1;  }
+
+  mysql -u$DB_USER $PASS_PARAM -e "create database $CMSdbName" || { echo "[[Please fix above MySQL error.]]"; exit 1;  }
   # Assign values to global variables.
   [ -z "$CMS_DB_USER" ]           && CMS_DB_USER="$DB_USER"
   [ -z "$CMS_DB_PASS" ]           && CMS_DB_PASS="$DB_PASS"
   [ -z "$CMS_DB_NAME" ]           && CMS_DB_NAME="$CMSdbName"
 
   CMS_DB_HOSTPORT=$(civihr_build_host_port "$CMS_DB_HOST" "$CMS_DB_PORT")
-  [ -z "$CMS_DB_DSN" ]           && CMS_DB_DSN="mysql://${DB_USER}:${DB_PASS}@${CMS_DB_HOSTPORT}/${CMSdbName}?new_link=true"
+
+  [ -z "$CMS_DB_DSN" ]           && CMS_DB_DSN="mysql://${USER_PASS}@${CMS_DB_HOSTPORT}/${CMSdbName}?new_link=true"
 }
 
 ##########################################################
@@ -310,14 +319,15 @@ function _database_install_civi() {
   echo "[[Setting up MySQL for CiviCRM]]"
   civihr_assert_vars _database_install_civi CMS_ROOT SITE_NAME SITE_ID TMPDIR
   # Create database.
-  mysql -u$DB_USER -p$DB_PASS -e "create database $CIVIdbName" || { echo "[[Please fix above MySQL error.]]"; exit 1;  }
+
+  mysql -u$DB_USER $PASS_PARAM -e "create database $CIVIdbName" || { echo "[[Please fix above MySQL error.]]"; exit 1;  }
   # Assign values to global variables.
   [ -z "$CIVI_DB_USER" ]           && CIVI_DB_USER="$DB_USER"
   [ -z "$CIVI_DB_PASS" ]           && CIVI_DB_PASS="$DB_PASS"
   [ -z "$CIVI_DB_NAME" ]           && CIVI_DB_NAME="$CIVIdbName"
 
   CIVI_DB_HOSTPORT=$(civihr_build_host_port "$CIVI_DB_HOST" "$CIVI_DB_PORT")
-  [ -z "$CIVI_DB_DSN" ]           && CIVI_DB_DSN="mysql://${DB_USER}:${DB_PASS}@${CIVI_DB_HOSTPORT}/${CIVIdbName}?new_link=true"
+  [ -z "$CIVI_DB_DSN" ]           && CIVI_DB_DSN="mysql://${USER_PASS}@${CIVI_DB_HOSTPORT}/${CIVIdbName}?new_link=true"
 }
 
 ##########################################################
@@ -345,12 +355,14 @@ function civicrm_install() {
 
   pushd "$CIVI_CORE" >> /dev/null
     if [ -e "sql/civicrm.mysql" -a -e "sql/civicrm_generated.mysql" ]; then
-      cat sql/civicrm.mysql sql/civicrm_generated.mysql | mysql -u"$CIVI_DB_USER" -p"$CIVI_DB_PASS" "$CIVI_DB_NAME"
+      cat sql/civicrm.mysql sql/civicrm_generated.mysql | mysql -u$CIVI_DB_USER $PASS_PARAM $CIVI_DB_NAME
+      
     else
       echo "Failed to locate civi SQL files"
     fi
   popd >> /dev/null
-  eval mysql -u"$CIVI_DB_USER" -p"$CIVI_DB_PASS" "$CIVI_DB_NAME" <<EOSQL
+
+  eval mysql -u$CIVI_DB_USER $PASS_PARAM $CIVI_DB_NAME <<EOSQL
     UPDATE civicrm_domain SET name = '$CIVI_DOMAIN_NAME';
     SELECT @option_group_id := id
       FROM civicrm_option_group n
@@ -371,8 +383,8 @@ EOSQL
 ##########################################################
 function civicrm_make_settings_php() {
   civihr_assert_vars civicrm_make_settings_php CIVI_SETTINGS CIVI_CORE CIVI_UF CIVI_TEMPLATEC CMS_URL CIVI_SITE_KEY
-  civihr_assert_vars civicrm_make_settings_php CMS_DB_HOST CMS_DB_NAME CMS_DB_PASS CMS_DB_USER
-  civihr_assert_vars civicrm_make_settings_php CIVI_DB_HOST CIVI_DB_NAME CIVI_DB_PASS CIVI_DB_USER
+  civihr_assert_vars civicrm_make_settings_php CMS_DB_HOST CMS_DB_NAME CMS_DB_USER
+  civihr_assert_vars civicrm_make_settings_php CIVI_DB_HOST CIVI_DB_NAME CIVI_DB_USER
 
   local tpl
 
@@ -423,7 +435,7 @@ EOF
 #   None
 ##########################################################
 function civicrm_make_setup_conf() {
-  civihr_assert_vars civicrm_make_setup_conf PRJDIR CMS_ROOT CIVI_CORE CIVI_UF CIVI_DB_NAME CIVI_DB_USER CIVI_DB_PASS
+  civihr_assert_vars civicrm_make_setup_conf PRJDIR CMS_ROOT CIVI_CORE CIVI_UF CIVI_DB_NAME CIVI_DB_USER
 
   cat > "$CIVI_CORE/bin/setup.conf" << EOF
     PRJDIR="$PRJDIR"
@@ -463,7 +475,7 @@ function drupal_install() {
 ##########################################################
 function drupal7_install() {
 
-  civihr_assert_vars drupal7_install CMS_ROOT SITE_ID CMS_TITLE CMS_DB_USER CMS_DB_PASS CMS_DB_HOST CMS_DB_NAME ADMIN_USER ADMIN_PASS CMS_URL
+  civihr_assert_vars drupal7_install CMS_ROOT SITE_ID CMS_TITLE CMS_DB_USER  CMS_DB_HOST CMS_DB_NAME ADMIN_USER ADMIN_PASS CMS_URL
   DRUPAL_SITE_DIR="$SITE_ID"
 
   CMS_DB_HOSTPORT=$(civihr_build_host_port "$CMS_DB_HOST" "$CMS_DB_PORT")
@@ -472,7 +484,7 @@ function drupal7_install() {
     [ -f "sites/$DRUPAL_SITE_DIR/settings.php" ] && rm -f "sites/$DRUPAL_SITE_DIR/settings.php"
 
     drush site-install -y "$@" \
-      --db-url="mysql://${CMS_DB_USER}:${CMS_DB_PASS}@${CMS_DB_HOSTPORT}/${CMS_DB_NAME}" \
+      --db-url="mysql://${USER_PASS}@${CMS_DB_HOSTPORT}/${CMS_DB_NAME}" \
       --account-name="$ADMIN_USER" \
       --account-pass="$ADMIN_PASS" \
       --account-mail="$ADMIN_EMAIL" \
@@ -481,6 +493,7 @@ function drupal7_install() {
     chmod u+w "sites/$DRUPAL_SITE_DIR"
     chmod u+w "sites/$DRUPAL_SITE_DIR/settings.php"
     chmod u-w "sites/$DRUPAL_SITE_DIR/settings.php"
+
 
     ## Setup extra directories
     civihr_mkdir "sites/${DRUPAL_SITE_DIR}/files"
@@ -592,6 +605,7 @@ function civihr_parse_options() {
   while [ -n "$1" ] ; do
     OPTION="$1"
     shift
+
     case "$OPTION" in
       -h|--help|-?)
         civihr_app_usage
@@ -604,10 +618,13 @@ function civihr_parse_options() {
         ;;
 
       --dbpass)
-        echo -n "Enter Password for Mysql:"
-        read -s DB_PASS 
-        echo 
+        if [ -z "$1" ]; then
+          echo -n "Enter Password for Mysql:"
+          read -s DB_PASS 
+          echo     
+        fi
         DB_PASS="$1"
+        [ -n "$DB_PASS" ] && PASS_PARAM="-p$DB_PASS" 
         shift
         ;;
 
@@ -633,6 +650,12 @@ function civihr_parse_options() {
         shift
         ;;
 
+      --force-drop)
+        mysql -u$DB_USER $PASS_PARAM -e "drop database $CMSdbName" || { echo "[[Please fix above MySQL error.]]"; exit 1;  }
+        mysql -u$DB_USER $PASS_PARAM -e "drop database $CIVIdbName" || { echo "[[Please fix above MySQL error.]]"; exit 1;  }
+        shift
+        ;;
+
       *)
          if [ "${OPTION::1}" == "-" ]; then
            echo "[[Unrecognized option: $OPTION]]"
@@ -647,6 +670,9 @@ function civihr_parse_options() {
 [ -z "$DB_USER" ] || [ -z "$CMSdbName" ] || [ -z "$CIVIdbName" ] || [ -z "$CMS_URL" ] && echo "[[Please provide missing options/agruments.]]" && civihr_app_usage && exit 99
 
 # Assigning values.
+[ -z "$USER_PASS" ]          && USER_PASS="$DB_USER"
+[ -n "$DB_PASS" ]            && USER_PASS="$DB_USER:$DB_PASS"
+
 [ -z "$SITE_NAME" ]          && civihr_app_usage && exit 99
 [ -z "$WEB_ROOT" ]           && WEB_ROOT="$BLDDIR/$SITE_NAME"
 [ -z "$CMS_ROOT" ]           && CMS_ROOT="$WEB_ROOT"
@@ -809,11 +835,11 @@ function civihr_install_site(){
   ## Creating databases for Drupal and CIVICRM.
   database_install
 
-  ## Grant access for the Drupal database user to access the Civi Database too.
-eval mysql -u"$CIVI_DB_USER" -p"$CIVI_DB_PASS" <<EOSQL
-    GRANT ALL PRIVILEGES ON $CIVI_DB_NAME.* TO $CMS_DB_USER@'%';
-EOSQL
-  
+#   ## Grant access for the Drupal database user to access the Civi Database too.
+# eval mysql -u"$CIVI_DB_USER" $PASS_PARAM <<EOSQL
+#     GRANT ALL PRIVILEGES ON $CIVI_DB_NAME.* TO $CMS_DB_USER@'%';
+# EOSQL
+
   ## Setup Drupal (config files, database tables)
   drupal_install
 
@@ -826,6 +852,7 @@ EOSQL
   CIVI_FILES="${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}/files/civicrm"
   CIVI_TEMPLATEC="${CIVI_FILES}/templates_c"
   CIVI_UF="Drupal"
+
 
   ## civicrm-core v4.7+ sets default ext dir; for older versions, we'll set our own.
   if [[ "$CIVI_VERSION" =~ ^4.[0123456](\.([0-9]|alpha|beta)+)?$ ]] ; then

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -103,6 +103,7 @@ CIVI_UF=
 # The name of the organization (for inclusion in footers, etc)
 CIVI_DOMAIN_NAME=
 
+
 # The default from email address
 CIVI_DOMAIN_EMAIL=
 
@@ -861,7 +862,7 @@ function civihr_install_site(){
 
     drush -y updatedb
     drush -y dis overlay shortcut color
-    drush -y en administerusersbyrole role_delegation subpermissions civicrm toolbar locale seven userprotect masquerade smtp
+    drush -y en administerusersbyrole role_delegation civicrm toolbar locale seven userprotect masquerade smtp
 
     install_civihr
 

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -110,6 +110,30 @@ CIVI_EXT_DIR=
 ## URL of the web-managed extension folder (required if CIVI_EXT_DIR is set)
 CIVI_EXT_URL=
 
+
+
+###############################################################################
+## Display usage message
+function civihr_app_usage() {
+  APP=$(basename "$0")
+
+  php -r 'echo file_get_contents("php://stdin");' <<EOT
+Common options:
+  <site-name>        The name of the site-directory to build
+
+Syntax: $APP     <build-name> [options]
+Description: Download and/or install the application
+
+  --dbuser <mysql-username>     Username for mysql
+  --dbpass <mysql-password>     Password for mysql
+  --cmsdb  <cms-database-name>  Database name for Drupal CMS installation
+  --crmdb  <crm-database-name>  Database name for CiviCRM CRM installation
+  --url <url>         The public URL of the site
+EOT
+  exit 99;
+}
+
+
 ###############################################################################
 ## Creates random password.
 function civihr_makepasswd() {
@@ -455,12 +479,14 @@ function git_cache_deref_remotes() {
 
   local cachedir="$1"
   local builddir="$2"
-  find "$builddir" -type d -name .git | while read gitdir; do
+  find "$builddir" -type d -name .git | while read -r gitdir; do
     pushd "$gitdir" >> /dev/null
       pushd ".." >> /dev/null
-        local origin_old=$(git config --get remote.origin.url)
+        local origin_old
+        origin_old=$(git config --get remote.origin.url)
         if [[ $origin_old == ${cachedir}* || $origin_old == file://${cachedir}* || $origin_old == file:///${cachedir}*  ]]; then
-          local origin_path=$(echo "$origin_old" | sed 's;file://;;')
+          local origin_path
+          origin_path=$(echo "$origin_old" | sed 's;file://;;')
           pushd "$origin_path" >> /dev/null
             origin_new=$(git config --get remote.origin.url)
           popd >> /dev/null
@@ -501,9 +527,9 @@ function civihr_parse() {
     OPTION="$1"
     shift
     case "$OPTION" in
-      # -h|--help|-?)
-      #   
-      #   ;;
+      -h|--help|-?)
+        civihr_app_usage
+        ;;
 
       --dbuser)
         DB_USER="$1"
@@ -536,12 +562,14 @@ function civihr_parse() {
       *)
          if [ "${OPTION::1}" == "-" ]; then
            echo "Unrecognized option: $OPTION"
+           civihr_app_usage
            exit
          fi
         ;;
     esac
   done
 
+[ -z "$SITE_NAME" ] && civihr_app_usage
 [ -z "$WEB_ROOT" ]           && WEB_ROOT="$BLDDIR/$SITE_NAME"
 [ -z "$CMS_ROOT" ]           && CMS_ROOT="$WEB_ROOT"
 [ -z "$CIVI_SITE_KEY" ]      && CIVI_SITE_KEY=$(civihr_makepasswd 16)
@@ -552,10 +580,6 @@ function civihr_parse() {
 [ -z "$SITE_TOKEN" ]         && SITE_TOKEN=$(civihr_makepasswd 16)
 
 }
-
-echo '******************************************';
-echo 'CiviHR Install script';
-echo '******************************************';
 
 function absdirname() {
   pushd $(dirname "$0") >> /dev/null

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 #
 # Setups CiviHR site using Drupal CMS and CiviCRM.
 

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -229,13 +229,14 @@ function database_install() {
   _database_install_civi
 }
 
+## Setting up Database for CMS i.e Drupal
 function _database_install_cms() {
 
   echo "[[Setup MySQL for CMS]]"
   civihr_assertvars _database_install_cms CMS_ROOT SITE_NAME SITE_ID TMPDIR
-
+  # Create database.
   mysql -u$DB_USER -p$DB_PASS -e "create database $CMSdbName" >/dev/null 2>&1 || { echo "[[Please provide CMS database name ( i.e --crmdb ) or Check if its already exists.]]";exit 1;  }
-
+  # Assign values to global variables.
   [ -z "$CMS_DB_USER" ]           && CMS_DB_USER="$DB_USER"
   [ -z "$CMS_DB_PASS" ]           && CMS_DB_PASS="$DB_PASS"
   [ -z "$CMS_DB_NAME" ]           && CMS_DB_NAME="$CMSdbName"
@@ -244,13 +245,14 @@ function _database_install_cms() {
   [ -z "$CMS_DB_DSN" ]           && CMS_DB_DSN="mysql://${DB_USER}:${DB_PASS}@${CMS_DB_HOSTPORT}/${CMSdbName}?new_link=true"
 }
 
+## Setting up Database for CRM i.e CiviHR
 function _database_install_civi() {
 
   echo "[[Setup MySQL for Civi]]"
   civihr_assertvars _database_install_civi CMS_ROOT SITE_NAME SITE_ID TMPDIR
-
+  # Create database.
   mysql -u$DB_USER -p$DB_PASS -e "create database $CIVIdbName" >/dev/null 2>&1 || { echo "[[Please provide CRM database name ( i.e --crmdb ) or Check if its already exists.]]";exit 1;  }
-
+  # Assign values to global variables.
   [ -z "$CIVI_DB_USER" ]           && CIVI_DB_USER="$DB_USER"
   [ -z "$CIVI_DB_PASS" ]           && CIVI_DB_PASS="$DB_PASS"
   [ -z "$CIVI_DB_NAME" ]           && CIVI_DB_NAME="$CIVIdbName"
@@ -258,7 +260,6 @@ function _database_install_civi() {
   CIVI_DB_HOSTPORT=$(civihr_build_hostport "$CIVI_DB_HOST" "$CIVI_DB_PORT")
   [ -z "$CIVI_DB_DSN" ]           && CIVI_DB_DSN="mysql://${DB_USER}:${DB_PASS}@${CIVI_DB_HOSTPORT}/${CIVIdbName}?new_link=true"
 }
-
 
 ###############################################################################
 ## Generate config files and setup database
@@ -297,10 +298,8 @@ function civicrm_install() {
 EOSQL
 }
 
-
-
 ###############################################################################
-## Generate a "civicrm.settings.php" file
+## Generate Civicrm "civicrm.settings.php" file.
 function civicrm_make_settings_php() {
   civihr_assertvars civicrm_make_settings_php CIVI_SETTINGS CIVI_CORE CIVI_UF CIVI_TEMPLATEC CMS_URL CIVI_SITE_KEY
   civihr_assertvars civicrm_make_settings_php CMS_DB_HOST CMS_DB_NAME CMS_DB_PASS CMS_DB_USER
@@ -349,7 +348,7 @@ EOF
 }
 
 ###############################################################################
-## Generate a "setup.conf" file
+## Generate Civicrm "setup.conf" file.
 function civicrm_make_setup_conf() {
   civihr_assertvars civicrm_make_setup_conf PRJDIR CMS_ROOT CIVI_CORE CIVI_UF CIVI_DB_NAME CIVI_DB_USER CIVI_DB_PASS
 
@@ -577,10 +576,12 @@ BLDDIR="$PRJDIR"
 export PATH="$PATH:$BINDIR"
 civihr_parse "$@"
 
+# Checking for Drush dependencies if not present downloading into temp.
 command -v drush >/dev/null 2>&1 || ( echo "[[Downloading dependencies.........]]" && curl -Lo "$TMPDIR/drush" "https://github.com/drush-ops/drush/releases/download/8.1.8/drush.phar"  && chmod +x "$TMPDIR/drush" && export PATH="$PATH:$TMPDIR/drush" )
 
+
 ###############################################################################
-## Runs download script - Download Drupal and CiviCRM
+## Downloads Drupal,CiviCRM and CiviHR from remote drush.make file.
 function civihr_setup_structure() {
 
   [ -z "$CMS_VERSION" ] && CMS_VERSION=7.x
@@ -599,7 +600,7 @@ function civihr_setup_structure() {
   drush -y make --concurrency=5 --working-copy "$MAKEFILE" "$WEB_ROOT"
 }
 
-##
+
 # Creates the default CiviHR users
 function create_default_users() {
   drush -y user-create --password="civihr_staff" --mail="civihr_staff@compucorp.co.uk" "civihr_staff"
@@ -659,10 +660,10 @@ function setup_themes {
 ## Create config files and databases; fill the databases
 function civihr_install_site(){
 
-  ## Create virtual-host and databases
+  ## Creating databases for Drupal and CIVICRM.
   database_install
 
-  ## Grant access for the Drupal database user to access the Civi Database too
+  ## Grant access for the Drupal database user to access the Civi Database too.
 eval mysql -u$CIVI_DB_USER -p$CIVI_DB_PASS <<EOSQL
     GRANT ALL PRIVILEGES ON $CIVI_DB_NAME.* TO $CMS_DB_USER@'%';
 EOSQL
@@ -687,7 +688,6 @@ EOSQL
     CIVI_EXT_DIR="${WEB_ROOT}/sites/${DRUPAL_SITE_DIR}/ext"
     CIVI_EXT_URL="${CMS_URL}/sites/${DRUPAL_SITE_DIR}/ext"
   fi
-
 
   civicrm_install
 
@@ -721,9 +721,9 @@ EOSQL
 }
 
 ###############################################################################
-## Run the download scripts if necessary
+## Downloads all the required repos for Drupal , CiviCRM and CiviHR.
 function civihr_app_download() {
-  civihr_assertvars civihr_app_download WEB_ROOT PRJDIR SITE_NAME TMPDIR #CACHE_DIR
+  civihr_assertvars civihr_app_download WEB_ROOT PRJDIR SITE_NAME TMPDIR
 
   echo "[[Download $SITE_NAME ( in '$WEB_ROOT')]]"
 

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -127,10 +127,11 @@ Description: Downloads and/or installs the application.
 
 Required options:
   --dbuser <mysql-username>     Username for mysql
-  --dbpass <mysql-password>     Password for mysql
+  --dbpass <mysql-password>     Password for mysql ( Optional )
   --cmsdb  <cms-database-name>  Database name for Drupal CMS installation
   --crmdb  <crm-database-name>  Database name for CiviCRM CRM installation
   --url    <url>                The public URL of the site
+
 EOT
   exit 99;
 }
@@ -541,11 +542,15 @@ function civihr_parse() {
         DB_USER="$1"
         shift
         ;;
+
       --dbpass)
-        [ "${1::1}" == "-" ] && echo "[[Missing value for option --dbpass.]]" && civihr_app_usage && exit 1
+        echo -n "Enter Password for Mysql:"
+        read -s DB_PASS 
+        echo 
         DB_PASS="$1"
         shift
         ;;
+
       --dbport)
         DB_PORT="$1"
         shift
@@ -579,7 +584,7 @@ function civihr_parse() {
   done
 
 # Checking for all required options/arguments.
-[ -z "$DB_USER" ] || [ -z "$DB_PASS" ] || [ -z "$CMSdbName" ] || [ -z "$CIVIdbName" ] || [ -z "$CMS_URL" ] && echo "[[Please provide missing options/agruments.]]" && civihr_app_usage && exit 99
+[ -z "$DB_USER" ] || [ -z "$CMSdbName" ] || [ -z "$CIVIdbName" ] || [ -z "$CMS_URL" ] && echo "[[Please provide missing options/agruments.]]" && civihr_app_usage && exit 99
 
 # Assigning values.
 [ -z "$SITE_NAME" ]          && civihr_app_usage && exit 99
@@ -588,8 +593,6 @@ function civihr_parse() {
 [ -z "$CIVI_SITE_KEY" ]      && CIVI_SITE_KEY=$(civihr_makepasswd 16)
 [ -z "$ADMIN_PASS" ]         && ADMIN_PASS=$(civihr_makepasswd 12)
 [ -z "$CMS_TITLE" ]          && CMS_TITLE="$SITE_NAME"
-[ -z "$CMS_HOSTNAME" ]       && CMS_HOSTNAME=$(php -r '$p = parse_url($argv[1]); echo $p["host"];' "$CMS_URL")
-[ -z "$CMS_PORT" ]           && CMS_PORT=$(php -r '$p = parse_url($argv[1]); echo $p["port"];' "$CMS_URL")
 [ -z "$SITE_TOKEN" ]         && SITE_TOKEN=$(civihr_makepasswd 16)
 
 }

--- a/bin/civihr-install
+++ b/bin/civihr-install
@@ -118,6 +118,9 @@ PASS_PARAM=
 # Defines username and password string for MySQL DSN.
 USER_PASS=
 
+# Defines flag to force drop databases.
+FORCE_DROP=
+
 ##########################################################
 # Displays usage message
 # Arguments:
@@ -251,11 +254,11 @@ function civihr_mkdir() {
 ##########################################################
 # Creates host and port to a single string.
 # Arguments:
-#   Folder Name.
+#   Host and Port.
 # Returns:
-#   Creates directory.
+#   Creates host and port of database string.
 # Usage:
-#   civihr_mkdir <directory-name>
+#   civihr_build_host_port <host> <port>
 ##########################################################
 function civihr_build_host_port() {
   local host=$1
@@ -293,8 +296,11 @@ function _database_install_cms() {
 
   echo "[[Setting up MySQL for CMS]]"
   civihr_assert_vars _database_install_cms CMS_ROOT SITE_NAME SITE_ID TMPDIR
+  # Force drop database.
+  if [ "$FORCE_DROP" ]; then
+      mysql -u$DB_USER $PASS_PARAM -e "drop database $CMSdbName" || { echo "[[Please fix above MySQL error.]]"; exit 1;  }
+  fi
   # Create database.
-
   mysql -u$DB_USER $PASS_PARAM -e "create database $CMSdbName" || { echo "[[Please fix above MySQL error.]]"; exit 1;  }
   # Assign values to global variables.
   [ -z "$CMS_DB_USER" ]           && CMS_DB_USER="$DB_USER"
@@ -318,8 +324,11 @@ function _database_install_civi() {
 
   echo "[[Setting up MySQL for CiviCRM]]"
   civihr_assert_vars _database_install_civi CMS_ROOT SITE_NAME SITE_ID TMPDIR
+  # Force drop database.
+  if [ "$FORCE_DROP" ]; then
+      mysql -u$DB_USER $PASS_PARAM -e "drop database $CIVIdbName" || { echo "[[Please fix above MySQL error.]]"; exit 1;  }
+  fi
   # Create database.
-
   mysql -u$DB_USER $PASS_PARAM -e "create database $CIVIdbName" || { echo "[[Please fix above MySQL error.]]"; exit 1;  }
   # Assign values to global variables.
   [ -z "$CIVI_DB_USER" ]           && CIVI_DB_USER="$DB_USER"
@@ -605,7 +614,6 @@ function civihr_parse_options() {
   while [ -n "$1" ] ; do
     OPTION="$1"
     shift
-
     case "$OPTION" in
       -h|--help|-?)
         civihr_app_usage
@@ -651,9 +659,7 @@ function civihr_parse_options() {
         ;;
 
       --force-drop)
-        mysql -u$DB_USER $PASS_PARAM -e "drop database $CMSdbName" || { echo "[[Please fix above MySQL error.]]"; exit 1;  }
-        mysql -u$DB_USER $PASS_PARAM -e "drop database $CIVIdbName" || { echo "[[Please fix above MySQL error.]]"; exit 1;  }
-        shift
+        FORCE_DROP=1
         ;;
 
       *)
@@ -835,11 +841,6 @@ function civihr_install_site(){
 
   ## Creating databases for Drupal and CIVICRM.
   database_install
-
-#   ## Grant access for the Drupal database user to access the Civi Database too.
-# eval mysql -u"$CIVI_DB_USER" $PASS_PARAM <<EOSQL
-#     GRANT ALL PRIVILEGES ON $CIVI_DB_NAME.* TO $CMS_DB_USER@'%';
-# EOSQL
 
   ## Setup Drupal (config files, database tables)
   drupal_install

--- a/bin/drush.make
+++ b/bin/drush.make
@@ -25,7 +25,7 @@ projects[] = drupal
 libraries[civicrm][destination] = modules
 libraries[civicrm][directory_name] = civicrm
 libraries[civicrm][download][type] = get
-libraries[civicrm][download][url] = "https://download.civicrm.org/civicrm-4.7.9-drupal.tar.gz"
+libraries[civicrm][download][url] = "https://download.civicrm.org/civicrm-4.7.18-drupal.tar.gz"
 
 libraries[civihr][destination] = modules
 libraries[civihr][directory_name] = civicrm/tools/extensions/civihr
@@ -40,7 +40,6 @@ libraries[civihr][overwrite] = TRUE
 
 projects[civicrm_error][subdir] = contrib
 projects[civicrm_error][version] = 2.0-rc3
-
 
 projects[libraries][subdir] = contrib
 projects[libraries][version] = 2.2
@@ -161,6 +160,9 @@ projects[views_autocomplete_filters][version] = "1.2"
 projects[views_merge_rows][subdir] = civihr-contrib-required
 projects[views_merge_rows][version] = "1.0-rc1"
 
+projects[masquerade][subdir] = civihr-contrib-required
+projects[masquerade][version] = "1.0-rc7"
+
 ; Patch for pagination
 projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_and_pagination-2188939-3_0.patch"
 projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_pagination-2724691-2.patch"
@@ -188,7 +190,7 @@ projects[views_json_query][patch][] = "https://raw.githubusercontent.com/compuco
 projects[views_data_export][subdir] = civihr-contrib-required
 projects[views_data_export][version] = 3.1
 
-projects[views_bulk_operations][subdir] = civihr-contrib-required 
+projects[views_bulk_operations][subdir] = civihr-contrib-required
 projects[views_bulk_operations][version] = 3.3
 
 projects[browserclass][subdir] = civihr-contrib-required
@@ -196,6 +198,10 @@ projects[browserclass][version] = 1.7
 
 projects[conditional_styles][subdir] = civihr-contrib-required
 projects[conditional_styles][version] = 2.2
+
+; SMTP Module
+projects[smtp][subdir] = civihr-contrib-required
+projects[smtp][version] = 1.6
 
 ; ****************************************
 ; Compucorp custom drupal modules
@@ -230,20 +236,28 @@ libraries[civihr_employee_portal_theme][overwrite] = TRUE
 projects[bootstrap][version] = "3.1"
 
 ; ****************************************
-; Compucorp custom civicrm modules (not required anymore as the extensions are moved to civihr repo)
+; Compucorp custom civicrm extensions
 ; ****************************************
-
-; libraries[civihr_compucorp][destination] = modules/civicrm/tools/extensions
-; libraries[civihr_compucorp][download][type] = git
-; libraries[civihr_compucorp][download][url] = https://github.com/compucorp/civihr-custom-civi-extensions
-; libraries[civihr_compucorp][download][branch] = master
-; libraries[civihr_compucorp][overwrite] = TRUE
 
 libraries[civihr_tasks][destination] = modules/civicrm/tools/extensions
 libraries[civihr_tasks][download][type] = git
 libraries[civihr_tasks][download][url] = https://github.com/compucorp/civihr-tasks-assignments
 libraries[civihr_tasks][download][branch] = master
 libraries[civihr_tasks][overwrite] = TRUE
+
+; ****************************************
+; Compucorp forks of civicrm modules (for internal development cycle)
+; ****************************************
+
+libraries[org.civicrm.shoreditch][destination] = modules/civicrm/tools/extensions
+libraries[org.civicrm.shoreditch][download][type] = git
+libraries[org.civicrm.shoreditch][download][url] = https://github.com/compucorp/org.civicrm.shoreditch
+libraries[org.civicrm.shoreditch][overwrite] = TRUE
+
+libraries[org.civicrm.styleguide][destination] = modules/civicrm/tools/extensions
+libraries[org.civicrm.styleguide][download][type] = git
+libraries[org.civicrm.styleguide][download][url] = https://github.com/compucorp/org.civicrm.styleguide
+libraries[org.civicrm.styleguide][overwrite] = TRUE
 
 ; ****************************************
 ; Compucorp custom libraries for Drupal

--- a/bin/drush.make
+++ b/bin/drush.make
@@ -1,0 +1,270 @@
+; A drush makefile for CiviCRM.
+; Call using:
+; drush make --working-copy civicrm.make
+
+; drush make API version
+api = 2
+
+; Drupal core
+core = 7.x
+
+; ****************************************
+; Drupal core
+; ****************************************
+
+projects[] = drupal
+
+; ****************************************
+; CiviCRM core
+; ****************************************
+
+; IMPORTANT: replace "github.com/civicrm" by your own fork of CiviCRM.
+; This will make it easier to submit pull-requests for patches.
+; see: http://wiki.civicrm.org/confluence/display/CRMDOC/Github+for+CiviCRM
+
+;libraries[civicrmdrupal][destination] = modules
+;libraries[civicrmdrupal][directory_name] = civicrm/drupal
+;libraries[civicrmdrupal][download][type] = git
+;libraries[civicrmdrupal][download][url] = %%CACHE_DIR%%/civicrm/civicrm-drupal.git
+;libraries[civicrmdrupal][download][tag] = 7.x-%%CIVI_VERSION%%
+;libraries[civicrmdrupal][overwrite] = TRUE
+
+;libraries[civicrmpackages][destination] = modules
+;libraries[civicrmpackages][directory_name] = civicrm/packages
+;libraries[civicrmpackages][download][type] = git
+;libraries[civicrmpackages][download][url] = %%CACHE_DIR%%/civicrm/civicrm-packages.git
+;libraries[civicrmpackages][download][tag] = %%CIVI_VERSION%%
+;libraries[civicrmpackages][overwrite] = TRUE
+
+libraries[civicrm][destination] = modules
+libraries[civicrm][directory_name] = civicrm
+libraries[civicrm][download][type] = get
+libraries[civicrm][download][url] = "https://download.civicrm.org/civicrm-4.7.9-drupal.tar.gz"
+
+libraries[civihr][destination] = modules
+libraries[civihr][directory_name] = civicrm/tools/extensions/civihr
+libraries[civihr][download][type] = git
+libraries[civihr][download][url] = https://github.com/civicrm/civihr.git
+libraries[civihr][download][branch] = master
+libraries[civihr][overwrite] = TRUE
+
+; ****************************************
+; Runtime Modules
+; ****************************************
+
+projects[civicrm_error][subdir] = contrib
+projects[civicrm_error][version] = 2.0-rc3
+
+
+projects[libraries][subdir] = contrib
+projects[libraries][version] = 2.2
+
+projects[redirect][subdir] = contrib
+projects[redirect][version] = 1.0-rc1
+
+projects[webform][subdir] = contrib
+projects[webform][version] = 4.12
+
+projects[webform_civicrm][subdir] = contrib
+projects[webform_civicrm][version] = "4.16"
+
+projects[views][subdir] = contrib
+projects[views][version] = 3.14
+projects[views][patch][] = "https://www.drupal.org/files/issues/views-exposed_forms_ajax_support-1183418-73.patch"
+
+projects[userprotect][subdir] = contrib
+projects[userprotect][version] = "1.1"
+
+; ****************************************
+; Developer modules
+; ****************************************
+
+projects[devel][subdir] = contrib
+projects[devel][version] = 1.5
+
+libraries[civicrmdeveloper][destination] = modules
+libraries[civicrmdeveloper][directory_name] = contrib/civicrm_developer
+libraries[civicrmdeveloper][download][type] = git
+libraries[civicrmdeveloper][download][url] = https://github.com/eileenmcnaughton/civicrm_developer.git
+libraries[civicrmdeveloper][download][branch] = master
+libraries[civicrmdeveloper][overwrite] = TRUE
+
+; ****************************************
+; Compucorp contrib modules
+; ****************************************
+
+projects[ctools][subdir] = civihr-contrib-required
+projects[ctools][version] = "1.9"
+
+projects[date][subdir] = civihr-contrib-required
+projects[date][version] = "2.8"
+
+projects[entity][subdir] = civihr-contrib-required
+projects[entity][version] = "1.6"
+
+projects[civicrm_entity][subdir] = civihr-contrib-required
+projects[civicrm_entity][version] = "2.x-dev"
+
+projects[features][subdir] = civihr-contrib-required
+projects[features][version] = "2.10"
+
+projects[features_extra][subdir] = civihr-contrib-required
+projects[features_extra][version] = "1.0"
+
+projects[jquery_update][subdir] = civihr-contrib-required
+projects[jquery_update][version] = "2.7"
+
+projects[panels][subdir] = civihr-contrib-required
+projects[panels][version] = "3.7"
+
+projects[rules][subdir] = civihr-contrib-required
+projects[rules][version] = "2.8"
+
+projects[tipsy][subdir] = civihr-contrib-required
+projects[tipsy][version] = "1.0-rc1"
+
+projects[strongarm][subdir] = civihr-contrib-required
+projects[strongarm][version] = "2.0"
+
+projects[views_block_area][subdir] = civihr-contrib-required
+projects[views_block_area][version] = "1.1"
+
+projects[views_tooltip][subdir] = civihr-contrib-required
+projects[views_tooltip][version] = "1.x-dev"
+
+projects[xautoload][subdir] = civihr-contrib-required
+projects[xautoload][version] = "5.1"
+
+projects[radix_layouts][subdir] = civihr-contrib-required
+projects[radix_layouts][version] = "3.3"
+
+projects[uuid][subdir] = civihr-contrib-required
+projects[uuid][version] = "1.0-alpha6"
+
+projects[node_export][subdir] = civihr-contrib-required
+projects[node_export][version] = "3.0"
+
+projects[fancy_login][subdir] = civihr-contrib-required
+projects[fancy_login][version] = "3.0-beta6"
+
+projects[jcarousel][subdir] = civihr-contrib-required
+projects[jcarousel][version] = "2.7"
+
+projects[download][subdir] = civihr-contrib-required
+projects[download][version] = "2.5"
+
+projects[views_fieldsets][subdir] = civihr-contrib-required
+projects[views_fieldsets][version] = "1.2"
+
+projects[options_element][subdir] = civihr-contrib-required
+projects[options_element][version] = "1.12"
+
+projects[views_datasource][subdir] = civihr-contrib-required
+projects[views_datasource][version] = "1.0-alpha2"
+
+projects[mimemail][subdir] = civihr-contrib-required
+projects[mimemail][version] = "1.0-beta3"
+
+projects[mailsystem][subdir] = civihr-contrib-required
+projects[mailsystem][version] = "2.34"
+projects[mailsystem][patch][] = "https://www.drupal.org/files/issues/mailsystem-newclass-wsod-2563443-16-7.x-2.34.patch"
+
+projects[views_autocomplete_filters][subdir] = civihr-contrib-required
+projects[views_autocomplete_filters][version] = "1.2"
+
+projects[views_merge_rows][subdir] = civihr-contrib-required
+projects[views_merge_rows][version] = "1.0-rc1"
+
+; Patch for pagination
+projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_and_pagination-2188939-3_0.patch"
+projects[views_merge_rows][patch][] = "https://www.drupal.org/files/issues/views_merge_rows-views_merge_rows_pagination-2724691-2.patch"
+
+projects[role_export][subdir] = civihr-contrib-required
+projects[role_export][version] = "1.0"
+
+projects[administerusersbyrole][subdir] = civihr-contrib-required
+projects[administerusersbyrole][version] = "2.0-rc1"
+
+projects[taxonomy_access_fix][subdir] = civihr-contrib-required
+projects[taxonomy_access_fix][version] = "2.2"
+
+projects[chain_menu_access][subdir] = civihr-contrib-required
+projects[chain_menu_access][version] = "2.0"
+
+projects[role_delegation][subdir] = civihr-contrib-required
+projects[role_delegation][version] = "1.1"
+
+projects[views_json_query][subdir] = civihr-contrib-required
+projects[views_json_query][version] = 1.x-dev
+projects[views_json_query][download][type] = "git"
+projects[views_json_query][patch][] = "https://raw.githubusercontent.com/compucorp/civihr-employee-portal/master/patches/views_json_query_civihr-v1.patch"
+
+projects[views_data_export][subdir] = civihr-contrib-required
+projects[views_data_export][version] = 3.1
+
+projects[views_bulk_operations][subdir] = civihr-contrib-required 
+projects[views_bulk_operations][version] = 3.3
+
+projects[browserclass][subdir] = civihr-contrib-required
+projects[browserclass][version] = 1.7
+
+projects[conditional_styles][subdir] = civihr-contrib-required
+projects[conditional_styles][version] = 2.2
+
+; ****************************************
+; Compucorp custom drupal modules
+; ****************************************
+
+libraries[civihr_employee_portal][destination] = modules
+libraries[civihr_employee_portal][directory_name] = civihr-custom
+libraries[civihr_employee_portal][download][type] = git
+libraries[civihr_employee_portal][download][url] = https://github.com/compucorp/civihr-employee-portal
+libraries[civihr_employee_portal][download][branch] = master
+libraries[civihr_employee_portal][overwrite] = TRUE
+
+; ****************************************
+; Compucorp custom drupal theme
+; ****************************************
+
+; Download Radix base theme
+projects[radix][version] = "3.4"
+
+; CiviHR Radix based default subtheme (dependent on the Radix theme)
+libraries[civihr_employee_portal_theme][destination] = themes
+libraries[civihr_employee_portal_theme][download][type] = git
+libraries[civihr_employee_portal_theme][download][url] = https://github.com/compucorp/civihr-employee-portal-theme
+libraries[civihr_employee_portal_theme][download][branch] = master
+libraries[civihr_employee_portal_theme][overwrite] = TRUE
+
+; ****************************************
+; Boostrap theme
+; ****************************************
+
+; Download Radix base theme
+projects[bootstrap][version] = "3.1"
+
+; ****************************************
+; Compucorp custom civicrm modules (not required anymore as the extensions are moved to civihr repo)
+; ****************************************
+
+; libraries[civihr_compucorp][destination] = modules/civicrm/tools/extensions
+; libraries[civihr_compucorp][download][type] = git
+; libraries[civihr_compucorp][download][url] = https://github.com/compucorp/civihr-custom-civi-extensions
+; libraries[civihr_compucorp][download][branch] = master
+; libraries[civihr_compucorp][overwrite] = TRUE
+
+libraries[civihr_tasks][destination] = modules/civicrm/tools/extensions
+libraries[civihr_tasks][download][type] = git
+libraries[civihr_tasks][download][url] = https://github.com/compucorp/civihr-tasks-assignments
+libraries[civihr_tasks][download][branch] = master
+libraries[civihr_tasks][overwrite] = TRUE
+
+; ****************************************
+; Compucorp custom libraries for Drupal
+; ****************************************
+
+libraries[pclzip][destination] = libraries
+libraries[pclzip][download][type] = git
+libraries[pclzip][download][url] = https://github.com/ivanlanin/pclzip
+libraries[pclzip][download][branch] = master
+libraries[pclzip][overwrite] = TRUE

--- a/bin/drush.make
+++ b/bin/drush.make
@@ -67,13 +67,6 @@ projects[userprotect][version] = "1.1"
 projects[devel][subdir] = contrib
 projects[devel][version] = 1.5
 
-libraries[civicrmdeveloper][destination] = modules
-libraries[civicrmdeveloper][directory_name] = contrib/civicrm_developer
-libraries[civicrmdeveloper][download][type] = git
-libraries[civicrmdeveloper][download][url] = https://github.com/eileenmcnaughton/civicrm_developer.git
-libraries[civicrmdeveloper][download][branch] = master
-libraries[civicrmdeveloper][overwrite] = TRUE
-
 ; ****************************************
 ; Compucorp contrib modules
 ; ****************************************

--- a/bin/drush.make
+++ b/bin/drush.make
@@ -22,20 +22,6 @@ projects[] = drupal
 ; This will make it easier to submit pull-requests for patches.
 ; see: http://wiki.civicrm.org/confluence/display/CRMDOC/Github+for+CiviCRM
 
-;libraries[civicrmdrupal][destination] = modules
-;libraries[civicrmdrupal][directory_name] = civicrm/drupal
-;libraries[civicrmdrupal][download][type] = git
-;libraries[civicrmdrupal][download][url] = %%CACHE_DIR%%/civicrm/civicrm-drupal.git
-;libraries[civicrmdrupal][download][tag] = 7.x-%%CIVI_VERSION%%
-;libraries[civicrmdrupal][overwrite] = TRUE
-
-;libraries[civicrmpackages][destination] = modules
-;libraries[civicrmpackages][directory_name] = civicrm/packages
-;libraries[civicrmpackages][download][type] = git
-;libraries[civicrmpackages][download][url] = %%CACHE_DIR%%/civicrm/civicrm-packages.git
-;libraries[civicrmpackages][download][tag] = %%CIVI_VERSION%%
-;libraries[civicrmpackages][overwrite] = TRUE
-
 libraries[civicrm][destination] = modules
 libraries[civicrm][directory_name] = civicrm
 libraries[civicrm][download][type] = get


### PR DESCRIPTION
## Purpose:
Need to create a unified installation script for CiviHR that will setup an CiviHR site with an single command line without having to depend on buildkit to spin up sites. Install script needs to be  executed without having to download any dependencies and would be an generic script that can ran to setup basic CiviHR site using and all its required installations. Script needs to be able to run from any instance ie within buildkit , as a standalone install script , with Drupal profiler and with Drush command to execute and setup the CiviHR site without having to know from where it has been execute from.

## Implementation:
Created a basic install script that implements below points -
1. Sets up databases
2. Fetches the latest CiviCRM (from https://download.civicrm.org/civicrm-4.7.9-drupal.tar.gz)
3. Fetches a remote drush.make file (from https://raw.githubusercontent.com/civicrm/civihr/PCHR-1666/bin/drush.make)
4. Installs Drupal, CiviCRM, CiviHR.

## Installation Steps:
1. Download Executable file from bin/civihr-install and to require location.(https://raw.githubusercontent.com/civicrm/civihr/PCHR-1666/bin/civihr-install)
2. Add civihr-install command to your $PATH variable , run below command from command prompt replacing location of file:
```html
export PATH=$PATH:/<location-of-file>
```
3. Now its time to execute installation , run below command replacing all the required parameters 
```html
civihr-install <civihr-site-name>  --dbuser <mysql-username> --dbpass <mysql-password> --cmsdb <name-of-drupal-database> --crmdb <name-of-civicrm-database> --url <site-url>
```
4. Setup Apache vhosts manually and hosts file to point to desired directory and restart apache (provides you details when you are finish with installation)

## Dependencies:
1. Requires up and running Apache , MySQL and PHP configuration.
2. Required Git to be installed.
