### PR TITLE
PCHR-1894: Fix Permission issue with LeaveRequest and LeavePeriodEntitlement

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/ACLQueryHelper.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/ACLQueryHelper.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Access Control Lists Custom Query generator class
+ *
+ * This class is basically an Utility class used to generate queries needed for overriding addSelectWhereClause
+ * for some specific BAO's
+ *
+ */
+class CRM_HRLeaveAndAbsences_API_Query_ACLQueryHelper {
+
+  /**
+   * This method returns a query string that limits contacts records that are available to a logged in user
+   * by taking into account user relationships. It checks whether the logged in user is a leave approver
+   * to some contacts or not. If yes the logged in user has access to contact records for the contacts/users he manages,
+   * If not the logged is limited to his/her own records only.
+   *
+   * @return string
+   *   Query String
+   */
+  public static function limitContactsByTakingUserRelationShipsIntoAccount() {
+    $contactsTable = CRM_Contact_BAO_Contact::getTableName();
+    $relationshipTable = CRM_Contact_BAO_Relationship::getTableName();
+    $relationshipTypeTable = CRM_Contact_BAO_RelationshipType::getTableName();
+    $loggedInUserID = (int) CRM_Core_Session::getLoggedInContactID();
+    $today = date('Y-m-d');
+
+    $query = "IN (
+      SELECT c.id
+      FROM {$contactsTable} c
+      LEFT JOIN {$relationshipTable} r ON c.id = r.contact_id_a
+      LEFT JOIN {$relationshipTypeTable} rt ON rt.id = r.relationship_type_id
+      WHERE (
+          (
+            r.is_active = 1
+            AND rt.is_active = 1
+            AND rt.name_a_b = 'has Leave Approved By'
+            AND r.contact_id_b = {$loggedInUserID}
+            AND (
+              r.start_date IS NULL
+              OR r.start_date <= '$today'
+              )
+            AND (
+              r.end_date IS NULL
+              OR r.end_date >= '$today'
+              )
+            )
+          OR (c.id = {$loggedInUserID})
+          )
+      )";
+
+    return $query;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
@@ -6,6 +6,7 @@ use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
 use CRM_HRLeaveAndAbsences_Exception_InvalidLeavePeriodEntitlementException as InvalidPeriodEntitlementException;
 use CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement as LeavePeriodEntitlement;
+use CRM_HRLeaveAndAbsences_API_Query_ACLQueryHelper as ACLQueryHelper;
 
 /**
  * Class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement
@@ -773,4 +774,18 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
     return $leaveBalanceTypeIdOptionsGroup;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function addSelectWhereClause() {
+    if (CRM_Core_Permission::check([['view all contacts', 'edit all contacts']])) {
+      return;
+    }
+
+    $query = ACLQueryHelper::limitContactsByTakingUserRelationShipsIntoAccount();
+    $clauses['contact_id'] = $query;
+
+    CRM_Utils_Hook::selectWhereClause($this, $clauses);
+    return $clauses;
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -9,6 +9,7 @@ use CRM_HRLeaveAndAbsences_BAO_WorkDay as WorkDay;
 use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
 use CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException as InvalidLeaveRequestException;
+use CRM_HRLeaveAndAbsences_API_Query_ACLQueryHelper as ACLQueryHelper;
 
 class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO_LeaveRequest {
 
@@ -752,5 +753,20 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
       ];
     }
     return $leaveRequestDayTypeOptionsGroup;
+  }
+
+  /**
+   *{@inheritdoc}
+   */
+  public function addSelectWhereClause() {
+    if (CRM_Core_Permission::check([['view all contacts', 'edit all contacts']])) {
+      return;
+    }
+
+    $query = ACLQueryHelper::limitContactsByTakingUserRelationShipsIntoAccount();
+    $clauses['contact_id'] = $query;
+
+    CRM_Utils_Hook::selectWhereClause($this, $clauses);
+    return $clauses;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -265,7 +265,7 @@ function hrleaveandabsences_civicrm_permission(&$permissions) {
 function hrleaveandabsences_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
   $actionEntities = [
     'get' => ['absence_type', 'absence_period', 'option_group', 'option_value',
-              'leave_period_entitlement', 'public_holiday'],
+              'leave_period_entitlement', 'public_holiday', 'leave_request'],
     'getbalancechangebyabsencetype' => ['leave_request'],
     'calculatebalancechange' => ['leave_request'],
     'create' => ['leave_request'],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ApiPermissionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ApiPermissionTest.php
@@ -30,6 +30,7 @@ class api_v3_ApiPermissionTest extends BaseHeadlessTest {
 
   public function apiPermissionsDataProvider() {
     return [
+      ['LeaveRequest', 'get'],
       ['LeaveRequest', 'isvalid'],
       ['LeaveRequest', 'getfull'],
       ['LeaveRequest', 'ismanagedby'],


### PR DESCRIPTION
This PR fixes permission issues with LeaveRequest.get, LeaveRequest.getFull and LeavePeriodEntitlement.get API endpoints.

**Problem:**

When logged in as an user belonging to either civihr_staff or civihr_manager roles, a call to LeaveRequest.get, LeaveRequest.getFull or LeavePeriodEntitlement.get will return an empty set, even if the user has entitlements or leave requests for the given period. The reason is that, internally, civicrm adds special clauses to any SELECT query made through the API to an entity with a contact_id FK linked to the civicrm_contact table such that only roles with view all contacts' and  'edit all contacts' permissions can view records.

**Solution**

The ` addSelectWhereClause` method of the core DAO class is overridden in LeavePeriodEntitlement and LeaveRequest BAO. The method is overridden such that a user belonging to a civihr_staff role can only see records linked to his/her contact_id and also a user belonging to civihr_manager role can see only records for the staffs he/she manages.

Also an Admin with view all contacts' and  'edit all contacts' permissions can view records for all contacts.
