### PR TITLE
PCHR-1825: Create LeaveRequestStatusMatrix Service

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrix.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrix.php
@@ -1,0 +1,162 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+
+class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix {
+
+  /**
+   * @var \CRM_HRLeaveAndAbsences_Service_LeaveManager
+   */
+  private $leaveManagerService;
+
+  /**
+   * @var array|null
+   *   Stores the list of option values for the LeaveRequest status_id field.
+   */
+  private static $leaveStatuses;
+
+  /**
+   * CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix constructor.
+   *
+   * @param \CRM_HRLeaveAndAbsences_Service_LeaveManager $leaveManagerService
+   */
+  public function __construct(LeaveManagerService $leaveManagerService) {
+    $this->leaveManagerService = $leaveManagerService;
+  }
+
+  /**
+   * Checks whether it is possible for the current user to change a leave request
+   * status from fromStatus to toStatus given the leave request contact id
+   * using the status matrix applicable to the current user
+   *
+   * @param int $fromStatus
+   * @param int $toStatus
+   * @param int $leaveRequestContactID
+   *
+   * @return bool
+   */
+  public function canTransitionTo($fromStatus, $toStatus, $leaveRequestContactID) {
+    $statusMatrix = $this->getStatusMatrixForCurrentUser($leaveRequestContactID);
+
+    if (empty($statusMatrix)) {
+      return false;
+    }
+
+    return !empty($statusMatrix[$fromStatus]) && in_array($toStatus, $statusMatrix[$fromStatus]);
+  }
+
+  /**
+   * Whether to use the manager status matrix for the current user or not
+   *
+   * @param int $leaveRequestContactID
+   *
+   * @return bool
+   */
+  private function shouldUseManagerMatrixForCurrentUser($leaveRequestContactID) {
+    return $this->leaveManagerService->currentUserIsLeaveManagerOf($leaveRequestContactID) ||
+           $this->leaveManagerService->currentUserIsAdmin();
+  }
+
+  /**
+   * Returns an array with all the possible transitions for a staff member.
+   *
+   * Each item of the array is a single status (the item key) with a list of the next
+   * statuses it can transition to. So, a item like:
+   *
+   *  1 => [3, 5, 6]
+   *
+   * Means that the status 1 can only be transitioned to the statuses 3, 5 and 6
+   *
+   * The null key represents the transition for a leave request with no prior status or an empty status
+   *
+   * @return array
+   */
+  private function getStaffStatusMatrix() {
+    $leaveRequestStatuses = self::getLeaveRequestStatuses();
+    $matrix = [];
+
+    $matrix[$leaveRequestStatuses['waiting_approval']] = [
+      $leaveRequestStatuses['waiting_approval'],
+      $leaveRequestStatuses['cancelled']
+    ];
+
+    $matrix[$leaveRequestStatuses['more_information_requested']] = $matrix[$leaveRequestStatuses['waiting_approval']];
+
+    $matrix[$leaveRequestStatuses['approved']] = [$leaveRequestStatuses['cancelled']];
+
+    $matrix[NULL] = [$leaveRequestStatuses['waiting_approval']];
+
+    return $matrix;
+  }
+
+  /**
+   * Returns an array with all the possible transitions for a Leave approver or L&A Admin
+   * The return array format is similar to getStaffStatusMatrix()
+   *
+   * The null key represents the transition for a leave request with no prior status or empty status
+   *
+   * @return array
+   */
+  private function getManagerStatusMatrix() {
+    $leaveRequestStatuses = self::getLeaveRequestStatuses();
+    $matrix = [];
+
+    $matrix[$leaveRequestStatuses['waiting_approval']] = [
+      $leaveRequestStatuses['more_information_requested'],
+      $leaveRequestStatuses['rejected'],
+      $leaveRequestStatuses['approved'],
+      $leaveRequestStatuses['cancelled']
+    ];
+
+    $matrix[$leaveRequestStatuses['more_information_requested']] = $matrix[$leaveRequestStatuses['waiting_approval']];
+
+    $matrix[$leaveRequestStatuses['rejected']] = $matrix[$leaveRequestStatuses['waiting_approval']];
+
+    $matrix[$leaveRequestStatuses['approved']] = $matrix[$leaveRequestStatuses['waiting_approval']];
+
+    $matrix[$leaveRequestStatuses['cancelled']] = array_merge(
+      $matrix[$leaveRequestStatuses['waiting_approval']],
+      [$leaveRequestStatuses['waiting_approval']]
+    );
+
+    $matrix[NULL] = [$leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['approved']];
+
+    return $matrix;
+  }
+
+  /**
+   * Returns the array of the option values for the LeaveRequest status_id field.
+   *
+   * @return array
+   */
+  private static function getLeaveRequestStatuses() {
+    if (is_null(self::$leaveStatuses)) {
+      self::$leaveStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    }
+
+    return self::$leaveStatuses;
+  }
+
+  /**
+   * Method to get the right status matrix for the current user
+   *
+   * @param int $leaveRequestContactID
+   *
+   * @return array
+   */
+  private function getStatusMatrixForCurrentUser($leaveRequestContactID) {
+    $currentUserID = CRM_Core_Session::getLoggedInContactID();
+    $statusMatrix = [];
+
+    if ($currentUserID == $leaveRequestContactID) {
+      $statusMatrix = $this->getStaffStatusMatrix();
+    }
+
+    if ($this->shouldUseManagerMatrixForCurrentUser($leaveRequestContactID)) {
+      $statusMatrix = $this->getManagerStatusMatrix();
+    }
+
+    return $statusMatrix;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrixTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrixTest.php
@@ -1,0 +1,180 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix as LeaveRequestStatusMatrixService;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrixTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrixTest extends BaseHeadlessTest {
+
+  use CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait;
+  use CRM_HRLeaveAndAbsences_SessionHelpersTrait;
+  use CRM_HRLeaveAndAbsences_LeaveManagerHelpersTrait;
+
+  /**
+   * @var \CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix
+   */
+  private $leaveRequestStatusMatrix;
+
+  private $contactID;
+
+  public function setUp() {
+    $leaveManagerService = new  LeaveManagerService();
+    $this->leaveRequestStatusMatrix = new LeaveRequestStatusMatrixService($leaveManagerService);
+
+    $this->contactID = 1;
+    $this->registerCurrentLoggedInContactInSession($this->contactID);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
+  }
+
+  /**
+   * @dataProvider allPossibleStatusTransitionForStaffDataProvider
+   */
+  public function testCanTransitionToForStaffReturnsTrueForAllPossibleTransitionStatuses($fromStatus, $toStatus) {
+    $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo($fromStatus, $toStatus, $this->contactID));
+  }
+
+  /**
+   * @dataProvider allNonPossibleStatusTransitionForStaffDataProvider
+   */
+  public function testCanTransitionToForStaffReturnsFalseForAllNonPossibleTransitionStatuses($fromStatus, $toStatus) {
+    $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($fromStatus, $toStatus, $this->contactID));
+  }
+
+  /**
+   * @dataProvider allPossibleStatusTransitionForLeaveApproverDataProvider
+   */
+  public function testCanTransitionToForLeaveApproverReturnsTrueForAllPossibleTransitionStatuses($manager, $leaveContact, $fromStatus, $toStatus) {
+    $this->registerCurrentLoggedInContactInSession($manager['id']);
+    $this->setContactAsLeaveApproverOf($manager, $leaveContact);
+
+    $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo($fromStatus, $toStatus, $leaveContact['id']));
+  }
+
+  /**
+   * @dataProvider allNonPossibleStatusTransitionForLeaveApproverDataProvider
+   */
+  public function testCanTransitionToForLeaveApproverReturnsFalseForAllNonPossibleTransitionStatuses($manager, $leaveContact, $fromStatus, $toStatus) {
+    $this->registerCurrentLoggedInContactInSession($manager['id']);
+    $this->setContactAsLeaveApproverOf($manager, $leaveContact);
+
+    $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($fromStatus, $toStatus, $leaveContact['id']));
+  }
+
+  /**
+   * @dataProvider allPossibleStatusTransitionForLeaveApproverDataProvider
+   */
+  public function testCanTransitionToForAdminForReturnsTrueAllPossibleTransitionStatuses($manager, $leaveContact, $fromStatus, $toStatus) {
+    $this->registerCurrentLoggedInContactInSession($manager['id']);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer leave and absences'];
+
+    $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo($fromStatus, $toStatus, $leaveContact['id']));
+  }
+
+  /**
+   * @dataProvider allNonPossibleStatusTransitionForLeaveApproverDataProvider
+   */
+  public function testCanTransitionToForAdminReturnsFalseForAllNonPossibleTransitionStatuses($manager, $leaveContact, $fromStatus, $toStatus) {
+    $this->registerCurrentLoggedInContactInSession($manager['id']);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer leave and absences'];
+
+    $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($fromStatus, $toStatus, $leaveContact['id']));
+  }
+
+  public function allPossibleStatusTransitionForStaffDataProvider() {
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+
+    return [
+      [$leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['waiting_approval']],
+      [$leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['cancelled']],
+      [$leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['waiting_approval']],
+      [$leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['cancelled']],
+      [$leaveRequestStatuses['approved'], $leaveRequestStatuses['cancelled']],
+      ['', $leaveRequestStatuses['waiting_approval']],
+    ];
+  }
+
+  public function allNonPossibleStatusTransitionForStaffDataProvider() {
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+
+    return [
+      [$leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['more_information_requested']],
+      [$leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['rejected']],
+      [$leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['approved']],
+      [$leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['more_information_requested']],
+      [$leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['rejected']],
+      [$leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['approved']],
+      [$leaveRequestStatuses['rejected'], $leaveRequestStatuses['waiting_approval']],
+      [$leaveRequestStatuses['rejected'], $leaveRequestStatuses['more_information_requested']],
+      [$leaveRequestStatuses['rejected'], $leaveRequestStatuses['rejected']],
+      [$leaveRequestStatuses['rejected'], $leaveRequestStatuses['approved']],
+      [$leaveRequestStatuses['rejected'], $leaveRequestStatuses['cancelled']],
+      [$leaveRequestStatuses['approved'], $leaveRequestStatuses['waiting_approval']],
+      [$leaveRequestStatuses['approved'], $leaveRequestStatuses['more_information_requested']],
+      [$leaveRequestStatuses['approved'], $leaveRequestStatuses['rejected']],
+      [$leaveRequestStatuses['approved'], $leaveRequestStatuses['approved']],
+      [$leaveRequestStatuses['cancelled'], $leaveRequestStatuses['waiting_approval']],
+      [$leaveRequestStatuses['cancelled'], $leaveRequestStatuses['more_information_requested']],
+      [$leaveRequestStatuses['cancelled'], $leaveRequestStatuses['rejected']],
+      [$leaveRequestStatuses['cancelled'], $leaveRequestStatuses['approved']],
+      [$leaveRequestStatuses['cancelled'], $leaveRequestStatuses['cancelled']],
+      ['', $leaveRequestStatuses['more_information_requested']],
+      ['', $leaveRequestStatuses['rejected']],
+      ['', $leaveRequestStatuses['approved']],
+      ['', $leaveRequestStatuses['cancelled']],
+    ];
+  }
+
+  public function allPossibleStatusTransitionForLeaveApproverDataProvider() {
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $manager = ContactFabricator::fabricate();
+    $leaveContact = ContactFabricator::fabricate();
+
+    return [
+      [$manager, $leaveContact, $leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['more_information_requested']],
+      [$manager, $leaveContact, $leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['rejected']],
+      [$manager, $leaveContact, $leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['approved']],
+      [$manager, $leaveContact, $leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['cancelled']],
+      [$manager, $leaveContact, $leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['more_information_requested']],
+      [$manager, $leaveContact, $leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['rejected']],
+      [$manager, $leaveContact, $leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['approved']],
+      [$manager, $leaveContact, $leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['cancelled']],
+      [$manager, $leaveContact, $leaveRequestStatuses['rejected'], $leaveRequestStatuses['more_information_requested']],
+      [$manager, $leaveContact, $leaveRequestStatuses['rejected'], $leaveRequestStatuses['rejected']],
+      [$manager, $leaveContact, $leaveRequestStatuses['rejected'], $leaveRequestStatuses['approved']],
+      [$manager, $leaveContact, $leaveRequestStatuses['rejected'], $leaveRequestStatuses['cancelled']],
+      [$manager, $leaveContact, $leaveRequestStatuses['approved'], $leaveRequestStatuses['more_information_requested']],
+      [$manager, $leaveContact, $leaveRequestStatuses['approved'], $leaveRequestStatuses['rejected']],
+      [$manager, $leaveContact, $leaveRequestStatuses['approved'], $leaveRequestStatuses['approved']],
+      [$manager, $leaveContact, $leaveRequestStatuses['approved'], $leaveRequestStatuses['cancelled']],
+      [$manager, $leaveContact, $leaveRequestStatuses['cancelled'], $leaveRequestStatuses['waiting_approval']],
+      [$manager, $leaveContact, $leaveRequestStatuses['cancelled'], $leaveRequestStatuses['more_information_requested']],
+      [$manager, $leaveContact,$leaveRequestStatuses['cancelled'], $leaveRequestStatuses['rejected']],
+      [$manager, $leaveContact, $leaveRequestStatuses['cancelled'], $leaveRequestStatuses['approved']],
+      [$manager, $leaveContact, $leaveRequestStatuses['cancelled'], $leaveRequestStatuses['cancelled']],
+      [$manager, $leaveContact, '', $leaveRequestStatuses['more_information_requested']],
+      [$manager, $leaveContact, '', $leaveRequestStatuses['approved']],
+    ];
+  }
+
+  public function allNonPossibleStatusTransitionForLeaveApproverDataProvider() {
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $manager = ContactFabricator::fabricate();
+    $leaveContact = ContactFabricator::fabricate();
+
+    return [
+      [$manager, $leaveContact, $leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['waiting_approval']],
+      [$manager, $leaveContact, $leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['waiting_approval']],
+      [$manager, $leaveContact, $leaveRequestStatuses['rejected'], $leaveRequestStatuses['waiting_approval']],
+      [$manager, $leaveContact, $leaveRequestStatuses['approved'], $leaveRequestStatuses['waiting_approval']],
+      [$manager, $leaveContact, '', $leaveRequestStatuses['waiting_approval']],
+      [$manager, $leaveContact, '', $leaveRequestStatuses['rejected']],
+      [$manager, $leaveContact, '', $leaveRequestStatuses['cancelled']],
+    ];
+  }
+}


### PR DESCRIPTION
This PR creates the LeaveRequestStatusMatrix Service. The service is used to determine if a leave request status can be updated according to some specific rules:

If the user changing the status is the contact_id of the Leave Request, then these are the changes allowed:
![staffmatrixq](https://cloud.githubusercontent.com/assets/6951813/22559528/ab893750-e971-11e6-83f5-fc8bec9bcf7b.png)
**For example, a staff member who is a leave request contact can update a leave request from 'Awaiting Approval' to 'Cancelled' status but cannot update from 'Awaiting Approval'  to 'More Information Requested' status**

If the user changing the status is the leave approver for of the Leave Request's contact or a Leave and Absence Admin, then these are the changes allowed:
![adminmatrix2](https://cloud.githubusercontent.com/assets/6951813/22559581/d248e200-e971-11e6-9331-94a61588983e.png)
**For example, a leave approver or a Leave and Absence admin can update a leave request from 'Awaiting Approval' to 'More Information Requested' status but cannot update from 'Awaiting Approval'  to 'Awaiting Approval' status**

If none of the conditions match, then no change is allowed.
