### PR TITLE
PCHR-1895: Fix permission issue when using LeaveRequest.create to update a Request

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -269,6 +269,7 @@ function hrleaveandabsences_civicrm_alterAPIPermissions($entity, $action, &$para
     'getbalancechangebyabsencetype' => ['leave_request'],
     'calculatebalancechange' => ['leave_request'],
     'create' => ['leave_request'],
+    'update' => ['leave_request'],
     'getcalendar' => ['work_pattern'],
     'ismanagedby' => ['leave_request'],
     'isvalid' => ['leave_request'],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ApiPermissionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ApiPermissionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Class api_v3_ApiPermissionTest
+ *
+ * @group headless
+ */
+class api_v3_ApiPermissionTest extends BaseHeadlessTest {
+
+  use CRM_HRLeaveAndAbsences_SessionHelpersTrait;
+
+  /**
+   * @dataProvider apiPermissionsDataProvider
+   */
+  public function testAPIPermissions($entity, $action) {
+    $contactID = 1;
+    $this->registerCurrentLoggedInContactInSession($contactID);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
+
+    $entityName = $this->formatSnakeToCamelCase($entity);
+    $this->setExpectedException('CiviCRM_API3_Exception', "API permission check failed for {$entityName}/{$action} call; insufficient permission: require access AJAX API");
+
+    $payload = ['check_permissions' => true];
+
+    if($action == 'update') {
+      $payload['id'] = 1;
+    }
+
+    civicrm_api3($entity, $action, $payload);
+  }
+
+  public function apiPermissionsDataProvider() {
+    return [
+      ['leave_request', 'isvalid'],
+      ['leave_request', 'getfull'],
+      ['leave_request', 'ismanagedby'],
+      ['leave_request', 'update'],
+      ['leave_request', 'create'],
+      ['leave_request', 'calculatebalancechange'],
+      ['leave_request', 'getbalancechangebyabsencetype'],
+      ['work_pattern', 'getcalendar'],
+      ['absence_type', 'get'],
+      ['absence_period', 'get'],
+      ['option_group', 'get'],
+      ['option_value', 'get'],
+      ['leave_period_entitlement', 'get'],
+      ['public_holiday', 'get']
+    ];
+  }
+
+  private function formatSnakeToCamelCase($text) {
+    $text_array = explode('_', $text);
+    $camelCaseText = '';
+    foreach ($text_array as $value){
+      $camelCaseText .= ucfirst($value);
+    }
+
+    return $camelCaseText;
+  }
+}
+
+


### PR DESCRIPTION
This PR fixes a permission issue when LeaveRequest.create API endpoint is used to update a leave request. 
Currently,  hook_civicrm_alterAPIPermissions is used to make sure that the only permission required for the Leave&Absence API endpoints is "access AJAX API".

**Problem**
Internally, the class responsible for permissions checks in the API considers create and update as two different actions/endpoints so in hook_civicrm_alterAPIPermissions, the permission is only applied to the create action.

**Solution**
hook_civicrm_alterAPIPermissions implementation on L&A is updated to add the "access AJAX API" permission to the "update" action of the "leave_request" entity