### PR TITLE
PCHR-1871: Redirect Invalid URL's to T&A Dashboard

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Page/Error404Checker.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Page/Error404Checker.php
@@ -1,0 +1,16 @@
+<?php
+
+require_once 'CRM/Core/Page.php';
+
+/**
+ * Handles CiviCRM paths that are not registered in menu table.
+ */
+class CRM_HRCore_Page_Error404Checker extends CRM_Core_Page {
+  
+  /**
+   * Redirects to Tasks & Assignments Dashboard.
+   */
+  public function run() {
+    CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/tasksassignments/dashboard', 'reset=1'));
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/xml/Menu/hrcore.xml
+++ b/uk.co.compucorp.civicrm.hrcore/xml/Menu/hrcore.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<menu>
+  <item>
+     <path>civicrm</path>
+     <title>CiviCRM</title>
+     <access_callback>CRM_Core_Permission::checkMenu</access_callback>
+     <access_arguments>access CiviCRM</access_arguments>
+     <page_callback>CRM_HRCore_Page_Error404Checker</page_callback>
+     <page_arguments>null</page_arguments>
+     <is_ssl>false</is_ssl>
+     <weight>0</weight>
+  </item>
+  <item>
+     <path>civicrm/dashboard</path>
+     <title>CiviCRM</title>
+     <access_callback>CRM_Core_Permission::checkMenu</access_callback>
+     <access_arguments>access CiviCRM</access_arguments>
+     <page_callback>CRM_HRCore_Page_Error404Checker</page_callback>
+     <page_arguments>null</page_arguments>
+     <is_ssl>false</is_ssl>
+     <weight>0</weight>
+  </item>
+  <item>
+     <path>civicrm/default/dashboard</path>
+     <title>CiviCRM</title>
+     <access_callback>CRM_Core_Permission::checkMenu</access_callback>
+     <access_arguments>access CiviCRM</access_arguments>
+     <page_callback>CRM_Contact_Page_DashBoard</page_callback>
+     <page_arguments>null</page_arguments>
+     <is_ssl>false</is_ssl>
+     <weight>0</weight>
+  </item>
+</menu>


### PR DESCRIPTION
## Problem
Accessing non existing pages in civicrm application results in showing invalid data, being showed by default CiviCRM dashboard.

![before](https://cloud.githubusercontent.com/assets/21999940/22661281/d3fb994a-ec72-11e6-8a94-77a0cf99db1c.png)


## Solution
Implemented handling of invalid CiviCRM paths by overriding "civicrm" default path and redirecting to T&A Dashboard.

![after](https://cloud.githubusercontent.com/assets/21999940/22692530/7bd2dcec-ed0d-11e6-9641-cdcb810e2552.png)
