### PR TITLE
PCHR-1833: Set "Has Leave Approved By" as the default Leave Approver relationship type

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -354,7 +354,7 @@ function _hrleaveandabsences_create_administer_menu() {
   $administerMenuId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Administer', 'id', 'name');
   $maxWeightOfAdminMenuItems = _hrleaveandabsences_get_max_child_weight_for_menu($administerMenuId);
 
-  $params = array(
+  $params = [
     'label'      => ts('Leave and Absences'),
     'name'       => 'leave_and_absences',
     'url'        => null,
@@ -363,7 +363,7 @@ function _hrleaveandabsences_create_administer_menu() {
     'parent_id'  => $administerMenuId,
     'weight'     => $maxWeightOfAdminMenuItems + 1,
     'permission' => 'administer leave and absences'
-  );
+  ];
 
   $leaveAndAbsencesAdminNavigation = _hrleaveandabsences_add_navigation_menu($params);
 
@@ -425,9 +425,9 @@ function _hrleaveandabsences_create_administer_menu_tree($leaveAndAbsencesAdminN
  */
 function _hrleaveandabsences_get_max_child_weight_for_menu($menu_id) {
   $query = "SELECT MAX(weight) AS max FROM civicrm_navigation WHERE parent_id = %1";
-  $params = array(
-    1 => array($menu_id, 'Integer')
-  );
+  $params = [
+    1 => [$menu_id, 'Integer']
+  ];
   $dao = CRM_Core_DAO::executeQuery($query, $params);
   $dao->fetch();
   if($dao->max) {
@@ -443,7 +443,7 @@ function _hrleaveandabsences_get_max_child_weight_for_menu($menu_id) {
 function _hrleavesandabsences_create_main_menu() {
   $vacanciesWeight = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Vacancies', 'weight', 'name');
 
-  $params = array(
+  $params = [
     'label'      => ts('Leave and Absences'),
     'name'       => 'leave_and_absences',
     'url'        => 'civicrm/leaveandabsences/dashboard',
@@ -451,7 +451,7 @@ function _hrleavesandabsences_create_main_menu() {
     'weight'     => $vacanciesWeight + 1,
     'is_active'  => 1,
     'permission' => 'access leave and absences'
-  );
+  ];
 
   _hrleaveandabsences_add_navigation_menu($params);
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -33,7 +33,6 @@ function hrleaveandabsences_civicrm_xmlMenu(&$files) {
 function hrleaveandabsences_civicrm_install() {
   _hrleavesandabsences_create_main_menu();
   _hrleaveandabsences_create_administer_menu();
-  _hrleaveandabsences_add_scheduled_jobs();
 
   _hrleaveandabsences_civix_civicrm_install();
 }
@@ -158,59 +157,6 @@ function _hrleaveandabsences_add_navigation_menu($params)
   $navigationMenu->save();
 
   return $navigationMenu;
-}
-
-/**
- * Adds the scheduled jobs for this extension
- */
-function _hrleaveandabsences_add_scheduled_jobs() {
-  _hrleaveandabsences_add_create_expiry_records_scheduled_job();
-  _hrleaveandabsences_add_process_public_holiday_leave_requests_updates_scheduled_job();
-}
-
-/**
- * Adds the "Create expiration records for expired LeaveBalanceChange records" scheduled job.
- */
-function _hrleaveandabsences_add_create_expiry_records_scheduled_job() {
-  $dao             = new CRM_Core_DAO_Job();
-  $dao->api_entity = 'LeaveBalanceChange';
-  $dao->api_action = 'create_expiry_records';
-  $dao->find(TRUE);
-  if (!$dao->id) {
-    $dao                = new CRM_Core_DAO_Job();
-    $dao->api_entity    = 'LeaveBalanceChange';
-    $dao->api_action    = 'create_expiry_records';
-    $dao->domain_id     = CRM_Core_Config::domainID();
-    $dao->run_frequency = 'Daily';
-    $dao->parameters    = NULL;
-    $dao->name          = 'Create expiry records for expired LeaveBalanceChanges';
-    $dao->description   = 'Checks the number of days taken as leave during the LeaveBalanceChange period and add a negative balance change to expire the number of days not used';
-    $dao->is_active     = 1;
-    $dao->save();
-  }
-}
-
-/**
- * Adds the "Process Public Holiday Leave Requests Update" scheduled job.
- */
-function _hrleaveandabsences_add_process_public_holiday_leave_requests_updates_scheduled_job() {
-  $dao             = new CRM_Core_DAO_Job();
-  $dao->api_entity = 'PublicHoliday';
-  $dao->api_action = 'process_public_holiday_leave_request_updates_queue';
-  $dao->find(TRUE);
-
-  if (!$dao->id) {
-    $dao                = new CRM_Core_DAO_Job();
-    $dao->api_entity    = 'PublicHoliday';
-    $dao->api_action    = 'process_public_holiday_leave_request_updates_queue';
-    $dao->domain_id     = CRM_Core_Config::domainID();
-    $dao->run_frequency = 'Always';
-    $dao->parameters    = NULL;
-    $dao->name          = 'Process Public Holiday Leave Requests Updates';
-    $dao->description   = 'Process all the tasks on the "Public Holiday Leave Requests Update" queue';
-    $dao->is_active     = 1;
-    $dao->save();
-  }
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -50,6 +50,7 @@ function hrleaveandabsences_civicrm_xmlMenu(&$files) {
 function hrleaveandabsences_civicrm_install() {
   _hrleavesandabsences_create_main_menu();
   _hrleaveandabsences_create_administer_menu();
+  _hrleaveandabsences_create_has_leave_approved_by_relationship_type();
 
   _hrleaveandabsences_civix_civicrm_install();
 }
@@ -61,6 +62,8 @@ function hrleaveandabsences_civicrm_install() {
  */
 function hrleaveandabsences_civicrm_uninstall() {
   _hrleaveandabsences_delete_extension_menus();
+  _hrleaveandabsences_delete_has_leave_approved_by_relationship_type();
+
   _hrleaveandabsences_civix_civicrm_uninstall();
 }
 
@@ -71,6 +74,8 @@ function hrleaveandabsences_civicrm_uninstall() {
  */
 function hrleaveandabsences_civicrm_enable() {
   _hrleaveandabsences_update_extension_is_active_flag(true);
+  _hrleaveandabsences_update_has_leave_approved_by_relationship_type_is_active_flag(true);
+
   _hrleaveandabsences_civix_civicrm_enable();
 }
 
@@ -81,6 +86,8 @@ function hrleaveandabsences_civicrm_enable() {
  */
 function hrleaveandabsences_civicrm_disable() {
   _hrleaveandabsences_update_extension_is_active_flag(false);
+  _hrleaveandabsences_update_has_leave_approved_by_relationship_type_is_active_flag(false);
+
   _hrleaveandabsences_civix_civicrm_disable();
 }
 
@@ -518,4 +525,73 @@ function _hrleaveandabsences_civicrm_post_absencetype($op, $objectId, &$objectRe
       $absenceTypeService->postUpdateActions($objectRef);
     } catch (Exception $e) {}
   }
+}
+
+/**
+ * Creates the "Has Leave Approved By" relationship type, if it doesn't exist
+ * yet.
+ */
+function _hrleaveandabsences_create_has_leave_approved_by_relationship_type() {
+  $relationshipType = _hrleaveandabsences_get_has_leave_approved_by_relationship_type();
+
+  if(NULL === $relationshipType) {
+    civicrm_api3('RelationshipType', 'create', [
+      'sequential'     => 1,
+      'description'    => 'Has Leave Approved By',
+      'name_a_b'       => 'has Leave Approved by',
+      'name_b_a'       => 'is Leave Approver of',
+      'contact_type_a' => 'Individual',
+      'contact_type_b' => 'Individual',
+    ]);
+  }
+}
+
+/**
+ * Deletes the "Has Leave Approved By" relationship type, if it exists
+ */
+function _hrleaveandabsences_delete_has_leave_approved_by_relationship_type() {
+  $relationshipType = _hrleaveandabsences_get_has_leave_approved_by_relationship_type();
+
+  if (NULL !== $relationshipType) {
+    civicrm_api3('RelationshipType', 'delete', [
+      'sequential' => 1,
+      'id' => $relationshipType['id']
+    ]);
+  }
+}
+
+/**
+ * Enable or disable the "Has Leave Approved By" relationship type, according to
+ * the value of the $active param.
+ *
+ * @param bool $active
+ */
+function _hrleaveandabsences_update_has_leave_approved_by_relationship_type_is_active_flag($active = true) {
+  $relationshipType = _hrleaveandabsences_get_has_leave_approved_by_relationship_type();
+
+  if ($relationshipType) {
+    civicrm_api3('RelationshipType', 'create', [
+      'id' => $relationshipType['id'],
+      'is_active' => $active
+    ]);
+  }
+}
+
+/**
+ * Returns the data for the "Has Leave Approved" relationship type. If it doesn't
+ * exist, returns null.
+ *
+ * @return mixed|null
+ */
+function _hrleaveandabsences_get_has_leave_approved_by_relationship_type() {
+  $result = civicrm_api3('RelationshipType', 'get', [
+    'sequential' => 1,
+    'name_a_b' => 'has Leave Approved by',
+  ]);
+
+  if (!empty($result['values'])) {
+    return $result['values'][0];
+  }
+
+  return NULL;
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -37,6 +37,9 @@ function hrleaveandabsences_civicrm_install() {
   _hrleaveandabsences_civix_civicrm_install();
 }
 
+/**
+ * Creates the "Leave and Absences" menu item under Civi's "Administer" menu
+ */
 function _hrleaveandabsences_create_administer_menu() {
   $administerMenuId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Administer', 'id', 'name');
   $maxWeightOfAdminMenuItems = _hrleaveandabsences_get_max_child_weight_for_menu($administerMenuId);
@@ -124,15 +127,18 @@ function _hrleaveandabsences_get_max_child_weight_for_menu($menu_id) {
   return 0;
 }
 
+/**
+ * Creates the extension's menu item on the main navigation
+ */
 function _hrleavesandabsences_create_main_menu() {
-  $reportWeight = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'job_contracts', 'weight', 'name');
+  $vacanciesWeight = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Vacancies', 'weight', 'name');
 
   $params = array(
       'label'      => ts('Leave and Absences'),
       'name'       => 'leave_and_absences',
       'url'        => 'civicrm/leaveandabsences/dashboard',
       'operator'   => null,
-      'weight'     => $reportWeight + 1,
+      'weight'     => $vacanciesWeight + 1,
       'is_active'  => 1,
       'permission' => 'access leave and absences'
   );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/managed_entities/Job.mgd.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/managed_entities/Job.mgd.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+  [
+    'name' => 'Scheduled Job: Create expiry records for expired LeaveBalanceChanges',
+    'entity' => 'Job',
+    'params' => [
+      'version'       => 3,
+      'api_entity'    => 'LeaveBalanceChange',
+      'api_action'    => 'create_expiry_records',
+      'domain_id'     => CRM_Core_Config::domainID(),
+      'run_frequency' => 'Daily',
+      'parameters'    => NULL,
+      'name'          => 'Create expiry records for expired LeaveBalanceChanges',
+      'description'   => 'Checks the number of days taken as leave during the LeaveBalanceChange period and add a negative balance change to expire the number of days not used',
+    ],
+  ],
+  [
+    'name' => 'Scheduled Job: Process Public Holiday Leave Requests Updates',
+    'entity' => 'Job',
+    'params' => [
+      'version'       => 3,
+      'api_entity'    => 'PublicHoliday',
+      'api_action'    => 'process_public_holiday_leave_request_updates_queue',
+      'domain_id'     => CRM_Core_Config::domainID(),
+      'run_frequency' => 'Always',
+      'parameters'    => NULL,
+      'name'          => 'Process Public Holiday Leave Requests Updates',
+      'description'   => 'Process all the tasks on the "Public Holiday Leave Requests Update" queue',
+    ],
+  ],
+];

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -250,7 +250,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
   }
 
   public function leaveRequestStatusesDataProvider() {
-    $leaveRequestStatuses =  $this->leaveRequestStatuses;
+    $leaveRequestStatuses =  $this->getLeaveRequestStatuses();
 
     return [
       [$leaveRequestStatuses['More Information Requested']['id']],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveManagerHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveManagerHelpersTrait.php
@@ -19,7 +19,7 @@ trait CRM_HRLeaveAndAbsences_LeaveManagerHelpersTrait {
 
   public function setContactAsLeaveApproverOf($leaveApprover, $contact, $startDate = null, $endDate = null, $isActive = true, $relationshipType = null) {
     if(!$relationshipType) {
-      $relationshipType = 'has Leave Approved By';
+      $relationshipType = 'leave approver is';
     }
 
     $relationshipType = $this->getRelationshipType($relationshipType);


### PR DESCRIPTION
With this PR, the L&A extension will now have a default Leave Approver relationship type right after it gets installed. The new relationship type is named "Has Leave Approved By" and it's the default value on the General Settings.

The enable/disable/install/uninstall hooks were all updated to make sure the RelationshipType gets updated properly on each of this events. Originally, the idea was to use Managed Entities to create the relationship type but was not possible. The reason is that the `hrabsence` extension also creates the same relationship type. So, if that extension is installed before l&a, the managed entity creation will fail because the type already exists. Using hook, we can first check if it exists and only create it if it doesn't.

Due to the fact that now the extensions creates the relationship type and it has the same name as the default one created by the `LeaveManagerHelpersTrait`, some tests started to fail (because the relationship already existed and the trait would set it as a leave approver relationship type). I changed the relationship type name used by the trait in order to fix this.

### Other changes includes with this PR
- Refactoring and reorganization of the code inside hrleaveandabsences.php
- Fix the positioning of the "Leave and Absences" menu item position on the main navigation menu. It used the Reports menu as a reference, but it doesn't exist anymore, so the Vacancies menu is now the reference.
- Use managed entities to handle the scheduled jobs