### PR TITLE
PCHR-1798: Use Leave Approver relationship types for the managed_by param

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
@@ -92,9 +92,10 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
     if(!empty($this->params['managed_by'])) {
       $managerID = (int)$this->params['managed_by'];
       $today =  '"' . date('Y-m-d') . '"';
+      $leaveApproverRelationshipTypes = $this->getLeaveApproverRelationshipTypes();
 
       $conditions[] = 'rt.is_active = 1';
-      $conditions[] = 'rt.name_a_b = "has Leave Approved by"';
+      $conditions[] = 'rt.id IN(' . implode(',', $leaveApproverRelationshipTypes) . ')';
       $conditions[] = 'r.is_active = 1';
       $conditions[] = "r.contact_id_b = {$managerID}";
       $conditions[] = "(r.start_date IS NULL OR r.start_date <= {$today})";
@@ -299,5 +300,15 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
     }
 
     return $toilLeaveRequestIDs;
+  }
+
+  /**
+   * Returns a list of relationship types stored on the
+   * 'relationship_types_allowed_to_approve_leave' setting
+   *
+   * @return array
+   */
+  private function getLeaveApproverRelationshipTypes() {
+    return Civi::service('hrleaveandabsences.settings_manager')->get('relationship_types_allowed_to_approve_leave');
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
@@ -10,7 +10,7 @@ use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
 use CRM_HRLeaveAndAbsences_BAO_TOILRequest as TOILRequest;
-
+use CRM_HRLeaveAndAbsences_Service_SettingsManager as SettingsManager;
 /**
  * This class is basically a wrapper around Civi\API\SelectQuery.
  *
@@ -40,8 +40,15 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
    */
   private $returnFullDetails = false;
 
-  public function __construct($params) {
+  /**
+   * @var CRM_HRLeaveAndAbsences_Service_SettingsManager
+   *   The SettingsManager instance passed to the constructor
+   */
+  private $settingsManager;
+
+  public function __construct($params, SettingsManager $settingsManager) {
     $this->params = $params;
+    $this->settingsManager = $settingsManager;
     $this->buildCustomQuery();
   }
 
@@ -92,7 +99,7 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
     if(!empty($this->params['managed_by'])) {
       $managerID = (int)$this->params['managed_by'];
       $today =  '"' . date('Y-m-d') . '"';
-      $leaveApproverRelationshipTypes = $this->getLeaveApproverRelationshipTypes();
+      $leaveApproverRelationshipTypes = $this->settingsManager->get('relationship_types_allowed_to_approve_leave');
 
       $conditions[] = 'rt.is_active = 1';
       $conditions[] = 'rt.id IN(' . implode(',', $leaveApproverRelationshipTypes) . ')';
@@ -300,15 +307,5 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
     }
 
     return $toilLeaveRequestIDs;
-  }
-
-  /**
-   * Returns a list of relationship types stored on the
-   * 'relationship_types_allowed_to_approve_leave' setting
-   *
-   * @return array
-   */
-  private function getLeaveApproverRelationshipTypes() {
-    return Civi::service('hrleaveandabsences.settings_manager')->get('relationship_types_allowed_to_approve_leave');
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -107,7 +107,8 @@ function _civicrm_api3_leave_request_get_spec(&$spec) {
  * @throws CiviCRM_API3_Exception
  */
 function civicrm_api3_leave_request_get($params) {
-  $query = new CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect($params);
+  $settingsManager = Civi::service('hrleaveandabsences.settings_manager');
+  $query = new CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect($params, $settingsManager);
   return civicrm_api3_create_success($query->run(), $params, '', 'get');
 }
 
@@ -149,7 +150,8 @@ function _civicrm_api3_leave_request_getfull_spec(&$spec) {
  * @throws CiviCRM_API3_Exception
  */
 function civicrm_api3_leave_request_getfull($params) {
-  $query = new CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect($params);
+  $settingsManager = Civi::service('hrleaveandabsences.settings_manager');
+  $query = new CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect($params, $settingsManager);
   $query->setReturnFullDetails(true);
 
   return civicrm_api3_create_success($query->run(), $params, '', 'getfull');

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -1920,7 +1920,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->fail("Expected to not find the LeaveRequest with {$leaveRequest->id}, but it was found");
   }
 
-  public function testGetShouldOnlyReturnTheLeaveRequestsOfStaffMembersManagedByTheContactOnTheManagedByParam() {
+  public function testGetAndGetFullShouldOnlyReturnTheLeaveRequestsOfStaffMembersManagedByTheContactOnTheManagedByParam() {
     $this->setLeaveApproverRelationshipTypes([
       'has Leaves Approved By',
       'has Leaves Managed By',
@@ -2007,36 +2007,34 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'to_date_type' => 1
     ], true);
 
-    $result = civicrm_api3('LeaveRequest', 'get');
-
-    // Without managed_by, all leave requests should be returned
-    $this->assertEquals(5, $result['count']);
-    $this->assertNotEmpty($result['values'][$leaveRequest1->id]);
-    $this->assertNotEmpty($result['values'][$leaveRequest2->id]);
-    $this->assertNotEmpty($result['values'][$leaveRequest3->id]);
-    $this->assertNotEmpty($result['values'][$leaveRequest4->id]);
-    $this->assertNotEmpty($result['values'][$leaveRequest5->id]);
-
     // On the Leave Requests of contacts managed by manager 1 (staff member 1) will
     // be returned
     $result = civicrm_api3('LeaveRequest', 'get', ['managed_by' => $manager1['id']]);
+    $resultGetFull = civicrm_api3('LeaveRequest', 'getFull', ['managed_by' => $manager1['id']]);
 
     // Without managed_by, all leave requests should be returned
     $this->assertEquals(2, $result['count']);
     $this->assertNotEmpty($result['values'][$leaveRequest1->id]);
     $this->assertNotEmpty($result['values'][$leaveRequest2->id]);
+    $this->assertEquals(2, $resultGetFull['count']);
+    $this->assertNotEmpty($resultGetFull['values'][$leaveRequest1->id]);
+    $this->assertNotEmpty($resultGetFull['values'][$leaveRequest2->id]);
 
     // On the Leave Requests of contacts managed by manager 2 (staff members 2 and 3) will
     // be returned
     $result = civicrm_api3('LeaveRequest', 'get', ['managed_by' => $manager2['id']]);
+    $resultGetFull = civicrm_api3('LeaveRequest', 'getFull', ['managed_by' => $manager2['id']]);
 
     // Without managed_by, all leave requests should be returned
     $this->assertEquals(2, $result['count']);
     $this->assertNotEmpty($result['values'][$leaveRequest3->id]);
     $this->assertNotEmpty($result['values'][$leaveRequest4->id]);
+    $this->assertEquals(2, $resultGetFull['count']);
+    $this->assertNotEmpty($resultGetFull['values'][$leaveRequest3->id]);
+    $this->assertNotEmpty($resultGetFull['values'][$leaveRequest4->id]);
   }
 
-  public function testGetShouldOnlyReturnTheLeaveRequestsOfStaffMembersManagedByManagersWithAnActiveLeaveApproverRelationship() {
+  public function testGetAndGetFullShouldOnlyReturnTheLeaveRequestsOfStaffMembersManagedByManagersWithAnActiveLeaveApproverRelationship() {
     $manager = ContactFabricator::fabricate();
     $staffMember = ContactFabricator::fabricate();
 
@@ -2061,19 +2059,24 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ], true);
 
     $result = civicrm_api3('LeaveRequest', 'get');
+    $resultGetFull = civicrm_api3('LeaveRequest', 'getFull');
 
     // Without managed_by, all leave requests should be returned
     $this->assertEquals(1, $result['count']);
     $this->assertNotEmpty($result['values'][$leaveRequest->id]);
+    $this->assertEquals(1, $resultGetFull['count']);
+    $this->assertNotEmpty($resultGetFull['values'][$leaveRequest->id]);
 
     $result = civicrm_api3('LeaveRequest', 'get', ['managed_by' => $manager['id']]);
+    $resultGetFull = civicrm_api3('LeaveRequest', 'getFull', ['managed_by' => $manager['id']]);
 
     // Even though the relationship was active during the Leave Request date,
     // it's not active today, so nothing will be returned
     $this->assertEquals(0, $result['count']);
+    $this->assertEquals(0, $resultGetFull['count']);
   }
 
-  public function testGetShouldOnlyReturnTheLeaveRequestsOfStaffMembersManagedByManagersWithAnEnabledLeaveApproverRelationship() {
+  public function testGetAndGetFullShouldOnlyReturnTheLeaveRequestsOfStaffMembersManagedByManagersWithAnEnabledLeaveApproverRelationship() {
     $manager = ContactFabricator::fabricate();
     $staffMember = ContactFabricator::fabricate();
 
@@ -2101,14 +2104,19 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ], true);
 
     $result = civicrm_api3('LeaveRequest', 'get');
+    $resultGetFull = civicrm_api3('LeaveRequest', 'getFull');
 
     // Without managed_by, all leave requests should be returned
     $this->assertEquals(1, $result['count']);
     $this->assertNotEmpty($result['values'][$leaveRequest->id]);
+    $this->assertEquals(1, $resultGetFull['count']);
+    $this->assertNotEmpty($resultGetFull['values'][$leaveRequest->id]);
 
     $result = civicrm_api3('LeaveRequest', 'get', ['managed_by' => $manager['id']]);
+    $resultGetFull = civicrm_api3('LeaveRequest', 'getFull', ['managed_by' => $manager['id']]);
 
     $this->assertEquals(0, $result['count']);
+    $this->assertEquals(0, $resultGetFull['count']);
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -1921,6 +1921,11 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testGetShouldOnlyReturnTheLeaveRequestsOfStaffMembersManagedByTheContactOnTheManagedByParam() {
+    $this->setLeaveApproverRelationshipTypes([
+      'has Leaves Approved By',
+      'has Leaves Managed By',
+    ]);
+
     $manager1 = ContactFabricator::fabricate();
     $manager2 = ContactFabricator::fabricate();
 
@@ -1953,9 +1958,9 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     // Set Leave Approvers for staffMembers 1, 2 and 3. Staff Member 4 won't have
     // a Leave Approver
-    $this->setContactAsLeaveApproverOf($manager1, $staffMember1);
-    $this->setContactAsLeaveApproverOf($manager2, $staffMember2);
-    $this->setContactAsLeaveApproverOf($manager2, $staffMember3);
+    $this->setContactAsLeaveApproverOf($manager1, $staffMember1, null, null, true, 'has Leaves Approved By');
+    $this->setContactAsLeaveApproverOf($manager2, $staffMember2, null, null, true, 'has Leaves Approved By');
+    $this->setContactAsLeaveApproverOf($manager2, $staffMember3, null, null, true, 'has Leaves Managed By');
 
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember1['id'],


### PR DESCRIPTION
When the `managed_by` param is present in a call to `LeaveRequest.get` or `LeaveRequest.getFull`, the `LeaveRequestSelect` class changes the database query to include filters to return only the leave requests of contacts managed by the contact with the ID given by `managed_by`.

`LeaveRequestSelect` was only filtering this by the 'has Leave Approved by' relationship type, though. Now that the extensions allows the configuration of multiple relationship types as "Leave Approvers", the class was updated to fetch the types from the settings and use them to build the query.

All the tests for the `managed_by` param were updated to also make sure they will work for both `get` and `getFull` endpoints.