### PR TITLE
PCHR-1893: Add contact.js to load on contact page load

### DIFF
--- a/hrjobcontract/tests/phpunit/CRM/Hrjobcontract/BAO/HRJobContractTest.php
+++ b/hrjobcontract/tests/phpunit/CRM/Hrjobcontract/BAO/HRJobContractTest.php
@@ -132,22 +132,19 @@ class CRM_Hrjobcontract_BAO_HRJobContractTest extends PHPUnit_Framework_TestCase
     $contactParams = array("first_name" => "chrollo", "last_name" => "lucilfer");
     $contactID =  $this->createContact($contactParams);
 
-    $params = array(
-      'position' => 'spiders boss',
-      'title' => 'spiders boss');
+    $params = ['position' => 'spiders boss', 'title' => 'spiders boss'];
     $this->createJobContract($contactID, '2015-06-01', '2015-10-01', $params);
 
-    $params = array(
-      'position' => 'spiders boss2',
-      'title' => 'spiders boss2');
+    $params['position'] = 'spiders boss2';
+    $params['title'] = 'spiders boss2';
     $this->createJobContract($contactID, '2016-06-01', null, $params);
 
-    $params = array(
-      'position' => 'spiders boss3',
-      'title' => 'spiders boss3');
+    $params['position'] = 'spiders boss3';
+    $params['title'] = 'spiders boss3';
     $this->createJobContract($contactID, '2014-06-01', '2014-10-01', $params);
 
     $currentContract = CRM_Hrjobcontract_BAO_HRJobContract::getCurrentContract($contactID);
+    $this->assertNotEquals(null, $currentContract);
     $this->assertEquals('spiders boss2', $currentContract->title);
   }
 

--- a/hrui/hrui.php
+++ b/hrui/hrui.php
@@ -56,6 +56,7 @@ function hrui_civicrm_pageRun($page) {
     CRM_Core_Resources::singleton()->addScriptFile('org.civicrm.hrui', 'js/src/civihr-popup/attrchange.js');
     CRM_Core_Resources::singleton()->addScriptFile('org.civicrm.hrui', 'js/src/civihr-popup/civihr-popup.js');
     CRM_Core_Resources::singleton()->addScriptFile('org.civicrm.hrui', 'js/src/hrui.js');
+    CRM_Core_Resources::singleton()->addScriptFile('org.civicrm.hrui', 'js/src/contact.js');
     CRM_Core_Resources::singleton()->addScriptFile('org.civicrm.hrui', 'js/src/perfect-scrollbar/perfect-scrollbar.min.js');
   } else {
     CRM_Core_Resources::singleton()->addScriptFile('org.civicrm.hrui', 'js/dist/hrui.min.js');


### PR DESCRIPTION
### Issue:
Currently contact header information was not updated on creating  or deleting existing contract for the given contact. Which was due to not loading `contact.js` form **hrui** module which si responsible to update the contact header.

### Solution:
Added `contract.js` in `hrui.php` of **hrui** module  to load on contact page load.
`CRM_Core_Resources::singleton()->addScriptFile('org.civicrm.hrui', 'js/src/contact.js');`

Added logic to _civicrm_hrjobcontract_api3_get_current_revision so that if no current revision is found, it searches for a future revision.

Included clauses to query on HRJobContract::getCurrentContract() to take into account revisions in the future and limited to current contracts.

Added an assertion to test use of HRJobContract::getCurrentContract() does not return null when there are current contracts defined.

### Screenshots:
1. Contract header gets updated on adding new contract for a contact.
![add-header-change](https://cloud.githubusercontent.com/assets/6307362/22583393/6ec3e736-ea14-11e6-8ceb-53701d9eb7f7.gif)

2. Contract header gets updated on deleting new contract for a contact.
![contact-header](https://cloud.githubusercontent.com/assets/6307362/22583409/78fd6bdc-ea14-11e6-8a33-d3ab5e9394a1.gif)

