### PR TITLE
PCHR-1682: Make the extension capable of expiring TOIL Requests

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -411,7 +411,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
    *
    * @return int The number of records created
    */
-  public static function createExpirationRecords() {
+  public static function createExpiryRecords() {
     $numberOfRecordsCreated = 0;
 
     $balanceChangesToExpire = self::getBalanceChangesToExpire();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -1,5 +1,6 @@
 <?php
 
+use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
 use CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement as LeavePeriodEntitlement;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
@@ -413,91 +414,43 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
   public static function createExpirationRecords() {
     $numberOfRecordsCreated = 0;
 
-    $tableName = self::getTableName();
-    $query = "
-      SELECT balance_to_expire.*
-      FROM {$tableName} balance_to_expire
-      LEFT JOIN {$tableName} expired_balance_change
-             ON balance_to_expire.id = expired_balance_change.expired_balance_change_id
-      WHERE balance_to_expire.expiry_date IS NOT NULL AND
-            balance_to_expire.expiry_date < CURDATE() AND
-            balance_to_expire.expired_balance_change_id IS NULL AND
-            expired_balance_change.id IS NULL
-      ORDER BY balance_to_expire.source_id ASC, balance_to_expire.expiry_date ASC
-    ";
+    $balanceChangesToExpire = self::getBalanceChangesToExpire();
+    $datesOverlappingBalanceChangesToExpire = self::getDatesOverlappingBalanceChangesToExpire($balanceChangesToExpire);
 
-    $startDate = null;
-    $sourceID = null;
-    $sourceType = null;
+    foreach($balanceChangesToExpire as $balanceChangeToExpire) {
+      $remainingAmount = $balanceChangeToExpire['amount'];
 
-    $dao = CRM_Core_DAO::executeQuery($query, [], true, self::class);
-    while($dao->fetch()) {
-      if($dao->source_id != $sourceID && $dao->source_type != $sourceType) {
-        $startDate = null;
-        $sourceID = $dao->source_id;
-        $sourceType = $dao->source_type;
+      foreach($datesOverlappingBalanceChangesToExpire as $i => $date) {
+        if($date['date'] >= $balanceChangeToExpire['start_date'] && $date['date'] <= $balanceChangeToExpire['expiry_date']) {
+          if($remainingAmount >= abs($date['amount'])) {
+            // Date already deducted, so new we remove it from the
+            // array so it won't be deducted again from another
+            // balance change
+            unset($datesOverlappingBalanceChangesToExpire[$i]);
+            $remainingAmount += $date['amount'];
+          }
+
+          if($remainingAmount === 0) {
+            break;
+          }
+        }
       }
 
-      $expiredAmount = self::calculateExpiredAmount($dao, $startDate);
-      // Since these days should be deducted from the entitlement,
-      // We need to store the expired amount as a negative number
-      $expiredAmount *= -1;
-
       self::create([
-        'source_id' => $dao->source_id,
-        'source_type' => $dao->source_type,
-        'type_id' => $dao->type_id,
-        'amount' => $expiredAmount,
-        'expiration_date' => date('YmdHis', strtotime($dao->expiry_date)),
-        'expired_balance_change_id' => $dao->id
+        'source_id' => $balanceChangeToExpire['source_id'],
+        'source_type' => $balanceChangeToExpire['source_type'],
+        'type_id' => $balanceChangeToExpire['type_id'],
+        // Since these days should be deducted from the entitlement,
+        // We need to store the expired amount as a negative number
+        'amount' => $remainingAmount * -1,
+        'expiration_date' => $balanceChangeToExpire['expiry_date']->format('YmdHis'),
+        'expired_balance_change_id' => $balanceChangeToExpire['id']
       ]);
 
       $numberOfRecordsCreated++;
-      $startDate = (new DateTime($dao->expiry_date))->modify('+1 day');
     }
+
     return $numberOfRecordsCreated;
-  }
-
-  /**
-   * This method calculates how many days of the given LeaveBalanceChange have
-   * expired.
-   *
-   * To do this, we get the leave request balance (in other words, the number of
-   * days taken as leave) up to the balance change expiry date and subtracts it
-   * from the balance change amount.
-   *
-   * This method also supports a $startDate param. When given, the method will
-   * calculate the expired amount counting only days taken as leave between the
-   * $startDate and the balance change expiry date.
-   *
-   * @param \CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange $balanceChange
-   * @param \DateTime|NULL $startDate
-   *
-   * @return float
-   */
-  private static function calculateExpiredAmount(
-    CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange $balanceChange,
-    DateTime $startDate = NULL
-  ) {
-    $leaveRequestStatus = array_flip(LeaveRequest::buildOptions('status_id'));
-    $approvedStatuses = [
-      $leaveRequestStatus['Approved'],
-      $leaveRequestStatus['Admin Approved']
-    ];
-
-    $balanceChange->amount = (float)$balanceChange->amount;
-
-    $entitlement = $balanceChange->getLeavePeriodEntitlement();
-    $expiredAmount = self::getLeaveRequestBalanceForEntitlement(
-      $entitlement,
-      $approvedStatuses,
-      new DateTime($balanceChange->expiry_date),
-      $startDate
-    );
-
-    // Since the the Leave Request Balance is negative, when we add it
-    // to the amount we're actually subtracting the value
-    return $balanceChange->amount + $expiredAmount;
   }
 
   /**
@@ -724,5 +677,143 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
     ];
 
     CRM_Core_DAO::executeQuery($query, $params);
+  }
+
+  /**
+   * Returns a list of dates which overlap the start_date and expiry_date of
+   * each of the balance changes passed on the $balanceChangesToExpire param.
+   * Each date is also followed by the amount of days deducted for it.
+   *
+   * Basically, this method goes to the LeaveRequestDate table and join with
+   * the LeaveBalanceChange table where LeaveRequestDate.date is between the
+   * start_date and expiry_date of the balance changes to expire.
+   *
+   * Note: This method also considers the LeavePeriodEntitlement in which the
+   * balance changes and dates are contained and it will only return dates
+   * within valid contracts and absence periods for the LeavePeriodEntitlement.
+   *
+   * @param array $balanceChangesToExpire
+   *
+   * @return array
+   */
+  private static function getDatesOverlappingBalanceChangesToExpire($balanceChangesToExpire) {
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+
+    $leaveRequestTable = LeaveRequest::getTableName();
+    $leaveRequestDateTable = LeaveRequestDate::getTableName();
+    $leaveBalanceChangeTable = self::getTableName();
+
+    $dates = [];
+    foreach($balanceChangesToExpire as $balanceChangeToExpire) {
+      $balanceChange = new self();
+      $balanceChange->source_id = $balanceChangeToExpire['source_id'];
+      $balanceChange->source_type = $balanceChangeToExpire['source_type'];
+      $periodEntitlement = $balanceChange->getLeavePeriodEntitlement();
+
+      $wherePeriodEntitlementDates = [];
+      $periodStartAndEndDates = $periodEntitlement->getStartAndEndDates();
+      foreach($periodStartAndEndDates as $dates) {
+        $wherePeriodEntitlementDates[] = "leave_request_date.date BETWEEN '{$dates['start_date']}' AND '{$dates['end_date']}'";
+      }
+      $wherePeriodEntitlementDates[] = '1=1';
+      $wherePeriodEntitlementDates = implode(' OR ', $wherePeriodEntitlementDates);
+
+      $query = "
+        SELECT
+          leave_request_date.id,
+          leave_request_date.date,
+          balance_change.amount
+        FROM {$leaveRequestDateTable} leave_request_date 
+        INNER JOIN {$leaveBalanceChangeTable} balance_change 
+            ON balance_change.source_id = leave_request_date.id AND balance_change.source_type = %1
+        INNER JOIN {$leaveRequestTable} leave_request
+            ON leave_request_date.leave_request_id = leave_request.id
+        WHERE ({$wherePeriodEntitlementDates}) AND 
+              (leave_request_date.date BETWEEN %2 AND %3) AND
+              (leave_request.status_id = %4)
+      ";
+
+      $params = [
+        1 => [self::SOURCE_LEAVE_REQUEST_DAY, 'String'],
+        2 => [$balanceChangeToExpire['start_date']->format('Y-m-d'), 'String'],
+        3 => [$balanceChangeToExpire['expiry_date']->format('Y-m-d'), 'String'],
+        4 => [$leaveRequestStatuses['approved'], 'String']
+      ];
+
+      $result = CRM_Core_DAO::executeQuery($query, $params);
+
+      while($result->fetch()) {
+        $dates[$result->id] = [
+          'id' => $result->id,
+          'date' => new DateTime($result->date),
+          'amount' => (float)$result->amount
+        ];
+      }
+    }
+
+    return $dates;
+  }
+
+  /**
+   * Returns all the Balance Changes where the expiry date is in the past and
+   * that still don't have an associated expired balance change (a balance change
+   * where expired_balance_change_id is not null).
+   *
+   * This method returns the Balance Changes as an array and not as instances
+   * of the LeaveBalanceChange BAO. It also returns a start_date, which is the
+   * date this balance change became valid. It's calculated on following this
+   * logic:
+   * - If the Balance Change is linked to a TOILRequest, then it will be the
+   * from_date from the LeaveRequest associated with the TOIL Request
+   * - If the Balance Change is linked to a LeavePeriodEntitlement, the the
+   * start date will be the start_date of the AbsencePeriod linked to that
+   * LeavePeriodEntitlement.
+   *
+   * @return array
+   */
+  private static function getBalanceChangesToExpire() {
+    $balanceChangeTable     = self::getTableName();
+    $toilRequestTable       = TOILRequest::getTableName();
+    $leaveRequestTable      = LeaveRequest::getTableName();
+    $periodEntitlementTable = LeavePeriodEntitlement::getTableName();
+    $absencePeriodTable     = AbsencePeriod::getTableName();
+
+    $query = "
+      SELECT 
+        balance_to_expire.*,
+        coalesce(absence_period.start_date, toil_leave_request.from_date) as start_date
+      FROM {$balanceChangeTable} balance_to_expire
+      LEFT JOIN {$balanceChangeTable} expired_balance_change
+             ON balance_to_expire.id = expired_balance_change.expired_balance_change_id
+      LEFT JOIN {$toilRequestTable} toil_request
+            ON balance_to_expire.source_type = 'toil_request' AND balance_to_expire.source_id = toil_request.id
+      LEFT JOIN {$leaveRequestTable} toil_leave_request
+            ON toil_request.leave_request_id = toil_leave_request.id
+      LEFT JOIN {$periodEntitlementTable} period_entitlement
+            ON balance_to_expire.source_type = 'entitlement' AND balance_to_expire.source_id = period_entitlement.id
+      LEFT JOIN {$absencePeriodTable} absence_period
+            ON period_entitlement.period_id = absence_period.id
+      WHERE balance_to_expire.expiry_date IS NOT NULL AND
+            balance_to_expire.expiry_date < CURDATE() AND
+            balance_to_expire.expired_balance_change_id IS NULL AND
+            expired_balance_change.id IS NULL
+      ORDER BY balance_to_expire.expiry_date ASC, balance_to_expire.id ASC
+    ";
+
+    $result = CRM_Core_DAO::executeQuery($query);
+    $balanceChangesToExpire = [];
+    while ($result->fetch()) {
+      $balanceChangesToExpire[] = [
+        'id'          => $result->id,
+        'type_id'     => $result->type_id,
+        'amount'      => (float) $result->amount,
+        'start_date'  => new DateTime($result->start_date),
+        'expiry_date' => new DateTime($result->expiry_date),
+        'source_type' => $result->source_type,
+        'source_id'   => $result->source_id
+      ];
+    }
+
+    return $balanceChangesToExpire;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
@@ -466,6 +466,35 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
   }
 
   /**
+   * Returns the LeavePeriodEntitlement for the given LeaveRequest. That is,
+   * the LeavePeriodEntitlement with the same contact and absence type as of
+   * the given LeaveRequest and for the Absence Period which contains the
+   * LeaveRequest dates.
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_LeaveRequest $leaveRequest
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement|null
+   *
+   * @throws \RuntimeException
+   */
+  public static function getForLeaveRequest(LeaveRequest $leaveRequest) {
+    $absencePeriod = AbsencePeriod::getPeriodContainingDates(
+      new DateTime($leaveRequest->from_date),
+      new DateTime($leaveRequest->to_date)
+    );
+
+    if($absencePeriod === null) {
+      throw new RuntimeException('It was not possible to find an AbsencePeriod containing the given LeaveRequest');
+    }
+
+    return self::getPeriodEntitlementForContact(
+      $leaveRequest->contact_id,
+      $absencePeriod->id,
+      $leaveRequest->type_id
+    );
+  }
+
+  /**
    * Returns the entitlement (number of days) for this LeavePeriodEntitlement.
    *
    * This is basic the sum of the amounts of the LeaveBalanceChanges that are

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.php
@@ -1,5 +1,8 @@
 <?php
 
+require_once __DIR__ . '/../../../tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php';
+require_once __DIR__ . '/../../../tests/phpunit/helpers/LeaveRequestHelpersTrait.php';
+
 /**
  * Class CRM_HRLeaveAndAbsences_Page_AbsencePeriod
  *
@@ -20,6 +23,9 @@ class CRM_HRLeaveAndAbsences_Page_AbsencePeriod extends CRM_Core_Page_Basic {
    */
   public function run() {
     CRM_Utils_System::setTitle(ts('Absence Periods'));
+
+    $this->createThings();
+
     parent::run();
   }
 
@@ -135,5 +141,144 @@ class CRM_HRLeaveAndAbsences_Page_AbsencePeriod extends CRM_Core_Page_Basic {
     $mask = array_sum(array_keys($this->links()));
 
     return $mask;
+  }
+
+  private function createThings() {
+    //===============================================================================================
+    // Contract
+
+    $contract = CRM_Hrjobcontract_Test_Fabricator_HRJobContract::fabricate(
+      ['contact_id' => 202],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    CRM_Hrjobcontract_Test_Fabricator_HRJobLeave::fabricate([
+      "values" => [
+        [
+          'jobcontract_id'      => $contract['id'],
+          'leave_type'          => 1,
+          'leave_amount'        => 20,
+          'add_public_holidays' => 1,
+        ],
+        [
+          'jobcontract_id'      => $contract['id'],
+          'leave_type'          => 2,
+          'leave_amount'        => 0,
+          'add_public_holidays' => 0,
+        ],
+        [
+          'jobcontract_id'      => $contract['id'],
+          'leave_type'          => 3,
+          'leave_amount'        => 0,
+          'add_public_holidays' => 0,
+        ],
+      ]
+    ]);
+
+    CRM_Hrjobcontract_Test_Fabricator_HRJobHour::fabricate([
+      'jobcontract_id' => $contract['id'],
+      'location_standard_hours' => 1,
+      'hours_type' => 8,
+    ]);
+
+    CRM_Hrjobcontract_Test_Fabricator_HRJobPay::fabricate([
+      'jobcontract_id' => $contract['id'],
+      'is_paid' => 0,
+    ]);
+
+    CRM_Hrjobcontract_Test_Fabricator_HRJobHealth::fabricate([
+      'jobcontract_id' => $contract['id'],
+    ]);
+
+    CRM_Hrjobcontract_Test_Fabricator_HRJobPension::fabricate([
+      'jobcontract_id' => $contract['id'],
+    ]);
+
+    CRM_Hrjobcontract_Test_Fabricator_HRJobPension::fabricate([
+      'jobcontract_id' => $contract['id'],
+    ]);
+
+    //===============================================================================================
+    // Absence Periods
+
+    $period2016 = CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod::fabricate([
+      'title' => '2016',
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+//===============================================================================================
+// 2016 Entitlement
+
+    $entitlement2016 = CRM_HRLeaveAndAbsences_Test_Fabricator_LeavePeriodEntitlement::fabricate([
+      'contact_id' => 202,
+      'period_id' => $period2016->id,
+      'type_id' => 2
+    ]);
+
+    $balanceChangeTypes = array_flip(CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange::buildOptions('type_id'));
+
+    CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange::fabricate([
+      'source_id' => $entitlement2016->id,
+      'source_type' => CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange::SOURCE_ENTITLEMENT,
+      'amount' => 0,
+      'type_id' => $balanceChangeTypes['Leave']
+    ]);
+
+    CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange::fabricate([
+      'source_id' => $entitlement2016->id,
+      'source_type' => CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange::SOURCE_ENTITLEMENT,
+      'amount' => 5,
+      'expiry_date' => CRM_Utils_Date::processDate('2016-02-27'),
+      'type_id' => $balanceChangeTypes['Brought Forward']
+    ]);
+
+//===============================================================================================
+// 2016 Leave Requests
+
+    $leaveRequestStatus = array_flip(CRM_HRLeaveAndAbsences_BAO_LeaveRequest::buildOptions('status_id'));
+    $sicknessReasons = array_flip(CRM_HRLeaveAndAbsences_BAO_SicknessRequest::buildOptions('reason'));
+    $balanceChangeService = new CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange();
+
+    CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest::fabricateWithoutValidation([
+      'contact_id' => $entitlement2016->contact_id,
+      'type_id' => $entitlement2016->type_id,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-05'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-05'),
+    ], true);
+
+    CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest::fabricateWithoutValidation([
+      'contact_id' => $entitlement2016->contact_id,
+      'type_id' => $entitlement2016->type_id,
+      'from_date' => CRM_Utils_Date::processDate('2016-02-01'),
+      'to_date' => CRM_Utils_Date::processDate('2016-02-01'),
+    ], true);
+
+    CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest::fabricateWithoutValidation([
+      'contact_id' => $entitlement2016->contact_id,
+      'type_id' => $entitlement2016->type_id,
+      'from_date' => CRM_Utils_Date::processDate('2016-02-26'),
+      'to_date' => CRM_Utils_Date::processDate('2016-02-28'),
+    ], true);
+
+    CRM_HRLeaveAndAbsences_Test_Fabricator_TOILRequest::fabricateWithoutValidation([
+      'contact_id' => $entitlement2016->contact_id,
+      'type_id' => $entitlement2016->type_id,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-17'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-17'),
+      'expiry_date' => CRM_Utils_Date::processDate('2016-02-17'),
+      'toil_to_accrue' => 1,
+      'duration' => 100
+    ]);
+
+    CRM_HRLeaveAndAbsences_Test_Fabricator_TOILRequest::fabricateWithoutValidation([
+      'contact_id' => $entitlement2016->contact_id,
+      'type_id' => $entitlement2016->type_id,
+      'from_date' => CRM_Utils_Date::processDate('2016-02-25'),
+      'to_date' => CRM_Utils_Date::processDate('2016-02-25'),
+      'expiry_date' => CRM_Utils_Date::processDate('2016-03-01'),
+      'toil_to_accrue' => 2,
+      'duration' => 100
+    ]);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveBalanceChange.php
@@ -46,11 +46,11 @@ function civicrm_api3_leave_balance_change_get($params) {
 }
 
 /**
- * LeaveBalanceChange.createexpirationrecords API
+ * LeaveBalanceChange.create_expiry_records API
  *
  * @return int The number of records created
  * @throws API_Exception
  */
-function civicrm_api3_leave_balance_change_createexpirationrecords() {
-  return CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange::createExpirationRecords();
+function civicrm_api3_leave_balance_change_create_expiry_records() {
+  return CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange::createExpiryRecords();
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -69,20 +69,21 @@ function civicrm_api3_leave_request_delete($params) {
 function _civicrm_api3_leave_request_get_spec(&$spec) {
   $spec['public_holiday'] = [
     'name' => 'public_holiday',
-    'title' => 'Include only Public Holiday Leave Requests?',
+    'title' => 'Public Holidays only?',
+    'description' => 'Include only Public Holiday Leave Requests?',
     'type' => CRM_Utils_Type::T_BOOLEAN,
     'api.required' => 0,
   ];
 
   $spec['managed_by'] = [
     'name' => 'managed_by',
-    'title' => 'Include only Leave Requests for contacts managed by the contact with the given ID',
+    'title' => 'Managed By',
+    'description' => 'Include only Leave Requests for contacts managed by the contact with the given ID',
     'type' => CRM_Utils_Type::T_INT,
     'api.required' => 0,
     'FKClassName'  => 'CRM_Contact_DAO_Contact',
     'FKApiName'    => 'Contact',
   ];
-
 }
 
 /**
@@ -118,9 +119,20 @@ function civicrm_api3_leave_request_get($params) {
 function _civicrm_api3_leave_request_getfull_spec(&$spec) {
   $spec['public_holiday'] = [
     'name' => 'public_holiday',
-    'title' => 'Include only Public Holiday Leave Requests?',
+    'title' => 'Public Holidays only?',
+    'description' => 'Include only Public Holiday Leave Requests?',
     'type' => CRM_Utils_Type::T_BOOLEAN,
     'api.required' => 0,
+  ];
+
+  $spec['managed_by'] = [
+    'name' => 'managed_by',
+    'title' => 'Managed By',
+    'description' => 'Include only Leave Requests for contacts managed by the contact with the given ID',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 0,
+    'FKClassName'  => 'CRM_Contact_DAO_Contact',
+    'FKApiName'    => 'Contact',
   ];
 }
 
@@ -243,16 +255,17 @@ function _civicrm_api3_leave_request_getbalancechangebyabsencetype_spec(&$spec) 
 
   $spec['public_holiday'] = [
     'name' => 'public_holiday',
-    'title' => 'Include only Public Holiday Leave Requests?',
+    'title' => 'Include Public Holidays only?',
+    'description' => 'Include only Public Holiday Leave Requests?',
     'type' => CRM_Utils_Type::T_BOOLEAN,
     'api.required' => 0,
   ];
 
   $spec['expired'] = [
     'name' => 'expired',
-    'type' => CRM_Utils_Type::T_BOOLEAN,
     'title' => 'Include expired balance changes only?',
     'description' => 'Only counts the days from expired balance changes',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
     'api.required' => 0,
   ];
 }
@@ -372,7 +385,7 @@ function _civicrm_api3_leave_request_ismanagedby_spec(&$spec) {
   $spec['leave_request_id'] = [
     'name' => 'leave_request_id',
     'type' => CRM_Utils_Type::T_INT,
-    'title' => 'Leave Request',
+    'title' => 'Leave Request ID',
     'description' => 'The Leave Request to check if the contact is the manager of',
     'api.required' => 1
   ];
@@ -380,7 +393,7 @@ function _civicrm_api3_leave_request_ismanagedby_spec(&$spec) {
   $spec['contact_id'] = [
     'name' => 'contact_id',
     'type' => CRM_Utils_Type::T_INT,
-    'title' => 'Contact',
+    'title' => 'Contact ID',
     'description' => 'The contact to check if the Leave Request is managed by',
     'api.required' => 1,
     'FKClassName'  => 'CRM_Contact_DAO_Contact',

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -158,25 +158,27 @@ function _hrleaveandabsences_add_navigation_menu($params)
  * Adds the scheduled jobs for this extension
  */
 function _hrleaveandabsences_add_scheduled_jobs() {
-  _hrleaveandabsences_add_create_expiration_records_scheduled_job();
+  _hrleaveandabsences_add_create_expiry_records_scheduled_job();
   _hrleaveandabsences_add_process_public_holiday_leave_requests_updates_scheduled_job();
 }
 
 /**
  * Adds the "Create expiration records for expired LeaveBalanceChange records" scheduled job.
  */
-function _hrleaveandabsences_add_create_expiration_records_scheduled_job() {
+function _hrleaveandabsences_add_create_expiry_records_scheduled_job() {
   $dao             = new CRM_Core_DAO_Job();
   $dao->api_entity = 'LeaveBalanceChange';
-  $dao->api_action = 'createexpirationrecords';
+  $dao->api_action = 'create_expiry_records';
   $dao->find(TRUE);
   if (!$dao->id) {
     $dao                = new CRM_Core_DAO_Job();
+    $dao->api_entity    = 'LeaveBalanceChange';
+    $dao->api_action    = 'create_expiry_records';
     $dao->domain_id     = CRM_Core_Config::domainID();
     $dao->run_frequency = 'Daily';
     $dao->parameters    = NULL;
-    $dao->name          = 'Create expiration records for expired LeaveBalanceChange records';
-    $dao->description   = 'Creates a record with a negative balance for any balance change';
+    $dao->name          = 'Create expiry records for expired LeaveBalanceChanges';
+    $dao->description   = 'Checks the number of days taken as leave during the LeaveBalanceChange period and add a negative balance change to expire the number of days not used';
     $dao->is_active     = 1;
     $dao->save();
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -7,9 +7,11 @@ use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement as LeavePeriodEntitlement;
 use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
 use CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern as ContactWorkPattern;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod as AbsencePeriodFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange as LeaveBalanceChangeFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern as WorkPatternFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_LeavePeriodEntitlement as LeavePeriodEntitlementFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest as PublicHolidayLeaveRequestFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_TOILRequest as TOILRequestFabricator;
 
@@ -1074,144 +1076,239 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $this->assertCount(0, $balanceChanges);
   }
 
-//  public function testCreateExpirationRecordsCreatesRecordsForExpiredBalanceChanges() {
-//    $this->createBroughtForwardBalanceChange(1, 5, date('YmdHis', strtotime('-1 day')));
-//    $this->createBroughtForwardBalanceChange(2, 7, date('YmdHis', strtotime('-8 days')));
-//
-//    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
-//    $this->assertEquals(2, $numberOfCreatedRecords);
-//
-//    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
-//    $this->assertEquals(0, $numberOfCreatedRecords);
-//  }
-//
-//  public function testCreateExpirationRecordsCreatesRecordsEntitlementsWithMultipleExpiredBalanceChanges() {
-//    // The entitlement with ID 1 has 2 balance changes to expire
-//    $this->createBroughtForwardBalanceChange(1, 5, date('YmdHis', strtotime('-1 day')));
-//    $this->createBroughtForwardBalanceChange(1, 7, date('YmdHis', strtotime('-8 days')));
-//
-//    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
-//    $this->assertEquals(2, $numberOfCreatedRecords);
-//
-//    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
-//    $this->assertEquals(0, $numberOfCreatedRecords);
-//  }
-//
-//  public function testCreateExpirationRecordsCalculatesTheExpiredAmountBasedOnTheApprovedLeaveRequestBalance() {
-//    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
-//
-//    $balanceChange = $this->createBroughtForwardBalanceChange(1, 5, date('YmdHis', strtotime('-1 day')));
-//
-//    //This 1 day approved leave request will be counted
-//    $this->createLeaveRequestBalanceChange(
-//      1,
-//      $leaveRequestStatuses['Approved'],
-//      date('Y-m-d', strtotime('-10 days'))
-//    );
-//
-//    // This 2 days cancelled leave request won't counted
-//    $this->createLeaveRequestBalanceChange(
-//      1,
-//      $leaveRequestStatuses['Cancelled'],
-//      date('Y-m-d', strtotime('-20 days')),
-//      date('Y-m-d', strtotime('-21 days'))
-//    );
-//
-//    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
-//    $this->assertEquals(1, $numberOfCreatedRecords);
-//
-//    $expirationRecord = $this->getExpirationRecordForBalanceChange($balanceChange->id);
-//    $this->assertNotNull($expirationRecord);
-//    // Since only the 1 day leave request was counted, 4 days expired
-//    // 5 - 1 = 4 (we store expired days as a negative number)
-//    $this->assertEquals(-4, $expirationRecord->amount);
-//  }
-//
-//  public function testCreateExpirationRecordsCalculatesPrioritizesAccordingToTheBalanceChangeExpiryDate() {
-//    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
-//
-//    $balanceChange1 = $this->createBroughtForwardBalanceChange(
-//      1,
-//      5,
-//      date('YmdHis', strtotime('-1 day'))
-//    );
-//    $balanceChange2 = $this->createBroughtForwardBalanceChange(
-//      1,
-//      5,
-//      date('YmdHis', strtotime('-5 days'))
-//    );
-//
-//    // A 7 days approved leave request
-//    $this->createLeaveRequestBalanceChange(
-//      1,
-//      $leaveRequestStatuses['Approved'],
-//      date('Y-m-d', strtotime('-7 days')),
-//      date('Y-m-d', strtotime('-1 day'))
-//    );
-//
-//    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
-//    $this->assertEquals(2, $numberOfCreatedRecords);
-//
-//    $expirationRecord2 = $this->getExpirationRecordForBalanceChange($balanceChange2->id);
-//    // Balance change 2 expires first, so we also handle it first
-//    // 3 days of leave request are deducted from it, so 2 days should expire
-//    $this->assertEquals(-2, $expirationRecord2->amount);
-//
-//    $expirationRecord1 = $this->getExpirationRecordForBalanceChange($balanceChange1->id);
-//    // Now we handle the balance change 1, which expires after balance change 2
-//    // Since we already deducted 3 days, now we just deduct the remaining 4 days
-//    // meaning only 1 day will expire
-//    $this->assertEquals(-1, $expirationRecord1->amount);
-//  }
-//
-//  public function testCreateExpirationRecordsCalculatesTheExpiredAmountBasedOnlyOnTheApprovedLeaveRequestBalancePriorToTheExpiryDate() {
-//    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
-//    $balanceChange = $this->createBroughtForwardBalanceChange(
-//      1,
-//      5,
-//      date('YmdHis', strtotime('-1 day'))
-//    );
-//
-//    // This leave request has 7 days, but only two of them
-//    // were taken before the brought forward expiry date
-//    $this->createLeaveRequestBalanceChange(
-//      1,
-//      $leaveRequestStatuses['Approved'],
-//      date('Y-m-d', strtotime('-2 days')),
-//      date('Y-m-d', strtotime('+5 days'))
-//    );
-//
-//    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
-//    $this->assertEquals(1, $numberOfCreatedRecords);
-//
-//    $expirationRecord = $this->getExpirationRecordForBalanceChange($balanceChange->id);
-//    $this->assertNotNull($expirationRecord);
-//    // Since only two days were taken before the brought forward
-//    // expiry date, the other 3 days will expire
-//    $this->assertEquals(-3, $expirationRecord->amount);
-//  }
-//
-//  public function testCreateExpirationRecordsDoesNotCreateRecordsForBalanceChangesThatNeverExpire() {
-//    // A Brought Forward without an expiry date will never expire
-//    $this->createBroughtForwardBalanceChange(1, 5);
-//
-//    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
-//    $this->assertEquals(0, $numberOfCreatedRecords);
-//  }
-//
-//  public function testCreateExpirationRecordsDoesNotCreateRecordsForNonExpiredBalanceChanges() {
-//    $this->createBroughtForwardBalanceChange(1, 5, date('YmdHis', strtotime('+1 day')));
-//
-//    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
-//    $this->assertEquals(0, $numberOfCreatedRecords);
-//  }
-//
-//  public function testCreateExpirationRecordsDoesCreatesRecordsForExpiredBalanceChanges() {
-//    $this->createExpiredBroughtForwardBalanceChange(1, 5, 10);
-//
-//    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
-//    $this->assertEquals(0, $numberOfCreatedRecords);
-//  }
+  public function testCreateExpirationRecordsCreatesRecordsForExpiredBalanceChanges() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-10 days'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days')
+    ]);
+
+    $periodEntitlement1 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => 1,
+      'period_id' => $absencePeriod->id,
+      'type_id' => 1,
+    ]);
+
+    $periodEntitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => 1,
+      'period_id' => $absencePeriod->id,
+      'type_id' => 2
+    ]);
+
+    $this->createBroughtForwardBalanceChange(
+      $periodEntitlement1->id,
+      5,
+      CRM_Utils_Date::processDate('-1 day')
+    );
+
+    $this->createBroughtForwardBalanceChange(
+      $periodEntitlement2->id,
+      7,
+      CRM_Utils_Date::processDate('-8 days')
+    );
+
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $this->assertEquals(2, $numberOfCreatedRecords);
+
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $this->assertEquals(0, $numberOfCreatedRecords);
+  }
+
+  public function testCreateExpirationRecordsCreatesRecordsEntitlementsWithMultipleExpiredBalanceChanges() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-10 days'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days')
+    ]);
+
+    $periodEntitlement1 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => 1,
+      'period_id' => $absencePeriod->id,
+      'type_id' => 1,
+    ]);
+
+    $periodEntitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => 1,
+      'period_id' => $absencePeriod->id,
+      'type_id' => 2
+    ]);
+
+    // The entitlement with ID 1 has 2 balance changes to expire
+    $this->createBroughtForwardBalanceChange(
+      $periodEntitlement1->id,
+      5,
+      CRM_Utils_Date::processDate('-1 day')
+    );
+
+    $this->createBroughtForwardBalanceChange(
+      $periodEntitlement2->id,
+      7,
+      CRM_Utils_Date::processDate('-8 days')
+    );
+
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $this->assertEquals(2, $numberOfCreatedRecords);
+
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $this->assertEquals(0, $numberOfCreatedRecords);
+  }
+
+  public function testCreateExpirationRecordsCalculatesTheExpiredAmountBasedOnTheApprovedLeaveRequestBalance() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-30 days'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days')
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => 1,
+      'period_id' => $absencePeriod->id,
+      'type_id' => 1,
+    ]);
+
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
+
+    $balanceChange = $this->createBroughtForwardBalanceChange(
+      $periodEntitlement->id,
+      5,
+      CRM_Utils_Date::processDate('-1 day')
+    );
+
+    //This 1 day approved leave request will be counted
+    $this->createLeaveRequestBalanceChange(
+      $periodEntitlement->type_id,
+      $periodEntitlement->contact_id,
+      $leaveRequestStatuses['Approved'],
+      CRM_Utils_Date::processDate('-10 days')
+    );
+
+    // This 2 days cancelled leave request won't counted
+    $this->createLeaveRequestBalanceChange(
+      $periodEntitlement->type_id,
+      $periodEntitlement->contact_id,
+      $leaveRequestStatuses['Cancelled'],
+      CRM_Utils_Date::processDate('-20 days'),
+      CRM_Utils_Date::processDate('-21 days')
+    );
+
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $this->assertEquals(1, $numberOfCreatedRecords);
+
+    $expirationRecord = $this->getExpirationRecordForBalanceChange($balanceChange->id);
+    $this->assertNotNull($expirationRecord);
+    // Since only the 1 day leave request was counted, 4 days expired
+    // 5 - 1 = 4 (we store expired days as a negative number)
+    $this->assertEquals(-4, $expirationRecord->amount);
+  }
+
+  public function testCreateExpirationRecordsCalculatesPrioritizesAccordingToTheBalanceChangeExpiryDate() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-30 days'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days')
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => 1,
+      'period_id' => $absencePeriod->id,
+      'type_id' => 1,
+    ]);
+
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
+
+    $balanceChange1 = $this->createBroughtForwardBalanceChange(
+      $periodEntitlement->id,
+      5,
+      CRM_Utils_Date::processDate('-1 day')
+    );
+
+    $balanceChange2 = $this->createBroughtForwardBalanceChange(
+      $periodEntitlement->id,
+      5,
+      CRM_Utils_Date::processDate('-5 days')
+    );
+
+    // A 7 days approved leave request
+    $this->createLeaveRequestBalanceChange(
+      $periodEntitlement->type_id,
+      $periodEntitlement->contact_id,
+      $leaveRequestStatuses['Approved'],
+      CRM_Utils_Date::processDate('-7 days'),
+      CRM_Utils_Date::processDate('-1 day')
+    );
+
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $this->assertEquals(2, $numberOfCreatedRecords);
+
+    $expirationRecord2 = $this->getExpirationRecordForBalanceChange($balanceChange2->id);
+    // Balance change 2 expires first, so we also handle it first
+    // 3 days of leave request are deducted from it, so 2 days should expire
+    $this->assertEquals(-2, $expirationRecord2->amount);
+
+    $expirationRecord1 = $this->getExpirationRecordForBalanceChange($balanceChange1->id);
+    // Now we handle the balance change 1, which expires after balance change 2
+    // Since we already deducted 3 days, now we just deduct the remaining 4 days
+    // meaning only 1 day will expire
+    $this->assertEquals(-1, $expirationRecord1->amount);
+  }
+
+  public function testCreateExpirationRecordsCalculatesTheExpiredAmountBasedOnlyOnTheApprovedLeaveRequestBalancePriorToTheExpiryDate() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-30 days'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days')
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => 1,
+      'period_id' => $absencePeriod->id,
+      'type_id' => 1,
+    ]);
+
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
+
+    $balanceChange = $this->createBroughtForwardBalanceChange(
+      $periodEntitlement->id,
+      5,
+      date('YmdHis', strtotime('-1 day'))
+    );
+
+    // This leave request has 7 days, but only two of them
+    // were taken before the brought forward expiry date
+    $this->createLeaveRequestBalanceChange(
+      $periodEntitlement->type_id,
+      $periodEntitlement->contact_id,
+      $leaveRequestStatuses['Approved'],
+      CRM_Utils_Date::processDate('-2 days'),
+      CRM_Utils_Date::processDate('+5 days')
+    );
+
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $this->assertEquals(1, $numberOfCreatedRecords);
+
+    $expirationRecord = $this->getExpirationRecordForBalanceChange($balanceChange->id);
+    $this->assertNotNull($expirationRecord);
+    // Since only two days were taken before the brought forward
+    // expiry date, the other 3 days will expire
+    $this->assertEquals(-3, $expirationRecord->amount);
+  }
+
+  public function testCreateExpirationRecordsDoesNotCreateRecordsForBalanceChangesThatNeverExpire() {
+    // A Brought Forward without an expiry date will never expire
+    $this->createBroughtForwardBalanceChange(1, 5);
+
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $this->assertEquals(0, $numberOfCreatedRecords);
+  }
+
+  public function testCreateExpirationRecordsDoesNotCreateRecordsForNonExpiredBalanceChanges() {
+    $this->createBroughtForwardBalanceChange(1, 5, date('YmdHis', strtotime('+1 day')));
+
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $this->assertEquals(0, $numberOfCreatedRecords);
+  }
+
+  public function testCreateExpirationRecordsDoesCreatesRecordsForExpiredBalanceChanges() {
+    $this->createExpiredBroughtForwardBalanceChange(1, 5, 10);
+
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $this->assertEquals(0, $numberOfCreatedRecords);
+  }
 
   private function createLeavePeriodEntitlement() {
     return LeavePeriodEntitlement::create([

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -1198,7 +1198,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $this->assertEquals(-4, $expirationRecord->amount);
   }
 
-  public function testCreateExpirationRecordsCalculatesPrioritizesAccordingToTheBalanceChangeExpiryDate() {
+  public function testCreateExpirationRecordsPrioritizesAccordingToTheBalanceChangeExpiryDate() {
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-30 days'),
       'end_date' => CRM_Utils_Date::processDate('+10 days')
@@ -1373,6 +1373,339 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
     $balanceChange->getLeavePeriodEntitlement();
   }
+
+  public function testCreateExpirationRecordsCanExpireTOILRequests() {
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
+
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-30 days'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days')
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => 1,
+      'period_id' => $absencePeriod->id,
+      'type_id' => 1,
+    ]);
+
+    TOILRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $periodEntitlement->contact_id,
+      'type_id' => $periodEntitlement->type_id,
+      'status_id' => $leaveRequestStatuses['Approved'],
+      'from_date' => CRM_Utils_Date::processDate('-20 days'),
+      'to_date' => CRM_Utils_Date::processDate('-20 days'),
+      'toil_to_accrue' => 1,
+      'duration' => 200,
+      'expiry_date' => CRM_Utils_Date::processDate('-10 days'),
+    ]);
+
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $this->assertEquals(1, $numberOfCreatedRecords);
+  }
+
+  public function testCreateExpirationRecordsCanExpireTOILRequestOverlappingBroughtForward() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31')
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => 1,
+      'period_id' => $absencePeriod->id,
+      'type_id' => 1,
+    ]);
+
+    $broughtForwardBalanceChange = LeaveBalanceChangeFabricator::fabricate([
+      'source_id' => $periodEntitlement->id,
+      'source_type' => CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange::SOURCE_ENTITLEMENT,
+      'amount' => 5,
+      'expiry_date' => CRM_Utils_Date::processDate('2016-02-27'),
+      'type_id' => $this->getBalanceChangeTypeValue('Brought Forward')
+    ]);
+
+    $toilRequest1 = TOILRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $periodEntitlement->contact_id,
+      'type_id' => $periodEntitlement->type_id,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-17'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-17'),
+      'expiry_date' => CRM_Utils_Date::processDate('2016-02-17'),
+      'toil_to_accrue' => 1,
+      'duration' => 100
+    ]);
+
+    $toilRequest2 = TOILRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $periodEntitlement->contact_id,
+      'type_id' => $periodEntitlement->type_id,
+      'from_date' => CRM_Utils_Date::processDate('2016-02-25'),
+      'to_date' => CRM_Utils_Date::processDate('2016-02-25'),
+      'expiry_date' => CRM_Utils_Date::processDate('2016-03-01'),
+      'toil_to_accrue' => 2,
+      'duration' => 100
+    ]);
+
+    // This leave request overlaps only the brought forward period
+    // so it will deduct 1 day from it
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $periodEntitlement->contact_id,
+      'type_id' => $periodEntitlement->type_id,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-05'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-05'),
+    ], true);
+
+    // This leave request overlaps both the first toil request
+    // period and the brought forward, but since the toil will
+    // expire first, the 1 day will be deducted from it
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $periodEntitlement->contact_id,
+      'type_id' => $periodEntitlement->type_id,
+      'from_date' => CRM_Utils_Date::processDate('2016-02-01'),
+      'to_date' => CRM_Utils_Date::processDate('2016-02-01'),
+    ], true);
+
+    // This is a 3 days leave request. The first 2 days
+    // overlap both the brought forward and the second toil request.
+    // The last day, overlaps only the toil request.
+    // Since the brought forward expires first than the toil request,
+    // the 2 days overlapping both should be deducted from it.
+    // The remaining 1 day should be deducted from the toil request.
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $periodEntitlement->contact_id,
+      'type_id' => $periodEntitlement->type_id,
+      'from_date' => CRM_Utils_Date::processDate('2016-02-26'),
+      'to_date' => CRM_Utils_Date::processDate('2016-02-28'),
+    ], true);
+
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $this->assertEquals(3, $numberOfCreatedRecords);
+
+    $expiredBroughtForward = $this->getExpirationRecordForBalanceChange($broughtForwardBalanceChange->id);
+    // Original 5 days. 3 days used (1 from the first leave request and 2 from the last one). 2 expired
+    $this->assertEquals(-2, $expiredBroughtForward->amount);
+
+    $expiredToilRequest1 = $this->getExpirationRecordForToilRequest($toilRequest1->id);
+    // Original 1 day. 1 day used from the second leave request. None expired.
+    $this->assertEquals(0, $expiredToilRequest1->amount);
+
+    // Original 2 days. 1 day used from the third leave request. 1 day expired
+    $expiredToilRequest2 = $this->getExpirationRecordForToilRequest($toilRequest2->id);
+    $this->assertEquals(-1, $expiredToilRequest2->amount);
+  }
+
+  public function testCreateExpirationRecordsCanCalculateTheExpiryAmounWhenTheNumberOfDaysTakenBeforeTheExpiryDateIsBiggerThanTheBalanceChangeAmount() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31')
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => 1,
+      'period_id' => $absencePeriod->id,
+      'type_id' => 1,
+    ]);
+
+    $broughtForwardBalanceChange = LeaveBalanceChangeFabricator::fabricate([
+      'source_id' => $periodEntitlement->id,
+      'source_type' => CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange::SOURCE_ENTITLEMENT,
+      'amount' => 5,
+      'expiry_date' => CRM_Utils_Date::processDate('2016-02-27'),
+      'type_id' => $this->getBalanceChangeTypeValue('Brought Forward')
+    ]);
+
+    $toilRequest1 = TOILRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $periodEntitlement->contact_id,
+      'type_id' => $periodEntitlement->type_id,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-17'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-17'),
+      'expiry_date' => CRM_Utils_Date::processDate('2016-02-26'),
+      'toil_to_accrue' => 1,
+      'duration' => 100
+    ]);
+
+    // A 7 days Leave Request, overlapping both the TOIL request period and
+    // the brought forward
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $periodEntitlement->contact_id,
+      'type_id' => $periodEntitlement->type_id,
+      'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
+      'to_date' => CRM_Utils_Date::processDate('2016-02-26'),
+    ], true);
+
+    $numberOfRecords = LeaveBalanceChange::createExpirationRecords();
+
+    $expiredBroughtForward = $this->getExpirationRecordForBalanceChange($broughtForwardBalanceChange->id);
+    $expiredTOILBalanceChange = $this->getExpirationRecordForToilRequest($toilRequest1->id);
+
+    $this->assertEquals(2, $numberOfRecords);
+
+    // TOIL Expires first, so we first deduct from it. Its amount is only 1,
+    // and since the leave request is 7 days, the whole 1 day will be user and
+    // nothing will expire.
+    $this->assertEquals(0, $expiredTOILBalanceChange->amount);
+
+    // 1 days of the Leave Request was deducted from TOIL. This leave us with
+    // 6 more days to deducted. The brought forward amount is 5, so this means
+    // that all the 5 days will be used and nothing will expired
+    $this->assertEquals(0, $expiredBroughtForward->amount);
+
+    // 1 day was deducted from TOIL and 5 were deducted from Brought Forward,
+    // so the remaining 1 day will be deducted from the entitlement. Since
+    // there's none, the balance will be -1:
+    $periodBalance = LeaveBalanceChange::getBalanceForEntitlement($periodEntitlement);
+    $this->assertEquals(-1, $periodBalance);
+  }
+
+  public function testCreateExpirationRecordsCanExpireFractionalDays() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31')
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => 1,
+      'period_id' => $absencePeriod->id,
+      'type_id' => 1,
+    ]);
+
+    $broughtForwardBalanceChange = LeaveBalanceChangeFabricator::fabricate([
+      'source_id' => $periodEntitlement->id,
+      'source_type' => CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange::SOURCE_ENTITLEMENT,
+      'amount' => 5,
+      'expiry_date' => CRM_Utils_Date::processDate('2016-02-27'),
+      'type_id' => $this->getBalanceChangeTypeValue('Brought Forward')
+    ]);
+
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $periodEntitlement->contact_id,
+      'type_id' => $periodEntitlement->type_id,
+      'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
+      'to_date' => CRM_Utils_Date::processDate('2016-02-21'),
+    ]);
+
+    // Because the fabricator creates all the balance changes with -1 as the
+    // amount, we need to create them manually in order to be able to have
+    // fractional values
+    $dates = $leaveRequest->getDates();
+    LeaveBalanceChangeFabricator::fabricate([
+      'amount' => -0.3,
+      'source_id' => $dates[0]->id,
+      'source_type' => LeaveBalanceChange::SOURCE_LEAVE_REQUEST_DAY,
+    ]);
+
+    LeaveBalanceChangeFabricator::fabricate([
+      'amount' => -0.4,
+      'source_id' => $dates[1]->id,
+      'source_type' => LeaveBalanceChange::SOURCE_LEAVE_REQUEST_DAY,
+    ]);
+
+    $numberOfRecords = LeaveBalanceChange::createExpirationRecords();
+    $this->assertEquals(1, $numberOfRecords);
+
+    $expiredBroughtForward = $this->getExpirationRecordForBalanceChange($broughtForwardBalanceChange->id);
+    $this->assertEquals(-4.3, $expiredBroughtForward->amount);
+  }
+
+  public function testCreateExpirationRecordsOnlyDeductsFromOneBalanceChangeWhenBothTOILAndBroughtForwardExpireOnTheSameDay() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31')
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => 1,
+      'period_id' => $absencePeriod->id,
+      'type_id' => 1,
+    ]);
+
+    $broughtForwardBalanceChange = LeaveBalanceChangeFabricator::fabricate([
+      'source_id' => $periodEntitlement->id,
+      'source_type' => CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange::SOURCE_ENTITLEMENT,
+      'amount' => 5,
+      'expiry_date' => CRM_Utils_Date::processDate('2016-02-27'),
+      'type_id' => $this->getBalanceChangeTypeValue('Brought Forward')
+    ]);
+
+    $toilRequest1 = TOILRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $periodEntitlement->contact_id,
+      'type_id' => $periodEntitlement->type_id,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-17'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-17'),
+      'expiry_date' => CRM_Utils_Date::processDate('2016-02-27'),
+      'toil_to_accrue' => 1,
+      'duration' => 100
+    ]);
+
+    // This Leave Request overlaps both toil and brought forward, but will be
+    // deduct only from one of them
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $periodEntitlement->contact_id,
+      'type_id' => $periodEntitlement->type_id,
+      'from_date' => CRM_Utils_Date::processDate('2016-02-26'),
+      'to_date' => CRM_Utils_Date::processDate('2016-02-26'),
+    ], true);
+
+    $numberOfRecords = LeaveBalanceChange::createExpirationRecords();
+
+    $expiredBroughtForward = $this->getExpirationRecordForBalanceChange($broughtForwardBalanceChange->id);
+    $expiredTOILBalanceChange = $this->getExpirationRecordForToilRequest($toilRequest1->id);
+
+    $this->assertEquals(2, $numberOfRecords);
+
+    // Since, internally, createExpirationRecords uses the balance_change.id as
+    // a tiebreaker for when both expiry dates are the same, we can know for sure
+    // that the date will always be deducted from the Brought Forward instead of
+    // TOIL
+    $this->assertEquals(-4, $expiredBroughtForward->amount);
+    $this->assertEquals(-1, $expiredTOILBalanceChange->amount);
+  }
+
+  public function testCreateExpirationRecordsConsidersOnlyTheApprovedLeaveRequestsBetweenTheTOILRequestDateAndTOILExpiryDateToExpireTOILRequests() {
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
+
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-30 days'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days')
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => 1,
+      'period_id' => $absencePeriod->id,
+      'type_id' => 1,
+    ]);
+
+    $toilRequest = TOILRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $periodEntitlement->contact_id,
+      'type_id' => $periodEntitlement->type_id,
+      'status_id' => $leaveRequestStatuses['Approved'],
+      'from_date' => CRM_Utils_Date::processDate('-20 days'),
+      'to_date' => CRM_Utils_Date::processDate('-20 days'),
+      'toil_to_accrue' => 2,
+      'duration' => 200,
+      'expiry_date' => CRM_Utils_Date::processDate('-10 days'),
+    ]);
+
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $periodEntitlement->contact_id,
+      'type_id' => $periodEntitlement->type_id,
+      'status_id' => $leaveRequestStatuses['Cancelled'],
+      'from_date' => CRM_Utils_Date::processDate('-15 days'),
+      'to_date' => CRM_Utils_Date::processDate('-15 days'),
+    ], true);
+
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $periodEntitlement->contact_id,
+      'type_id' => $periodEntitlement->type_id,
+      'status_id' => $leaveRequestStatuses['Approved'],
+      'from_date' => CRM_Utils_Date::processDate('-13 days'),
+      'to_date' => CRM_Utils_Date::processDate('-13 days'),
+    ], true);
+
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $this->assertEquals(1, $numberOfCreatedRecords);
+
+    $expiredBalanceChange = $this->getExpirationRecordForToilRequest($toilRequest->id);
+    $this->assertEquals(-1, $expiredBalanceChange->amount);
+  }
+
   public function testCreateExpirationRecordsDoesNotCreateRecordsForBalanceChangesThatNeverExpire() {
     // A Brought Forward without an expiry date will never expire
     $this->createBroughtForwardBalanceChange(1, 5);
@@ -1388,7 +1721,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $this->assertEquals(0, $numberOfCreatedRecords);
   }
 
-  public function testCreateExpirationRecordsDoesCreatesRecordsForExpiredBalanceChanges() {
+  public function testCreateExpirationRecordsDoesCreatesRecordsForAlreadyExpiredBalanceChanges() {
     $this->createExpiredBroughtForwardBalanceChange(1, 5, 10);
 
     $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
@@ -1406,6 +1739,20 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   private function getExpirationRecordForBalanceChange($balanceChangeID) {
     $record = new LeaveBalanceChange();
     $record->expired_balance_change_id = $balanceChangeID;
+    $record->find();
+    if($record->N == 1) {
+      $record->fetch();
+      return $record;
+    }
+
+    return null;
+  }
+
+  private function getExpirationRecordForToilRequest($toilRequestID) {
+    $record = new LeaveBalanceChange();
+    $record->source_id = $toilRequestID;
+    $record->source_type = LeaveBalanceChange::SOURCE_TOIL_REQUEST;
+    $record->whereAdd('expired_balance_change_id IS NOT NULL');
     $record->find();
     if($record->N == 1) {
       $record->fetch();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -1076,7 +1076,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $this->assertCount(0, $balanceChanges);
   }
 
-  public function testCreateExpirationRecordsCreatesRecordsForExpiredBalanceChanges() {
+  public function testCreateExpiryRecordsCreatesRecordsForExpiredBalanceChanges() {
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-10 days'),
       'end_date' => CRM_Utils_Date::processDate('+10 days')
@@ -1106,14 +1106,14 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       CRM_Utils_Date::processDate('-8 days')
     );
 
-    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpiryRecords();
     $this->assertEquals(2, $numberOfCreatedRecords);
 
-    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpiryRecords();
     $this->assertEquals(0, $numberOfCreatedRecords);
   }
 
-  public function testCreateExpirationRecordsCreatesRecordsEntitlementsWithMultipleExpiredBalanceChanges() {
+  public function testCreateExpiryRecordsCreatesRecordsEntitlementsWithMultipleExpiredBalanceChanges() {
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-10 days'),
       'end_date' => CRM_Utils_Date::processDate('+10 days')
@@ -1144,14 +1144,14 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       CRM_Utils_Date::processDate('-8 days')
     );
 
-    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpiryRecords();
     $this->assertEquals(2, $numberOfCreatedRecords);
 
-    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpiryRecords();
     $this->assertEquals(0, $numberOfCreatedRecords);
   }
 
-  public function testCreateExpirationRecordsCalculatesTheExpiredAmountBasedOnTheApprovedLeaveRequestBalance() {
+  public function testCreateExpiryRecordsCalculatesTheExpiredAmountBasedOnTheApprovedLeaveRequestBalance() {
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-30 days'),
       'end_date' => CRM_Utils_Date::processDate('+10 days')
@@ -1188,17 +1188,17 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       CRM_Utils_Date::processDate('-21 days')
     );
 
-    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpiryRecords();
     $this->assertEquals(1, $numberOfCreatedRecords);
 
-    $expirationRecord = $this->getExpirationRecordForBalanceChange($balanceChange->id);
-    $this->assertNotNull($expirationRecord);
+    $expiryRecord = $this->getExpiryRecordForBalanceChange($balanceChange->id);
+    $this->assertNotNull($expiryRecord);
     // Since only the 1 day leave request was counted, 4 days expired
     // 5 - 1 = 4 (we store expired days as a negative number)
-    $this->assertEquals(-4, $expirationRecord->amount);
+    $this->assertEquals(-4, $expiryRecord->amount);
   }
 
-  public function testCreateExpirationRecordsPrioritizesAccordingToTheBalanceChangeExpiryDate() {
+  public function testCreateExpiryRecordsPrioritizesAccordingToTheBalanceChangeExpiryDate() {
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-30 days'),
       'end_date' => CRM_Utils_Date::processDate('+10 days')
@@ -1233,22 +1233,22 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       CRM_Utils_Date::processDate('-1 day')
     );
 
-    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpiryRecords();
     $this->assertEquals(2, $numberOfCreatedRecords);
 
-    $expirationRecord2 = $this->getExpirationRecordForBalanceChange($balanceChange2->id);
+    $expiryRecord2 = $this->getExpiryRecordForBalanceChange($balanceChange2->id);
     // Balance change 2 expires first, so we also handle it first
     // 3 days of leave request are deducted from it, so 2 days should expire
-    $this->assertEquals(-2, $expirationRecord2->amount);
+    $this->assertEquals(-2, $expiryRecord2->amount);
 
-    $expirationRecord1 = $this->getExpirationRecordForBalanceChange($balanceChange1->id);
+    $expiryRecord1 = $this->getExpiryRecordForBalanceChange($balanceChange1->id);
     // Now we handle the balance change 1, which expires after balance change 2
     // Since we already deducted 3 days, now we just deduct the remaining 4 days
     // meaning only 1 day will expire
-    $this->assertEquals(-1, $expirationRecord1->amount);
+    $this->assertEquals(-1, $expiryRecord1->amount);
   }
 
-  public function testCreateExpirationRecordsCalculatesTheExpiredAmountBasedOnlyOnTheApprovedLeaveRequestBalancePriorToTheExpiryDate() {
+  public function testCreateExpiryRecordsCalculatesTheExpiredAmountBasedOnlyOnTheApprovedLeaveRequestBalancePriorToTheExpiryDate() {
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-30 days'),
       'end_date' => CRM_Utils_Date::processDate('+10 days')
@@ -1278,14 +1278,14 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       CRM_Utils_Date::processDate('+5 days')
     );
 
-    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpiryRecords();
     $this->assertEquals(1, $numberOfCreatedRecords);
 
-    $expirationRecord = $this->getExpirationRecordForBalanceChange($balanceChange->id);
-    $this->assertNotNull($expirationRecord);
+    $expiryRecord = $this->getExpiryRecordForBalanceChange($balanceChange->id);
+    $this->assertNotNull($expiryRecord);
     // Since only two days were taken before the brought forward
     // expiry date, the other 3 days will expire
-    $this->assertEquals(-3, $expirationRecord->amount);
+    $this->assertEquals(-3, $expiryRecord->amount);
   }
 
   public function testGetLeavePeriodEntitlementCanReturnThePeriodEntitlementWhenTheSourceTypeIsEntitlement() {
@@ -1374,7 +1374,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $balanceChange->getLeavePeriodEntitlement();
   }
 
-  public function testCreateExpirationRecordsCanExpireTOILRequests() {
+  public function testCreateExpiryRecordsCanExpireTOILRequests() {
     $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
 
     $absencePeriod = AbsencePeriodFabricator::fabricate([
@@ -1399,11 +1399,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'expiry_date' => CRM_Utils_Date::processDate('-10 days'),
     ]);
 
-    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpiryRecords();
     $this->assertEquals(1, $numberOfCreatedRecords);
   }
 
-  public function testCreateExpirationRecordsCanExpireTOILRequestOverlappingBroughtForward() {
+  public function testCreateExpiryRecordsCanExpireTOILRequestOverlappingBroughtForward() {
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'end_date' => CRM_Utils_Date::processDate('2016-12-31')
@@ -1475,23 +1475,23 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'to_date' => CRM_Utils_Date::processDate('2016-02-28'),
     ], true);
 
-    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpiryRecords();
     $this->assertEquals(3, $numberOfCreatedRecords);
 
-    $expiredBroughtForward = $this->getExpirationRecordForBalanceChange($broughtForwardBalanceChange->id);
+    $expiredBroughtForward = $this->getExpiryRecordForBalanceChange($broughtForwardBalanceChange->id);
     // Original 5 days. 3 days used (1 from the first leave request and 2 from the last one). 2 expired
     $this->assertEquals(-2, $expiredBroughtForward->amount);
 
-    $expiredToilRequest1 = $this->getExpirationRecordForToilRequest($toilRequest1->id);
+    $expiredToilRequest1 = $this->getExpiryRecordForToilRequest($toilRequest1->id);
     // Original 1 day. 1 day used from the second leave request. None expired.
     $this->assertEquals(0, $expiredToilRequest1->amount);
 
     // Original 2 days. 1 day used from the third leave request. 1 day expired
-    $expiredToilRequest2 = $this->getExpirationRecordForToilRequest($toilRequest2->id);
+    $expiredToilRequest2 = $this->getExpiryRecordForToilRequest($toilRequest2->id);
     $this->assertEquals(-1, $expiredToilRequest2->amount);
   }
 
-  public function testCreateExpirationRecordsCanCalculateTheExpiryAmounWhenTheNumberOfDaysTakenBeforeTheExpiryDateIsBiggerThanTheBalanceChangeAmount() {
+  public function testCreateExpiryRecordsCanCalculateTheExpiryAmounWhenTheNumberOfDaysTakenBeforeTheExpiryDateIsBiggerThanTheBalanceChangeAmount() {
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'end_date' => CRM_Utils_Date::processDate('2016-12-31')
@@ -1530,10 +1530,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'to_date' => CRM_Utils_Date::processDate('2016-02-26'),
     ], true);
 
-    $numberOfRecords = LeaveBalanceChange::createExpirationRecords();
+    $numberOfRecords = LeaveBalanceChange::createExpiryRecords();
 
-    $expiredBroughtForward = $this->getExpirationRecordForBalanceChange($broughtForwardBalanceChange->id);
-    $expiredTOILBalanceChange = $this->getExpirationRecordForToilRequest($toilRequest1->id);
+    $expiredBroughtForward = $this->getExpiryRecordForBalanceChange($broughtForwardBalanceChange->id);
+    $expiredTOILBalanceChange = $this->getExpiryRecordForToilRequest($toilRequest1->id);
 
     $this->assertEquals(2, $numberOfRecords);
 
@@ -1554,7 +1554,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $this->assertEquals(-1, $periodBalance);
   }
 
-  public function testCreateExpirationRecordsCanExpireFractionalDays() {
+  public function testCreateExpiryRecordsCanExpireFractionalDays() {
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'end_date' => CRM_Utils_Date::processDate('2016-12-31')
@@ -1597,14 +1597,14 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'source_type' => LeaveBalanceChange::SOURCE_LEAVE_REQUEST_DAY,
     ]);
 
-    $numberOfRecords = LeaveBalanceChange::createExpirationRecords();
+    $numberOfRecords = LeaveBalanceChange::createExpiryRecords();
     $this->assertEquals(1, $numberOfRecords);
 
-    $expiredBroughtForward = $this->getExpirationRecordForBalanceChange($broughtForwardBalanceChange->id);
+    $expiredBroughtForward = $this->getExpiryRecordForBalanceChange($broughtForwardBalanceChange->id);
     $this->assertEquals(-4.3, $expiredBroughtForward->amount);
   }
 
-  public function testCreateExpirationRecordsOnlyDeductsFromOneBalanceChangeWhenBothTOILAndBroughtForwardExpireOnTheSameDay() {
+  public function testCreateExpiryRecordsOnlyDeductsFromOneBalanceChangeWhenBothTOILAndBroughtForwardExpireOnTheSameDay() {
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'end_date' => CRM_Utils_Date::processDate('2016-12-31')
@@ -1643,10 +1643,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'to_date' => CRM_Utils_Date::processDate('2016-02-26'),
     ], true);
 
-    $numberOfRecords = LeaveBalanceChange::createExpirationRecords();
+    $numberOfRecords = LeaveBalanceChange::createExpiryRecords();
 
-    $expiredBroughtForward = $this->getExpirationRecordForBalanceChange($broughtForwardBalanceChange->id);
-    $expiredTOILBalanceChange = $this->getExpirationRecordForToilRequest($toilRequest1->id);
+    $expiredBroughtForward = $this->getExpiryRecordForBalanceChange($broughtForwardBalanceChange->id);
+    $expiredTOILBalanceChange = $this->getExpiryRecordForToilRequest($toilRequest1->id);
 
     $this->assertEquals(2, $numberOfRecords);
 
@@ -1658,7 +1658,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $this->assertEquals(-1, $expiredTOILBalanceChange->amount);
   }
 
-  public function testCreateExpirationRecordsConsidersOnlyTheApprovedLeaveRequestsBetweenTheTOILRequestDateAndTOILExpiryDateToExpireTOILRequests() {
+  public function testCreateExpiryRecordsConsidersOnlyTheApprovedLeaveRequestsBetweenTheTOILRequestDateAndTOILExpiryDateToExpireTOILRequests() {
     $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
 
     $absencePeriod = AbsencePeriodFabricator::fabricate([
@@ -1699,32 +1699,32 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'to_date' => CRM_Utils_Date::processDate('-13 days'),
     ], true);
 
-    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpiryRecords();
     $this->assertEquals(1, $numberOfCreatedRecords);
 
-    $expiredBalanceChange = $this->getExpirationRecordForToilRequest($toilRequest->id);
+    $expiredBalanceChange = $this->getExpiryRecordForToilRequest($toilRequest->id);
     $this->assertEquals(-1, $expiredBalanceChange->amount);
   }
 
-  public function testCreateExpirationRecordsDoesNotCreateRecordsForBalanceChangesThatNeverExpire() {
+  public function testCreateExpiryRecordsDoesNotCreateRecordsForBalanceChangesThatNeverExpire() {
     // A Brought Forward without an expiry date will never expire
     $this->createBroughtForwardBalanceChange(1, 5);
 
-    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpiryRecords();
     $this->assertEquals(0, $numberOfCreatedRecords);
   }
 
-  public function testCreateExpirationRecordsDoesNotCreateRecordsForNonExpiredBalanceChanges() {
+  public function testCreateExpiryRecordsDoesNotCreateRecordsForNonExpiredBalanceChanges() {
     $this->createBroughtForwardBalanceChange(1, 5, date('YmdHis', strtotime('+1 day')));
 
-    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpiryRecords();
     $this->assertEquals(0, $numberOfCreatedRecords);
   }
 
-  public function testCreateExpirationRecordsDoesCreatesRecordsForAlreadyExpiredBalanceChanges() {
+  public function testCreateExpiryRecordsDoesCreatesRecordsForAlreadyExpiredBalanceChanges() {
     $this->createExpiredBroughtForwardBalanceChange(1, 5, 10);
 
-    $numberOfCreatedRecords = LeaveBalanceChange::createExpirationRecords();
+    $numberOfCreatedRecords = LeaveBalanceChange::createExpiryRecords();
     $this->assertEquals(0, $numberOfCreatedRecords);
   }
 
@@ -1736,7 +1736,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     ]);
   }
 
-  private function getExpirationRecordForBalanceChange($balanceChangeID) {
+  private function getExpiryRecordForBalanceChange($balanceChangeID) {
     $record = new LeaveBalanceChange();
     $record->expired_balance_change_id = $balanceChangeID;
     $record->find();
@@ -1748,7 +1748,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     return null;
   }
 
-  private function getExpirationRecordForToilRequest($toilRequestID) {
+  private function getExpiryRecordForToilRequest($toilRequestID) {
     $record = new LeaveBalanceChange();
     $record->source_id = $toilRequestID;
     $record->source_type = LeaveBalanceChange::SOURCE_TOIL_REQUEST;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -1417,7 +1417,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
     $broughtForwardBalanceChange = LeaveBalanceChangeFabricator::fabricate([
       'source_id' => $periodEntitlement->id,
-      'source_type' => CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange::SOURCE_ENTITLEMENT,
+      'source_type' => LeaveBalanceChange::SOURCE_ENTITLEMENT,
       'amount' => 5,
       'expiry_date' => CRM_Utils_Date::processDate('2016-02-27'),
       'type_id' => $this->getBalanceChangeTypeValue('Brought Forward')
@@ -1505,7 +1505,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
     $broughtForwardBalanceChange = LeaveBalanceChangeFabricator::fabricate([
       'source_id' => $periodEntitlement->id,
-      'source_type' => CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange::SOURCE_ENTITLEMENT,
+      'source_type' => LeaveBalanceChange::SOURCE_ENTITLEMENT,
       'amount' => 5,
       'expiry_date' => CRM_Utils_Date::processDate('2016-02-27'),
       'type_id' => $this->getBalanceChangeTypeValue('Brought Forward')
@@ -1568,7 +1568,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
     $broughtForwardBalanceChange = LeaveBalanceChangeFabricator::fabricate([
       'source_id' => $periodEntitlement->id,
-      'source_type' => CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange::SOURCE_ENTITLEMENT,
+      'source_type' => LeaveBalanceChange::SOURCE_ENTITLEMENT,
       'amount' => 5,
       'expiry_date' => CRM_Utils_Date::processDate('2016-02-27'),
       'type_id' => $this->getBalanceChangeTypeValue('Brought Forward')
@@ -1618,7 +1618,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
     $broughtForwardBalanceChange = LeaveBalanceChangeFabricator::fabricate([
       'source_id' => $periodEntitlement->id,
-      'source_type' => CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange::SOURCE_ENTITLEMENT,
+      'source_type' => LeaveBalanceChange::SOURCE_ENTITLEMENT,
       'amount' => 5,
       'expiry_date' => CRM_Utils_Date::processDate('2016-02-27'),
       'type_id' => $this->getBalanceChangeTypeValue('Brought Forward')

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveBalanceChangeTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod as AbsencePeriodFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_LeavePeriodEntitlement as LeavePeriodEntitlementFabricator;
+
 /**
  * Class api_v3_LeaveBalanceChangeTest
  *
@@ -20,17 +23,44 @@ class api_v3_LeaveBalanceChangeTest extends BaseHeadlessTest {
     CRM_Core_DAO::executeQuery("SET foreign_key_checks = 1;");
   }
 
-  public function testCreateExpirationRecords() {
-//    $result = civicrm_api3('LeaveBalanceChange', 'createexpirationrecords');
-//    $this->assertEquals(0, $result);
-//
-//    $this->createBroughtForwardBalanceChange(1, 2, date('YmdHis', strtotime('-1 day')));
-//    $this->createBroughtForwardBalanceChange(2, 5, date('YmdHis'));
-//    $this->createBroughtForwardBalanceChange(3, 3.5, date('YmdHis', strtotime('-2 days')));
-//
-//    // Should create two records: one for the entitlement 1 and another one
-//    // for entitlement 3. The brought forward for entitlement 2 has not expired
-//    $result = civicrm_api3('LeaveBalanceChange', 'createexpirationrecords');
-//    $this->assertEquals(2, $result);
+  /**
+   * A very basic test, just to make sure that the API will call the right
+   * BAO method
+   */
+  public function testCreateExpiryRecords() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-30 days'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days')
+    ]);
+
+    $periodEntitlement1 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => 1,
+      'period_id' => $absencePeriod->id,
+      'type_id' => 1,
+    ]);
+
+    $periodEntitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => 1,
+      'period_id' => $absencePeriod->id,
+      'type_id' => 2,
+    ]);
+
+    $periodEntitlement3 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => 1,
+      'period_id' => $absencePeriod->id,
+      'type_id' => 3,
+    ]);
+
+    $result = civicrm_api3('LeaveBalanceChange', 'create_expiry_records');
+    $this->assertEquals(0, $result);
+
+    $this->createBroughtForwardBalanceChange($periodEntitlement1->id, 2, date('YmdHis', strtotime('-1 day')));
+    $this->createBroughtForwardBalanceChange($periodEntitlement2->id, 5, date('YmdHis'));
+    $this->createBroughtForwardBalanceChange($periodEntitlement3->id, 3.5, date('YmdHis', strtotime('-2 days')));
+
+    // Should create two records: one for the entitlement 1 and another one
+    // for entitlement 3. The brought forward for entitlement 2 has not expired
+    $result = civicrm_api3('LeaveBalanceChange', 'create_expiry_records');
+    $this->assertEquals(2, $result);
   }
 }


### PR DESCRIPTION
The `LeaveBalanceChange.createExpirationRecords()` method was created a long time ago and with all the changes in the data structure, it was not working anymore. The first thing this PR does is to fix all the existing tests for that method and make them all pass. Next, the method itself was updated to also be able to expire TOIL Requests and to be able to handle some complex cases, like when a TOIL Request overlaps a Brought Forward and we have to deduct a LeaveRequest which overlaps both, like on this example:

![expiring_balance_changes](https://cloud.githubusercontent.com/assets/388373/22060572/8127d8c4-dd58-11e6-9285-55d45bf9590f.png)

The logic is as follow:
- First we load all the LeaveBalanceChanges where the expiry_date is in the past but still don't have a expiry record yet (that is an associated LeaveBalanceChange where `expired_balance_changed_id` is `NOT NULL`)
- To each expired balance change, we also fetch a start date (when that balance change is considered to have started being active). For balance changes of type 'entitlement', the start date will be the `start_date` of the AbsencePeriod of the LeavePeriodEntitlement it's associated to. For those of type 'toil_request', the start date will be the `from_date` of the LeaveRequest of the TOILRequest it's associated to.
- Next we load all the LeaveRequestDates and the amount of days deducted for them (only for approved leave requests) between the `start_date` and `expiry_date` of expired balance changes
-  We loop through all the expired balance changes (in ascending order, according to their expiry date) and check if there's any data overlapping it. If there's, and the remaining no. of days for that balance change is >= than the number of days deducted for the date, we deduct it from the expired balance change and remove the date from the list (so it won't be deducted again from other balance change)
- Finally, we create a new balance change with the remaining no. of days (it will be 0 if all the days were used) and save it as a new balance change where the `expired_balance_change_id` will point to the expired balance change.

In the end, the `createExpirationRecords()` was renamed to `createExpiryRecords()` in order to make it consistent with `expiry_date` field and also to make the code a little more British :D 

### What else has changed
The commit 79b9674 has a small change not really related to this task. It's just the addition of a description to some of the LeaveRequest API specifications.