### PR TITLE
PCHR-1791: Add Leave and Absence General Settings Page

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/GeneralSettings.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/GeneralSettings.php
@@ -1,0 +1,156 @@
+<?php
+
+require_once 'CRM/Core/Form.php';
+
+/**
+ * Form controller class
+ *
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC43/QuickForm+Reference
+ */
+class CRM_HRLeaveAndAbsences_Form_GeneralSettings extends CRM_Core_Form {
+
+  /**
+   * @var array
+   *   The filter to pass to the setting.getfields API
+   */
+  private $settingFilter = ['group' => 'leave_and_absences_general_settings'];
+
+  /**
+   * @var array
+   *   An array to store settings once it has been retrieved from the settings API
+   */
+  private $settings = [];
+
+  private $submittedValues = [];
+
+  public function buildQuickForm() {
+    $settings = $this->getFormSettings();
+
+    foreach ($settings as $name => $setting) {
+      if ($name == 'relationship_types_allowed_to_approve_leave') {
+        $this->$setting['html_type'](
+          $name,
+          [
+            'options' => $this->getRelationshipTypes(),
+            'multiple' => true,
+            'label' => $setting['label'],
+            'style' => $setting['html_attributes']['style'],
+          ],
+          true
+        );
+      }
+    }
+
+    $this->addButtons($this->getAvailableButtons());
+
+    $this->assign('elementNames', $this->getRenderableElementNames());
+
+    CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/hrleaveandabsences.css');
+    parent::buildQuickForm();
+  }
+
+  public function postProcess() {
+    $this->submittedValues = $this->exportValues();
+    $this->saveSettings();
+
+    $url = CRM_Utils_System::url('civicrm/admin/leaveandabsences/general_settings');
+    $session = CRM_Core_Session::singleton();
+    $session->replaceUserContext($url);
+  }
+
+  /**
+   * Get the fields/elements defined in this form.
+   *
+   * @return array
+   */
+  public function getRenderableElementNames() {
+    // The _elements list includes some items which should not be
+    // auto-rendered in the loop -- such as "qfKey" and "buttons". These
+    // items don't have labels. We'll identify renderable by filtering on
+    // the 'label'.
+    $elementNames = [];
+    foreach ($this->_elements as $element) {
+      $label = $element->getLabel();
+      if (!empty($label)) {
+        $elementNames[] = $element->getName();
+      }
+    }
+    return $elementNames;
+  }
+
+  /**
+   * Get the settings we are going to allow to be set on this form.
+   *
+   * @return array
+   */
+  public function getFormSettings() {
+    if (empty($this->settings)) {
+      $settings = civicrm_api3('Setting', 'getfields', ['filters' => $this->settingFilter]);
+    }
+
+    return $settings['values'];
+  }
+
+  /**
+   * Save settings.
+   */
+  public function saveSettings() {
+    $values = array_intersect_key($this->submittedValues, $this->getFormSettings());
+    civicrm_api3('Setting', 'create', $values);
+  }
+
+  /**
+   * Set defaults for form.
+   *
+   * @see CRM_Core_Form::setDefaultValues()
+   *
+   * @return array
+   */
+  public function setDefaultValues() {
+    $existing = civicrm_api3('Setting', 'get', ['return' => array_keys($this->getFormSettings())]);
+    $defaults = [];
+    $domainID = CRM_Core_Config::domainID();
+
+    foreach ($existing['values'][$domainID] as $name => $value) {
+      $defaults[$name] = $value;
+    }
+    return $defaults;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefaultEntity() {
+    return 'Setting';
+  }
+
+  /**
+   * Get RelationShip Types needed to populate the relationship_types_allowed_to_approve_leave
+   * multi-select field
+   *
+   * @return array
+   */
+  private function getRelationshipTypes() {
+    $relationshipTypes = civicrm_api3('RelationshipType', 'get');
+    $result = [];
+    foreach ($relationshipTypes['values'] as $relationshipType) {
+      $result[$relationshipType['id']] = $relationshipType['name_a_b'];
+    }
+
+    return $result;
+  }
+
+  /**
+   * Return buttons for this form
+   *
+   * @return array
+   */
+  private function getAvailableButtons() {
+    $buttons = [
+      [ 'type' => 'next', 'name' => ts('Save'), 'isDefault' => true],
+      [ 'type' => 'cancel', 'name' => ts('Cancel')],
+
+    ];
+    return $buttons;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -62,32 +62,38 @@ function _hrleaveandabsences_create_administer_menu() {
  * @param $leaveAndAbsencesAdminNavigation
  */
 function _hrleaveandabsences_create_administer_menu_tree($leaveAndAbsencesAdminNavigation) {
-  $leaveAndAbsencesAdministerMenuTree = array(
-      array(
-          'label'      => ts('Leave/Absence Types'),
-          'name'       => 'leave_and_absence_types',
-          'url'        => 'civicrm/admin/leaveandabsences/types?action=browse&reset=1',
-          'permission' => 'administer leave and absences',
-      ),
-      array(
-          'label'      => ts('Leave/Absence Periods'),
-          'name'       => 'leave_and_absence_periods',
-          'url'        => 'civicrm/admin/leaveandabsences/periods?action=browse&reset=1',
-          'permission' => 'administer leave and absences',
-      ),
-      array(
-          'label'      => ts('Public Holidays'),
-          'name'       => 'leave_and_absence_public_holidays',
-          'url'        => 'civicrm/admin/leaveandabsences/public_holidays?action=browse&reset=1',
-          'permission' => 'administer leave and absences',
-      ),
-      array(
-          'label'      => ts('Manage Work Patterns'),
-          'name'       => 'leave_and_absence_manage_work_patterns',
-          'url'        => 'civicrm/admin/leaveandabsences/work_patterns?action=browse&reset=1',
-          'permission' => 'administer leave and absences',
-      )
-  );
+  $leaveAndAbsencesAdministerMenuTree = [
+    [
+      'label' => ts('Leave/Absence Types'),
+      'name' => 'leave_and_absence_types',
+      'url' => 'civicrm/admin/leaveandabsences/types?action=browse&reset=1',
+      'permission' => 'administer leave and absences',
+    ],
+    [
+      'label' => ts('Leave/Absence Periods'),
+      'name' => 'leave_and_absence_periods',
+      'url' => 'civicrm/admin/leaveandabsences/periods?action=browse&reset=1',
+      'permission' => 'administer leave and absences',
+    ],
+    [
+      'label' => ts('Public Holidays'),
+      'name' => 'leave_and_absence_public_holidays',
+      'url' => 'civicrm/admin/leaveandabsences/public_holidays?action=browse&reset=1',
+      'permission' => 'administer leave and absences',
+    ],
+    [
+      'label' => ts('Manage Work Patterns'),
+      'name' => 'leave_and_absence_manage_work_patterns',
+      'url' => 'civicrm/admin/leaveandabsences/work_patterns?action=browse&reset=1',
+      'permission' => 'administer leave and absences',
+    ],
+    [
+      'label' => ts('General Settings'),
+      'name' => 'leave_and_absence_general_settings',
+      'url' => 'civicrm/admin/leaveandabsences/general_settings',
+      'permission' => 'administer leave and absences',
+    ]
+  ];
 
   foreach ($leaveAndAbsencesAdministerMenuTree as $i => $item) {
     $item['weight']    = $i;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/settings/leaveandabsence.setting.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/settings/leaveandabsence.setting.php
@@ -1,0 +1,19 @@
+<?php
+
+  return [
+    'relationship_types_allowed_to_approve_leave' => [
+      'group_name' => 'Leave and Absences General Settings',
+      'group' => 'leave_and_absences_general_settings',
+      'name' => 'relationship_types_allowed_to_approve_leave',
+      'type' => 'Array',
+      'description' => 'Relationship types that are allowed to approve a Leave Request',
+      'label' =>  'Relationship types that are allowed to approve leave: <br/> 
+                   <span class="crm-marker">(Please note that CiviHR administrators are always able to approve all leave)</span>',
+      'html_type' => 'addSelect',
+      'is_domain' => 0,
+      'html_attributes' => [
+        'style' => 'width:350px',
+      ],
+      'quick_form_type' => 'Element',
+    ],
+  ];

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/GeneralSettings.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/GeneralSettings.tpl
@@ -1,0 +1,17 @@
+<h1 class="title">{ts}Leave and Absences General Settings{/ts}</h1>
+
+<div class="crm-block crm-form-block crm-general_settings-form-block crm-leave-and-absences-form-block">
+      <div class="row">
+          <div class="col-sm-6">
+              {foreach from=$elementNames item=elementName}
+                  <div class="crm-section">
+                      <div class="label">{$form.$elementName.label}</div>
+                      <div class="content">{$form.$elementName.html}</div>
+                      <div class="clear"></div>
+                  </div>
+              {/foreach}
+            </div>
+      </div>
+
+    <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+</div>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/Menu/hrleaveandabsences.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/Menu/hrleaveandabsences.xml
@@ -36,4 +36,10 @@
     <title>Calculation details</title>
     <access_arguments>administer leave and absences</access_arguments>
   </item>
+  <item>
+    <path>civicrm/admin/leaveandabsences/general_settings</path>
+    <page_callback>CRM_HRLeaveAndAbsences_Form_GeneralSettings</page_callback>
+    <title>General Settings</title>
+    <access_arguments>administer leave and absences</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
This PR creates the Leave and absence general settings page. The general settings page hinges on the core Setting API to create, save and retrieve settings. 

The only setting added in this PR is the 'Relationships that are allowed to approve a Leave Request' setting. This field/setting gets its values from the RelationshipType.get API endpoint. It is a multi select field that allows selection of one or more relationship type. The values for this field is saved in civicrm_setting table.

![generalsettings](https://cloud.githubusercontent.com/assets/6951813/22515167/e3590cf8-e8a1-11e6-9cdb-0cec6b851649.gif)

