### PR TITLE
PCHR-1834: Create LeaveRequestRights Service

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
@@ -1,0 +1,98 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
+
+class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
+
+  /**
+   * @var \CRM_HRLeaveAndAbsences_Service_LeaveManager
+   */
+  private $leaveManagerService;
+
+  /**
+   * CRM_HRLeaveAndAbsences_Service_LeaveRequestRights constructor.
+   *
+   * @param \CRM_HRLeaveAndAbsences_Service_LeaveManager $leaveManagerService
+   */
+  public function __construct(LeaveManagerService $leaveManagerService) {
+    $this->leaveManagerService = $leaveManagerService;
+  }
+
+  /**
+   * Checks whether the current user can cancel a leave request or not
+   * on behalf of the given contactID based on a set of rules.
+   *
+   * @param int $contactID
+   *   The contactID of the leave request
+   *
+   * @return bool
+   */
+  public function canCancelFor($contactID) {
+    return $this->currentUserIsManagerOrAdmin($contactID) || CRM_Core_Session::getLoggedInContactID() == $contactID;
+  }
+
+  /**
+   * Checks whether the current user can approve a leave request or not
+   * on behalf of the given contactID
+   *
+   * @param int $contactID
+   *   The contactID of the leave request
+   *
+   * @return bool
+   */
+  public function canApproveFor($contactID) {
+    return $this->currentUserIsManagerOrAdmin($contactID);
+  }
+
+  /**
+   * Checks whether the current user can reject a leave request or not
+   * on behalf of the given contactID
+   *
+   * @param int $contactID
+   *   The contactID of the leave request
+   *
+   * @return bool
+   */
+  public function canRejectFor($contactID) {
+    return $this->currentUserIsManagerOrAdmin($contactID);
+  }
+
+  /**
+   * Checks whether the current user can request more information or not
+   * for a leave request on behalf of the given contactID
+   *
+   * @param int $contactID
+   *   The contactID of the leave request
+   *
+   * @return bool
+   */
+  public function canRequestMoreInformationFor($contactID) {
+    return $this->currentUserIsManagerOrAdmin($contactID);
+  }
+
+  /**
+   * Checks whether the current user can put a leave request in waiting approval
+   * or not on behalf of the given contactID
+   *
+   * @param int $contactID
+   *   The contactID of the leave request
+   *
+   * @return bool
+   */
+  public function canPutInWaitingForApprovalFor($contactID) {
+    return $this->currentUserIsManagerOrAdmin($contactID);
+  }
+
+  /**
+   * Checks if the current user is either a leave manager or an Admin
+   *
+   * @param int $contactID
+   *   The contactID of the leave request
+   *
+   * @return bool
+   */
+  private function currentUserIsManagerOrAdmin($contactID) {
+    return $this->leaveManagerService->currentUserIsLeaveManagerOf($contactID) ||
+           $this->leaveManagerService->currentUserIsAdmin();
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadlessTest {
+
+  use CRM_HRLeaveAndAbsences_SessionHelpersTrait;
+  use CRM_HRLeaveAndAbsences_LeaveManagerHelpersTrait;
+
+  /**
+   * @var int
+   */
+  private $leaveContact;
+
+  public function setUp() {
+    $this->leaveContact = 1;
+    $this->registerCurrentLoggedInContactInSession($this->leaveContact);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
+  }
+
+  public function testCanCancelForReturnsTrueWhenCurrentUserIsLeaveRequestContact() {
+    $this->assertTrue($this->getLeaveRightsService()->canCancelFor($this->leaveContact));
+  }
+
+  public function testCanCancelForReturnsTrueWhenCurrentUserIsLeaveManager() {
+    $this->assertTrue($this->getLeaveRequestRightsForLeaveManagerAsCurrentUser()->canCancelFor($this->leaveContact));
+  }
+
+  public function testCanCancelForReturnsTrueWhenCurrentUserIsAdmin() {
+    $this->assertTrue($this->getLeaveRequestRightsForAdminAsCurrentUser()->canCancelFor($this->leaveContact));
+  }
+
+  public function testCanCancelForReturnsFalseWhenCurrentUserIsNotAnAdminOrLeaveManagerOrLeaveContact() {
+    $contactID = 3;
+    $this->assertFalse($this->getLeaveRightsService()->canCancelFor($contactID));
+  }
+
+  public function testCanApproveForReturnsTrueWhenCurrentUserIsLeaveManager() {
+    $this->assertTrue($this->getLeaveRequestRightsForLeaveManagerAsCurrentUser()->canApproveFor($this->leaveContact));
+  }
+
+  public function testCanApproveForReturnsTrueWhenCurrentUserIsAdmin() {
+    $this->assertTrue($this->getLeaveRequestRightsForAdminAsCurrentUser()->canApproveFor($this->leaveContact));
+  }
+
+  public function testCanApproveForReturnsFalseWhenCurrentUserIsLeaveContact() {
+    $this->assertFalse($this->getLeaveRightsService()->canApproveFor($this->leaveContact));
+  }
+
+  public function testCanRejectForReturnsTrueWhenCurrentUserIsLeaveManager() {
+    $this->assertTrue($this->getLeaveRequestRightsForLeaveManagerAsCurrentUser()->canRejectFor($this->leaveContact));
+  }
+
+  public function testCanRejectForReturnsTrueWhenCurrentUserIsAdmin() {
+    $this->assertTrue($this->getLeaveRequestRightsForAdminAsCurrentUser()->canRejectFor($this->leaveContact));
+  }
+
+  public function testCanRejectForReturnsFalseWhenCurrentUserIsLeaveContact() {
+    $this->assertFalse($this->getLeaveRightsService()->canRejectFor($this->leaveContact));
+  }
+
+  public function testCanRequestMoreInformationForReturnsTrueWhenCurrentUserIsLeaveManager() {
+    $this->assertTrue($this->getLeaveRequestRightsForLeaveManagerAsCurrentUser()->canRequestMoreInformationFor($this->leaveContact));
+  }
+
+  public function testCanRequestMoreInformationForReturnsTrueWhenCurrentUserIsAdmin() {
+    $this->assertTrue($this->getLeaveRequestRightsForAdminAsCurrentUser()->canRequestMoreInformationFor($this->leaveContact));
+  }
+
+  public function testCanRequestMoreInformationForReturnsFalseWhenCurrentUserIsLeaveContact() {
+    $this->assertFalse($this->getLeaveRightsService()->canRequestMoreInformationFor($this->leaveContact));
+  }
+
+  public function testCanPutInWaitingForApprovalForReturnsTrueWhenCurrentUserIsLeaveManager() {
+    $this->assertTrue($this->getLeaveRequestRightsForLeaveManagerAsCurrentUser()->canPutInWaitingForApprovalFor($this->leaveContact));
+  }
+
+  public function testCanPutInWaitingForApprovalForReturnsTrueWhenCurrentUserIsAdmin() {
+    $this->assertTrue($this->getLeaveRequestRightsForAdminAsCurrentUser()->canPutInWaitingForApprovalFor($this->leaveContact['id']));
+  }
+
+  public function testCanPutInWaitingForApprovalForReturnsFalseWhenCurrentUserIsLeaveContact() {
+    $this->assertFalse($this->getLeaveRightsService()->canPutInWaitingForApprovalFor($this->leaveContact));
+  }
+
+  private function getLeaveRightsService($isAdmin = false, $isManager = false) {
+    $leaveManagerService = $this->createLeaveLeaveManagerServiceMock($isAdmin, $isManager);
+    return new LeaveRequestRightsService($leaveManagerService);
+  }
+
+  private function getLeaveRequestRightsForAdminAsCurrentUser() {
+    return $this->getLeaveRightsService(true, false);
+  }
+
+  private function getLeaveRequestRightsForLeaveManagerAsCurrentUser() {
+    return $this->getLeaveRightsService(false, true);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveManagerHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveManagerHelpersTrait.php
@@ -40,4 +40,20 @@ trait CRM_HRLeaveAndAbsences_LeaveManagerHelpersTrait {
 
     return $result['values'][0];
   }
+
+  public function createLeaveLeaveManagerServiceMock($isAdmin = false, $isManager = false) {
+    $leaveManagerService = $this->getMockBuilder(CRM_HRLeaveAndAbsences_Service_LeaveManager::class)
+                                ->setMethods(['currentUserIsAdmin', 'currentUserIsLeaveManagerOf'])
+                                ->getMock();
+
+    $leaveManagerService->expects($this->any())
+                        ->method('currentUserIsAdmin')
+                        ->will($this->returnValue($isAdmin));
+
+    $leaveManagerService->expects($this->any())
+                        ->method('currentUserIsLeaveManagerOf')
+                        ->will($this->returnValue($isManager));
+
+    return $leaveManagerService;
+  }
 }


### PR DESCRIPTION
This PR creates the LeaveRequestRights Service.
This service handles permission checks on different leave request status changes.

The service has various methods each dedicated to a leave request status and checks if the current user is authorized or permitted to change the status.

e.g `canCancelFor` method checks if the current user can cancel the leave request or not