### PR TITLE
PCHR-1838: Modify SicknessRequest Service

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/SicknessRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/SicknessRequest.php
@@ -20,9 +20,6 @@ class CRM_HRLeaveAndAbsences_BAO_SicknessRequest extends CRM_HRLeaveAndAbsences_
     $hook = empty($params['id']) ? 'create' : 'edit';
     CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
 
-    if ($validate) {
-      self::validateParams($params);
-    }
     $instance = new self();
 
     if ($hook == 'edit') {
@@ -30,11 +27,19 @@ class CRM_HRLeaveAndAbsences_BAO_SicknessRequest extends CRM_HRLeaveAndAbsences_
       $instance->find(true);
 
       if ($instance->leave_request_id) {
-        $instance->copyValues($params);
-        $params['id'] = $instance->leave_request_id;
-        LeaveRequest::create($params, false);
-        $instance->save();
+        $params['leave_request_id'] = $instance->leave_request_id;
       }
+    }
+
+    if ($validate) {
+      self::validateParams($params);
+    }
+
+    if ($hook == 'edit') {
+      $instance->copyValues($params);
+      $params['id'] = $instance->leave_request_id;
+      LeaveRequest::create($params, false);
+      $instance->save();
     }
 
     if ($hook == 'create') {
@@ -62,6 +67,9 @@ class CRM_HRLeaveAndAbsences_BAO_SicknessRequest extends CRM_HRLeaveAndAbsences_
     self::validateAbsenceTypeAllowsSicknessRequest($params);
 
     //run LeaveRequest Validation after all validations on Sickness Request
+    if (isset($params['leave_request_id'])) {
+      $params['id'] = $params['leave_request_id'];
+    }
     LeaveRequest::validateParams($params);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/SicknessRequestService.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/SicknessRequestService.php
@@ -1,0 +1,34 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange as LeaveBalanceChangeService;
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix as LeaveRequestStatusMatrixService;
+use CRM_HRLeaveAndAbsences_Service_SicknessRequest as SicknessRequestService;
+use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
+
+/**
+ * A factory for the SicknessRequest service, which can be used
+ * to get instances of this service without having to manually create all of
+ * its dependencies
+ */
+class CRM_HRLeaveAndAbsences_Factory_SicknessRequestService {
+
+  /**
+   * Returns a new instance of a SicknessRequest Service
+   *
+   * @return \CRM_HRLeaveAndAbsences_Service_SicknessRequest
+   */
+  public static function create() {
+    $leaveBalanceChangeService = new LeaveBalanceChangeService();
+    $leaveManagerService = new LeaveManagerService();
+    $leaveRequestStatusMatrixService = new LeaveRequestStatusMatrixService($leaveManagerService);
+    $leaveRequestRightsService = new LeaveRequestRightsService($leaveManagerService);
+
+    return new SicknessRequestService(
+      $leaveBalanceChangeService,
+      $leaveRequestStatusMatrixService,
+      $leaveRequestRightsService
+    );
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -12,7 +12,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
   /**
    * @var \LeaveBalanceChangeService
    */
-  private $leaveBalanceChangeService;
+  protected $leaveBalanceChangeService;
 
   /**
    * @var \CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix
@@ -28,7 +28,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    * @var \CRM_HRLeaveAndAbsences_BAO_LeaveRequest
    *   The leave request object before it gets updated.
    */
-  private $oldLeaveRequest;
+  protected $oldLeaveRequest;
 
   /**
    * CRM_HRLeaveAndAbsences_Service_LeaveRequest constructor.
@@ -164,7 +164,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    *
    * @return bool
    */
-  private function canChangeDatesFor($params) {
+  protected function canChangeDatesFor($params) {
     return $this->leaveRequestRightsService->canChangeDatesFor($params['contact_id'], $params['status_id']);
   }
 
@@ -274,7 +274,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    *
    * @return \CRM_HRLeaveAndAbsences_BAO_LeaveRequest
    */
-  private function getOldLeaveRequest($leaveRequestID) {
+  protected function getOldLeaveRequest($leaveRequestID) {
     if (!$this->oldLeaveRequest) {
       $this->oldLeaveRequest = LeaveRequest::findById($leaveRequestID);
     }
@@ -288,7 +288,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    *
    * @return \CRM_HRLeaveAndAbsences_BAO_LeaveRequest|NULL
    */
-  private function createLeaveRequestWithBalanceChange($params) {
+  protected function createLeaveRequestWithBalanceChange($params) {
     $leaveRequest = LeaveRequest::create($params, false);
     $this->leaveBalanceChangeService->createForLeaveRequest($leaveRequest);
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -299,6 +299,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    * Run necessary BAO validations
    *
    * @param array $params
+   *
+   * @throws CRM_HRLeaveAndAbsences_Exception_EntityValidationException
    */
   protected function runValidation($params) {
     LeaveRequest::validateParams($params);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -57,7 +57,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    */
   public function create($params, $validate = true) {
     if ($validate) {
-      LeaveRequest::validateParams($params);
+      $this->runValidation($params);
     }
 
     if(!$this->canCreateAndUpdateLeaveRequestFor($params['contact_id'])) {
@@ -72,7 +72,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
       throw new RuntimeException("You can't create a Leave Request with this status");
     }
 
-    return $this->createLeaveRequestWithBalanceChange($params);
+    return $this->createRequestWithBalanceChanges($params);
   }
 
   /**
@@ -108,7 +108,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
       );
     }
 
-    return $this->createLeaveRequestWithBalanceChange($params);
+    return $this->createRequestWithBalanceChanges($params);
   }
 
   /**
@@ -288,10 +288,19 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    *
    * @return \CRM_HRLeaveAndAbsences_BAO_LeaveRequest|NULL
    */
-  protected function createLeaveRequestWithBalanceChange($params) {
+  protected function createRequestWithBalanceChanges($params) {
     $leaveRequest = LeaveRequest::create($params, false);
     $this->leaveBalanceChangeService->createForLeaveRequest($leaveRequest);
 
     return $leaveRequest;
+  }
+
+  /**
+   * Run necessary BAO validations
+   *
+   * @param array $params
+   */
+  protected function runValidation($params) {
+    LeaveRequest::validateParams($params);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/SicknessRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/SicknessRequest.php
@@ -62,6 +62,10 @@ class CRM_HRLeaveAndAbsences_Service_SicknessRequest extends LeaveRequestService
    * {@inheritDoc}
    */
   protected function runValidation($params) {
+    if (isset($params['id'])) {
+      $params['leave_request_id'] = $this->getOldLeaveRequest($params['id'])->id;
+    }
+
     SicknessRequest::validateParams($params);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/SicknessRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/SicknessRequest.php
@@ -4,7 +4,7 @@ use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_BAO_SicknessRequest as SicknessRequest;
 use CRM_HRLeaveAndAbsences_Service_LeaveRequest as LeaveRequestService;
 
-class CRM_HRLeaveAndAbsences_Service_SicknessRequest extends CRM_HRLeaveAndAbsences_Service_LeaveRequest {
+class CRM_HRLeaveAndAbsences_Service_SicknessRequest extends LeaveRequestService {
 
   /**
    * {@inheritDoc}
@@ -21,7 +21,7 @@ class CRM_HRLeaveAndAbsences_Service_SicknessRequest extends CRM_HRLeaveAndAbsen
    *
    * @return \CRM_HRLeaveAndAbsences_BAO_SicknessRequest|NULL
    */
-  protected function createLeaveRequestWithBalanceChange($params) {
+  protected function createRequestWithBalanceChanges($params) {
     $sicknessRequest = SicknessRequest::create($params, false);
     $leaveRequest = LeaveRequest::findById($sicknessRequest->leave_request_id);
     $this->leaveBalanceChangeService->createForLeaveRequest($leaveRequest);
@@ -56,5 +56,12 @@ class CRM_HRLeaveAndAbsences_Service_SicknessRequest extends CRM_HRLeaveAndAbsen
     $sicknessRequest = SicknessRequest::findById($sicknessRequestID);
     parent::delete($sicknessRequest->leave_request_id);
     $sicknessRequest->delete();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function runValidation($params) {
+    SicknessRequest::validateParams($params);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/SicknessRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/SicknessRequest.php
@@ -97,10 +97,7 @@ function civicrm_api3_sickness_request_create($params) {
   _civicrm_api3_check_edit_permissions($bao, $params);
   _civicrm_api3_format_params_for_create($params, null);
 
-  $leaveBalanceChangeService = new CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange();
-  $leaveRequestService = CRM_HRLeaveAndAbsences_Factory_LeaveRequestService::create();
-  $service = new CRM_HRLeaveAndAbsences_Service_SicknessRequest($leaveBalanceChangeService, $leaveRequestService);
-
+  $service = CRM_HRLeaveAndAbsences_Factory_SicknessRequestService::create();
   $sicknessRequest = $service->create($params);
   $values = [];
   _civicrm_api3_object_to_array($sicknessRequest, $values[$sicknessRequest->id]);
@@ -123,9 +120,7 @@ function civicrm_api3_sickness_request_delete($params) {
   civicrm_api3_verify_mandatory($params, NULL, ['id']);
   _civicrm_api3_check_edit_permissions($bao, ['id' => $params['id']]);
 
-  $leaveBalanceChangeService = new CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange();
-  $leaveRequestService = CRM_HRLeaveAndAbsences_Factory_LeaveRequestService::create();
-  $service = new CRM_HRLeaveAndAbsences_Service_SicknessRequest($leaveBalanceChangeService, $leaveRequestService);
+  $service = CRM_HRLeaveAndAbsences_Factory_SicknessRequestService::create();
   $service->delete($params['id']);
 
   return civicrm_api3_create_success(true);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/SicknessRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/SicknessRequestTest.php
@@ -3,9 +3,6 @@
 use CRM_HRLeaveAndAbsences_BAO_SicknessRequest as SicknessRequest;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
-use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
-use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod as AbsencePeriodFabricator;
-use CRM_HRLeaveAndAbsences_Test_Fabricator_LeavePeriodEntitlement as LeavePeriodEntitlementFabricator;
 
 /**
  * Class CRM_HRLeaveAndAbsences_BAO_SicknessRequestTest
@@ -19,8 +16,6 @@ class CRM_HRLeaveAndAbsences_BAO_SicknessRequestTest extends BaseHeadlessTest {
   use CRM_HRLeaveAndAbsences_SessionHelpersTrait;
   use CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait;
 
-  private $leaveContact;
-
   public function setUp() {
     CRM_Core_DAO::executeQuery("SET foreign_key_checks = 0;");
 
@@ -28,10 +23,6 @@ class CRM_HRLeaveAndAbsences_BAO_SicknessRequestTest extends BaseHeadlessTest {
     $this->leaveRequestDayTypes = $this->getLeaveRequestDayTypes();
     $this->sicknessRequestReasons = $this->getSicknessRequestReasons();
     $this->leaveRequestStatuses = $this->getLeaveRequestStatuses();
-
-    $this->leaveContact = 1;
-    $this->registerCurrentLoggedInContactInSession($this->leaveContact);
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
   }
 
   public function testCreateSicknessRequest() {
@@ -218,61 +209,5 @@ class CRM_HRLeaveAndAbsences_BAO_SicknessRequestTest extends BaseHeadlessTest {
       'from_date' => $fromDate->format('YmdHis'),
       'required_documents' => $requiredDocuments
     ]);
-  }
-
-  public function testCreateAndUpdateSicknessRequest() {
-    $startDate = new DateTime('next monday');
-    $endDate = new DateTime('+10 days');
-
-    HRJobContractFabricator::fabricate(
-      ['contact_id' => $this->leaveContact],
-      ['period_start_date' => $startDate->format('Y-m-d')]
-    );
-
-    $period = AbsencePeriodFabricator::fabricate([
-      'start_date' => $startDate->format('YmdHis'),
-      'end_date' => $endDate->format('YmdHis')
-    ]);
-
-    $type = AbsenceTypeFabricator::fabricate([
-      'is_sick' => true
-    ]);
-
-    $leavePeriodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
-      'contact_id' => $this->leaveContact,
-      'period_id' => $period->id,
-      'type_id' => $type->id,
-    ]);
-
-    $this->createLeaveBalanceChange($leavePeriodEntitlement->id, 10);
-
-    $params = [
-      'contact_id' => $this->leaveContact,
-      'type_id' => $type->id,
-      'status_id' => $this->leaveRequestStatuses['Waiting Approval']['value'],
-      'from_date' => $startDate->format('YmdHis'),
-      'from_date_type' => $this->leaveRequestDayTypes['All Day']['value'],
-      'to_date' => $startDate->format('YmdHis'),
-      'to_date_type' => $this->leaveRequestDayTypes['All Day']['value'],
-      'reason' => $this->sicknessRequestReasons['Accident']['value'],
-      'required_documents' => $this->requiredDocumentOptions['Self certification form required']['value'],
-    ];
-
-    $sicknessRequest = SicknessRequest::create($params);
-
-    $this->assertInstanceOf(SicknessRequest::class, $sicknessRequest);
-    $this->assertEquals($sicknessRequest->reason, $params ['reason']);
-    $this->assertEquals($sicknessRequest->required_documents, $params ['required_documents']);
-
-    //update the Sickness Request
-    $params['id'] = $sicknessRequest->id;
-    $params['required_documents'] = $this->requiredDocumentOptions['Back to work interview required']['value'];
-    $params['reason'] = $this->sicknessRequestReasons['Appointment']['value'];
-
-    $sicknessRequest2 = SicknessRequest::create($params);
-
-    $this->assertInstanceOf(SicknessRequest::class, $sicknessRequest2);
-    $this->assertEquals($sicknessRequest2->reason, $params ['reason']);
-    $this->assertEquals($sicknessRequest2->required_documents, $params ['required_documents']);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Factory/SicknessRequestServiceTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Factory/SicknessRequestServiceTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_SicknessRequest as SicknessRequestService;
+use CRM_HRLeaveAndAbsences_Factory_SicknessRequestService as SicknessRequestServiceFactory;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Factory_SicknessRequestServiceTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_Factory_SicknessRequestServiceTest extends BaseHeadlessTest  {
+
+  public function testCreate() {
+    $service = SicknessRequestServiceFactory::create();
+
+    $this->assertInstanceOf(SicknessRequestService::class, $service);
+  }
+}


### PR DESCRIPTION
This PR modifies the already existing SicknessRequest Service by making the it to extend LeaveRequest Service [#1420](https://github.com/civicrm/civihr/pull/1420). 

Some necessary methods that needed a different implementation in SicknessRequest Service child class  were overridden and modified.

One of such is the fact that Leave Approvers and Admins can modify SicknessRequest dates on behalf of the Leave Contact, this was not possible in LeaveRequest Service. So the `canChangeDatesFor` function of Sickness Request service was added as an overridden function of the parent class to reflect this change.

Also the way a leave request is created and deleted is a bit different from that of SicknessRequest, this also was taken into consideration and the methods required for this in the parent Leave Request Service class was overridden and modified in the child Sickness Request Service class.

Hopefully, this is a better way than reinventing the wheel and duplicating the methods of the LeaveRequest Service in the SicknessRequest Service.

