### PR TITLE
PCHR-1677: More Improvements to Leave Request validation 

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -373,7 +373,12 @@ function civicrm_api3_leave_request_isvalid($params) {
     $result[$e->getField()] = [$e->getExceptionCode()];
   }
 
-  return civicrm_api3_create_success($result);
+  $results =  civicrm_api3_create_success($result);
+  if (isset($results['id'])) {
+    unset($results['id']);
+  }
+
+  return $results;
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestCommentTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestCommentTest.php
@@ -14,6 +14,7 @@ use CRM_HRLeaveAndAbsences_Service_LeaveRequestComment as LeaveRequestCommentSer
 class CRM_HRLeaveAndAbsences_Service_LeaveRequestCommentTest extends BaseHeadlessTest {
 
   use CRM_HRLeaveAndAbsences_LeaveManagerHelpersTrait;
+  use CRM_HRLeaveAndAbsences_SessionHelpersTrait;
 
   private $leaveRequestCommentService;
 
@@ -290,10 +291,4 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestCommentTest extends BaseHeadles
 
     $this->leaveRequestCommentService->delete(['comment_id' => 12]);
   }
-
-  private function registerCurrentLoggedInContactInSession($contactID) {
-    $session = CRM_Core_Session::singleton();
-    $session->set('userID', $contactID);
-  }
-
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -1270,12 +1270,13 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $expectedResult = [
       'is_error' => 0,
+      'version' => 3,
       'count' => 1,
       'values' => [
         'from_date' => ['leave_request_empty_from_date']
       ]
     ];
-    $this->assertArraySubset($expectedResult, $result);
+    $this->assertEquals($expectedResult, $result);
   }
 
   public function testLeaveRequestIsValidShouldReturnErrorWhenContactIDIsEmpty() {
@@ -1289,12 +1290,13 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $expectedResult = [
       'is_error' => 0,
+      'version' => 3,
       'count' => 1,
       'values' => [
         'contact_id' => ['leave_request_empty_contact_id']
       ]
     ];
-    $this->assertArraySubset($expectedResult, $result);
+    $this->assertEquals($expectedResult, $result);
   }
 
   public function testLeaveRequestIsValidShouldReturnErrorWhenTypeIDIsEmpty() {
@@ -1308,12 +1310,13 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $expectedResult = [
       'is_error' => 0,
+      'version' => 3,
       'count' => 1,
       'values' => [
         'type_id' => ['leave_request_empty_type_id']
       ]
     ];
-    $this->assertArraySubset($expectedResult, $result);
+    $this->assertEquals($expectedResult, $result);
   }
 
   public function testLeaveRequestIsValidShouldReturnErrorWhenStatusIDIsEmpty() {
@@ -1327,12 +1330,13 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $expectedResult = [
       'is_error' => 0,
+      'version' => 3,
       'count' => 1,
       'values' => [
         'status_id' => ['leave_request_empty_status_id']
       ]
     ];
-    $this->assertArraySubset($expectedResult, $result);
+    $this->assertEquals($expectedResult, $result);
   }
 
   public function testLeaveRequestIsValidShouldReturnErrorWhenToDateIsNotEmptyAndToDateTypeIsEmpty() {
@@ -1349,12 +1353,13 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $expectedResult = [
       'is_error' => 0,
+      'version' => 3,
       'count' => 1,
       'values' => [
         'to_date_type' => ['leave_request_empty_to_date_type']
       ]
     ];
-    $this->assertArraySubset($expectedResult, $result);
+    $this->assertEquals($expectedResult, $result);
   }
 
   public function testLeaveRequestIsValidShouldReturnErrorWhenEndDateIsGreaterThanStartDate() {
@@ -1372,12 +1377,13 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $expectedResult = [
       'is_error' => 0,
+      'version' => 3,
       'count' => 1,
       'values' => [
         'from_date' => ['leave_request_from_date_greater_than_end_date']
       ]
     ];
-    $this->assertArraySubset($expectedResult, $result);
+    $this->assertEquals($expectedResult, $result);
   }
 
   public function testLeaveRequestIsValidShouldReturnErrorWhenThereAreOverlappingLeaveRequests() {
@@ -1430,12 +1436,13 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $expectedResult = [
       'is_error' => 0,
+      'version' => 3,
       'count' => 1,
       'values' => [
         'from_date' => ['leave_request_overlaps_another_leave_request']
       ]
     ];
-    $this->assertArraySubset($expectedResult, $result);
+    $this->assertEquals($expectedResult, $result);
   }
 
   public function testLeaveRequestIsValidShouldReturnErrorWhenBalanceChangeGreaterThanPeriodEntitlementBalanceChangeAndAllowOveruseFalse() {
@@ -1486,12 +1493,13 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $expectedResult = [
       'is_error' => 0,
+      'version' => 3,
       'count' => 1,
       'values' => [
         'type_id' => ['leave_request_balance_change_greater_than_remaining_balance']
       ]
     ];
-    $this->assertArraySubset($expectedResult, $result);
+    $this->assertEquals($expectedResult, $result);
   }
 
   public function testLeaveRequestIsValidShouldReturnErrorWhenLeaveRequestHasNoWorkingDay() {
@@ -1540,12 +1548,13 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $expectedResult = [
       'is_error' => 0,
+      'version' => 3,
       'count' => 1,
       'values' => [
         'from_date' => ['leave_request_doesnt_have_working_day']
       ]
     ];
-    $this->assertArraySubset($expectedResult, $result);
+    $this->assertEquals($expectedResult, $result);
   }
 
   public function testLeaveRequestIsValidShouldReturnErrorWhenTheDatesAreNotContainedInValidAbsencePeriod() {
@@ -1572,12 +1581,13 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $expectedResult = [
       'is_error' => 0,
+      'version' => 3,
       'count' => 1,
       'values' => [
         'from_date' => ['leave_request_not_within_absence_period']
       ]
     ];
-    $this->assertArraySubset($expectedResult, $result);
+    $this->assertEquals($expectedResult, $result);
   }
 
   public function testLeaveRequestIsValidShouldReturnErrorWhenTheDatesOverlapMoreThanOneContract() {
@@ -1639,12 +1649,13 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $expectedResult = [
       'is_error' => 0,
+      'version' => 3,
       'count' => 1,
       'values' => [
         'from_date' => ['leave_request_overlapping_multiple_contracts']
       ]
     ];
-    $this->assertArraySubset($expectedResult, $result);
+    $this->assertEquals($expectedResult, $result);
   }
 
   public function testLeaveRequestIsValidShouldReturnErrorWhenTheAbsenceTypeIsNotActive() {
@@ -1830,10 +1841,11 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $expectedResult = [
       'is_error' => 0,
+      'version' => 3,
       'count' => 0,
       'values' => []
     ];
-    $this->assertArraySubset($expectedResult, $result);
+    $this->assertEquals($expectedResult, $result);
   }
 
   public function testCreateAlsoCreatesTheBalanceChangesForTheLeaveRequest() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
@@ -13,6 +13,7 @@ require_once 'helpers/SicknessRequestHelpersTrait.php';
 require_once 'helpers/WorkPatternHelpersTrait.php';
 require_once 'helpers/TOILRequestHelpersTrait.php';
 require_once 'helpers/LeaveManagerHelpersTrait.php';
+require_once 'helpers/SessionHelpersTrait.php';
 
 /**
  * Call the "cv" command.

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/SessionHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/SessionHelpersTrait.php
@@ -1,0 +1,9 @@
+<?php
+
+trait CRM_HRLeaveAndAbsences_SessionHelpersTrait {
+
+  private function registerCurrentLoggedInContactInSession($contactID) {
+    $session = CRM_Core_Session::singleton();
+    $session->set('userID', $contactID);
+  }
+}


### PR DESCRIPTION
This PR improves the Leave Request BAO validations. New sets of validations related to absence type settings were added.

The new validations are: 

- A LeaveRequest where the number of days between from_date and end_date is greater than the number of days in max_consecutive_leave_days for the request's Absence Type cannot be created or updated. If max_consecutive_leave_days is blank (NULL, it means unlimited).

- A user is not allowed to cancel his/her own leave request if any of the following conditions is true:

If AbsenceType.allow_request_cancelation is true and LeaveRequest.from_date is in the past
If AbsenceType.allow_request_cancelation is false

- A Leave Request cannot be created for an absence type that is not active