### PR TITLE
PCHR-1839: Improvements to Sickness BAO validations

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/SicknessRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/SicknessRequest.php
@@ -170,7 +170,12 @@ function civicrm_api3_sickness_request_isvalid($params) {
     $result[$e->getField()] = [$e->getExceptionCode()];
   }
 
-  return civicrm_api3_create_success($result);
+  $results =  civicrm_api3_create_success($result);
+  if (isset($results['id'])) {
+    unset($results['id']);
+  }
+
+  return $results;
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/SicknessRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/SicknessRequest.php
@@ -166,7 +166,7 @@ function civicrm_api3_sickness_request_isvalid($params) {
   try {
     CRM_HRLeaveAndAbsences_BAO_SicknessRequest::validateParams($params);
   }
-  catch (CRM_HRLeaveAndAbsences_Exception_InvalidSicknessRequestException $e) {
+  catch (CRM_HRLeaveAndAbsences_Exception_EntityValidationException $e) {
     $result[$e->getField()] = [$e->getExceptionCode()];
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/SicknessRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/SicknessRequestTest.php
@@ -249,10 +249,14 @@ class SicknessRequestTest extends BaseHeadlessTest {
       ['period_start_date' => $startDate->format('Y-m-d')]
     );
 
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'is_sick' => true
+    ]);
+
     $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
       'contact_id' => $contact['id'],
       'period_id' => $period->id,
-      'type_id' => 1
+      'type_id' => $absenceType->id
     ]);
 
     $this->createLeaveBalanceChange($periodEntitlement->id, 20);
@@ -263,7 +267,7 @@ class SicknessRequestTest extends BaseHeadlessTest {
 
     $result = civicrm_api3('SicknessRequest', 'create', [
       'contact_id' => $contact['id'],
-      'type_id' => 1,
+      'type_id' => $absenceType->id,
       'from_date' => $startDate->format('Y-m-d'),
       'from_date_type' => $fromType = $this->leaveRequestDayTypes['All Day']['id'],
       'to_date' => $endDate->format('Y-m-d'),

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/SicknessRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/SicknessRequestTest.php
@@ -47,12 +47,13 @@ class SicknessRequestTest extends BaseHeadlessTest {
 
     $expectedResult = [
       'is_error' => 0,
+      'version' => 3,
       'count' => 1,
       'values' => [
         'reason' => ['sickness_request_empty_reason']
       ]
     ];
-    $this->assertArraySubset($expectedResult, $result);
+    $this->assertEquals($expectedResult, $result);
   }
 
   public function testSicknessRequestIsValidReturnsErrorWhenAbsenceTypeDoesNotAllowSicknessRequest() {
@@ -76,12 +77,13 @@ class SicknessRequestTest extends BaseHeadlessTest {
 
     $expectedResult = [
       'is_error' => 0,
+      'version' => 3,
       'count' => 1,
       'values' => [
         'type_id' => ['sickness_request_absence_type_does_not_allow_sickness_request']
       ]
     ];
-    $this->assertArraySubset($expectedResult, $result);
+    $this->assertEquals($expectedResult, $result);
   }
 
   public function testSicknessRequestIsValidReturnsLeaveRequestTypeErrorWhenLeaveRequestValidationFails() {
@@ -103,12 +105,13 @@ class SicknessRequestTest extends BaseHeadlessTest {
 
     $expectedResult = [
       'is_error' => 0,
+      'version' => 3,
       'count' => 1,
       'values' => [
         'from_date_type' => ['leave_request_empty_from_date_type']
       ]
     ];
-    $this->assertArraySubset($expectedResult, $result);
+    $this->assertEquals($expectedResult, $result);
   }
 
   public function testSicknessRequestIsValidShouldNotReturnErrorWhenValidationsPass() {
@@ -157,11 +160,12 @@ class SicknessRequestTest extends BaseHeadlessTest {
 
     $expectedResult = [
       'is_error' => 0,
+      'version' => 3,
       'count' => 0,
       'values' => []
     ];
 
-    $this->assertArraySubset($expectedResult, $result);
+    $this->assertEquals($expectedResult, $result);
   }
 
   public function testSicknessRequestGetShouldReturnAssociatedLeaveRequestData() {


### PR DESCRIPTION
This PR improves the validations on SicknessRequest BAO. It adds an additional validation related to the is_sick flag on an Absence Type i.e

- SicknessRequests can no longer be created/updated for AbsenceTypes where is_sick is false

This PR also fixes a loophole in SicknessRequest.isValid API endpoint.

**Problem:**  

A sickness request is created from a combination of parameters needed to create a leave request and additional parameters specific to a sickness request. Before this PR, SicknessRequest.isValid only runs the SicknessRequest validation function only(which only runs validation for SicknessRequest specific parameters), the fallout of this is that if the validations pass and for some reason some required conditions for creating a leave request was not met, this gives a false assurance to whatever calls the SicknessRequest.isValid API that a subsequent call to create a SicknessRequest will go through.

**Solution:**

In addition to calling the SicknessRequest validation function, the LeaveRequest Validation function is also called inside the validation function of the SicknessRequest.