### PR TITLE
PCHR-1417: Implement sickness instance

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/models/instances/sickness-leave-request-instance.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/models/instances/sickness-leave-request-instance.js
@@ -8,41 +8,40 @@ define([
     'LeaveRequestAPI',
     'LeaveRequestInstance',
     function (LeaveRequestAPI, LeaveRequestInstance) {
-      var sicknessInstance = Object.create(LeaveRequestInstance);
+      return LeaveRequestInstance.extend({
 
-      /**
-       * Create a new sickness request
-       *
-       * @return {Promise} Resolved with {Object} Created Leave request with
-       *  newly created id for this instance
-       */
-      sicknessInstance.create = function () {
-        return LeaveRequestAPI.create(this.toAPI(), 'sick')
-          .then(function (result) {
-            this.id = result.id;
-          }.bind(this));
-      };
+        /**
+         * Create a new sickness request
+         *
+         * @return {Promise} Resolved with {Object} Created Leave request with
+         *  newly created id for this instance
+         */
+        create: function () {
+          return LeaveRequestAPI.create(this.toAPI(), 'sick')
+            .then(function (result) {
+              this.id = result.id;
+            }.bind(this));
+        },
 
-      /**
-       * Validate sickness request instance attributes.
-       *
-       * @return {Promise} empty array if no error found otherwise an object
-       *  with is_error set and array of errors
-       */
-      sicknessInstance.isValid = function () {
-        return LeaveRequestAPI.isValid(this.toAPI(), 'sick');
-      };
+        /**
+         * Validate sickness request instance attributes.
+         *
+         * @return {Promise} empty array if no error found otherwise an object
+         *  with is_error set and array of errors
+         */
+        isValid: function () {
+          return LeaveRequestAPI.isValid(this.toAPI(), 'sick');
+        },
 
-      /**
-       * Update a sickness request
-       *
-       * @return {Promise} Resolved with {Object} Updated sickness request
-       */
-      sicknessInstance.update = function () {
-        return LeaveRequestAPI.update(this.toAPI(), 'sick');
-      };
-
-      return sicknessInstance;
+        /**
+         * Update a sickness request
+         *
+         * @return {Promise} Resolved with {Object} Updated sickness request
+         */
+        update: function () {
+          return LeaveRequestAPI.update(this.toAPI(), 'sick');
+        }
+      });
     }
   ]);
 });

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/models/instances/sickness-leave-request-instance.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/models/instances/sickness-leave-request-instance.js
@@ -1,0 +1,48 @@
+define([
+  'leave-absences/shared/modules/models-instances',
+  'leave-absences/shared/models/instances/leave-request-instance',
+], function (modelInstances) {
+  'use strict';
+
+  modelInstances.factory('SicknessRequestInstance', [
+    'LeaveRequestAPI',
+    'LeaveRequestInstance',
+    function (LeaveRequestAPI, LeaveRequestInstance) {
+      var sicknessInstance = Object.create(LeaveRequestInstance);
+
+      /**
+       * Create a new sickness request
+       *
+       * @return {Promise} Resolved with {Object} Created Leave request with
+       *  newly created id for this instance
+       */
+      sicknessInstance.create = function () {
+        return LeaveRequestAPI.create(this.toAPI(), 'sick')
+          .then(function (result) {
+            this.id = result.id;
+          }.bind(this));
+      };
+
+      /**
+       * Validate sickness request instance attributes.
+       *
+       * @return {Promise} empty array if no error found otherwise an object
+       *  with is_error set and array of errors
+       */
+      sicknessInstance.isValid = function () {
+        return LeaveRequestAPI.isValid(this.toAPI(), 'sick');
+      };
+
+      /**
+       * Update a sickness request
+       *
+       * @return {Promise} Resolved with {Object} Updated sickness request
+       */
+      sicknessInstance.update = function () {
+        return LeaveRequestAPI.update(this.toAPI(), 'sick');
+      };
+
+      return sicknessInstance;
+    }
+  ]);
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/instances/sickness-leave-request-instance_test.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/instances/sickness-leave-request-instance_test.js
@@ -7,7 +7,7 @@ define([
   'use strict';
 
   describe('SicknessRequestInstance', function () {
-    var expectedError, instance, LeaveRequestAPI, $provide, promise, $q, requestData, $rootScope;
+    var expectedError, instance, LeaveRequestAPI, $provide, promise, requestData, $rootScope;
 
     beforeEach(module('leave-absences.models.instances', 'leave-absences.mocks', function (_$provide_) {
       $provide = _$provide_;
@@ -19,12 +19,11 @@ define([
     }));
 
     beforeEach(inject([
-      'SicknessRequestInstance', '$rootScope', 'LeaveRequestAPI', '$q',
-      function (_SicknessRequestInstance_, _$rootScope_, _LeaveRequestAPI_, _$q_) {
+       '$rootScope', 'LeaveRequestAPI', 'SicknessRequestInstance',
+      function (_$rootScope_, _LeaveRequestAPI_, _SicknessRequestInstance_) {
         instance = _SicknessRequestInstance_.init({}, false);
         $rootScope = _$rootScope_;
         LeaveRequestAPI = _LeaveRequestAPI_;
-        $q = _$q_;
 
         spyOn(LeaveRequestAPI, 'create').and.callThrough();
         spyOn(LeaveRequestAPI, 'update').and.callThrough();
@@ -52,33 +51,19 @@ define([
 
       it('calls equivalent API method', function () {
         promise.then(function () {
-          expect(LeaveRequestAPI.create).toHaveBeenCalled();
+          expect(LeaveRequestAPI.create).toHaveBeenCalledWith(jasmine.any(Object), 'sick');
         });
       });
 
-      it('id is appended to instance', function () {
-        expect(instance.id).not.toBeDefined();
-        promise.then(function () {
-          expect(instance.id).toBeDefined();
-          expect(instance.id).toEqual(jasmine.any(String));
-        });
-      });
-
-      describe('when one mandatory field is missing', function () {
-        beforeEach(function () {
-          expectedError = 'contact_id, from_date and from_date_type in params are mandatory';
-          delete instance.contact_id;
-          promise = instance.create();
+      describe('id field', function() {
+        it('is not appended to instance before API returns data', function() {
+          expect(instance.id).not.toBeDefined();
         });
 
-        afterEach(function () {
-          //to excute the promise force an digest
-          $rootScope.$apply();
-        });
-
-        it('fails to create instance', function () {
-          promise.catch(function (error) {
-            expect(error).toBe(expectedError);
+        it('is appended to instance before API returns data', function() {
+          promise.then(function () {
+            expect(instance.id).toBeDefined();
+            expect(instance.id).toEqual(jasmine.any(String));
           });
         });
       });
@@ -99,32 +84,7 @@ define([
 
       it('calls equivalent API method', function () {
         promise.then(function () {
-          expect(LeaveRequestAPI.isValid).toHaveBeenCalled();
-        });
-      });
-
-      describe('when leave request is valid', function () {
-        it('returns no error', function () {
-          promise.then(function (result) {
-            expect(result).toEqual([]);
-          });
-        });
-
-        describe('when valid data not present', function () {
-          beforeEach(function () {
-            delete instance.contact_id;
-            promise = instance.isValid();
-          });
-
-          afterEach(function () {
-            $rootScope.$apply();
-          });
-
-          it('returns array of errors', function () {
-            promise.catch(function (result) {
-              expect(Object.keys(result).length).toBeGreaterThan(0);
-            });
-          });
+          expect(LeaveRequestAPI.isValid).toHaveBeenCalledWith(jasmine.any(Object), 'sick');
         });
       });
     });
@@ -135,11 +95,7 @@ define([
         };
 
       beforeEach(function () {
-        var defer = $q.defer();
-        LeaveRequestAPI.update.and.returnValue(defer.promise);
-        defer.resolve(jasmine.any(Object));
         spyOn(instance, 'toAPI').and.returnValue(toAPIReturnValue);
-
         promise = instance.update();
       });
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/instances/sickness-leave-request-instance_test.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/instances/sickness-leave-request-instance_test.js
@@ -7,7 +7,7 @@ define([
   'use strict';
 
   describe('SicknessRequestInstance', function () {
-    var expectedError, instance, LeaveRequestAPI, $provide, promise, requestData, $rootScope;
+    var $rootScope, $provide, expectedError, instance, LeaveRequestAPI, promise, requestData, toAPIReturnValue;
 
     beforeEach(module('leave-absences.models.instances', 'leave-absences.mocks', function (_$provide_) {
       $provide = _$provide_;
@@ -24,10 +24,14 @@ define([
         instance = _SicknessRequestInstance_.init({}, false);
         $rootScope = _$rootScope_;
         LeaveRequestAPI = _LeaveRequestAPI_;
+        toAPIReturnValue = {
+            key: jasmine.any(String)
+          };
 
         spyOn(LeaveRequestAPI, 'create').and.callThrough();
         spyOn(LeaveRequestAPI, 'update').and.callThrough();
         spyOn(LeaveRequestAPI, 'isValid').and.callThrough();
+        spyOn(instance, 'toAPI').and.returnValue(toAPIReturnValue);
       }
     ]));
 
@@ -51,18 +55,23 @@ define([
 
       it('calls equivalent API method', function () {
         promise.then(function () {
-          expect(LeaveRequestAPI.create).toHaveBeenCalledWith(jasmine.any(Object), 'sick');
+          expect(LeaveRequestAPI.create).toHaveBeenCalledWith(toAPIReturnValue, 'sick');
+        });
+      });
+
+      it('calls toAPI method', function () {
+        promise.then(function () {
+          expect(instance.toAPI).toHaveBeenCalled();
         });
       });
 
       describe('id field', function() {
-        it('is not appended to instance before API returns data', function() {
+        it('is not appended to instance after API returns data', function() {
           expect(instance.id).not.toBeDefined();
         });
 
-        it('is appended to instance before API returns data', function() {
+        it('is appended to instance after API returns data', function() {
           promise.then(function () {
-            expect(instance.id).toBeDefined();
             expect(instance.id).toEqual(jasmine.any(String));
           });
         });
@@ -84,18 +93,19 @@ define([
 
       it('calls equivalent API method', function () {
         promise.then(function () {
-          expect(LeaveRequestAPI.isValid).toHaveBeenCalledWith(jasmine.any(Object), 'sick');
+          expect(LeaveRequestAPI.isValid).toHaveBeenCalledWith(toAPIReturnValue, 'sick');
+        });
+      });
+
+      it('calls toAPI method', function () {
+        promise.then(function () {
+          expect(instance.toAPI).toHaveBeenCalled();
         });
       });
     });
 
     describe('update()', function () {
-      var toAPIReturnValue = {
-          key: jasmine.any(String)
-        };
-
       beforeEach(function () {
-        spyOn(instance, 'toAPI').and.returnValue(toAPIReturnValue);
         promise = instance.update();
       });
 
@@ -113,7 +123,7 @@ define([
         promise.then(function () {
           expect(instance.toAPI).toHaveBeenCalled();
         });
-      })
+      });
     });
   });
 });

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/instances/sickness-leave-request-instance_test.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/instances/sickness-leave-request-instance_test.js
@@ -1,11 +1,9 @@
 define([
-  'mocks/data/leave-request-data',
-  'mocks/data/sickness-leave-request-data',
   'mocks/helpers/helper',
   'mocks/apis/leave-request-api-mock',
   'mocks/apis/option-group-api-mock',
   'leave-absences/shared/models/instances/sickness-leave-request-instance',
-], function (mockData, sicknessMockData, helper) {
+], function (helper) {
   'use strict';
 
   describe('SicknessRequestInstance', function () {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/instances/sickness-leave-request-instance_test.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/instances/sickness-leave-request-instance_test.js
@@ -1,0 +1,165 @@
+define([
+  'mocks/data/leave-request-data',
+  'mocks/data/sickness-leave-request-data',
+  'mocks/helpers/helper',
+  'mocks/apis/leave-request-api-mock',
+  'mocks/apis/option-group-api-mock',
+  'leave-absences/shared/models/instances/sickness-leave-request-instance',
+], function (mockData, sicknessMockData, helper) {
+  'use strict';
+
+  describe('SicknessRequestInstance', function () {
+    var expectedError, instance, LeaveRequestAPI, $provide, promise, $q, requestData, $rootScope;
+
+    beforeEach(module('leave-absences.models.instances', 'leave-absences.mocks', function (_$provide_) {
+      $provide = _$provide_;
+    }));
+
+    beforeEach(inject(function (_LeaveRequestAPIMock_, _OptionGroupAPIMock_) {
+      $provide.value('LeaveRequestAPI', _LeaveRequestAPIMock_);
+      $provide.value('OptionGroup', _OptionGroupAPIMock_);
+    }));
+
+    beforeEach(inject([
+      'SicknessRequestInstance', '$rootScope', 'LeaveRequestAPI', '$q',
+      function (_SicknessRequestInstance_, _$rootScope_, _LeaveRequestAPI_, _$q_) {
+        instance = _SicknessRequestInstance_.init({}, false);
+        $rootScope = _$rootScope_;
+        LeaveRequestAPI = _LeaveRequestAPI_;
+        $q = _$q_;
+
+        spyOn(LeaveRequestAPI, 'create').and.callThrough();
+        spyOn(LeaveRequestAPI, 'update').and.callThrough();
+        spyOn(LeaveRequestAPI, 'isValid').and.callThrough();
+      }
+    ]));
+
+    describe('init', function () {
+      it('sickness request', function () {
+        expect(instance).toBeDefined();
+      });
+    });
+
+    describe('create()', function () {
+      beforeEach(function () {
+        requestData = helper.createRandomSicknessRequest();
+        instance = instance.init(requestData, false);
+        promise = instance.create();
+      });
+
+      afterEach(function () {
+        //to excute the promise force an digest
+        $rootScope.$apply();
+      });
+
+      it('calls equivalent API method', function () {
+        promise.then(function () {
+          expect(LeaveRequestAPI.create).toHaveBeenCalled();
+        });
+      });
+
+      it('id is appended to instance', function () {
+        expect(instance.id).not.toBeDefined();
+        promise.then(function () {
+          expect(instance.id).toBeDefined();
+          expect(instance.id).toEqual(jasmine.any(String));
+        });
+      });
+
+      describe('when one mandatory field is missing', function () {
+        beforeEach(function () {
+          expectedError = 'contact_id, from_date and from_date_type in params are mandatory';
+          delete instance.contact_id;
+          promise = instance.create();
+        });
+
+        afterEach(function () {
+          //to excute the promise force an digest
+          $rootScope.$apply();
+        });
+
+        it('fails to create instance', function () {
+          promise.catch(function (error) {
+            expect(error).toBe(expectedError);
+          });
+        });
+      });
+    });
+
+    describe('isValid()', function () {
+      beforeEach(function () {
+        requestData = {
+          contact_id: '123'
+        };
+        instance = instance.init(requestData);
+        promise = instance.isValid();
+      });
+
+      afterEach(function () {
+        $rootScope.$apply();
+      });
+
+      it('calls equivalent API method', function () {
+        promise.then(function () {
+          expect(LeaveRequestAPI.isValid).toHaveBeenCalled();
+        });
+      });
+
+      describe('when leave request is valid', function () {
+        it('returns no error', function () {
+          promise.then(function (result) {
+            expect(result).toEqual([]);
+          });
+        });
+
+        describe('when valid data not present', function () {
+          beforeEach(function () {
+            delete instance.contact_id;
+            promise = instance.isValid();
+          });
+
+          afterEach(function () {
+            $rootScope.$apply();
+          });
+
+          it('returns array of errors', function () {
+            promise.catch(function (result) {
+              expect(Object.keys(result).length).toBeGreaterThan(0);
+            });
+          });
+        });
+      });
+    });
+
+    describe('update()', function () {
+      var toAPIReturnValue = {
+          key: jasmine.any(String)
+        };
+
+      beforeEach(function () {
+        var defer = $q.defer();
+        LeaveRequestAPI.update.and.returnValue(defer.promise);
+        defer.resolve(jasmine.any(Object));
+        spyOn(instance, 'toAPI').and.returnValue(toAPIReturnValue);
+
+        promise = instance.update();
+      });
+
+      afterEach(function () {
+        $rootScope.$apply();
+      });
+
+      it('calls update api method with the return value of toAPI method', function () {
+        promise.then(function () {
+          expect(LeaveRequestAPI.update).toHaveBeenCalledWith(toAPIReturnValue, 'sick');
+        });
+      });
+
+      it('calls toAPI method', function () {
+        promise.then(function () {
+          expect(instance.toAPI).toHaveBeenCalled();
+        });
+      })
+    });
+  });
+});


### PR DESCRIPTION
The `LeaveRequestInstance` is extended to provide support for `SicknessRequestInstance`. 

The `create`, `isValid` and `update` methods are extended.

The appropriate `LeaveRequestAPI` endpoint is called with `sick` leave type status set.