### PR TITLE
PCHR-1894: Build ACL filter using Leave Approver relationship types in settings

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/SettingsManager.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/SettingsManager.php
@@ -1,0 +1,16 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_InMemorySettingsManager as InMemorySettingsManager;
+use CRM_HRLeaveAndAbsences_Service_APISettingsManager as APISettingsManager;
+
+class CRM_HRLeaveAndAbsences_Factory_SettingsManager {
+
+  public static function create($inMemory = false) {
+    if ($inMemory) {
+      return new InMemorySettingsManager();
+    }
+
+    return new APISettingsManager();
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/SettingsManager.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/SettingsManager.php
@@ -3,8 +3,22 @@
 use CRM_HRLeaveAndAbsences_Service_InMemorySettingsManager as InMemorySettingsManager;
 use CRM_HRLeaveAndAbsences_Service_APISettingsManager as APISettingsManager;
 
+/**
+ * Creates CRM_HRLeaveAndAbsences_Service_SettingsManager instances
+ */
 class CRM_HRLeaveAndAbsences_Factory_SettingsManager {
 
+  /**
+   * Instantiate a new CRM_HRLeaveAndAbsences_Service_SettingsManager
+   * implementation and returns it.
+   *
+   * By default, it will create an APISettingsManager instance, but if $inMemory
+   * is true, an InMemorySettings instance will be returned
+   *
+   * @param bool $inMemory
+   *
+   * @return \CRM_HRLeaveAndAbsences_Service_SettingsManager
+   */
   public static function create($inMemory = false) {
     if ($inMemory) {
       return new InMemorySettingsManager();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/APISettingsManager.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/APISettingsManager.php
@@ -2,8 +2,15 @@
 
 use CRM_HRLeaveAndAbsences_Service_SettingsManager as SettingsManager;
 
+/**
+ * A CRM_HRLeaveAndAbsences_Service_SettingsManager implementation that uses the
+ * CiviCRM Setting API to store and retrieve settings.
+ */
 class CRM_HRLeaveAndAbsences_Service_APISettingsManager implements SettingsManager {
 
+  /**
+   * {@inheritdoc}
+   */
   public function get($setting) {
     $result = civicrm_api3('Setting', 'get', [
       'sequential' => 1,
@@ -17,6 +24,9 @@ class CRM_HRLeaveAndAbsences_Service_APISettingsManager implements SettingsManag
     return null;
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function set($setting, $value) {
     civicrm_api3('Setting', 'create', [
       'sequential' => 1,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/APISettingsManager.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/APISettingsManager.php
@@ -1,0 +1,26 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_SettingsManager as SettingsManager;
+
+class CRM_HRLeaveAndAbsences_Service_APISettingsManager implements SettingsManager {
+
+  public function get($setting) {
+    $result = civicrm_api3('Setting', 'get', [
+      'sequential' => 1,
+      'return' => [$setting],
+    ]);
+
+    if(!empty($result['values'][0][$setting])) {
+      return $result['values'][0][$setting];
+    }
+
+    return null;
+  }
+
+  public function set($setting, $value) {
+    civicrm_api3('Setting', 'create', [
+      'sequential' => 1,
+      $setting => $value
+    ]);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/InMemorySettingsManager.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/InMemorySettingsManager.php
@@ -2,14 +2,33 @@
 
 use CRM_HRLeaveAndAbsences_Service_SettingsManager as SettingsManager;
 
+/**
+ * A CRM_HRLeaveAndAbsences_Service_SettingsManager implementation that stores
+ * the settings in a array in memory.
+ *
+ * This main purpose of this class is to be used in tests and avoid caching
+ * problems with the Setting API. Also, using in an actual/production
+ * environment would not be very useful, as the settings would be lost after
+ * every request.
+ */
 class CRM_HRLeaveAndAbsences_Service_InMemorySettingsManager implements SettingsManager {
 
+  /**
+   * @var array
+   *   Array to store the settings
+   */
   private $settings = [];
 
+  /**
+   * {@inheritdoc}
+   */
   public function get($setting) {
     return isset($this->settings[$setting]) ? $this->settings[$setting] : null;
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function set($setting, $value) {
     $this->settings[$setting] = $value;
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/InMemorySettingsManager.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/InMemorySettingsManager.php
@@ -1,0 +1,16 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_SettingsManager as SettingsManager;
+
+class CRM_HRLeaveAndAbsences_Service_InMemorySettingsManager implements SettingsManager {
+
+  private $settings = [];
+
+  public function get($setting) {
+    return isset($this->settings[$setting]) ? $this->settings[$setting] : null;
+  }
+
+  public function set($setting, $value) {
+    $this->settings[$setting] = $value;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/SettingsManager.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/SettingsManager.php
@@ -1,0 +1,6 @@
+<?php
+
+interface CRM_HRLeaveAndAbsences_Service_SettingsManager {
+  public function get($setting);
+  public function set($setting, $value);
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/SettingsManager.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/SettingsManager.php
@@ -1,6 +1,29 @@
 <?php
 
+/**
+ * A Setting is a pair of name and value. A implementation of a Settings manager
+ * should be able to store the setting somewhere and, given a setting name,
+ * retrieve its value.
+ */
 interface CRM_HRLeaveAndAbsences_Service_SettingsManager {
+
+  /**
+   * Returns the value of the given setting. If the setting doesn't exist, then
+   * null will be returned.
+   *
+   * @param string $setting
+   *
+   * @return mixed|null
+   */
   public function get($setting);
+
+  /**
+   * Sets the value of the given settting. The value can be of any type, except
+   * objects. The reason is that we want all the implementations to support the
+   * same types, and the CiviCRM API doesn't support them.
+   *
+   * @param string $setting
+   * @param mixed $value
+   */
   public function set($setting, $value);
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -515,3 +515,21 @@ function _hrleaveandabsences_civicrm_post_absencetype($op, $objectId, &$objectRe
     } catch (Exception $e) {}
   }
 }
+
+/**
+ * Uses the hook_civicrm_container hook in order to insert L&A services in the
+ * global Civi container.
+ *
+ * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+ */
+function hrleaveandabsences_civicrm_container(\Symfony\Component\DependencyInjection\ContainerBuilder $container) {
+  $settingsManagerDefinition = new Symfony\Component\DependencyInjection\Definition(
+    CRM_HRLeaveAndAbsences_Service_SettingsManager::class
+  );
+  $settingsManagerDefinition->setFactoryClass(CRM_HRLeaveAndAbsences_Factory_SettingsManager::class);
+  $settingsManagerDefinition->setFactoryMethod('create');
+  // If we running unit tests, this will make the factory return an InMemorySettingsManager
+  $settingsManagerDefinition->setArguments([CIVICRM_UF == 'UnitTests']);
+
+  $container->setDefinition('hrleaveandabsences.settings_manager', $settingsManagerDefinition);
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Factory/SettingsManagerTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Factory/SettingsManagerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Factory_SettingsManager as SettingsManagerFactory;
+use CRM_HRLeaveAndAbsences_Service_APISettingsManager as APISettingsManager;
+use CRM_HRLeaveAndAbsences_Service_InMemorySettingsManager as InMemorySettingsManager;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Factory_SettingsManagerTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_Factory_SettingsManagerTest extends BaseHeadlessTest {
+
+  public function testItCreatesAnAPISettingsManagerByDefault() {
+    $settingsManager = SettingsManagerFactory::create();
+
+    $this->assertInstanceOf(APISettingsManager::class, $settingsManager);
+  }
+
+  public function testItCreatesAnInMemorySettingsManagerWhenInMemoryParamIsTrue() {
+    $settingsManager = SettingsManagerFactory::create(true);
+
+    $this->assertInstanceOf(InMemorySettingsManager::class, $settingsManager);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/APISettingsManagerTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/APISettingsManagerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_APISettingsManager as APISettingsManager;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Service_InMemorySettingsManagerTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_Service_APISettingsManagerTest extends BaseHeadlessTest {
+
+  /**
+   * @var CRM_HRLeaveAndAbsences_Service_SettingsManager
+   */
+  private $settingsManager;
+
+  public function setUp() {
+    $this->settingsManager = new APISettingsManager();
+  }
+
+  public function testItReturnsNullIfTheSettingDoesntExist() {
+    $this->assertNull($this->settingsManager->get('whatever'));
+  }
+
+  /**
+   * @dataProvider settingValuesInDifferentTypes
+   */
+  public function testItReturnsTheStoredSetting($value) {
+    $setting = 'lorem_ipsum';
+
+    // It's very hard to test things that use the Setting API. It requires a
+    // complete system/cache flush which is very slow to do in a test. For this
+    // reason, we mock the API 'create' and 'get' methods here in a way to
+    // check that the Service will call the right actions with the right params
+    $apiKernel = \Civi::service('civi_api_kernel');
+    $adhocProvider = new \Civi\API\Provider\AdhocProvider(3, 'Setting');
+    $apiKernel->registerApiProvider($adhocProvider);
+
+    $adhocProvider->addAction('create', '', function ($apiRequest) use($value, $setting) {
+      $this->assertEquals($value, $apiRequest['params'][$setting]);
+
+      return civicrm_api3_create_success([
+        $setting => $value
+      ]);
+    });
+
+    $adhocProvider->addAction('get', '', function ($apiRequest) use($value, $setting) {
+      $this->assertEquals(1, $apiRequest['params']['sequential']);
+      $this->assertEquals([$setting], $apiRequest['params']['return']);
+
+      return civicrm_api3_create_success([
+        [$setting => $value]
+      ], [], 'Setting', 'get');
+    });
+
+    $this->settingsManager->set($setting, $value);
+
+    $this->assertEquals($value, $this->settingsManager->get($setting));
+  }
+
+  public function settingValuesInDifferentTypes() {
+    return [
+      [1],
+      ['2'],
+      ['lambda, lambda, lambda'],
+      [false],
+      [true],
+      [[1, 3, 'dasdsa', 4 => ['dasdsadsa']]]
+    ];
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/InMemorySettingsManagerTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/InMemorySettingsManagerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_InMemorySettingsManager as InMemorySettingsManager;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Service_InMemorySettingsManagerTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_Service_InMemorySettingsManagerTest extends BaseHeadlessTest {
+
+  /**
+   * @var CRM_HRLeaveAndAbsences_Service_SettingsManager
+   */
+  private $settingsManager;
+
+  public function setUp() {
+    $this->settingsManager = new InMemorySettingsManager();
+  }
+
+  public function testItReturnsNullIfTheSettingDoesntExist() {
+    $this->assertNull($this->settingsManager->get('whatever'));
+  }
+
+  /**
+   * @dataProvider settingValuesInDifferentTypes
+   */
+  public function testItReturnsTheStoredSetting($value) {
+    $setting = 'lorem_ipsum';
+    $this->settingsManager->set($setting, $value);
+
+    $this->assertEquals($value, $this->settingsManager->get($setting));
+  }
+
+  public function testItCanUpdateTheValueOfAnExistingSetting() {
+    $setting = 'yadda';
+
+    $this->settingsManager->set($setting, 'value 1');
+
+    $this->assertEquals('value 1', $this->settingsManager->get($setting));
+
+    $this->settingsManager->set($setting, 'value 2');
+
+    $this->assertEquals('value 2', $this->settingsManager->get($setting));
+  }
+
+  public function settingValuesInDifferentTypes() {
+    return [
+      [1],
+      ['2'],
+      ['lambda, lambda, lambda'],
+      [false],
+      [true],
+      [[1, 3, 'dasdsa', 4 => ['dasdsadsa']]],
+    ];
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrixTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrixTest.php
@@ -46,44 +46,56 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrixTest extends BaseHe
     $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($fromStatus, $toStatus, $this->contactID));
   }
 
-  /**
-   * @dataProvider allPossibleStatusTransitionForLeaveApproverDataProvider
-   */
-  public function testCanTransitionToForLeaveApproverReturnsTrueForAllPossibleTransitionStatuses($manager, $leaveContact, $fromStatus, $toStatus) {
+  public function testCanTransitionToForLeaveApproverReturnsTrueForAllPossibleTransitionStatuses() {
+    $manager = ContactFabricator::fabricate();
+    $leaveContact = ContactFabricator::fabricate();
     $this->registerCurrentLoggedInContactInSession($manager['id']);
     $this->setContactAsLeaveApproverOf($manager, $leaveContact);
 
-    $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo($fromStatus, $toStatus, $leaveContact['id']));
+    $possibleTransitions = $this->allPossibleStatusTransitionForLeaveApprover();
+
+    foreach($possibleTransitions as $transition) {
+      $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $leaveContact['id']));
+    }
   }
 
-  /**
-   * @dataProvider allNonPossibleStatusTransitionForLeaveApproverDataProvider
-   */
-  public function testCanTransitionToForLeaveApproverReturnsFalseForAllNonPossibleTransitionStatuses($manager, $leaveContact, $fromStatus, $toStatus) {
+  public function testCanTransitionToForLeaveApproverReturnsFalseForAllNonPossibleTransitionStatuses() {
+    $manager = ContactFabricator::fabricate();
+    $leaveContact = ContactFabricator::fabricate();
     $this->registerCurrentLoggedInContactInSession($manager['id']);
     $this->setContactAsLeaveApproverOf($manager, $leaveContact);
 
-    $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($fromStatus, $toStatus, $leaveContact['id']));
+    $nonPossibleTransitions = $this->allNonPossibleStatusTransitionForLeaveApprover();
+
+    foreach($nonPossibleTransitions as $transition) {
+      $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $leaveContact['id']));
+    }
   }
 
-  /**
-   * @dataProvider allPossibleStatusTransitionForLeaveApproverDataProvider
-   */
-  public function testCanTransitionToForAdminForReturnsTrueAllPossibleTransitionStatuses($manager, $leaveContact, $fromStatus, $toStatus) {
+  public function testCanTransitionToForAdminForReturnsTrueAllPossibleTransitionStatuses() {
+    $manager = ContactFabricator::fabricate();
+    $leaveContact = ContactFabricator::fabricate();
     $this->registerCurrentLoggedInContactInSession($manager['id']);
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer leave and absences'];
 
-    $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo($fromStatus, $toStatus, $leaveContact['id']));
+    $possibleTransitions = $this->allPossibleStatusTransitionForLeaveApprover();
+
+    foreach($possibleTransitions as $transition) {
+      $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $leaveContact['id']));
+    }
   }
 
-  /**
-   * @dataProvider allNonPossibleStatusTransitionForLeaveApproverDataProvider
-   */
-  public function testCanTransitionToForAdminReturnsFalseForAllNonPossibleTransitionStatuses($manager, $leaveContact, $fromStatus, $toStatus) {
+  public function testCanTransitionToForAdminReturnsFalseForAllNonPossibleTransitionStatuses() {
+    $manager = ContactFabricator::fabricate();
+    $leaveContact = ContactFabricator::fabricate();
     $this->registerCurrentLoggedInContactInSession($manager['id']);
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer leave and absences'];
 
-    $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($fromStatus, $toStatus, $leaveContact['id']));
+    $nonPossibleTransitions = $this->allNonPossibleStatusTransitionForLeaveApprover();
+
+    foreach($nonPossibleTransitions as $transition) {
+      $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $leaveContact['id']));
+    }
   }
 
   public function allPossibleStatusTransitionForStaffDataProvider() {
@@ -130,51 +142,47 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrixTest extends BaseHe
     ];
   }
 
-  public function allPossibleStatusTransitionForLeaveApproverDataProvider() {
+  public function allPossibleStatusTransitionForLeaveApprover() {
     $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
-    $manager = ContactFabricator::fabricate();
-    $leaveContact = ContactFabricator::fabricate();
 
     return [
-      [$manager, $leaveContact, $leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['more_information_requested']],
-      [$manager, $leaveContact, $leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['rejected']],
-      [$manager, $leaveContact, $leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['approved']],
-      [$manager, $leaveContact, $leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['cancelled']],
-      [$manager, $leaveContact, $leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['more_information_requested']],
-      [$manager, $leaveContact, $leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['rejected']],
-      [$manager, $leaveContact, $leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['approved']],
-      [$manager, $leaveContact, $leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['cancelled']],
-      [$manager, $leaveContact, $leaveRequestStatuses['rejected'], $leaveRequestStatuses['more_information_requested']],
-      [$manager, $leaveContact, $leaveRequestStatuses['rejected'], $leaveRequestStatuses['rejected']],
-      [$manager, $leaveContact, $leaveRequestStatuses['rejected'], $leaveRequestStatuses['approved']],
-      [$manager, $leaveContact, $leaveRequestStatuses['rejected'], $leaveRequestStatuses['cancelled']],
-      [$manager, $leaveContact, $leaveRequestStatuses['approved'], $leaveRequestStatuses['more_information_requested']],
-      [$manager, $leaveContact, $leaveRequestStatuses['approved'], $leaveRequestStatuses['rejected']],
-      [$manager, $leaveContact, $leaveRequestStatuses['approved'], $leaveRequestStatuses['approved']],
-      [$manager, $leaveContact, $leaveRequestStatuses['approved'], $leaveRequestStatuses['cancelled']],
-      [$manager, $leaveContact, $leaveRequestStatuses['cancelled'], $leaveRequestStatuses['waiting_approval']],
-      [$manager, $leaveContact, $leaveRequestStatuses['cancelled'], $leaveRequestStatuses['more_information_requested']],
-      [$manager, $leaveContact,$leaveRequestStatuses['cancelled'], $leaveRequestStatuses['rejected']],
-      [$manager, $leaveContact, $leaveRequestStatuses['cancelled'], $leaveRequestStatuses['approved']],
-      [$manager, $leaveContact, $leaveRequestStatuses['cancelled'], $leaveRequestStatuses['cancelled']],
-      [$manager, $leaveContact, '', $leaveRequestStatuses['more_information_requested']],
-      [$manager, $leaveContact, '', $leaveRequestStatuses['approved']],
+      [$leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['more_information_requested']],
+      [$leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['rejected']],
+      [$leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['approved']],
+      [$leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['cancelled']],
+      [$leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['more_information_requested']],
+      [$leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['rejected']],
+      [$leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['approved']],
+      [$leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['cancelled']],
+      [$leaveRequestStatuses['rejected'], $leaveRequestStatuses['more_information_requested']],
+      [$leaveRequestStatuses['rejected'], $leaveRequestStatuses['rejected']],
+      [$leaveRequestStatuses['rejected'], $leaveRequestStatuses['approved']],
+      [$leaveRequestStatuses['rejected'], $leaveRequestStatuses['cancelled']],
+      [$leaveRequestStatuses['approved'], $leaveRequestStatuses['more_information_requested']],
+      [$leaveRequestStatuses['approved'], $leaveRequestStatuses['rejected']],
+      [$leaveRequestStatuses['approved'], $leaveRequestStatuses['approved']],
+      [$leaveRequestStatuses['approved'], $leaveRequestStatuses['cancelled']],
+      [$leaveRequestStatuses['cancelled'], $leaveRequestStatuses['waiting_approval']],
+      [$leaveRequestStatuses['cancelled'], $leaveRequestStatuses['more_information_requested']],
+      [$leaveRequestStatuses['cancelled'], $leaveRequestStatuses['rejected']],
+      [$leaveRequestStatuses['cancelled'], $leaveRequestStatuses['approved']],
+      [$leaveRequestStatuses['cancelled'], $leaveRequestStatuses['cancelled']],
+      ['', $leaveRequestStatuses['more_information_requested']],
+      ['', $leaveRequestStatuses['approved']],
     ];
   }
 
-  public function allNonPossibleStatusTransitionForLeaveApproverDataProvider() {
+  public function allNonPossibleStatusTransitionForLeaveApprover() {
     $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
-    $manager = ContactFabricator::fabricate();
-    $leaveContact = ContactFabricator::fabricate();
-
+    
     return [
-      [$manager, $leaveContact, $leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['waiting_approval']],
-      [$manager, $leaveContact, $leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['waiting_approval']],
-      [$manager, $leaveContact, $leaveRequestStatuses['rejected'], $leaveRequestStatuses['waiting_approval']],
-      [$manager, $leaveContact, $leaveRequestStatuses['approved'], $leaveRequestStatuses['waiting_approval']],
-      [$manager, $leaveContact, '', $leaveRequestStatuses['waiting_approval']],
-      [$manager, $leaveContact, '', $leaveRequestStatuses['rejected']],
-      [$manager, $leaveContact, '', $leaveRequestStatuses['cancelled']],
+      [$leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['waiting_approval']],
+      [$leaveRequestStatuses['more_information_requested'], $leaveRequestStatuses['waiting_approval']],
+      [$leaveRequestStatuses['rejected'], $leaveRequestStatuses['waiting_approval']],
+      [$leaveRequestStatuses['approved'], $leaveRequestStatuses['waiting_approval']],
+      ['', $leaveRequestStatuses['waiting_approval']],
+      ['', $leaveRequestStatuses['rejected']],
+      ['', $leaveRequestStatuses['cancelled']],
     ];
   }
 }


### PR DESCRIPTION
This PR updates the `ACLQueryHelper` to build the ACL filter using the leave approver relationship types from the General Settings (https://github.com/civicrm/civihr/pull/1391). Before this, the filter would always use the 'has Leave Approved by' relationship.

The relationship types are stored in settings as a list of IDs. This IDs are added to the where clauses as `WHERE relationship_type.id IN(list, of, ids)`.

Testing code that uses the Setting API is a PAIN. You have to flush the cache/system on every test, making things really, really slow. In order to avoid that, I've created a `SettingsManager` interface and two implementations: `InMemorySettingsManager` and `APISettingsManager`. Together with that, there's a SettingsManager Factory, which is able to create instances of both, depending on a given param. Finally, using the civicrm container, I added a `hrleaveandabsences.settings_manager` service, which uses the factory and will always return a InMemorySettingsManager if we are in a test environment (if CIVICRM_UF == 'UnitTests').  The In Memory version doesn't call the API and hence there's no need to flush caches and everything.