### PR TITLE
PCHR-1836: Modify Leave Request Service

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/LeaveRequestService.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/LeaveRequestService.php
@@ -1,0 +1,34 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange as LeaveBalanceChangeService;
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix as LeaveRequestStatusMatrixService;
+use CRM_HRLeaveAndAbsences_Service_LeaveRequest as LeaveRequestService;
+use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
+
+/**
+ * A factory for the LeaveRequest service, which can be used
+ * to get instances of this service without having to manually create all of
+ * its dependencies
+ */
+class CRM_HRLeaveAndAbsences_Factory_LeaveRequestService {
+
+  /**
+   * Returns a new instance of a LeaveRequest Service
+   *
+   * @return \CRM_HRLeaveAndAbsences_Service_LeaveRequest
+   */
+  public static function create() {
+    $leaveBalanceChangeService = new LeaveBalanceChangeService();
+    $leaveManagerService = new LeaveManagerService();
+    $leaveRequestStatusMatrixService = new LeaveRequestStatusMatrixService($leaveManagerService);
+    $leaveRequestRightsService = new LeaveRequestRightsService($leaveManagerService);
+
+    return new LeaveRequestService(
+      $leaveBalanceChangeService,
+      $leaveRequestStatusMatrixService,
+      $leaveRequestRightsService
+    );
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -5,7 +5,6 @@ use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
 use CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange as LeaveBalanceChangeService;
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
-use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix as LeaveRequestStatusMatrixService;
 
 class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
@@ -14,11 +13,6 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    * @var \LeaveBalanceChangeService
    */
   private $leaveBalanceChangeService;
-
-  /**
-   * @var \CRM_HRLeaveAndAbsences_Service_LeaveManager
-   */
-  private $leaveManagerService;
 
   /**
    * @var \CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix
@@ -40,19 +34,15 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    * CRM_HRLeaveAndAbsences_Service_LeaveRequest constructor.
    *
    * @param \CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange $leaveBalanceChangeService
-   * @param \CRM_HRLeaveAndAbsences_Service_LeaveManager $leaveManagerService
    * @param \CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix $leaveRequestStatusMatrixService
    * @param \CRM_HRLeaveAndAbsences_Service_LeaveRequestRights $leaveRequestRightsService
    */
   public function __construct(
     LeaveBalanceChangeService $leaveBalanceChangeService,
-    LeaveManagerService $leaveManagerService,
     LeaveRequestStatusMatrixService $leaveRequestStatusMatrixService,
     LeaveRequestRightsService $leaveRequestRightsService
-
   ) {
     $this->leaveBalanceChangeService = $leaveBalanceChangeService;
-    $this->leaveManagerService = $leaveManagerService;
     $this->leaveRequestStatusMatrixService = $leaveRequestStatusMatrixService;
     $this->leaveRequestRightsService = $leaveRequestRightsService;
   }
@@ -86,7 +76,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
   }
 
   /**
-   * Performs some checks before a leave request can be updated
+   * Performs some checks/validations required
    *
    * @param array $params
    *

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -4,6 +4,9 @@ use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
 use CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange as LeaveBalanceChangeService;
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
+use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix as LeaveRequestStatusMatrixService;
 
 class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
 
@@ -12,8 +15,46 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    */
   private $leaveBalanceChangeService;
 
-  public function __construct(LeaveBalanceChangeService $leaveBalanceChangeService) {
+  /**
+   * @var \CRM_HRLeaveAndAbsences_Service_LeaveManager
+   */
+  private $leaveManagerService;
+
+  /**
+   * @var \CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix
+   */
+  private $leaveRequestStatusMatrixService;
+
+  /**
+   * @var \CRM_HRLeaveAndAbsences_Service_LeaveRequestRights
+   */
+  private $leaveRequestRightsService;
+
+  /**
+   * The leave request object before it gets updated.
+   * @var CRM_HRLeaveAndAbsences_BAO_LeaveRequest
+   */
+  private $oldLeaveRequest;
+
+  /**
+   * CRM_HRLeaveAndAbsences_Service_LeaveRequest constructor.
+   *
+   * @param \CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange $leaveBalanceChangeService
+   * @param \CRM_HRLeaveAndAbsences_Service_LeaveManager $leaveManagerService
+   * @param \CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix $leaveRequestStatusMatrixService
+   * @param \CRM_HRLeaveAndAbsences_Service_LeaveRequestRights $leaveRequestRightsService
+   */
+  public function __construct(
+    LeaveBalanceChangeService $leaveBalanceChangeService,
+    LeaveManagerService $leaveManagerService,
+    LeaveRequestStatusMatrixService $leaveRequestStatusMatrixService,
+    LeaveRequestRightsService $leaveRequestRightsService
+
+  ) {
     $this->leaveBalanceChangeService = $leaveBalanceChangeService;
+    $this->leaveManagerService = $leaveManagerService;
+    $this->leaveRequestStatusMatrixService = $leaveRequestStatusMatrixService;
+    $this->leaveRequestRightsService = $leaveRequestRightsService;
   }
 
   /**
@@ -25,10 +66,62 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    * @return \CRM_HRLeaveAndAbsences_BAO_LeaveRequest|NULL
    */
   public function create($params, $validate = true) {
-    $leaveRequest = LeaveRequest::create($params, $validate);
+    if ($validate) {
+      LeaveRequest::validateParams($params);
+    }
+
+    if(!$this->canCreateAndUpdateLeaveRequestFor($params['contact_id'])) {
+      throw new RuntimeException('You are not allowed to create or update a leave request for this employee');
+    }
+
+    if(!empty($params['id'])) {
+      return $this->update($params);
+    }
+
+    if(!$this->isValidStatusTransition('', $params['status_id'], $params['contact_id'])) {
+      throw new RuntimeException("You can't create a Leave Request with this status");
+    }
+
+    $leaveRequest = LeaveRequest::create($params, false);
     $this->leaveBalanceChangeService->createForLeaveRequest($leaveRequest);
 
     return $leaveRequest;
+  }
+
+  /**
+   * Performs some checks before a leave request can be updated
+   *
+   * @param array $params
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_LeaveRequest|NULL
+   */
+  protected function update($params) {
+    if ($this->datesChanged($params) && !$this->canChangeDatesFor($params)) {
+      throw new RuntimeException('You are not allowed to change the request dates');
+    }
+
+    if ($this->absenceTypeChanged($params) && !$this->canChangeAbsenceTypeFor($params)) {
+      throw new RuntimeException('You are not allowed to change the type of a request');
+    }
+
+    if ($this->statusChanged($params) && !$this->isValidStatusTransition(
+      $this->getCurrentStatus($params), $params['status_id'], $params['contact_id'])
+    ) {
+      throw new RuntimeException(
+        "You can't change the Leave Request status from ".
+        $this->getCurrentStatus($params). " to {$params['status_id']}"
+      );
+    }
+
+    if ($this->statusChanged($params) && !$this->currentUserCanChangeStatusTo(
+      $params['status_id'], $params['contact_id'])
+    ) {
+      throw new RuntimeException(
+        "You don't have enough permission to change the status to {$params['status_id']}"
+      );
+    }
+
+    return LeaveRequest::create($params, false);
   }
 
   /**
@@ -50,5 +143,154 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
     } catch(Exception $e) {
       $transaction->rollback();
     }
+  }
+
+  /**
+   * Checks if the status transition from $fromStatus to $toStatus is possible
+   * using the method provided by the leaveRequestStatusMatrix service.
+   *
+   * @param int $fromStatus
+   * @param int $toStatus
+   * @param int $contactID
+   *
+   * @return bool
+   */
+  private function isValidStatusTransition($fromStatus, $toStatus, $contactID) {
+    return $this->leaveRequestStatusMatrixService->canTransitionTo($fromStatus, $toStatus, $contactID);
+  }
+
+  /**
+   * Checks if the current user can create/update a leave request
+   *
+   * @param int $contactID
+   *
+   * @return bool
+   */
+  private function canCreateAndUpdateLeaveRequestFor($contactID) {
+    return $this->leaveRequestRightsService->canCreateAndUpdateFor($contactID);
+  }
+
+  /**
+   * Checks if the current user can change/update the leave request dates
+   *
+   * @param array $params
+   *
+   * @return bool
+   */
+  private function canChangeDatesFor($params) {
+    return $this->leaveRequestRightsService->canChangeDatesFor($params['contact_id'], $params['status_id']);
+  }
+
+  /**
+   * Checks if the current user can update the absence type of a leave request
+   *
+   * @param array $params
+   *
+   * @return bool
+   */
+  private function canChangeAbsenceTypeFor($params) {
+    return $this->leaveRequestRightsService->canChangeAbsenceTypeFor($params['contact_id'], $params['status_id']);
+  }
+
+  /**
+   * Checks if the from_date or to_date of a leave request has changed by comparing the
+   * date values to be updated to the current values in the database
+   *
+   * @param array $params
+   *
+   * @return bool
+   */
+  private function datesChanged($params) {
+    $oldLeaveRequest = self::getOldLeaveRequest($params['id']);
+    $fromDate = new DateTime($params['from_date']);
+    $toDate = new DateTime($params['to_date']);
+    $leaveRequestFromDate = new DateTime($oldLeaveRequest->from_date);
+    $leaveRequestToDate = new DateTime($oldLeaveRequest->to_date);
+
+    return $leaveRequestFromDate != $fromDate || $leaveRequestToDate != $toDate;
+  }
+
+  /**
+   * Checks if the current user has permissions to update the leave request to the new status
+   *
+   * @param int $newStatus
+   * @param int $contactID
+   *
+   * @return bool
+   */
+  private function currentUserCanChangeStatusTo($newStatus, $contactID) {
+    $leaveStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+
+    switch ($newStatus) {
+      case $leaveStatuses['cancelled']:
+        return $this->leaveRequestRightsService->canCancelFor($contactID);
+
+      case $leaveStatuses['approved']:
+        return $this->leaveRequestRightsService->canApproveFor($contactID);
+
+      case $leaveStatuses['rejected']:
+        return $this->leaveRequestRightsService->canRejectFor($contactID);
+
+      case $leaveStatuses['more_information_requested']:
+        return $this->leaveRequestRightsService->canRequestMoreInformationFor($contactID);
+
+      case $leaveStatuses['waiting_approval']:
+        return $this->leaveRequestRightsService->canPutInWaitingForApprovalFor($contactID);
+
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * Checks if absence type of a leave request has changed by comparing the
+   * value to be updated to the current absence type value in the database
+   *
+   * @param array $params
+   *
+   * @return bool
+   */
+  private function absenceTypeChanged($params) {
+    $oldLeaveRequest = self::getOldLeaveRequest($params['id']);
+    return $oldLeaveRequest->type_id != $params['type_id'];
+  }
+
+  /**
+   * Checks if the status of a leave request has changed by comparing the
+   * value to be updated to the current status_id value in the database
+   *
+   * @param array $params
+   *
+   * @return bool
+   */
+  private function statusChanged($params) {
+    $oldLeaveRequest = $this->getOldLeaveRequest($params['id']);
+    return $oldLeaveRequest->status_id != $params['status_id'];
+  }
+
+  /**
+   * Returns the current status of the leave request before it gets updated
+   *
+   * @param array $params
+   *
+   * @return int
+   */
+  private function getCurrentStatus($params) {
+    $oldLeaveRequest = $this->getOldLeaveRequest($params['id']);
+    return $oldLeaveRequest->status_id;
+  }
+
+  /**
+   * Returns the LeaveRequest object in its current state (i.e before it gets updated)
+   *
+   * @param int $leaveRequestID
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_LeaveRequest
+   */
+  private function getOldLeaveRequest($leaveRequestID) {
+    if (!$this->oldLeaveRequest) {
+      $this->oldLeaveRequest = LeaveRequest::findById($leaveRequestID);
+    }
+    return $this->oldLeaveRequest;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -31,8 +31,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
   private $leaveRequestRightsService;
 
   /**
-   * The leave request object before it gets updated.
-   * @var CRM_HRLeaveAndAbsences_BAO_LeaveRequest
+   * @var \CRM_HRLeaveAndAbsences_BAO_LeaveRequest
+   *   The leave request object before it gets updated.
    */
   private $oldLeaveRequest;
 
@@ -82,10 +82,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
       throw new RuntimeException("You can't create a Leave Request with this status");
     }
 
-    $leaveRequest = LeaveRequest::create($params, false);
-    $this->leaveBalanceChangeService->createForLeaveRequest($leaveRequest);
-
-    return $leaveRequest;
+    return $this->createLeaveRequestWithBalanceChange($params);
   }
 
   /**
@@ -121,7 +118,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
       );
     }
 
-    return LeaveRequest::create($params, false);
+    return $this->createLeaveRequestWithBalanceChange($params);
   }
 
   /**
@@ -201,7 +198,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    * @return bool
    */
   private function datesChanged($params) {
-    $oldLeaveRequest = self::getOldLeaveRequest($params['id']);
+    $oldLeaveRequest = $this->getOldLeaveRequest($params['id']);
     $fromDate = new DateTime($params['from_date']);
     $toDate = new DateTime($params['to_date']);
     $leaveRequestFromDate = new DateTime($oldLeaveRequest->from_date);
@@ -251,7 +248,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    * @return bool
    */
   private function absenceTypeChanged($params) {
-    $oldLeaveRequest = self::getOldLeaveRequest($params['id']);
+    $oldLeaveRequest = $this->getOldLeaveRequest($params['id']);
     return $oldLeaveRequest->type_id != $params['type_id'];
   }
 
@@ -292,5 +289,19 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
       $this->oldLeaveRequest = LeaveRequest::findById($leaveRequestID);
     }
     return $this->oldLeaveRequest;
+  }
+
+  /**
+   * Creates/Updates a leave request along with it's balance changes
+   *
+   * @param array $params
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_LeaveRequest|NULL
+   */
+  private function createLeaveRequestWithBalanceChange($params) {
+    $leaveRequest = LeaveRequest::create($params, false);
+    $this->leaveBalanceChangeService->createForLeaveRequest($leaveRequest);
+
+    return $leaveRequest;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 
 class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
 
@@ -8,6 +9,12 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
    * @var \CRM_HRLeaveAndAbsences_Service_LeaveManager
    */
   private $leaveManagerService;
+
+  /**
+   * @var array|null
+   *   Stores the list of option values for the LeaveRequest status_id field.
+   */
+  private static $leaveStatuses;
 
   /**
    * CRM_HRLeaveAndAbsences_Service_LeaveRequestRights constructor.
@@ -28,7 +35,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
    * @return bool
    */
   public function canCancelFor($contactID) {
-    return $this->currentUserIsManagerOrAdmin($contactID) || CRM_Core_Session::getLoggedInContactID() == $contactID;
+    return $this->currentUserIsManagerOrAdmin($contactID) || $this->currentUserIsLeaveContact($contactID);
   }
 
   /**
@@ -84,6 +91,50 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
   }
 
   /**
+   * Checks whether the current user has permissions to create/update the leave request
+   *
+   * @param int $contactID
+   *   The contactID of the leave request
+   *
+   * @return bool
+   */
+  public function canCreateAndUpdateFor($contactID) {
+    return $this->currentUserIsLeaveContact($contactID) || $this->currentUserIsManagerOrAdmin($contactID);
+  }
+
+  /**
+   * Checks whether the current user can update the dates for the leave request or not.
+   *
+   * @param $contactID
+   *   The contactID of the leave request
+   * @param $statusID
+   *   The statusID of the leave request
+   *
+   * @return bool
+   */
+  public function canChangeDatesFor($contactID, $statusID) {
+    $leaveRequestStatuses = self::getLeaveRequestStatuses();
+    return $this->currentUserIsLeaveContact($contactID) &&
+           in_array($statusID, [$leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['more_information_requested']]);
+  }
+
+  /**
+   * Checks whether the current user can update the absence type for the leave request or not.
+   *
+   * @param int $contactID
+   *   The contactID of the leave request
+   * @param int $statusID
+   *   The statusID of the leave request
+   *
+   * @return bool
+   */
+  public function canChangeAbsenceTypeFor($contactID, $statusID) {
+    $leaveRequestStatuses = self::getLeaveRequestStatuses();
+    return $this->currentUserIsLeaveContact($contactID) &&
+           in_array($statusID, [$leaveRequestStatuses['waiting_approval'], $leaveRequestStatuses['more_information_requested']]);
+  }
+
+  /**
    * Checks if the current user is either a leave manager or an Admin
    *
    * @param int $contactID
@@ -94,5 +145,30 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
   private function currentUserIsManagerOrAdmin($contactID) {
     return $this->leaveManagerService->currentUserIsLeaveManagerOf($contactID) ||
            $this->leaveManagerService->currentUserIsAdmin();
+  }
+
+  /**
+   * Checks whether the current user is the leave request contact or not.
+   *
+   * @param int $contactID
+   *   The contactID of the leave request
+   *
+   * @return bool
+   */
+  private function currentUserIsLeaveContact($contactID) {
+    return CRM_Core_Session::getLoggedInContactID() == $contactID;
+  }
+
+  /**
+   * Returns the array of the option values for the LeaveRequest status_id field.
+   *
+   * @return array
+   */
+  private static function getLeaveRequestStatuses() {
+    if (is_null(self::$leaveStatuses)) {
+      self::$leaveStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    }
+
+    return self::$leaveStatuses;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -32,17 +32,7 @@ function civicrm_api3_leave_request_create($params) {
   _civicrm_api3_check_edit_permissions($bao, $params);
   _civicrm_api3_format_params_for_create($params, null);
 
-  $leaveBalanceChangeService = new CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange();
-  $leaveManagerService = new CRM_HRLeaveAndAbsences_Service_LeaveManager();
-  $leaveRequestStatusMatrixService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix($leaveManagerService);
-  $leaveRequestRightsService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestRights($leaveManagerService);
-
-  $service = new CRM_HRLeaveAndAbsences_Service_LeaveRequest(
-    $leaveBalanceChangeService,
-    $leaveManagerService,
-    $leaveRequestStatusMatrixService,
-    $leaveRequestRightsService
-  );
+  $service = CRM_HRLeaveAndAbsences_Factory_LeaveRequestService::create();
 
   $leaveRequest = $service->create($params);
   $values = [];
@@ -64,18 +54,7 @@ function civicrm_api3_leave_request_delete($params) {
   _civicrm_api3_check_edit_permissions($bao, array('id' => $params['id']));
   civicrm_api3_create_success(true);
 
-  $leaveBalanceChangeService = new CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange();
-  $leaveManagerService = new CRM_HRLeaveAndAbsences_Service_LeaveManager();
-  $leaveRequestStatusMatrixService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix($leaveManagerService);
-  $leaveRequestRightsService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestRights($leaveManagerService);
-
-  $service = new CRM_HRLeaveAndAbsences_Service_LeaveRequest(
-    $leaveBalanceChangeService,
-    $leaveManagerService,
-    $leaveRequestStatusMatrixService,
-    $leaveRequestRightsService
-  );
-
+  $service = CRM_HRLeaveAndAbsences_Factory_LeaveRequestService::create();
   $service->delete($params['id']);
 
   return civicrm_api3_create_success(true);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -33,7 +33,17 @@ function civicrm_api3_leave_request_create($params) {
   _civicrm_api3_format_params_for_create($params, null);
 
   $leaveBalanceChangeService = new CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange();
-  $service = new CRM_HRLeaveAndAbsences_Service_LeaveRequest($leaveBalanceChangeService);
+  $leaveManagerService = new CRM_HRLeaveAndAbsences_Service_LeaveManager();
+  $leaveRequestStatusMatrixService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix($leaveManagerService);
+  $leaveRequestRightsService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestRights($leaveManagerService);
+
+  $service = new CRM_HRLeaveAndAbsences_Service_LeaveRequest(
+    $leaveBalanceChangeService,
+    $leaveManagerService,
+    $leaveRequestStatusMatrixService,
+    $leaveRequestRightsService
+  );
+
   $leaveRequest = $service->create($params);
   $values = [];
   _civicrm_api3_object_to_array($leaveRequest, $values[$leaveRequest->id]);
@@ -55,7 +65,17 @@ function civicrm_api3_leave_request_delete($params) {
   civicrm_api3_create_success(true);
 
   $leaveBalanceChangeService = new CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange();
-  $service = new CRM_HRLeaveAndAbsences_Service_LeaveRequest($leaveBalanceChangeService);
+  $leaveManagerService = new CRM_HRLeaveAndAbsences_Service_LeaveManager();
+  $leaveRequestStatusMatrixService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix($leaveManagerService);
+  $leaveRequestRightsService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestRights($leaveManagerService);
+
+  $service = new CRM_HRLeaveAndAbsences_Service_LeaveRequest(
+    $leaveBalanceChangeService,
+    $leaveManagerService,
+    $leaveRequestStatusMatrixService,
+    $leaveRequestRightsService
+  );
+
   $service->delete($params['id']);
 
   return civicrm_api3_create_success(true);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/SicknessRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/SicknessRequest.php
@@ -98,7 +98,16 @@ function civicrm_api3_sickness_request_create($params) {
   _civicrm_api3_format_params_for_create($params, null);
 
   $leaveBalanceChangeService = new CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange();
-  $leaveRequestService = new CRM_HRLeaveAndAbsences_Service_LeaveRequest($leaveBalanceChangeService);
+  $leaveManagerService = new CRM_HRLeaveAndAbsences_Service_LeaveManager();
+  $leaveRequestStatusMatrixService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix($leaveManagerService);
+  $leaveRequestRightsService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestRights($leaveManagerService);
+
+  $leaveRequestService = new CRM_HRLeaveAndAbsences_Service_LeaveRequest(
+    $leaveBalanceChangeService,
+    $leaveManagerService,
+    $leaveRequestStatusMatrixService,
+    $leaveRequestRightsService
+  );
   $service = new CRM_HRLeaveAndAbsences_Service_SicknessRequest($leaveBalanceChangeService, $leaveRequestService);
 
   $sicknessRequest = $service->create($params);
@@ -124,7 +133,16 @@ function civicrm_api3_sickness_request_delete($params) {
   _civicrm_api3_check_edit_permissions($bao, ['id' => $params['id']]);
 
   $leaveBalanceChangeService = new CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange();
-  $leaveRequestService = new CRM_HRLeaveAndAbsences_Service_LeaveRequest($leaveBalanceChangeService);
+  $leaveManagerService = new CRM_HRLeaveAndAbsences_Service_LeaveManager();
+  $leaveRequestStatusMatrixService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix($leaveManagerService);
+  $leaveRequestRightsService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestRights($leaveManagerService);
+
+  $leaveRequestService = new CRM_HRLeaveAndAbsences_Service_LeaveRequest(
+    $leaveBalanceChangeService,
+    $leaveManagerService,
+    $leaveRequestStatusMatrixService,
+    $leaveRequestRightsService
+  );
   $service = new CRM_HRLeaveAndAbsences_Service_SicknessRequest($leaveBalanceChangeService, $leaveRequestService);
   $service->delete($params['id']);
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/SicknessRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/SicknessRequest.php
@@ -98,16 +98,7 @@ function civicrm_api3_sickness_request_create($params) {
   _civicrm_api3_format_params_for_create($params, null);
 
   $leaveBalanceChangeService = new CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange();
-  $leaveManagerService = new CRM_HRLeaveAndAbsences_Service_LeaveManager();
-  $leaveRequestStatusMatrixService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix($leaveManagerService);
-  $leaveRequestRightsService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestRights($leaveManagerService);
-
-  $leaveRequestService = new CRM_HRLeaveAndAbsences_Service_LeaveRequest(
-    $leaveBalanceChangeService,
-    $leaveManagerService,
-    $leaveRequestStatusMatrixService,
-    $leaveRequestRightsService
-  );
+  $leaveRequestService = CRM_HRLeaveAndAbsences_Factory_LeaveRequestService::create();
   $service = new CRM_HRLeaveAndAbsences_Service_SicknessRequest($leaveBalanceChangeService, $leaveRequestService);
 
   $sicknessRequest = $service->create($params);
@@ -133,16 +124,7 @@ function civicrm_api3_sickness_request_delete($params) {
   _civicrm_api3_check_edit_permissions($bao, ['id' => $params['id']]);
 
   $leaveBalanceChangeService = new CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange();
-  $leaveManagerService = new CRM_HRLeaveAndAbsences_Service_LeaveManager();
-  $leaveRequestStatusMatrixService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix($leaveManagerService);
-  $leaveRequestRightsService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestRights($leaveManagerService);
-
-  $leaveRequestService = new CRM_HRLeaveAndAbsences_Service_LeaveRequest(
-    $leaveBalanceChangeService,
-    $leaveManagerService,
-    $leaveRequestStatusMatrixService,
-    $leaveRequestRightsService
-  );
+  $leaveRequestService = CRM_HRLeaveAndAbsences_Factory_LeaveRequestService::create();
   $service = new CRM_HRLeaveAndAbsences_Service_SicknessRequest($leaveBalanceChangeService, $leaveRequestService);
   $service->delete($params['id']);
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Factory/LeaveRequestServiceTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Factory/LeaveRequestServiceTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_LeaveRequest as LeaveRequestService;
+use CRM_HRLeaveAndAbsences_Factory_LeaveRequestService as LeaveRequestServiceFactory;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Factory_LeaveRequestService
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_Factory_LeaveRequestServiceTest extends BaseHeadlessTest  {
+
+  public function testCreate() {
+    $service = LeaveRequestServiceFactory::create();
+
+    $this->assertInstanceOf(LeaveRequestService::class, $service);
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 
 /**
  * Class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest
@@ -144,27 +145,29 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     );
   }
 
-  public function testCanChangeDatesForReturnsFalseWhenCurrentUserNotLeaveContactIrrespectiveOfStatusPassed() {
+  /**
+   * @dataProvider leaveRequestStatusesDataProvider
+   */
+  public function testCanChangeDatesForReturnsFalseWhenCurrentUserNotLeaveContactIrrespectiveOfStatusPassed($status) {
     $contactID = 2;
-
     $this->assertFalse(
       $this->getLeaveRequestRightsForLeaveManagerAsCurrentUser()->canChangeDatesFor(
         $contactID,
-        $this->leaveRequestStatuses['Cancelled']['id']
+        $status
       )
     );
 
     $this->assertFalse(
       $this->getLeaveRequestRightsForAdminAsCurrentUser()->canChangeDatesFor(
         $contactID,
-        $this->leaveRequestStatuses['Rejected']['id']
+        $status
       )
     );
 
     $this->assertFalse(
       $this->getLeaveRightsService()->canChangeDatesFor(
         $contactID,
-        $this->leaveRequestStatuses['Approved']['id']
+        $status
       )
     );
   }
@@ -205,27 +208,30 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     );
   }
 
-  public function testCanChangeAbsenceTypeForReturnsFalseWhenCurrentUserNotLeaveContactIrrespectiveOfStatusPassed() {
+  /**
+   * @dataProvider leaveRequestStatusesDataProvider
+   */
+  public function testCanChangeAbsenceTypeForReturnsFalseWhenCurrentUserNotLeaveContactIrrespectiveOfStatusPassed($status) {
     $contactID = 2;
 
     $this->assertFalse(
       $this->getLeaveRequestRightsForLeaveManagerAsCurrentUser()->canChangeAbsenceTypeFor(
         $contactID,
-        $this->leaveRequestStatuses['More Information Requested']['id']
+        $status
       )
     );
 
     $this->assertFalse(
       $this->getLeaveRequestRightsForAdminAsCurrentUser()->canChangeAbsenceTypeFor(
         $contactID,
-        $this->leaveRequestStatuses['Waiting Approval']['id']
+        $status
       )
     );
 
     $this->assertFalse(
       $this->getLeaveRightsService()->canChangeAbsenceTypeFor(
         $contactID,
-        $this->leaveRequestStatuses['Cancelled']['id']
+        $status
       )
     );
   }
@@ -241,5 +247,18 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
 
   private function getLeaveRequestRightsForLeaveManagerAsCurrentUser() {
     return $this->getLeaveRightsService(false, true);
+  }
+
+  public function leaveRequestStatusesDataProvider() {
+    $leaveRequestStatuses =  $this->leaveRequestStatuses;
+
+    return [
+      [$leaveRequestStatuses['More Information Requested']['id']],
+      [$leaveRequestStatuses['Waiting Approval']['id']],
+      [$leaveRequestStatuses['Cancelled']['id']],
+      [$leaveRequestStatuses['Rejected']['id']],
+      [$leaveRequestStatuses['Admin Approved']['id']],
+      [$leaveRequestStatuses['Approved']['id']],
+    ];
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -11,6 +11,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
 
   use CRM_HRLeaveAndAbsences_SessionHelpersTrait;
   use CRM_HRLeaveAndAbsences_LeaveManagerHelpersTrait;
+  use CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait;
 
   /**
    * @var int
@@ -21,6 +22,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     $this->leaveContact = 1;
     $this->registerCurrentLoggedInContactInSession($this->leaveContact);
     CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
+
+    $this->leaveRequestStatuses = $this->getLeaveRequestStatuses();
   }
 
   public function testCanCancelForReturnsTrueWhenCurrentUserIsLeaveRequestContact() {
@@ -81,11 +84,150 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
   }
 
   public function testCanPutInWaitingForApprovalForReturnsTrueWhenCurrentUserIsAdmin() {
-    $this->assertTrue($this->getLeaveRequestRightsForAdminAsCurrentUser()->canPutInWaitingForApprovalFor($this->leaveContact['id']));
+    $this->assertTrue($this->getLeaveRequestRightsForAdminAsCurrentUser()->canPutInWaitingForApprovalFor($this->leaveContact));
   }
 
   public function testCanPutInWaitingForApprovalForReturnsFalseWhenCurrentUserIsLeaveContact() {
     $this->assertFalse($this->getLeaveRightsService()->canPutInWaitingForApprovalFor($this->leaveContact));
+  }
+
+  public function testCanCreateAndUpdateForReturnsTrueWhenCurrentUserIsLeaveRequestContact() {
+    $this->assertTrue($this->getLeaveRightsService()->canCreateAndUpdateFor($this->leaveContact));
+  }
+
+  public function testCanCreateAndUpdateForReturnsTrueWhenCurrentUserIsLeaveManager() {
+    $this->assertTrue($this->getLeaveRequestRightsForLeaveManagerAsCurrentUser()->canCreateAndUpdateFor($this->leaveContact));
+  }
+
+  public function testCanCreateAndUpdateForReturnsTrueWhenCurrentUserIsAdmin() {
+    $this->assertTrue($this->getLeaveRequestRightsForAdminAsCurrentUser()->canCreateAndUpdateFor($this->leaveContact));
+  }
+
+  public function testCanCreateAndUpdateForReturnsFalseWhenCurrentUserIsNotAnAdminOrLeaveManagerOrLeaveContact() {
+    $contactID = 3;
+    $this->assertFalse($this->getLeaveRightsService()->canCreateAndUpdateFor($contactID));
+  }
+
+  public function testCanChangeDatesForReturnsTrueWhenCurrentUserIsLeaveContactAndStatusPassedIsInAllowedStatuses() {
+    //When user is leave request contact and status is 'More information Requested'
+    $this->assertTrue(
+      $this->getLeaveRightsService()->canChangeDatesFor(
+        $this->leaveContact,
+        $this->leaveRequestStatuses['More Information Requested']['id']
+      )
+    );
+
+    //When user is leave request contact and status is 'Waiting Approval'
+    $this->assertTrue(
+      $this->getLeaveRightsService()->canChangeDatesFor(
+        $this->leaveContact,
+        $this->leaveRequestStatuses['Waiting Approval']['id']
+      )
+    );
+  }
+
+  public function testCanChangeDatesForReturnsFalseWhenCurrentUserIsLeaveContactAndStatusPassedIsNotInAllowedStatuses() {
+    //When user is leave request contact and status is 'Approved'
+    $this->assertFalse(
+      $this->getLeaveRightsService()->canChangeDatesFor(
+        $this->leaveContact,
+        $this->leaveRequestStatuses['Approved']['id']
+      )
+    );
+
+    //When user is leave request contact and status is 'Admin Approved'
+    $this->assertFalse(
+      $this->getLeaveRightsService()->canChangeDatesFor(
+        $this->leaveContact,
+        $this->leaveRequestStatuses['Admin Approved']['id']
+      )
+    );
+  }
+
+  public function testCanChangeDatesForReturnsFalseWhenCurrentUserNotLeaveContactIrrespectiveOfStatusPassed() {
+    $contactID = 2;
+
+    $this->assertFalse(
+      $this->getLeaveRequestRightsForLeaveManagerAsCurrentUser()->canChangeDatesFor(
+        $contactID,
+        $this->leaveRequestStatuses['More Information Requested']['id']
+      )
+    );
+
+    $this->assertFalse(
+      $this->getLeaveRequestRightsForAdminAsCurrentUser()->canChangeDatesFor(
+        $contactID,
+        $this->leaveRequestStatuses['Admin Approved']['id']
+      )
+    );
+
+    $this->assertFalse(
+      $this->getLeaveRightsService()->canChangeDatesFor(
+        $contactID,
+        $this->leaveRequestStatuses['Approved']['id']
+      )
+    );
+  }
+
+  public function testCanChangeAbsenceTypeForReturnsTrueWhenCurrentUserIsLeaveContactAndStatusPassedIsInAllowedStatuses() {
+    //When user is leave request contact and status is 'More information Requested'
+    $this->assertTrue(
+      $this->getLeaveRightsService()->canChangeAbsenceTypeFor(
+        $this->leaveContact,
+        $this->leaveRequestStatuses['More Information Requested']['id']
+      )
+    );
+
+    //When user is leave request contact and status is 'Waiting Approval'
+    $this->assertTrue(
+      $this->getLeaveRightsService()->canChangeAbsenceTypeFor(
+        $this->leaveContact,
+        $this->leaveRequestStatuses['Waiting Approval']['id']
+      )
+    );
+  }
+
+  public function testCanChangeAbsenceTypeForReturnsFalseWhenCurrentUserIsLeaveContactAndStatusPassedIsNotInAllowedStatuses() {
+    //When user is leave request contact and status is 'Approved'
+    $this->assertFalse(
+      $this->getLeaveRightsService()->canChangeAbsenceTypeFor(
+        $this->leaveContact,
+        $this->leaveRequestStatuses['Approved']['id']
+      )
+    );
+
+    //When user is leave request contact and status is 'Admin Approved'
+    $this->assertFalse(
+      $this->getLeaveRightsService()->canChangeAbsenceTypeFor(
+        $this->leaveContact,
+        $this->leaveRequestStatuses['Admin Approved']['id']
+      )
+    );
+  }
+
+  public function testCanChangeAbsenceTypeForReturnsFalseWhenCurrentUserNotLeaveContactIrrespectiveOfStatusPassed() {
+    $contactID = 2;
+
+    $this->assertFalse(
+      $this->getLeaveRequestRightsForLeaveManagerAsCurrentUser()->canChangeAbsenceTypeFor(
+        $contactID,
+        $this->leaveRequestStatuses['More Information Requested']['id']
+      )
+    );
+
+    $this->assertFalse(
+      $this->getLeaveRequestRightsForAdminAsCurrentUser()->canChangeAbsenceTypeFor(
+        $contactID,
+        $this->leaveRequestStatuses['Admin Approved']['id']
+      )
+    );
+
+    $this->assertFalse(
+      $this->getLeaveRightsService()->canChangeAbsenceTypeFor(
+        $contactID,
+        $this->leaveRequestStatuses['Approved']['id']
+      )
+    );
   }
 
   private function getLeaveRightsService($isAdmin = false, $isManager = false) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -150,14 +150,14 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     $this->assertFalse(
       $this->getLeaveRequestRightsForLeaveManagerAsCurrentUser()->canChangeDatesFor(
         $contactID,
-        $this->leaveRequestStatuses['More Information Requested']['id']
+        $this->leaveRequestStatuses['Cancelled']['id']
       )
     );
 
     $this->assertFalse(
       $this->getLeaveRequestRightsForAdminAsCurrentUser()->canChangeDatesFor(
         $contactID,
-        $this->leaveRequestStatuses['Admin Approved']['id']
+        $this->leaveRequestStatuses['Rejected']['id']
       )
     );
 
@@ -218,20 +218,20 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     $this->assertFalse(
       $this->getLeaveRequestRightsForAdminAsCurrentUser()->canChangeAbsenceTypeFor(
         $contactID,
-        $this->leaveRequestStatuses['Admin Approved']['id']
+        $this->leaveRequestStatuses['Waiting Approval']['id']
       )
     );
 
     $this->assertFalse(
       $this->getLeaveRightsService()->canChangeAbsenceTypeFor(
         $contactID,
-        $this->leaveRequestStatuses['Approved']['id']
+        $this->leaveRequestStatuses['Cancelled']['id']
       )
     );
   }
 
   private function getLeaveRightsService($isAdmin = false, $isManager = false) {
-    $leaveManagerService = $this->createLeaveLeaveManagerServiceMock($isAdmin, $isManager);
+    $leaveManagerService = $this->createLeaveManagerServiceMock($isAdmin, $isManager);
     return new LeaveRequestRightsService($leaveManagerService);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
 use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
 use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
@@ -8,7 +7,6 @@ use CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange as LeaveBalanceChangeServi
 use CRM_HRLeaveAndAbsences_Service_LeaveRequest as LeaveRequestService;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern as WorkPatternFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
-use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix as LeaveRequestStatusMatrixService;
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
 
@@ -21,30 +19,22 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
 
   use CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait;
   use CRM_HRLeaveAndAbsences_SessionHelpersTrait;
+  use CRM_HRLeaveAndAbsences_LeaveManagerHelpersTrait;
 
-  /**
-   * @var \CRM_HRLeaveAndAbsences_Service_LeaveRequest
-   */
-  private $leaveRequestService;
+
+  private $leaveBalanceChangeService;
 
   private $leaveContact;
 
   public function setUp() {
-    $leaveBalanceChangeService = new LeaveBalanceChangeService();
-    $leaveManagerService = new LeaveManagerService();
-    $leaveRequestStatusMatrixService = new LeaveRequestStatusMatrixService($leaveManagerService);
-    $leaveRequestRightsService = new LeaveRequestRightsService($leaveManagerService);
-
-    $this->leaveRequestService = new LeaveRequestService(
-      $leaveBalanceChangeService,
-      $leaveManagerService,
-      $leaveRequestStatusMatrixService,
-      $leaveRequestRightsService
-    );
+    CRM_Core_DAO::executeQuery("SET foreign_key_checks = 0;");
+    $this->leaveBalanceChangeService = new LeaveBalanceChangeService();
 
     $this->leaveContact = 1;
     $this->registerCurrentLoggedInContactInSession($this->leaveContact);
     CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
+
+    $this->leaveRequestStatuses = $this->getLeaveRequestStatuses();
   }
 
   public function testCreateAlsoCreateTheLeaveRequestBalanceChanges() {
@@ -56,7 +46,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default']);
 
     // a 7 days leave request, from monday to sunday
-    $leaveRequest = $this->leaveRequestService->create([
+    $leaveRequest = $this->getleaveRequestService()->create([
       'type_id' => 1,
       'contact_id' => $this->leaveContact,
       'status_id' => 3,
@@ -96,7 +86,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
       'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
     ];
 
-    $leaveRequest = $this->leaveRequestService->create($params, false);
+    $leaveRequest = $this->getleaveRequestService()->create($params, false);
 
     $balance = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
     // Since the 40 hours work pattern was used, and it this is a week long
@@ -111,7 +101,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     // Increase the Leave Request period by 4 days (2 weekend + 2 working days)
     $params['id'] = $leaveRequest->id;
     $params['to_date'] = CRM_Utils_Date::processDate('2016-01-11');
-    $this->leaveRequestService->create($params, false);
+    $this->getleaveRequestService()->create($params, false);
 
     $balance = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
     // 5 from before + 2 (from the 2 new working days)
@@ -140,7 +130,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertCount(7, $balanceChanges);
     $this->assertCount(7, $dates);
 
-    $this->leaveRequestService->delete($leaveRequest->id);
+    $this->getleaveRequestService()->delete($leaveRequest->id);
 
     $balanceChanges = LeaveBalanceChange::getBreakdownForLeaveRequest($leaveRequest);
     $dates          = $leaveRequest->getDates();
@@ -154,5 +144,301 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     }
 
     $this->fail("Expected to not find the LeaveRequest with {$leaveRequest->id}, but it was found");
+  }
+
+  /**
+   * @expectedException RuntimeException
+   * @expectedExceptionMessage You are not allowed to create or update a leave request for this employee
+   */
+  public function testCreateThrowsAnExceptionWhenCurrentUserDoesNotHaveCreateAndUpdateLeaveRequestPermission() {
+    //logged in user has no permissions, also a contactID different from that of the logged in user is passed
+    $contactID = 2;
+    $this->getleaveRequestService()->create([
+      'type_id' => 1,
+      'contact_id' => $contactID,
+      'status_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date' => CRM_Utils_Date::processDate('2016-01-10'),
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+    ], false);
+  }
+
+  /**
+   * @expectedException RuntimeException
+   * @expectedExceptionMessage You can't create a Leave Request with this status
+   */
+  public function testCreateThrowsAnExceptionWhenTransitionStatusIsNotValidForNewLeaveRequest() {
+    //A leave contact trying to set a new leave request to approved status
+    $this->getleaveRequestService()->create([
+      'type_id' => 1,
+      'contact_id' => $this->leaveContact,
+      'status_id' => $this->leaveRequestStatuses['Approved']['id'],
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date' => CRM_Utils_Date::processDate('2016-01-10'),
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+    ], false);
+  }
+
+  /**
+   * @expectedException RuntimeException
+   * @expectedExceptionMessage You can't create a Leave Request with this status
+   */
+  public function testCreateThrowsAnExceptionForAdminWhenTransitionStatusIsNotValidForNewLeaveRequest() {
+    //An admin trying to set a new leave request to rejected status
+    $this->getLeaveRequestServiceWhenCurrentUserIsAdmin()->create([
+      'type_id' => 1,
+      'contact_id' => 5,
+      'status_id' => $this->leaveRequestStatuses['Rejected']['id'],
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date' => CRM_Utils_Date::processDate('2016-01-10'),
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+    ], false);
+  }
+
+  /**
+   * @expectedException RuntimeException
+   * @expectedExceptionMessage You can't create a Leave Request with this status
+   */
+  public function testCreateThrowsAnExceptionForLeaveApproverWhenTransitionStatusIsNotValidForNewLeaveRequest() {
+    //A leave manager trying to set a new leave request to cancelled status
+    $this->getLeaveRequestServiceWhenCurrentUserIsLeaveManager()->create([
+      'type_id' => 1,
+      'contact_id' => 5,
+      'status_id' => $this->leaveRequestStatuses['Cancelled']['id'],
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date' => CRM_Utils_Date::processDate('2016-01-10'),
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+    ], false);
+  }
+
+  public function testCreateThrowsAnExceptionForLeaveApproverWhenTransitionStatusIsNotValidWhenUpdatingLeaveRequestStatus() {
+    $contactID = 5;
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contactID,
+      'type_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date' => CRM_Utils_Date::processDate('2016-01-10'),
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'status_id' => $this->leaveRequestStatuses['More Information Requested']['id'],
+      'sequential' => 1,
+    ]);
+
+    $this->setExpectedException(
+      'RuntimeException', "You can't change the Leave Request status from ".
+      $this->leaveRequestStatuses['More Information Requested']['id']. " to {$this->leaveRequestStatuses['Waiting Approval']['id']}"
+    );
+
+    $this->getLeaveRequestServiceWhenCurrentUserIsLeaveManager()->create([
+      'id' => $leaveRequest->id,
+      'type_id' => 1,
+      'contact_id' => 5,
+      'status_id' => $this->leaveRequestStatuses['Waiting Approval']['id'],
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date' => CRM_Utils_Date::processDate('2016-01-10'),
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+    ], false);
+  }
+
+  public function testCreateThrowsAnExceptionForAdminWhenTransitionStatusIsNotValidWhenUpdatingLeaveRequestStatus() {
+    $contactID = 5;
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contactID,
+      'type_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date' => CRM_Utils_Date::processDate('2016-01-10'),
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'status_id' => $this->leaveRequestStatuses['Approved']['id'],
+      'sequential' => 1,
+    ]);
+
+    $this->setExpectedException(
+      'RuntimeException', "You can't change the Leave Request status from ".
+      $this->leaveRequestStatuses['Approved']['id']. " to {$this->leaveRequestStatuses['Waiting Approval']['id']}"
+    );
+
+    $this->getLeaveRequestServiceWhenCurrentUserIsAdmin()->create([
+      'id' => $leaveRequest->id,
+      'type_id' => 1,
+      'contact_id' => 5,
+      'status_id' => $this->leaveRequestStatuses['Waiting Approval']['id'],
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date' => CRM_Utils_Date::processDate('2016-01-10'),
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+    ], false);
+  }
+
+  public function testCreateThrowsAnExceptionForLeaveContactWhenUpdatingLeaveStatusWithoutPermission() {
+    //The leave manager creates a leave request with More information requested status
+    $leaveRequest = $this->getLeaveRequestServiceWhenCurrentUserIsLeaveManager()->create([
+      'type_id' => 1,
+      'contact_id' => $this->leaveContact,
+      'status_id' => $this->leaveRequestStatuses['More Information Requested']['id'],
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date' => CRM_Utils_Date::processDate('2016-01-10'),
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+    ], false);
+
+
+    //The leave contact tries to change the status to 'Waiting Approval'
+    //Even though it was a valid status transition but the leave contact does not have the permission
+    $this->setExpectedException(
+      'RuntimeException', "You don't have enough permission to change the status to {$this->leaveRequestStatuses['Waiting Approval']['id']}"
+    );
+    $this->getLeaveRequestService()->create([
+      'id' => $leaveRequest->id,
+      'type_id' => 1,
+      'contact_id' => $this->leaveContact,
+      'status_id' => $this->leaveRequestStatuses['Waiting Approval']['id'],
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date' => CRM_Utils_Date::processDate('2016-01-10'),
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+    ], false);
+  }
+
+  /**
+   * @expectedException RuntimeException
+   * @expectedExceptionMessage You are not allowed to change the request dates
+   */
+  public function testCreateThrowsAnExceptionWhenLeaveApproverUpdatesDatesForLeaveRequest() {
+    $contactID = 5;
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contactID,
+      'type_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date' => CRM_Utils_Date::processDate('2016-01-10'),
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'status_id' => 1,
+      'sequential' => 1,
+    ]);
+
+    $this->getLeaveRequestServiceWhenCurrentUserIsLeaveManager()->create([
+      'id' => $leaveRequest->id,
+      'type_id' => 1,
+      'contact_id' => $contactID,
+      'status_id' => $this->leaveRequestStatuses['Cancelled']['id'],
+      'from_date' => CRM_Utils_Date::processDate('2016-01-10'),
+      'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date' => CRM_Utils_Date::processDate('2016-01-15'),
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+    ], false);
+  }
+
+  /**
+   * @expectedException RuntimeException
+   * @expectedExceptionMessage You are not allowed to change the request dates
+   */
+  public function testCreateThrowsAnExceptionWhenAdminUpdatesDatesForLeaveRequest() {
+    $contactID = 5;
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contactID,
+      'type_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date' => CRM_Utils_Date::processDate('2016-01-10'),
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'status_id' => 1,
+      'sequential' => 1,
+    ]);
+
+    $this->getLeaveRequestServiceWhenCurrentUserIsAdmin()->create([
+      'id' => $leaveRequest->id,
+      'type_id' => 1,
+      'contact_id' => $contactID,
+      'status_id' => $this->leaveRequestStatuses['Cancelled']['id'],
+      'from_date' => CRM_Utils_Date::processDate('2016-01-10'),
+      'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date' => CRM_Utils_Date::processDate('2016-01-15'),
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+    ], false);
+  }
+
+  /**
+   * @expectedException RuntimeException
+   * @expectedExceptionMessage You are not allowed to change the type of a request
+   */
+  public function testCreateThrowsAnExceptionWhenLeaveApproverUpdatesAbsenceTypeForLeaveRequest() {
+    $contactID = 5;
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contactID,
+      'type_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'status_id' => 1,
+      'sequential' => 1,
+    ]);
+
+    $this->getLeaveRequestServiceWhenCurrentUserIsLeaveManager()->create([
+      'id' => $leaveRequest->id,
+      'type_id' => 2,
+      'contact_id' => $contactID,
+      'status_id' => $this->leaveRequestStatuses['Cancelled']['id'],
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+    ], false);
+  }
+
+  /**
+   * @expectedException RuntimeException
+   * @expectedExceptionMessage You are not allowed to change the type of a request
+   */
+  public function testCreateThrowsAnExceptionWhenAdminUpdatesAbsenceTypeForLeaveRequest() {
+    $contactID = 5;
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contactID,
+      'type_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date' => CRM_Utils_Date::processDate('2016-01-10'),
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'status_id' => 1,
+      'sequential' => 1,
+    ]);
+
+    $this->getLeaveRequestServiceWhenCurrentUserIsAdmin()->create([
+      'id' => $leaveRequest->id,
+      'type_id' => 2,
+      'contact_id' => $contactID,
+      'status_id' => $this->leaveRequestStatuses['Cancelled']['id'],
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date' => CRM_Utils_Date::processDate('2016-01-10'),
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+    ], false);
+  }
+
+  private function getLeaveRequestService($isAdmin = false, $isManager = false) {
+    $leaveManagerService = $this->createLeaveLeaveManagerServiceMock($isAdmin, $isManager);
+    $leaveRequestStatusMatrixService = new LeaveRequestStatusMatrixService($leaveManagerService);
+    $leaveRequestRightsService = new LeaveRequestRightsService($leaveManagerService);
+
+    return new LeaveRequestService(
+      $this->leaveBalanceChangeService,
+      $leaveManagerService,
+      $leaveRequestStatusMatrixService,
+      $leaveRequestRightsService
+    );
+  }
+
+  private function getLeaveRequestServiceWhenCurrentUserIsAdmin() {
+    return $this->getLeaveRequestService(true, false);
+  }
+
+  private function getLeaveRequestServiceWhenCurrentUserIsLeaveManager() {
+    return $this->getLeaveRequestService(false, true);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -166,17 +166,16 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testCreateThrowsAnExceptionWhenTransitionStatusIsNotValidWhenUpdatingLeaveRequestStatus() {
-    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($this->getDefaultParams());
+    $params = $this->getDefaultParams();
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
 
     $this->setExpectedException(
       'RuntimeException', "You can't change the Leave Request status from ".
       $this->getDefaultParams()['status_id']. " to {$this->leaveRequestStatuses['Waiting Approval']['id']}"
     );
 
-    $params = $this->getDefaultParams([
-      'id' => $leaveRequest->id,
-      'status_id' => $this->leaveRequestStatuses['Waiting Approval']['id']
-    ]);
+    $params['id'] = $leaveRequest->id;
+    $params['status_id'] = $this->leaveRequestStatuses['Waiting Approval']['id'];
 
     $this->getLeaveRequestServiceWhenStatusTransitionIsNotAllowed()->create($params, false);
   }
@@ -188,10 +187,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
 
     //The leave contact tries to change the status to 'Waiting Approval'
     //Even though it was a valid status transition but the leave contact does not have the permission
-    $params = $this->getDefaultParams([
-      'id' => $leaveRequest->id,
-      'status_id' => $this->leaveRequestStatuses['Waiting Approval']['id']
-    ]);
+    $params['id'] = $leaveRequest->id;
+    $params['status_id'] = $this->leaveRequestStatuses['Waiting Approval']['id'];
 
     $this->setExpectedException(
       'RuntimeException', "You don't have enough permission to change the status to {$this->leaveRequestStatuses['Waiting Approval']['id']}"
@@ -208,11 +205,9 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     $params = $this->getDefaultParams(['contact_id' => $contactID]);
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
 
-    $params = $this->getDefaultParams([
-      'from_date' => CRM_Utils_Date::processDate('2016-01-10'),
-      'to_date' => CRM_Utils_Date::processDate('2016-01-15'),
-      'id' => $leaveRequest->id
-    ]);
+    $params['from_date'] = CRM_Utils_Date::processDate('2016-01-10');
+    $params['to_date'] = CRM_Utils_Date::processDate('2016-01-15');
+    $params['id'] = $leaveRequest->id;
 
     $this->getLeaveRequestServiceWhenCurrentUserIsLeaveManager()->create($params, false);
   }
@@ -226,11 +221,9 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     $params = $this->getDefaultParams(['contact_id' => $contactID]);
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
 
-    $params = $this->getDefaultParams([
-      'from_date' => CRM_Utils_Date::processDate('2016-01-10'),
-      'to_date' => CRM_Utils_Date::processDate('2016-01-15'),
-      'id' => $leaveRequest->id
-    ]);
+    $params['from_date'] = CRM_Utils_Date::processDate('2016-01-10');
+    $params['to_date'] = CRM_Utils_Date::processDate('2016-01-15');
+    $params['id'] = $leaveRequest->id;
 
     $this->getLeaveRequestServiceWhenCurrentUserIsAdmin()->create($params, false);
   }
@@ -244,10 +237,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     $params = $this->getDefaultParams(['contact_id' => $contactID]);
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
 
-    $params = $this->getDefaultParams([
-      'type_id' => 2,
-      'id' => $leaveRequest->id
-    ]);
+    $params['id'] = $leaveRequest->id;
+    $params['type_id'] = 2;
 
     $this->getLeaveRequestServiceWhenCurrentUserIsLeaveManager()->create($params, false);
   }
@@ -261,10 +252,9 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     $params = $this->getDefaultParams(['contact_id' => $contactID]);
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
 
-    $params = $this->getDefaultParams([
-      'type_id' => 2,
-      'id' => $leaveRequest->id
-    ]);
+    $params['id'] = $leaveRequest->id;
+    $params['type_id'] = 2;
+
     $this->getLeaveRequestServiceWhenCurrentUserIsAdmin()->create($params, false);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -428,7 +428,6 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
 
     return new LeaveRequestService(
       $this->leaveBalanceChangeService,
-      $leaveManagerService,
       $leaveRequestStatusMatrixService,
       $leaveRequestRightsService
     );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/SicknessRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/SicknessRequestTest.php
@@ -27,7 +27,6 @@ class CRM_HRLeaveAndAbsences_Service_SicknessRequestTest extends BaseHeadlessTes
 
   public function setUp() {
     $this->leaveBalanceChangeService = new LeaveBalanceChangeService();
-    $this->leaveBalanceChangeService = new LeaveBalanceChangeService();
   }
 
   public function testCreateAlsoCreateTheLeaveRequestBalanceChanges() {
@@ -174,7 +173,7 @@ class CRM_HRLeaveAndAbsences_Service_SicknessRequestTest extends BaseHeadlessTes
   }
 
   private function getLeaveRequestService($isAdmin = false, $isManager = false) {
-    $leaveManagerService = $this->createLeaveLeaveManagerServiceMock($isAdmin, $isManager);
+    $leaveManagerService = $this->createLeaveManagerServiceMock($isAdmin, $isManager);
     $leaveRequestStatusMatrixService = new LeaveRequestStatusMatrixService($leaveManagerService);
     $leaveRequestRightsService = new LeaveRequestRightsService($leaveManagerService);
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/SicknessRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/SicknessRequestTest.php
@@ -10,7 +10,6 @@ use CRM_HRLeaveAndAbsences_Service_LeaveRequest as LeaveRequestService;
 use CRM_HRLeaveAndAbsences_Service_SicknessRequest as SicknessRequestService;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern as WorkPatternFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_SicknessRequest as SicknessRequestFabricator;
-use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix as LeaveRequestStatusMatrixService;
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
 
@@ -181,7 +180,6 @@ class CRM_HRLeaveAndAbsences_Service_SicknessRequestTest extends BaseHeadlessTes
 
     return new LeaveRequestService(
       $this->leaveBalanceChangeService,
-      $leaveManagerService,
       $leaveRequestStatusMatrixService,
       $leaveRequestRightsService
     );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/SicknessRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/SicknessRequestTest.php
@@ -12,6 +12,7 @@ use CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern as WorkPatternFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_SicknessRequest as SicknessRequestFabricator;
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix as LeaveRequestStatusMatrixService;
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
+use CRM_HRLeaveAndAbsences_Factory_LeaveRequestService as LeaveRequestServiceFactory;
 
 /**
  * Class CRM_HRLeaveAndAbsences_Service_SicknessRequestTest
@@ -173,14 +174,7 @@ class CRM_HRLeaveAndAbsences_Service_SicknessRequestTest extends BaseHeadlessTes
   }
 
   private function getLeaveRequestService($isAdmin = false, $isManager = false) {
-    $leaveManagerService = $this->createLeaveManagerServiceMock($isAdmin, $isManager);
-    $leaveRequestStatusMatrixService = new LeaveRequestStatusMatrixService($leaveManagerService);
-    $leaveRequestRightsService = new LeaveRequestRightsService($leaveManagerService);
 
-    return new LeaveRequestService(
-      $this->leaveBalanceChangeService,
-      $leaveRequestStatusMatrixService,
-      $leaveRequestRightsService
-    );
+    return LeaveRequestServiceFactory::create();
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -1849,6 +1849,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testCreateAlsoCreatesTheBalanceChangesForTheLeaveRequest() {
+    $contactID = 1;
+    $this->registerCurrentLoggedInContactInSession($contactID);
     $startDate = new DateTime();
     $endDate = new DateTime('+5 days');
 
@@ -1858,7 +1860,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ]);
 
     $contract = HRJobContractFabricator::fabricate(
-      ['contact_id' => 1],
+      ['contact_id' => $contactID],
       ['period_start_date' => $startDate->format('Y-m-d')]
     );
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
@@ -14,6 +14,7 @@ require_once 'helpers/WorkPatternHelpersTrait.php';
 require_once 'helpers/TOILRequestHelpersTrait.php';
 require_once 'helpers/LeaveManagerHelpersTrait.php';
 require_once 'helpers/SessionHelpersTrait.php';
+require_once 'helpers/LeaveRequestStatusMatrixHelpersTrait.php';
 
 /**
  * Call the "cv" command.

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveManagerHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveManagerHelpersTrait.php
@@ -23,7 +23,7 @@ trait CRM_HRLeaveAndAbsences_LeaveManagerHelpersTrait {
     }
 
     $relationshipType = $this->getRelationshipType($relationshipType);
-  
+
     RelationshipFabricator::fabricate([
       'contact_id_a' => $contact['id'],
       'contact_id_b' => $leaveApprover['id'],
@@ -77,7 +77,7 @@ trait CRM_HRLeaveAndAbsences_LeaveManagerHelpersTrait {
     );
   }
 
-  public function createLeaveLeaveManagerServiceMock($isAdmin = false, $isManager = false) {
+  public function createLeaveManagerServiceMock($isAdmin = false, $isManager = false) {
     $leaveManagerService = $this->getMockBuilder(CRM_HRLeaveAndAbsences_Service_LeaveManager::class)
                                 ->setMethods(['currentUserIsAdmin', 'currentUserIsLeaveManagerOf'])
                                 ->getMock();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestStatusMatrixHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestStatusMatrixHelpersTrait.php
@@ -1,0 +1,19 @@
+<?php
+
+
+trait CRM_HRLeaveAndAbsences_LeaveRequestStatusMatrixHelpersTrait {
+
+  public function createLeaveRequestStatusMatrixServiceMock($canTransitionTo = false) {
+    $leaveRequestStatusMatrixService = $this->getMockBuilder(CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix::class)
+                                             ->setConstructorArgs([new CRM_HRLeaveAndAbsences_Service_LeaveManager()])
+                                             ->setMethods(['canTransitionTo'])
+                                             ->getMock();
+
+    $leaveRequestStatusMatrixService->expects($this->any())
+                                    ->method('canTransitionTo')
+                                    ->will($this->returnValue($canTransitionTo));
+
+
+    return $leaveRequestStatusMatrixService;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestStatusMatrixHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestStatusMatrixHelpersTrait.php
@@ -1,6 +1,5 @@
 <?php
 
-
 trait CRM_HRLeaveAndAbsences_LeaveRequestStatusMatrixHelpersTrait {
 
   public function createLeaveRequestStatusMatrixServiceMock($canTransitionTo = false) {


### PR DESCRIPTION
This PR actually modifies the existing LeaveRequest Service. This create method of this class is a wrapper around the LeaveRequest::create BAO method. This PR adds some checks/validations to the already existing LeaveRequest Service create method. 

The validations are:
- Status can only be changed according to the LeaveRequestStatusMatrix: [#1399](https://github.com/civicrm/civihr/pull/1399)
- Status can only be updated only if the user has the permission required for the status  according to the LeaveRequestRights [#1407](https://github.com/civicrm/civihr/pull/1407)
- Managers cannot change the dates or absence type of their managees leave requests