### PR TITLE
PCHR-1835: Change LeaveManager Service to use relationship types in general settings

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/ACL/LeaveApproverTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/ACL/LeaveApproverTrait.php
@@ -1,24 +1,21 @@
 <?php
 
-/**
- * Access Control Lists Custom Query generator class
- *
- * This class is basically an Utility class used to generate queries needed for overriding addSelectWhereClause
- * for some specific BAO's
- *
- */
-class CRM_HRLeaveAndAbsences_API_Query_ACLQueryHelper {
+trait CRM_HRLeaveAndAbsences_ACL_LeaveApproverTrait {
+
+  use CRM_HRLeaveAndAbsences_Service_SettingsManagerTrait;
 
   /**
-   * This method returns a query string that limits contacts records that are available to a logged in user
-   * by taking into account user relationships. It checks whether the logged in user is a leave approver
-   * to some contacts or not. If yes the logged in user has access to contact records for the contacts/users he manages,
-   * If not the logged is limited to his/her own records only.
+   * This method returns a query string that limits contacts records that are
+   * available to a logged in user by taking into account user relationships.
+   * It checks whether the logged in user is a leave approver to some contacts
+   * or not. If yes the logged in user has access to contact records for the
+   * contacts/users he manages. If not the logged is limited to his/her own
+   * records only.
    *
    * @return string
    *   Query String
    */
-  public static function limitContactsByTakingUserRelationShipsIntoAccount() {
+  public function getLeaveApproverACLClauses() {
     $contactsTable = CRM_Contact_BAO_Contact::getTableName();
     $relationshipTable = CRM_Contact_BAO_Relationship::getTableName();
     $relationshipTypeTable = CRM_Contact_BAO_RelationshipType::getTableName();
@@ -28,7 +25,8 @@ class CRM_HRLeaveAndAbsences_API_Query_ACLQueryHelper {
     $conditions = [];
     $conditions[] = "(c.id = {$loggedInUserID})";
 
-    $leaveApproverRelationships = self::getLeaveApproverRelationships();
+    $leaveApproverRelationships = $this->getLeaveApproverRelationshipsTypes();
+
     if(!empty($leaveApproverRelationships)) {
       $conditions[] = "(
         r.is_active = 1 AND
@@ -51,15 +49,5 @@ class CRM_HRLeaveAndAbsences_API_Query_ACLQueryHelper {
     )";
 
     return $query;
-  }
-
-  /**
-   * Returns a list of relationship types stored on the
-   * 'relationship_types_allowed_to_approve_leave' setting
-   *
-   * @return array
-   */
-  private static function getLeaveApproverRelationships() {
-    return Civi::service('hrleaveandabsences.settings_manager')->get('relationship_types_allowed_to_approve_leave');
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/ACL/LeaveInformationTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/ACL/LeaveInformationTrait.php
@@ -1,21 +1,28 @@
 <?php
 
-trait CRM_HRLeaveAndAbsences_ACL_LeaveApproverTrait {
+trait CRM_HRLeaveAndAbsences_ACL_LeaveInformationTrait {
 
   use CRM_HRLeaveAndAbsences_Service_SettingsManagerTrait;
 
   /**
-   * This method returns a query string that limits contacts records that are
-   * available to a logged in user by taking into account user relationships.
-   * It checks whether the logged in user is a leave approver to some contacts
-   * or not. If yes the logged in user has access to contact records for the
-   * contacts/users he manages. If not the logged is limited to his/her own
-   * records only.
+   * For any leave information (Entitlement, Leave Requests etc) the access
+   * rules are:
+   *   - Staff members can only see their own information
+   *   - Managers can see their own information + the information from their
+   *     managees
+   *
+   * This method creates ACL clauses that can be added to queries in order to
+   * filter results to follow these rules.
+   *
+   * The manager > managee relationship is determined by checking if there's an
+   * active relationship between the two contacts and that the type of this
+   * relationship is one of those configured as a "Leave Approver Relationship
+   * Type" on the extension's General Settings.
    *
    * @return string
    *   Query String
    */
-  public function getLeaveApproverACLClauses() {
+  public function getLeaveInformationACLClauses() {
     $contactsTable = CRM_Contact_BAO_Contact::getTableName();
     $relationshipTable = CRM_Contact_BAO_Relationship::getTableName();
     $relationshipTypeTable = CRM_Contact_BAO_RelationshipType::getTableName();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
@@ -10,7 +10,7 @@ use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
 use CRM_HRLeaveAndAbsences_BAO_TOILRequest as TOILRequest;
-use CRM_HRLeaveAndAbsences_Service_SettingsManager as SettingsManager;
+
 /**
  * This class is basically a wrapper around Civi\API\SelectQuery.
  *
@@ -20,6 +20,8 @@ use CRM_HRLeaveAndAbsences_Service_SettingsManager as SettingsManager;
  * Public Holiday Leave Requests.
  */
 class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
+
+  use CRM_HRLeaveAndAbsences_Service_SettingsManagerTrait;
 
   /**
    * @var array
@@ -40,15 +42,8 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
    */
   private $returnFullDetails = false;
 
-  /**
-   * @var CRM_HRLeaveAndAbsences_Service_SettingsManager
-   *   The SettingsManager instance passed to the constructor
-   */
-  private $settingsManager;
-
-  public function __construct($params, SettingsManager $settingsManager) {
+  public function __construct($params) {
     $this->params = $params;
-    $this->settingsManager = $settingsManager;
     $this->buildCustomQuery();
   }
 
@@ -99,7 +94,7 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
     if(!empty($this->params['managed_by'])) {
       $managerID = (int)$this->params['managed_by'];
       $today =  '"' . date('Y-m-d') . '"';
-      $leaveApproverRelationshipTypes = $this->settingsManager->get('relationship_types_allowed_to_approve_leave');
+      $leaveApproverRelationshipTypes = $this->getLeaveApproverRelationshipsTypesForWhereIn();
 
       $conditions[] = 'rt.is_active = 1';
       $conditions[] = 'rt.id IN(' . implode(',', $leaveApproverRelationshipTypes) . ')';

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
@@ -6,7 +6,6 @@ use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
 use CRM_HRLeaveAndAbsences_Exception_InvalidLeavePeriodEntitlementException as InvalidPeriodEntitlementException;
 use CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement as LeavePeriodEntitlement;
-use CRM_HRLeaveAndAbsences_API_Query_ACLQueryHelper as ACLQueryHelper;
 
 /**
  * Class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
@@ -13,6 +13,8 @@ use CRM_HRLeaveAndAbsences_API_Query_ACLQueryHelper as ACLQueryHelper;
  */
 class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAbsences_DAO_LeavePeriodEntitlement {
 
+  use CRM_HRLeaveAndAbsences_ACL_LeaveApproverTrait;
+
   /**
    * Create a new LeavePeriodEntitlement based on array-data
    *
@@ -782,8 +784,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
       return;
     }
 
-    $query = ACLQueryHelper::limitContactsByTakingUserRelationShipsIntoAccount();
-    $clauses['contact_id'] = $query;
+    $clauses['contact_id'] = $this->getLeaveApproverACLClauses();
 
     CRM_Utils_Hook::selectWhereClause($this, $clauses);
     return $clauses;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
@@ -12,7 +12,7 @@ use CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement as LeavePeriodEntitlement;
  */
 class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAbsences_DAO_LeavePeriodEntitlement {
 
-  use CRM_HRLeaveAndAbsences_ACL_LeaveApproverTrait;
+  use CRM_HRLeaveAndAbsences_ACL_LeaveInformationTrait;
 
   /**
    * Create a new LeavePeriodEntitlement based on array-data
@@ -783,7 +783,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
       return;
     }
 
-    $clauses['contact_id'] = $this->getLeaveApproverACLClauses();
+    $clauses['contact_id'] = $this->getLeaveInformationACLClauses();
 
     CRM_Utils_Hook::selectWhereClause($this, $clauses);
     return $clauses;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -9,7 +9,6 @@ use CRM_HRLeaveAndAbsences_BAO_WorkDay as WorkDay;
 use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
 use CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException as InvalidLeaveRequestException;
-use CRM_HRLeaveAndAbsences_API_Query_ACLQueryHelper as ACLQueryHelper;
 
 class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO_LeaveRequest {
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -12,7 +12,7 @@ use CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException as InvalidLeav
 
 class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO_LeaveRequest {
 
-  use CRM_HRLeaveAndAbsences_ACL_LeaveApproverTrait;
+  use CRM_HRLeaveAndAbsences_ACL_LeaveInformationTrait;
 
   /**
    * Create a new LeaveRequest based on array-data
@@ -764,7 +764,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
       return;
     }
 
-    $clauses['contact_id'] = $this->getLeaveApproverACLClauses();
+    $clauses['contact_id'] = $this->getLeaveInformationACLClauses();
 
     CRM_Utils_Hook::selectWhereClause($this, $clauses);
     return $clauses;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -13,6 +13,8 @@ use CRM_HRLeaveAndAbsences_API_Query_ACLQueryHelper as ACLQueryHelper;
 
 class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO_LeaveRequest {
 
+  use CRM_HRLeaveAndAbsences_ACL_LeaveApproverTrait;
+
   /**
    * Create a new LeaveRequest based on array-data
    *
@@ -763,8 +765,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
       return;
     }
 
-    $query = ACLQueryHelper::limitContactsByTakingUserRelationShipsIntoAccount();
-    $clauses['contact_id'] = $query;
+    $clauses['contact_id'] = $this->getLeaveApproverACLClauses();
 
     CRM_Utils_Hook::selectWhereClause($this, $clauses);
     return $clauses;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveManager.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveManager.php
@@ -8,6 +8,8 @@
  */
 class CRM_HRLeaveAndAbsences_Service_LeaveManager {
 
+  use CRM_HRLeaveAndAbsences_Service_SettingsManagerTrait;
+
   /**
    * Checks contact given by $contactID is managed by the contact given by
    * $managerID.
@@ -29,12 +31,14 @@ class CRM_HRLeaveAndAbsences_Service_LeaveManager {
     $relationshipTable = CRM_Contact_BAO_Relationship::getTableName();
     $relationshipTypeTable = CRM_Contact_BAO_RelationshipType::getTableName();
 
+    $leaveApproveRelationshipTypes = $this->getLeaveApproverRelationshipsTypesForWhereIn();
+
     $query = "SELECT r.id 
                 FROM {$relationshipTable} r
                 INNER JOIN {$relationshipTypeTable} rt ON rt.id = r.relationship_type_id
               WHERE r.is_active = 1 AND 
                     rt.is_active = 1 AND 
-                    rt.name_a_b = 'has Leave Approved By' AND
+                    rt.id IN(" . implode(',', $leaveApproveRelationshipTypes) . ") AND
                     r.contact_id_a = %1 AND
                     r.contact_id_b = %2 AND
                     (r.start_date IS NULL OR r.start_date <= %3) AND 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/SettingsManagerTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/SettingsManagerTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+trait CRM_HRLeaveAndAbsences_Service_SettingsManagerTrait {
+
+  /**
+   * Returns a list of relationship types stored on the
+   * 'relationship_types_allowed_to_approve_leave' setting.
+   *
+   * Basically, this is just a helper method that gets this information from
+   * the Settings Manager service.
+   *
+   * @return array
+   */
+  public function getLeaveApproverRelationshipsTypes() {
+    return Civi::service('hrleaveandabsences.settings_manager')->get('relationship_types_allowed_to_approve_leave');
+  }
+
+  /**
+   * Returns a list of of relationship types IDs, stored on the
+   * 'relationship_types_allowed_to_approve_leave' setting.
+   *
+   * This methods is guaranteed to return an array that can be used to
+   * build a WHERE IN() query, since it always return a non empty array. If
+   * there's no relationship type in settings, it will return a array with a
+   * single invalid ID (-1), which will make the query return nothing. The idea
+   * is that, if no relationship is set, then the leave approver should not be
+   * able to see anything.
+   */
+  public function getLeaveApproverRelationshipsTypesForWhereIn() {
+    $relationshipTypes = $this->getLeaveApproverRelationshipsTypes();
+    $relationshipTypes[] = -1;
+
+    return $relationshipTypes;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveManagerTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveManagerTest.php
@@ -72,7 +72,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveManagerTest extends BaseHeadlessTest {
     $this->assertFalse($this->leaveManagerService->isContactManagedBy($this->staffMember['id'], $this->manager['id']));
   }
 
-  public function testIsContactManagedByWhenTheCurrentRelationshipIsNotActive() {
+  public function testIsContactManagedByWhenRelationshipIsNotActive() {
     $this->assertFalse($this->leaveManagerService->isContactManagedBy($this->staffMember['id'], $this->manager['id']));
 
     $this->setContactAsLeaveApproverOf($this->manager, $this->staffMember, null, null, false);
@@ -80,7 +80,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveManagerTest extends BaseHeadlessTest {
     $this->assertFalse($this->leaveManagerService->isContactManagedBy($this->staffMember['id'], $this->manager['id']));
   }
 
-  public function testIsContactManagedByWhenCurrentUserHasMoreThanOneRelationshipWithTheEmployee() {
+  public function testIsContactManagedByWhenThereAreMultipleLeaveApproverRelationshipsAndOnlyOneIsActive() {
     $this->setLeaveApproverRelationshipTypes([
       'approves leaves for',
       'manages leaves for'
@@ -98,6 +98,20 @@ class CRM_HRLeaveAndAbsences_Service_LeaveManagerTest extends BaseHeadlessTest {
 
     // this relationship uses another one of the "Leave Approver" types and it's active,
     // so this should return true
+    $this->assertTrue($this->leaveManagerService->isContactManagedBy($this->staffMember['id'], $this->manager['id']));
+  }
+
+  public function testIsContactManagedByWhenThereAreMultipleActiveLeaveApproverRelationships() {
+    $this->setLeaveApproverRelationshipTypes([
+      'approves leaves for',
+      'manages leaves for'
+    ]);
+
+    $this->assertFalse($this->leaveManagerService->isContactManagedBy($this->staffMember['id'], $this->manager['id']));
+
+    $this->setContactAsLeaveApproverOf($this->manager, $this->staffMember, null, null, true, 'approves leaves for');
+    $this->setContactAsLeaveApproverOf($this->manager, $this->staffMember, null, null, true, 'manages leaves for');
+
     $this->assertTrue($this->leaveManagerService->isContactManagedBy($this->staffMember['id'], $this->manager['id']));
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveManagerTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveManagerTest.php
@@ -91,6 +91,30 @@ class CRM_HRLeaveAndAbsences_Service_LeaveManagerTest extends BaseHeadlessTest {
     $this->assertFalse($this->leaveManagerService->isContactManagedBy($staffMember['id'], $manager['id']));
   }
 
+  public function testIsContactManagedByWhenCurrentUserHasMoreThanOneRelationshipWithTheEmployee() {
+    $this->setLeaveApproverRelationshipTypes([
+      'approves leaves for',
+      'manages leaves for'
+    ]);
+
+    $manager = ContactFabricator::fabricate();
+    $staffMember = ContactFabricator::fabricate();
+
+    $this->assertFalse($this->leaveManagerService->isContactManagedBy($staffMember['id'], $manager['id']));
+
+    $this->setContactAsLeaveApproverOf($manager, $staffMember, null, null, false, 'approves leaves for');
+
+    // the relationship is of one of the "Leave Approver" types, but it's not active,
+    // so this should return false
+    $this->assertFalse($this->leaveManagerService->isContactManagedBy($staffMember['id'], $manager['id']));
+
+    $this->setContactAsLeaveApproverOf($manager, $staffMember, null, null, true, 'manages leaves for');
+
+    // this relationship uses another one of the "Leave Approver" types and it's active,
+    // so this should return true
+    $this->assertTrue($this->leaveManagerService->isContactManagedBy($staffMember['id'], $manager['id']));
+  }
+
   public function testCurrentUserIsLeaveManagerOf() {
     $staffMember = ContactFabricator::fabricate();
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/SessionHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/SessionHelpersTrait.php
@@ -6,4 +6,9 @@ trait CRM_HRLeaveAndAbsences_SessionHelpersTrait {
     $session = CRM_Core_Session::singleton();
     $session->set('userID', $contactID);
   }
+
+  private function unregisterCurrentLoggedInContactFromSession() {
+    $session = CRM_Core_Session::singleton();
+    $session->set('userID', null);
+  }
 }


### PR DESCRIPTION
This PR updates the `LeaveManager.isContactManagedBy` method to use the leave approver relationship types in general settings in order to check if the a contact is managed by another. Before this, it would only consider the 'has Leave Approved by' relationship type as the only one valid for a leave approver.

The PR also includes some overall refactorings:
- Lots of removed duplication on the LeaveManager tests
- A SettingsManagerTrait was added in order to centralize the code to fetch the leave approver relationship types from settings
- The ACLQueryHelper was replaced by a trait, so it can be more easily reused in BAOs. Also, is make possible for this trait to use another trait (the SettingsManagerTrait) and avoid some code duplication