### PR TITLE
PCHR-1837: Create TOILRequest Service

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/TOILRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/TOILRequest.php
@@ -29,9 +29,9 @@ class CRM_HRLeaveAndAbsences_BAO_TOILRequest extends CRM_HRLeaveAndAbsences_DAO_
     $leaveRequestParams = self::parseLeaveRequestParams($params);
 
     //set from_date_type and to_date_type to be full day by default
-    $dateTypeOptions = array_flip(LeaveRequest::buildOptions('from_date_type'));
-    $leaveRequestParams['from_date_type'] = $dateTypeOptions['All Day'];
-    $leaveRequestParams['to_date_type'] = $dateTypeOptions['All Day'];
+    $dateTypeOptions = array_flip(LeaveRequest::buildOptions('from_date_type', 'validate'));
+    $leaveRequestParams['from_date_type'] = $dateTypeOptions['all_day'];
+    $leaveRequestParams['to_date_type'] = $dateTypeOptions['all_day'];
 
     if ($hook == 'edit') {
       $instance->id = $toilRequestParams['id'];

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/TOILRequestService.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/TOILRequestService.php
@@ -1,0 +1,34 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange as LeaveBalanceChangeService;
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix as LeaveRequestStatusMatrixService;
+use CRM_HRLeaveAndAbsences_Service_TOILRequest as TOILRequestService;
+use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
+
+/**
+ * A factory for the TOILRequest service, which can be used
+ * to get instances of this service without having to manually create all of
+ * its dependencies
+ */
+class CRM_HRLeaveAndAbsences_Factory_TOILRequestService {
+
+  /**
+   * Returns a new instance of a TOILRequest Service
+   *
+   * @return \CRM_HRLeaveAndAbsences_Service_TOILRequest
+   */
+  public static function create() {
+    $leaveBalanceChangeService = new LeaveBalanceChangeService();
+    $leaveManagerService = new LeaveManagerService();
+    $leaveRequestStatusMatrixService = new LeaveRequestStatusMatrixService($leaveManagerService);
+    $leaveRequestRightsService = new LeaveRequestRightsService($leaveManagerService);
+
+    return new TOILRequestService(
+      $leaveBalanceChangeService,
+      $leaveRequestStatusMatrixService,
+      $leaveRequestRightsService
+    );
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChange.php
@@ -62,14 +62,14 @@ class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange {
   public function createForTOILRequest(TOILRequest $toilRequest, $absenceTypeID, $toilToAccrue, DateTime $expiryDate = null) {
     $this->deleteForTOILRequest($toilRequest);
 
-    $balanceChangeTypes = array_flip(LeaveBalanceChange::buildOptions('type_id'));
+    $balanceChangeTypes = array_flip(LeaveBalanceChange::buildOptions('type_id', 'validate'));
     if($expiryDate === null) {
       $absenceType = AbsenceType::findById($absenceTypeID);
       $expiryDate =  $absenceType->calculateToilExpiryDate(new DateTime());
     }
 
     LeaveBalanceChange::create([
-      'type_id' => $balanceChangeTypes['Credit'],
+      'type_id' => $balanceChangeTypes['credit'],
       'amount' => $toilToAccrue,
       'expiry_date' => $expiryDate ? $expiryDate->format('Ymd') : null,
       'source_id' => $toilRequest->id,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChange.php
@@ -2,6 +2,8 @@
 
 use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+use CRM_HRLeaveAndAbsences_BAO_TOILRequest as TOILRequest;
 
 class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange {
 
@@ -44,5 +46,46 @@ class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange {
       !empty($leaveRequest->to_date) ? new DateTime($leaveRequest->to_date) : null,
       $leaveRequest->to_date_type
     );
+  }
+
+  /**
+   * Creates LeaveBalanceChange for the given TOILRequest
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_TOILRequest $toilRequest
+   * @param int $absenceTypeID
+   *   The absence type for which the TOIL was requested
+   * @param int $toilToAccrue
+   *   The TOIL amount to accrue
+   * @param \DateTime|NULL $expiryDate
+   *   The TOIL balance change expiry date
+   */
+  public function createForTOILRequest(TOILRequest $toilRequest, $absenceTypeID, $toilToAccrue, DateTime $expiryDate = null) {
+    $this->deleteForTOILRequest($toilRequest);
+
+    $balanceChangeTypes = array_flip(LeaveBalanceChange::buildOptions('type_id'));
+    if($expiryDate === null) {
+      $absenceType = AbsenceType::findById($absenceTypeID);
+      $expiryDate =  $absenceType->calculateToilExpiryDate(new DateTime());
+    }
+
+    LeaveBalanceChange::create([
+      'type_id' => $balanceChangeTypes['Credit'],
+      'amount' => $toilToAccrue,
+      'expiry_date' => $expiryDate ? $expiryDate->format('Ymd') : null,
+      'source_id' => $toilRequest->id,
+      'source_type' => LeaveBalanceChange::SOURCE_TOIL_REQUEST
+    ]);
+  }
+
+  /**
+   * Deletes LeaveBalanceChange for the given TOILRequest
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_TOILRequest $toilRequest
+   */
+  public function deleteForTOILRequest(TOILRequest $toilRequest) {
+    $dao = new LeaveBalanceChange();
+    $dao->source_id = $toilRequest->id;
+    $dao->source_type = LeaveBalanceChange::SOURCE_TOIL_REQUEST;
+    $dao->delete();
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/TOILRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/TOILRequest.php
@@ -54,19 +54,9 @@ class CRM_HRLeaveAndAbsences_Service_TOILRequest extends LeaveRequestService {
    */
   public function delete($toilRequestID) {
     $toilRequest = TOILRequest::findById($toilRequestID);
-    $leaveRequest = LeaveRequest::findById($toilRequest->leave_request_id);
-
-    $transaction = new CRM_Core_Transaction();
-    try {
-      $this->leaveBalanceChangeService->deleteForTOILRequest($toilRequest);
-      LeaveRequestDate::deleteDatesForLeaveRequest($toilRequest->leave_request_id);
-      $leaveRequest->delete();
-      $toilRequest->delete();
-
-      $transaction->commit();
-    } catch(Exception $e) {
-      $transaction->rollback();
-    }
+    parent::delete($toilRequest->leave_request_id);
+    $this->leaveBalanceChangeService->deleteForTOILRequest($toilRequest);
+    $toilRequest->delete();
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/TOILRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/TOILRequest.php
@@ -1,0 +1,82 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
+use CRM_HRLeaveAndAbsences_BAO_TOILRequest as TOILRequest;
+use CRM_HRLeaveAndAbsences_Service_LeaveRequest as LeaveRequestService;
+
+class CRM_HRLeaveAndAbsences_Service_TOILRequest extends LeaveRequestService {
+
+  /**
+   * This method creates/updates the TOILRequest along with the
+   * associated LeaveRequest and it's LeaveBalanceChanges
+   *
+   * @param array $params
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_TOILRequest|NULL
+   */
+  protected function createRequestWithBalanceChanges($params) {
+    $toilRequest = TOILRequest::create($params, false);
+    $expiryDate = !empty($params['expiry_date']) ? new DateTime($params['expiry_date']) : null;
+
+    $this->leaveBalanceChangeService->createForTOILRequest(
+      $toilRequest,
+      $params['type_id'],
+      $params['toil_to_accrue'],
+      $expiryDate
+    );
+
+    return $toilRequest;
+  }
+
+  /**
+   * Returns the LeaveRequest object associated with the TOILRequest
+   * in its current state (i.e before it gets updated)
+   *
+   * @param int $toilRequestID
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_LeaveRequest
+   */
+  protected function getOldLeaveRequest($toilRequestID) {
+    $toilRequest = TOILRequest::findById($toilRequestID);
+    if (!$this->oldLeaveRequest) {
+      $this->oldLeaveRequest = LeaveRequest::findById($toilRequest->leave_request_id);
+    }
+    return $this->oldLeaveRequest;
+  }
+
+  /**
+   * Deletes the TOILRequest with the given $toilRequestID, including
+   * its associated LeaveRequest and all of its LeaveRequestDates and
+   * TOIL LeaveBalanceChanges
+   *
+   * @param int $toilRequestID
+   */
+  public function delete($toilRequestID) {
+    $toilRequest = TOILRequest::findById($toilRequestID);
+    $leaveRequest = LeaveRequest::findById($toilRequest->leave_request_id);
+
+    $transaction = new CRM_Core_Transaction();
+    try {
+      $this->leaveBalanceChangeService->deleteForTOILRequest($toilRequest);
+      LeaveRequestDate::deleteDatesForLeaveRequest($toilRequest->leave_request_id);
+      $leaveRequest->delete();
+      $toilRequest->delete();
+
+      $transaction->commit();
+    } catch(Exception $e) {
+      $transaction->rollback();
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function runValidation($params) {
+    if (isset($params['id'])) {
+      $params['leave_request_id'] = $this->getOldLeaveRequest($params['id'])->id;
+    }
+
+    TOILRequest::validateParams($params);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveBalanceChange.php
@@ -2,6 +2,7 @@
 
 use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
+use CRM_HRLeaveAndAbsences_BAO_TOILRequest as TOILRequest;
 
 class CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange {
 
@@ -33,5 +34,25 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange {
       'amount' => -1,
       'type_id' => self::getTypeId('Leave')
     ];
+  }
+
+  public static function fabricateForTOIL(TOILRequest $toilRequest, $toilToAccrue, DateTime $expiryDate = null) {
+    //delete any existing TOIL LeaveBalanceChanges
+    self::deleteForTOIL($toilRequest);
+
+    return self::fabricate([
+      'type_id' => self::getTypeId('Credit'),
+      'amount' => $toilToAccrue,
+      'source_id' => $toilRequest->id,
+      'expiry_date' => $expiryDate ? $expiryDate->format('Ymd') : null,
+      'source_type' => LeaveBalanceChange::SOURCE_TOIL_REQUEST
+    ]);
+  }
+
+  private static function deleteForTOIL(TOILRequest $toilRequest) {
+    $dao = new LeaveBalanceChange();
+    $dao->source_id = $toilRequest->id;
+    $dao->source_type = LeaveBalanceChange::SOURCE_TOIL_REQUEST;
+    $dao->delete();
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/TOILRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/TOILRequest.php
@@ -2,29 +2,42 @@
 
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_BAO_TOILRequest as TOILRequest;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange as LeaveBalanceChangeFabricator;
 
 class CRM_HRLeaveAndAbsences_Test_Fabricator_TOILRequest {
 
   private static $leaveRequestStatuses;
   private static $toilAmounts;
 
-  public static function fabricate($params) {
+  public static function fabricate($params, $withBalanceChanges = false) {
     $params = self::mergeDefaultParams($params);
+    $toilRequest =  TOILRequest::create($params);
 
-    return TOILRequest::create($params);
+    if($withBalanceChanges) {
+     self::createBalanceChange($toilRequest, $params);
+    }
+
+    return $toilRequest;
   }
 
   /**
    * Creates a new TOIL Request without running any validation
    *
    * @param array $params
+   * @param boolean $withBalanceChanges
    *
    * @return \CRM_HRLeaveAndAbsences_BAO_TOILRequest
    */
-  public static function fabricateWithoutValidation($params = []) {
+  public static function fabricateWithoutValidation($params = [], $withBalanceChanges = false) {
     $params = self::mergeDefaultParams($params);
+    $toilRequest =  TOILRequest::create($params, false);
 
-    return TOILRequest::create($params, false);
+    if($withBalanceChanges) {
+      self::createBalanceChange($toilRequest, $params);
+    }
+
+    return $toilRequest;
+
   }
 
   private static function mergeDefaultParams($params) {
@@ -53,5 +66,13 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_TOILRequest {
     }
 
     return self::$toilAmounts[$reasonLabel];
+  }
+
+  private static function createBalanceChange(TOILRequest $toilRequest, $params) {
+    $expiryDate = null;
+    if(!empty($params['expiry_date'])) {
+      $expiryDate = new DateTime($params['expiry_date']);
+    }
+    LeaveBalanceChangeFabricator::fabricateForTOIL($toilRequest, $params['toil_to_accrue'], $expiryDate);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/TOILRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/TOILRequest.php
@@ -97,7 +97,17 @@ function _civicrm_api3_t_o_i_l_request_create_spec(&$spec) {
  * @throws API_Exception
  */
 function civicrm_api3_t_o_i_l_request_create($params) {
-  $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  $bao = _civicrm_api3_get_BAO(__FUNCTION__);
+  _civicrm_api3_check_edit_permissions($bao, $params);
+  _civicrm_api3_format_params_for_create($params, null);
+
+  $service = CRM_HRLeaveAndAbsences_Factory_TOILRequestService::create();
+  $toilRequest = $service->create($params);
+  $values = [];
+  _civicrm_api3_object_to_array($toilRequest, $values[$toilRequest->id]);
+
+  $result = civicrm_api3_create_success($values, $params, null, 'create', $toilRequest);
+
   if ($result['count'] > 0) {
     array_walk($result['values'], '_civicrm_api3_t_o_i_l_request_merge_with_leave_request');
   }
@@ -113,7 +123,14 @@ function civicrm_api3_t_o_i_l_request_create($params) {
  * @throws API_Exception
  */
 function civicrm_api3_t_o_i_l_request_delete($params) {
-  return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  $bao = _civicrm_api3_get_BAO(__FUNCTION__);
+  civicrm_api3_verify_mandatory($params, NULL, ['id']);
+  _civicrm_api3_check_edit_permissions($bao, ['id' => $params['id']]);
+
+  $service = CRM_HRLeaveAndAbsences_Factory_TOILRequestService::create();
+  $service->delete($params['id']);
+
+  return civicrm_api3_create_success(true);
 }
 
 function _civicrm_api3_t_o_i_l_request_get_spec(&$spec) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Factory/TOILRequestServiceTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Factory/TOILRequestServiceTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_TOILRequest as TOILRequestService;
+use CRM_HRLeaveAndAbsences_Factory_TOILRequestService as TOILRequestServiceFactory;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Factory_TOILRequestServiceTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_Factory_TOILRequestServiceTest extends BaseHeadlessTest  {
+
+  public function testCreate() {
+    $service = TOILRequestServiceFactory::create();
+
+    $this->assertInstanceOf(TOILRequestService::class, $service);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChangeTest.php
@@ -4,9 +4,12 @@ use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
 use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
 use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 use CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange as LeaveBalanceChangeService;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern as WorkPatternFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_TOILRequest as TOILRequestFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
 
 /**
  * Class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChangeTest
@@ -14,6 +17,15 @@ use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricato
  * @group headless
  */
 class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChangeTest extends BaseHeadlessTest {
+
+  use CRM_HRLeaveAndAbsences_TOILRequestHelpersTrait;
+
+  private $leaveBalanceChangeService;
+
+  public function setUp() {
+    CRM_Core_DAO::executeQuery("SET foreign_key_checks = 0;");
+    $this->leaveBalanceChangeService = new LeaveBalanceChangeService();
+  }
 
   public function testItCanCreateBalanceChangesForALeaveRequest() {
     $contact = ContactFabricator::fabricate();
@@ -38,8 +50,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChangeTest extends BaseHeadless
       'to_date_type' => $leaveRequestDateTypes['all_day'],
     ]);
 
-    $service = new LeaveBalanceChangeService();
-    $service->createForLeaveRequest($leaveRequest);
+    $this->leaveBalanceChangeService->createForLeaveRequest($leaveRequest);
 
     $balance = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
     // Since the 40 hours work pattern was used and there are 3 weekend days on the
@@ -53,4 +64,139 @@ class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChangeTest extends BaseHeadless
     $this->assertCount(9, $balanceChanges);
   }
 
+  public function testCreateForTOILRequestDoesNotCreateDuplicateBalanceChanges() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'max_leave_accrual' => 1,
+    ]);
+
+    $params = $this->getDefaultTOILparams(['type_id' => $absenceType->id]);
+    $toilRequest = TOILRequestFabricator::fabricateWithoutValidation($params);
+
+    $this->leaveBalanceChangeService->createForTOILRequest($toilRequest, $params['type_id'], $params['toil_to_accrue']);
+
+    $toilBalanceChange = new LeaveBalanceChange();
+    $toilBalanceChange->source_id = $toilRequest->id;
+    $toilBalanceChange->source_type = LeaveBalanceChange::SOURCE_TOIL_REQUEST;
+    $toilBalanceChange->find();
+    //No duplicates
+    $this->assertEquals(1, $toilBalanceChange->N);
+
+    //verify the balance change
+    $toilBalanceChange->fetch();
+    $this->assertEquals($params['toil_to_accrue'], $toilBalanceChange->amount);
+  }
+
+  public function testCreateForTOILRequestDoesNotCreateDuplicateBalanceChangeForAnUpdatedTOIL() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'max_leave_accrual' => 4,
+    ]);
+
+    $params = $this->getDefaultTOILParams(['type_id' => $absenceType->id]);
+    $toilRequest1 = TOILRequestFabricator::fabricateWithoutValidation($params);
+    $this->leaveBalanceChangeService->createForTOILRequest($toilRequest1, $params['type_id'], $params['toil_to_accrue']);
+
+    $params['id'] = $toilRequest1->id;
+    $params['toil_to_accrue'] = 3;
+    //update TOIL
+    $toilRequest2 = TOILRequestFabricator::fabricateWithoutValidation($params);
+    $this->leaveBalanceChangeService->createForTOILRequest($toilRequest2, $params['type_id'], $params['toil_to_accrue']);
+
+    $toilBalanceChange = new LeaveBalanceChange();
+    $toilBalanceChange->source_id = $toilRequest2->id;
+    $toilBalanceChange->source_type = LeaveBalanceChange::SOURCE_TOIL_REQUEST;
+    $toilBalanceChange->find();
+    //No duplicates
+    $this->assertEquals(1, $toilBalanceChange->N);
+
+    $toilBalanceChange->fetch();
+    $this->assertEquals($params['toil_to_accrue'], $toilBalanceChange->amount);
+  }
+
+  public function testDeleteForTOILRequestDeletesTheTOILBalanceChange() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'max_leave_accrual' => 4,
+    ]);
+
+    $params = $this->getDefaultTOILParams(['type_id' => $absenceType->id]);
+    $toilRequest = TOILRequestFabricator::fabricateWithoutValidation($params);
+
+    $this->leaveBalanceChangeService->createForTOILRequest($toilRequest, $params['type_id'], $params['toil_to_accrue']);
+
+    //delete balance change for toil
+    $this->leaveBalanceChangeService->deleteForTOILRequest($toilRequest);
+    $this->assertNull($this->getTOILBalanceChange($toilRequest->id));
+  }
+
+  public function testCreateForTOILRequestWhenNoExpiryDateIsGivenAndAbsenceTypeSaysTOILNeverExpires() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'max_leave_accrual' => 4,
+    ]);
+
+    $params = $this->getDefaultTOILParams(['type_id' => $absenceType->id]);
+    $toilRequest = TOILRequestFabricator::fabricateWithoutValidation($params);
+
+    $this->leaveBalanceChangeService->createForTOILRequest($toilRequest, $params['type_id'], $params['toil_to_accrue']);
+
+    $toilBalanceChange = $this->getTOILBalanceChange($toilRequest->id);
+    $this->assertNull($toilBalanceChange->expiry_date);
+  }
+
+  public function testCreateForTOILRequestWhenNoExpiryDateIsGivenAndAbsenceTypeHasTOILExpiryDuration() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'max_leave_accrual' => 10,
+      'allow_accruals_request' => true,
+      'accrual_expiration_duration' => 10,
+      'accrual_expiration_unit' => AbsenceType::EXPIRATION_UNIT_DAYS,
+    ]);
+
+    $params = $this->getDefaultTOILParams(['type_id' => $absenceType->id]);
+    $toilRequest = TOILRequestFabricator::fabricateWithoutValidation($params);
+
+    $this->leaveBalanceChangeService->createForTOILRequest($toilRequest, $params['type_id'], $params['toil_to_accrue']);
+
+    $expectedExpiryDate = new DateTime('+10 days');
+
+    $toilBalanceChange = $this->getTOILBalanceChange($toilRequest->id);
+
+    $this->assertEquals($toilBalanceChange->expiry_date, $expectedExpiryDate->format('Y-m-d'));
+  }
+
+  public function testCreateForTOILWhenATOILExpiryDateIsGiven() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'max_leave_accrual' => 10,
+      'allow_accruals_request' => true,
+      'accrual_expiration_duration' => 10,
+      'accrual_expiration_unit' => AbsenceType::EXPIRATION_UNIT_DAYS,
+    ]);
+
+    $expiryDate = new DateTime('+100 days');
+
+    $params = $this->getDefaultTOILParams(['type_id' => $absenceType->id]);
+    $toilRequest = TOILRequestFabricator::fabricateWithoutValidation($params);
+
+    $this->leaveBalanceChangeService->createForTOILRequest($toilRequest, $params['type_id'], $params['toil_to_accrue'], $expiryDate);
+    $toilBalanceChange = $this->getTOILBalanceChange($toilRequest->id);
+
+    // The settings on the AbsenceType says TOIL Requests should expire in 10 days,
+    // but the expiry date passed to create was 100 days, so that should be the
+    // date used
+    $this->assertEquals($expiryDate->format('Y-m-d'), $toilBalanceChange->expiry_date);
+  }
+
+  private function getDefaultTOILParams($params = []) {
+    $defaultParams = [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-04-10'),
+      'to_date' => CRM_Utils_Date::processDate('2016-04-12'),
+      'toil_to_accrue' => 2,
+      'duration' => 120,
+      'expiry_date' => CRM_Utils_Date::processDate('2016-12-10')
+    ];
+    return array_merge($defaultParams, $params);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChangeTest.php
@@ -18,7 +18,7 @@ use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
  */
 class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChangeTest extends BaseHeadlessTest {
 
-  use CRM_HRLeaveAndAbsences_TOILRequestHelpersTrait;
+  use CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait;
 
   private $leaveBalanceChangeService;
 
@@ -127,7 +127,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChangeTest extends BaseHeadless
 
     //delete balance change for toil
     $this->leaveBalanceChangeService->deleteForTOILRequest($toilRequest);
-    $this->assertNull($this->getTOILBalanceChange($toilRequest->id));
+    $this->assertNull($this->findToilRequestBalanceChange($toilRequest->id));
   }
 
   public function testCreateForTOILRequestWhenNoExpiryDateIsGivenAndAbsenceTypeSaysTOILNeverExpires() {
@@ -141,7 +141,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChangeTest extends BaseHeadless
 
     $this->leaveBalanceChangeService->createForTOILRequest($toilRequest, $params['type_id'], $params['toil_to_accrue']);
 
-    $toilBalanceChange = $this->getTOILBalanceChange($toilRequest->id);
+    $toilBalanceChange = $this->findToilRequestBalanceChange($toilRequest->id);
     $this->assertNull($toilBalanceChange->expiry_date);
   }
 
@@ -160,7 +160,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChangeTest extends BaseHeadless
 
     $expectedExpiryDate = new DateTime('+10 days');
 
-    $toilBalanceChange = $this->getTOILBalanceChange($toilRequest->id);
+    $toilBalanceChange = $this->findToilRequestBalanceChange($toilRequest->id);
 
     $this->assertEquals($toilBalanceChange->expiry_date, $expectedExpiryDate->format('Y-m-d'));
   }
@@ -179,7 +179,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChangeTest extends BaseHeadless
     $toilRequest = TOILRequestFabricator::fabricateWithoutValidation($params);
 
     $this->leaveBalanceChangeService->createForTOILRequest($toilRequest, $params['type_id'], $params['toil_to_accrue'], $expiryDate);
-    $toilBalanceChange = $this->getTOILBalanceChange($toilRequest->id);
+    $toilBalanceChange = $this->findToilRequestBalanceChange($toilRequest->id);
 
     // The settings on the AbsenceType says TOIL Requests should expire in 10 days,
     // but the expiry date passed to create was 100 days, so that should be the

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChangeTest.php
@@ -23,7 +23,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChangeTest extends BaseHeadless
   private $leaveBalanceChangeService;
 
   public function setUp() {
-    CRM_Core_DAO::executeQuery("SET foreign_key_checks = 0;");
+    CRM_Core_DAO::executeQuery('SET foreign_key_checks = 0;');
     $this->leaveBalanceChangeService = new LeaveBalanceChangeService();
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/TOILRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/TOILRequestTest.php
@@ -1,0 +1,150 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use CRM_HRLeaveAndAbsences_BAO_TOILRequest as TOILRequest;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_TOILRequest as TOILRequestFabricator;
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix as LeaveRequestStatusMatrixService;
+use CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange as LeaveBalanceChangeService;
+use CRM_HRLeaveAndAbsences_Service_TOILRequest as TOILRequestService;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Service_TOILRequestTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_Service_TOILRequestTest extends BaseHeadlessTest {
+
+  use CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait;
+  use CRM_HRLeaveAndAbsences_LeaveManagerHelpersTrait;
+  use CRM_HRLeaveAndAbsences_SessionHelpersTrait;
+  use CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait;
+  use CRM_HRLeaveAndAbsences_TOILRequestHelpersTrait;
+
+  private $leaveContact;
+
+  private $absenceType;
+
+  private $leaveBalanceChangeService;
+
+  public function setUp() {
+    CRM_Core_DAO::executeQuery("SET foreign_key_checks = 0;");
+
+    $this->absenceType = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'max_leave_accrual' => 10
+    ]);
+
+    $this->leaveBalanceChangeService = new LeaveBalanceChangeService();
+
+    $this->leaveContact = 1;
+    $this->registerCurrentLoggedInContactInSession($this->leaveContact);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
+  }
+
+  public function testCreateAlsoCreatesTheLeaveRequestAndTheTOILRequestBalanceChange() {
+    $toilRequestService = $this->getTOILRequestService();
+    $params = $this->getDefaultParams();
+    $toilRequest = $toilRequestService->create($params, false);
+
+    LeaveRequest::findById($toilRequest->leave_request_id);
+    $toilBalanceChange = $this->findToilRequestBalanceChange($toilRequest->id);
+    $this->assertEquals($toilBalanceChange->amount, $params['toil_to_accrue']);
+  }
+
+  public function testDeleteAlsoDeletesTheLeaveRequestItsBalanceChangesAndDates() {
+    $params = $this->getDefaultParams([
+      'from_date' => CRM_Utils_Date::processDate('+1 day'),
+      'to_date' => CRM_Utils_Date::processDate('+3 days'),
+    ]);
+    $toilRequest = TOILRequestFabricator::fabricateWithoutValidation($params, true);
+
+    $leaveRequest = LeaveRequest::findById($toilRequest->leave_request_id);
+    $toilBalanceChange = $this->findToilRequestBalanceChange($toilRequest->id);
+    $leaveRequestDates = $leaveRequest->getDates();
+    $this->assertCount(3, $leaveRequestDates);
+    $this->assertInstanceOf(LeaveBalanceChange::class, $toilBalanceChange);
+
+    //delete the TOIL
+    $service = $this->getTOILRequestService();
+    $service->delete($toilRequest->id);
+
+    $this->assertNull($this->findToilRequestBalanceChange($toilRequest->id));
+    $dates = $leaveRequest->getDates();
+    $this->assertCount(0, $dates);
+
+    try {
+      LeaveRequest::findById($leaveRequest->id);
+      $this->fail("Expected to not find the LeaveRequest with {$leaveRequest->id}, but it was found");
+    } catch (Exception $e) {
+      return;
+    }
+
+    try {
+      TOILRequest::findById($toilRequest->id);
+      $this->fail("Expected to not find the TOILRequest with {$toilRequest->id}, but it was found");
+    } catch (Exception $e) {
+      return;
+    }
+  }
+
+  /**
+   * @expectedException RuntimeException
+   * @expectedExceptionMessage You are not allowed to change the type of a request
+   */
+  public function testCreateThrowsAnExceptionWhenLeaveApproverUpdatesAbsenceTypeForTOILRequest() {
+    $contactID = 5;
+    $params = $this->getDefaultParams(['contact_id' => $contactID]);
+    $toilRequest = TOILRequestFabricator::fabricateWithoutValidation($params, true);
+
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'max_leave_accrual' => 10
+    ]);
+
+    $params['id'] = $toilRequest->id;
+    $params['type_id'] = $absenceType->id;
+
+    $toilRequestService = $this->getTOILRequestServiceWhenCurrentUserIsLeaveManager();
+    $toilRequestService->create($params, false);
+  }
+
+  private function getTOILRequestService($isAdmin = false, $isManager = false) {
+    $leaveManagerService = $this->createLeaveManagerServiceMock($isAdmin, $isManager);
+    $leaveRequestStatusMatrixService = new LeaveRequestStatusMatrixService($leaveManagerService);
+    $leaveRequestRightsService = new LeaveRequestRightsService($leaveManagerService);
+
+    return new TOILRequestService(
+      $this->leaveBalanceChangeService,
+      $leaveRequestStatusMatrixService,
+      $leaveRequestRightsService
+    );
+  }
+
+  private function getTOILRequestServiceWhenCurrentUserIsAdmin() {
+    return $this->getTOILRequestService(true, false);
+  }
+
+  private function getTOILRequestServiceWhenCurrentUserIsLeaveManager() {
+    return $this->getTOILRequestService(false, true);
+  }
+
+  private function getDefaultParams($params = []) {
+    $defaultParams = [
+      'contact_id' => $this->leaveContact,
+      'type_id' => $this->absenceType->id,
+      'status_id' => $this->getLeaveRequestStatuses()['Waiting Approval']['value'],
+      'from_date' => CRM_Utils_Date::processDate('today'),
+      'to_date' => CRM_Utils_Date::processDate('today'),
+      'from_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'to_date_type' => $this->getLeaveRequestDayTypes()['All Day']['value'],
+      'toil_to_accrue' => 2,
+      'duration' => 60,
+      'sequential' => 1
+    ];
+
+    return array_merge($defaultParams, $params);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/TOILRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/TOILRequestTest.php
@@ -90,27 +90,6 @@ class CRM_HRLeaveAndAbsences_Service_TOILRequestTest extends BaseHeadlessTest {
     }
   }
 
-  /**
-   * @expectedException RuntimeException
-   * @expectedExceptionMessage You are not allowed to change the type of a request
-   */
-  public function testCreateThrowsAnExceptionWhenLeaveApproverUpdatesAbsenceTypeForTOILRequest() {
-    $contactID = 5;
-    $params = $this->getDefaultParams(['contact_id' => $contactID]);
-    $toilRequest = TOILRequestFabricator::fabricateWithoutValidation($params, true);
-
-    $absenceType = AbsenceTypeFabricator::fabricate([
-      'allow_accruals_request' => true,
-      'max_leave_accrual' => 10
-    ]);
-
-    $params['id'] = $toilRequest->id;
-    $params['type_id'] = $absenceType->id;
-
-    $toilRequestService = $this->getTOILRequestServiceWhenCurrentUserIsLeaveManager();
-    $toilRequestService->create($params, false);
-  }
-
   private function getTOILRequestService($isAdmin = false, $isManager = false) {
     $leaveManagerService = $this->createLeaveManagerServiceMock($isAdmin, $isManager);
     $leaveRequestStatusMatrixService = new LeaveRequestStatusMatrixService($leaveManagerService);
@@ -121,10 +100,6 @@ class CRM_HRLeaveAndAbsences_Service_TOILRequestTest extends BaseHeadlessTest {
       $leaveRequestStatusMatrixService,
       $leaveRequestRightsService
     );
-  }
-
-  private function getTOILRequestServiceWhenCurrentUserIsLeaveManager() {
-    return $this->getTOILRequestService(false, true);
   }
 
   private function getDefaultParams($params = []) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/TOILRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/TOILRequestTest.php
@@ -30,7 +30,7 @@ class CRM_HRLeaveAndAbsences_Service_TOILRequestTest extends BaseHeadlessTest {
   private $leaveBalanceChangeService;
 
   public function setUp() {
-    CRM_Core_DAO::executeQuery("SET foreign_key_checks = 0;");
+    CRM_Core_DAO::executeQuery('SET foreign_key_checks = 0;');
 
     $this->absenceType = AbsenceTypeFabricator::fabricate([
       'allow_accruals_request' => true,
@@ -121,10 +121,6 @@ class CRM_HRLeaveAndAbsences_Service_TOILRequestTest extends BaseHeadlessTest {
       $leaveRequestStatusMatrixService,
       $leaveRequestRightsService
     );
-  }
-
-  private function getTOILRequestServiceWhenCurrentUserIsAdmin() {
-    return $this->getTOILRequestService(true, false);
   }
 
   private function getTOILRequestServiceWhenCurrentUserIsLeaveManager() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/TOILRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/TOILRequestTest.php
@@ -25,7 +25,7 @@ class api_v3_TOILRequestTest extends BaseHeadlessTest {
   private $leaveContact;
 
   public function setUp() {
-    CRM_Core_DAO::executeQuery("SET foreign_key_checks = 0;");
+    CRM_Core_DAO::executeQuery('SET foreign_key_checks = 0;');
 
     $this->toilAmounts = $this->toilAmountOptions();
     $this->leaveRequestDayTypes = $this->getLeaveRequestDayTypes();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/TOILRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/TOILRequestTest.php
@@ -191,7 +191,7 @@ class api_v3_TOILRequestTest extends BaseHeadlessTest {
       'is_active' => 1,
     ]);
 
-    $toilRequest1 = TOILRequest::create([
+    $toilRequest1 = TOILRequestFabricator::fabricateWithoutValidation([
       'type_id' => $absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
@@ -201,9 +201,9 @@ class api_v3_TOILRequestTest extends BaseHeadlessTest {
       'to_date_type' => $toType,
       'toil_to_accrue' => $this->toilAmounts['2 Days']['value'],
       'duration' => 60
-    ], false);
+    ], true);
 
-    $toilRequest2 = TOILRequest::create([
+    $toilRequest2 = TOILRequestFabricator::fabricateWithoutValidation([
       'type_id' => $absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
@@ -213,7 +213,7 @@ class api_v3_TOILRequestTest extends BaseHeadlessTest {
       'to_date_type' => $toType,
       'toil_to_accrue' => $this->toilAmounts['3 Days']['value'],
       'duration' => 120
-    ], false);
+    ], true);
 
     $expectedResult = [
       [
@@ -417,7 +417,7 @@ class api_v3_TOILRequestTest extends BaseHeadlessTest {
       'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'duration' => 10,
       'expiry_date' => '20160110'
-    ]);
+    ], true);
 
     $toilRequestBalanceChange = $this->findToilRequestBalanceChange($toilRequest1->id);
     LeaveBalanceChangeFabricator::fabricate([
@@ -440,7 +440,7 @@ class api_v3_TOILRequestTest extends BaseHeadlessTest {
       'to_date' => $nextMonday->format('Ymd'),
       'duration' => 10,
       'expiry_date' => $nextMonday->modify('+5 days')->format('Ymd')
-    ]);
+    ], true);
 
     $result = civicrm_api3('TOILRequest', 'get');
     $this->assertEquals(2, $result['count']);
@@ -465,7 +465,7 @@ class api_v3_TOILRequestTest extends BaseHeadlessTest {
       'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'duration' => 10,
       'expiry_date' => CRM_Utils_Date::processDate('2016-01-10')
-    ]);
+    ], true);
 
     $toilRequestBalanceChange = $this->findToilRequestBalanceChange($toilRequest1->id);
     LeaveBalanceChangeFabricator::fabricate([
@@ -481,14 +481,14 @@ class api_v3_TOILRequestTest extends BaseHeadlessTest {
 
     // This is not expired yet and it will not be included on
     // the response
-    $toilRequest2 = TOILRequestFabricator::fabricateWithoutValidation([
+    TOILRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact['id'],
       'type_id' => $type->id,
       'from_date' => $nextMonday->format('Ymd'),
       'to_date' => $nextMonday->format('Ymd'),
       'duration' => 10,
       'expiry_date' => $nextMonday->modify('+5 days')->format('Ymd')
-    ]);
+    ], true);
 
     $result = civicrm_api3('TOILRequest', 'get', ['expired' => true]);
     $this->assertEquals(1, $result['count']);
@@ -512,7 +512,7 @@ class api_v3_TOILRequestTest extends BaseHeadlessTest {
       'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'duration' => 10,
       'expiry_date' => '20160110'
-    ]);
+    ], true);
 
     $result = civicrm_api3('TOILRequest', 'get', ['expired' => true]);
     // The expiry date is in the past and the expired leave balance change was

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/TOILRequestHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/TOILRequestHelpersTrait.php
@@ -1,7 +1,5 @@
 <?php
 
-use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
-
 trait CRM_HRLeaveAndAbsences_TOILRequestHelpersTrait {
 
   protected $toilAmounts = [];
@@ -23,13 +21,5 @@ trait CRM_HRLeaveAndAbsences_TOILRequestHelpersTrait {
       $toilAmounts[$toilAmount['label']] = $option;
     }
     return $toilAmounts;
-  }
-
-  protected function getTOILBalanceChange($toilRequestID) {
-    $toilBalanceChange = new LeaveBalanceChange();
-    $toilBalanceChange->source_id = $toilRequestID;
-    $toilBalanceChange->source_type = LeaveBalanceChange::SOURCE_TOIL_REQUEST;
-    $toilBalanceChange->find(true);
-    return $toilBalanceChange;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/TOILRequestHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/TOILRequestHelpersTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
+
 trait CRM_HRLeaveAndAbsences_TOILRequestHelpersTrait {
 
   protected $toilAmounts = [];
@@ -21,5 +23,13 @@ trait CRM_HRLeaveAndAbsences_TOILRequestHelpersTrait {
       $toilAmounts[$toilAmount['label']] = $option;
     }
     return $toilAmounts;
+  }
+
+  protected function getTOILBalanceChange($toilRequestID) {
+    $toilBalanceChange = new LeaveBalanceChange();
+    $toilBalanceChange->source_id = $toilRequestID;
+    $toilBalanceChange->source_type = LeaveBalanceChange::SOURCE_TOIL_REQUEST;
+    $toilBalanceChange->find(true);
+    return $toilBalanceChange;
   }
 }


### PR DESCRIPTION
This PR creates the TOILRequest Service by making the it to extend LeaveRequest Service #1420.

Some necessary methods that needed a different implementation in TOILRequest Service child class were overridden and modified.

One of such is the fact that a TOILRequest creates its own balance changes, so the `createRequestWithBalanceChanges` method of the TOILRequest service was created to override that of the parent LeaveRequest Service class.

Also a bug that prevents a TOIL request from being updated due to an `overlapping leave request` error was fixed in this PR.

The methods for Creating and Deleting LeaveRequestBalance Changes were removed completely from the TOILRequest BAO and moved to the LeaveBalanceChange Service. Also TOILRequest Fabricator was updated to create its balance changes when needed.
