### PR TITLE
PCHR-1896: Recalculate Brought Forward/TOIL for leave request past days

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -396,7 +396,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
 
     $datesOverlappingBalanceChangesToExpire = self::getDatesOverlappingBalanceChangesToExpire($balanceChangesToExpire);
 
-    return self::calculateBalanceChange($balanceChangesToExpire, $datesOverlappingBalanceChangesToExpire);
+    return self::calculateExpiryAmount($balanceChangesToExpire, $datesOverlappingBalanceChangesToExpire);
   }
 
   /**
@@ -847,7 +847,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
       return $numberOfRecordsUpdated;
     }
 
-    return self::calculateBalanceChange($expiredBalanceChanges, $leaveRequestPastDates);
+    return self::calculateExpiryAmount($expiredBalanceChanges, $leaveRequestPastDates);
   }
 
   /**
@@ -949,7 +949,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
    * @return int
    *   Number of records created/updated
    */
-  private static function calculateBalanceChange($balanceChanges, $datesOverlappingBalanceChanges) {
+  private static function calculateExpiryAmount($balanceChanges, $datesOverlappingBalanceChanges) {
     $numberOfRecords = 0;
 
     foreach ($balanceChanges as $balanceChange) {
@@ -983,7 +983,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
         // Since these days should be deducted from the entitlement,
         // We need to store the expired amount as a negative number
         'amount' => $remainingAmount * -1,
-        'expiration_date' => $balanceChange['expiry_date']->format('YmdHis'),
+        'expiry_date' => $balanceChange['expiry_date']->format('YmdHis'),
         'expired_balance_change_id' => $balanceChange['id']
       ];
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChange.php
@@ -88,4 +88,15 @@ class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange {
     $dao->source_type = LeaveBalanceChange::SOURCE_TOIL_REQUEST;
     $dao->delete();
   }
+
+  /**
+   * Recalculates expired TOIL/Brought Forward balance changes for
+   * a leave request with past dates having expired LeaveBalanceChanges that expired on or after the
+   * LeaveRequest past date using the function provided by LeaveBalanceChange BAO
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_LeaveRequest $leaveRequest
+   */
+  public function recalculateExpiredBalanceChangesForLeaveRequestPastDates(LeaveRequest $leaveRequest) {
+    LeaveBalanceChange::recalculateExpiredBalanceChangesForLeaveRequestPastDates($leaveRequest);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -34,7 +34,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    * @var array|null
    *   Stores the list of option values for the LeaveRequest status_id field.
    */
-  private static $leaveStatuses;
+  private $leaveStatuses;
 
   /**
    * CRM_HRLeaveAndAbsences_Service_LeaveRequest constructor.
@@ -212,7 +212,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    * @return bool
    */
   private function currentUserCanChangeStatusTo($newStatus, $contactID) {
-    $leaveStatuses = self::getLeaveRequestStatuses();
+    $leaveStatuses = $this->getLeaveRequestStatuses();
 
     switch ($newStatus) {
       case $leaveStatuses['cancelled']:
@@ -298,7 +298,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
     $leaveRequest = LeaveRequest::create($params, false);
     $this->leaveBalanceChangeService->createForLeaveRequest($leaveRequest);
 
-    $this->reCalculateExpiredBalanceChange($leaveRequest);
+    $this->recalculateExpiredBalanceChange($leaveRequest);
     return $leaveRequest;
   }
 
@@ -320,14 +320,13 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    *
    * @param \CRM_HRLeaveAndAbsences_BAO_LeaveRequest $leaveRequest
    */
-  private function reCalculateExpiredBalanceChange(LeaveRequest $leaveRequest) {
-    $leaveStatuses = self::getLeaveRequestStatuses();
+  private function recalculateExpiredBalanceChange(LeaveRequest $leaveRequest) {
+    $leaveStatuses = $this->getLeaveRequestStatuses();
     $today = new DateTime();
     $leaveRequestDate = new DateTime($leaveRequest->from_date);
 
     if($leaveRequestDate < $today && $leaveRequest->status_id == $leaveStatuses['approved']) {
-
-      LeaveBalanceChange::recalculateExpiredBalanceChangesForLeaveRequestPastDates($leaveRequest);
+      $this->leaveBalanceChangeService->recalculateExpiredBalanceChangesForLeaveRequestPastDates($leaveRequest);
     }
   }
 
@@ -336,11 +335,11 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    *
    * @return array
    */
-  private static function getLeaveRequestStatuses() {
-    if (is_null(self::$leaveStatuses)) {
-      self::$leaveStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+  private function getLeaveRequestStatuses() {
+    if (is_null($this->leaveStatuses)) {
+      $this->leaveStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
     }
 
-    return self::$leaveStatuses;
+    return $this->leaveStatuses;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -31,6 +31,12 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
   protected $oldLeaveRequest;
 
   /**
+   * @var array|null
+   *   Stores the list of option values for the LeaveRequest status_id field.
+   */
+  private static $leaveStatuses;
+
+  /**
    * CRM_HRLeaveAndAbsences_Service_LeaveRequest constructor.
    *
    * @param \CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange $leaveBalanceChangeService
@@ -206,7 +212,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    * @return bool
    */
   private function currentUserCanChangeStatusTo($newStatus, $contactID) {
-    $leaveStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveStatuses = self::getLeaveRequestStatuses();
 
     switch ($newStatus) {
       case $leaveStatuses['cancelled']:
@@ -292,6 +298,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
     $leaveRequest = LeaveRequest::create($params, false);
     $this->leaveBalanceChangeService->createForLeaveRequest($leaveRequest);
 
+    $this->reCalculateExpiredBalanceChange($leaveRequest);
     return $leaveRequest;
   }
 
@@ -304,5 +311,36 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    */
   protected function runValidation($params) {
     LeaveRequest::validateParams($params);
+  }
+
+  /**
+   * Recalculates expired TOIL/Brought Forward balance changes for
+   * a leave request with past dates having expired LeaveBalanceChanges that expired on or after the
+   * LeaveRequest past date.
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_LeaveRequest $leaveRequest
+   */
+  private function reCalculateExpiredBalanceChange(LeaveRequest $leaveRequest) {
+    $leaveStatuses = self::getLeaveRequestStatuses();
+    $today = new DateTime();
+    $leaveRequestDate = new DateTime($leaveRequest->from_date);
+
+    if($leaveRequestDate < $today && $leaveRequest->status_id == $leaveStatuses['approved']) {
+
+      LeaveBalanceChange::recalculateExpiredBalanceChangesForLeaveRequestPastDates($leaveRequest);
+    }
+  }
+
+  /**
+   * Returns the array of the option values for the LeaveRequest status_id field.
+   *
+   * @return array
+   */
+  private static function getLeaveRequestStatuses() {
+    if (is_null(self::$leaveStatuses)) {
+      self::$leaveStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    }
+
+    return self::$leaveStatuses;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -707,7 +707,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
       'toil_to_accrue' => 2,
       'duration' => 120,
       'expiry_date' => CRM_Utils_Date::processDate('+100 days')
-    ]);
+    ], true);
 
     $toilRequest2 = TOILRequestFabricator::fabricateWithoutValidation([
       'type_id' => $absenceType->id,
@@ -717,7 +717,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
       'toil_to_accrue' => 2,
       'duration' => 120,
       'expiry_date' => CRM_Utils_Date::processDate('2016-12-10')
-    ]);
+    ], true);
 
     //assert the records exist first before updating absence type
     $balanceChanges = new LeaveBalanceChange();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -1076,6 +1076,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     // Since only the 1 day leave request was counted, 4 days expired
     // 5 - 1 = 4 (we store expired days as a negative number)
     $this->assertEquals(-4, $expiryRecord->amount);
+
+    //assert expiry date is same
+    $expiryRecordDate = new DateTime($expiryRecord->expiry_date);
+    $balanceChangeExpiryDate = new DateTime($balanceChange->expiry_date);
+    $this->assertEquals($expiryRecordDate->format('Y-m-d'), $balanceChangeExpiryDate->format('Y-m-d'));
+
   }
 
   public function testCreateExpiryRecordsPrioritizesAccordingToTheBalanceChangeExpiryDate() {
@@ -1126,6 +1132,15 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     // Since we already deducted 3 days, now we just deduct the remaining 4 days
     // meaning only 1 day will expire
     $this->assertEquals(-1, $expiryRecord1->amount);
+
+    //assert expiry date is same
+    $expiryRecordDate = new DateTime($expiryRecord1->expiry_date);
+    $balanceChangeExpiryDate = new DateTime($balanceChange1->expiry_date);
+    $this->assertEquals($expiryRecordDate->format('Y-m-d'), $balanceChangeExpiryDate->format('Y-m-d'));
+
+    $expiryRecordDate2 = new DateTime($expiryRecord2->expiry_date);
+    $balanceChangeExpiryDate2 = new DateTime($balanceChange2->expiry_date);
+    $this->assertEquals($expiryRecordDate2->format('Y-m-d'), $balanceChangeExpiryDate2->format('Y-m-d'));
   }
 
   public function testCreateExpiryRecordsCalculatesTheExpiredAmountBasedOnlyOnTheApprovedLeaveRequestBalancePriorToTheExpiryDate() {
@@ -1166,6 +1181,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     // Since only two days were taken before the brought forward
     // expiry date, the other 3 days will expire
     $this->assertEquals(-3, $expiryRecord->amount);
+
+    //assert expiry date is same
+    $expiryRecordDate = new DateTime($expiryRecord->expiry_date);
+    $balanceChangeExpiryDate = new DateTime($balanceChange->expiry_date);
+    $this->assertEquals($expiryRecordDate->format('Y-m-d'), $balanceChangeExpiryDate->format('Y-m-d'));
   }
 
   public function testCreateExpiryRecordsCalculatesTheExpiredAmountCorrectlyForMoreThanOneContact() {
@@ -1234,6 +1254,15 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     // Since only four days were taken before the brought forward
     // expiry date, the remaining one expire
     $this->assertEquals(-1, $expiryRecord2->amount);
+
+    //assert expiry date is same
+    $expiryRecordDate = new DateTime($expiryRecord1->expiry_date);
+    $balanceChangeExpiryDate = new DateTime($balanceChange1->expiry_date);
+    $this->assertEquals($expiryRecordDate->format('Y-m-d'), $balanceChangeExpiryDate->format('Y-m-d'));
+
+    $expiryRecordDate2 = new DateTime($expiryRecord2->expiry_date);
+    $balanceChangeExpiryDate2 = new DateTime($balanceChange2->expiry_date);
+    $this->assertEquals($expiryRecordDate2->format('Y-m-d'), $balanceChangeExpiryDate2->format('Y-m-d'));
   }
 
   public function testCreateExpiryRecordsWhenExpiredAmountAbsenceTypeIsDifferentFromTheAbsenceTypeOfTheLeaveRequestDates() {
@@ -1279,6 +1308,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     // The absence type linked to the balance change that expired is different from
     // the absence type on the leave request, therefore the amount remains intact
     $this->assertEquals(-5, $expiryRecord->amount);
+
+    //assert expiry date is same
+    $expiryRecordDate = new DateTime($expiryRecord->expiry_date);
+    $balanceChangeExpiryDate = new DateTime($balanceChange->expiry_date);
+    $this->assertEquals($expiryRecordDate->format('Y-m-d'), $balanceChangeExpiryDate->format('Y-m-d'));
   }
 
   public function testGetLeavePeriodEntitlementCanReturnThePeriodEntitlementWhenTheSourceTypeIsEntitlement() {
@@ -1741,6 +1775,18 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     return null;
   }
 
+  private function getBalanceChangeRecord($balanceChangeID) {
+    $record = new LeaveBalanceChange();
+    $record->id = $balanceChangeID;
+    $record->find();
+    if($record->N == 1) {
+      $record->fetch();
+      return $record;
+    }
+
+    return null;
+  }
+
   private function getExpiryRecordForToilRequest($toilRequestID) {
     $record = new LeaveBalanceChange();
     $record->source_id = $toilRequestID;
@@ -1959,21 +2005,24 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $numberOfUpdatedRecords = LeaveBalanceChange::recalculateExpiredBalanceChangesForLeaveRequestPastDates($leaveRequest);
     $this->assertEquals(2, $numberOfUpdatedRecords);
 
-    $expiredBroughtForwardPeriod1 = new LeaveBalanceChange();
-    $expiredBroughtForwardPeriod1->id = $broughtForwardPeriod1->id;
-    $expiredBroughtForwardPeriod1->find(true);
-
-    $expiredBroughtForward2Period1 = new LeaveBalanceChange();
-    $expiredBroughtForward2Period1->id = $broughtForward2Period1->id;
-    $expiredBroughtForward2Period1->find(true);
-
-    $expiredAccruedToilPeriod1 = new LeaveBalanceChange();
-    $expiredAccruedToilPeriod1->id = $accruedToilPeriod1->id;
-    $expiredAccruedToilPeriod1->find(true);
+    $expiredBroughtForwardPeriod1 = $this->getBalanceChangeRecord($broughtForwardPeriod1->id);
+    $expiredBroughtForward2Period1 = $this->getBalanceChangeRecord($broughtForward2Period1->id);
+    $expiredAccruedToilPeriod1 = $this->getBalanceChangeRecord($accruedToilPeriod1->id);
 
     $this->assertEquals(0, $expiredBroughtForwardPeriod1->amount);
     $this->assertEquals(-5, $expiredBroughtForward2Period1->amount);
     $this->assertEquals(-3, $expiredAccruedToilPeriod1->amount);
+
+
+    //assert expiry date are same for expired balance change and the record it expired
+    $balanceChangeExpiredByBroughtForwardPeriod1 = $this->getBalanceChangeRecord($expiredBroughtForwardPeriod1->expired_balance_change_id);
+    $this->assertEquals($balanceChangeExpiredByBroughtForwardPeriod1->expiry_date, $expiredBroughtForwardPeriod1->expiry_date);
+
+    $balanceChangeExpiredByBroughtForward2Period1 = $this->getBalanceChangeRecord($expiredBroughtForward2Period1->expired_balance_change_id);
+    $this->assertEquals($balanceChangeExpiredByBroughtForward2Period1->expiry_date, $expiredBroughtForward2Period1->expiry_date);
+
+    $balanceChangeExpiredByAccruedToilPeriod1 = $this->getBalanceChangeRecord($expiredAccruedToilPeriod1->expired_balance_change_id);
+    $this->assertEquals($balanceChangeExpiredByAccruedToilPeriod1->expiry_date, $expiredAccruedToilPeriod1->expiry_date);
   }
 
   public function testRecalculateExpiredBalanceChangesForLeaveRequestPastDatesWhenSomeLeaveRequestDatesArePastAndOthersAreFuture() {
@@ -2010,13 +2059,15 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $numberOfUpdatedRecords = LeaveBalanceChange::recalculateExpiredBalanceChangesForLeaveRequestPastDates($leaveRequest);
     $this->assertEquals(1, $numberOfUpdatedRecords);
 
-    $expiredBalanceChangePeriod1 = new LeaveBalanceChange();
-    $expiredBalanceChangePeriod1->id = $balanceChangePeriod1->id;
-    $expiredBalanceChangePeriod1->find(true);
+    $expiredBalanceChangePeriod1 = $this->getBalanceChangeRecord($balanceChangePeriod1->id);
 
     //The first day of the leave request falls on the day $balanceChangePeriod1 expired so only that day is deducted
     //from $balanceChangePeriod1 remaining 4 left after recalculation.
     $this->assertEquals(-4, $expiredBalanceChangePeriod1->amount);
+
+    //assert that both balance changes carry same expiry date
+    $balanceChangeExpiredByBalanceChangePeriod1 = $this->getBalanceChangeRecord($expiredBalanceChangePeriod1->expired_balance_change_id);
+    $this->assertEquals($balanceChangeExpiredByBalanceChangePeriod1->expiry_date, $expiredBalanceChangePeriod1->expiry_date);
   }
 
   public function testRecalculateExpiredBalanceChangesForUnApprovedLeaveRequestPastDates() {
@@ -2053,9 +2104,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $numberOfUpdatedRecords = LeaveBalanceChange::recalculateExpiredBalanceChangesForLeaveRequestPastDates($leaveRequest);
     $this->assertEquals(0, $numberOfUpdatedRecords);
 
-    $expiredBalanceChangePeriod1 = new LeaveBalanceChange();
-    $expiredBalanceChangePeriod1->id = $balanceChangePeriod1->id;
-    $expiredBalanceChangePeriod1->find(true);
+    $expiredBalanceChangePeriod1 = $this->getBalanceChangeRecord($balanceChangePeriod1->id);
 
     //no recalculation is done because the leave request is not yet approved
     $this->assertEquals(-5, $expiredBalanceChangePeriod1->amount);
@@ -2093,9 +2142,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $numberOfUpdatedRecords = LeaveBalanceChange::recalculateExpiredBalanceChangesForLeaveRequestPastDates($leaveRequest);
     $this->assertEquals(0, $numberOfUpdatedRecords);
 
-    $expiredBalanceChangePeriod1 = new LeaveBalanceChange();
-    $expiredBalanceChangePeriod1->id = $balanceChangePeriod1->id;
-    $expiredBalanceChangePeriod1->find(true);
+    $expiredBalanceChangePeriod1 = $this->getBalanceChangeRecord($balanceChangePeriod1->id);
 
     //no recalculation is done because the leave request has no past days that falls on days
     //before the brought forward expired
@@ -2140,9 +2187,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $numberOfUpdatedRecords = LeaveBalanceChange::recalculateExpiredBalanceChangesForLeaveRequestPastDates($leaveRequest);
     $this->assertEquals(0, $numberOfUpdatedRecords);
 
-    $expiredBalanceChangePeriod1 = new LeaveBalanceChange();
-    $expiredBalanceChangePeriod1->id = $balanceChangePeriod1->id;
-    $expiredBalanceChangePeriod1->find(true);
+
+    $expiredBalanceChangePeriod1 = $this->getBalanceChangeRecord($balanceChangePeriod1->id);
 
     //no recalculation is done because the the absence type on the expired brought forward balance change is
     //different from that on the leave request

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -714,7 +714,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'duration' => 360,
       'toil_to_accrue' => 2,
       'expiry_date' => CRM_Utils_Date::processDate('+30 days'),
-    ]);
+    ], true);
 
     // This will deduct 1 day from the 2 accrued by the toil request
     LeaveRequestFabricator::fabricateWithoutValidation([
@@ -1207,7 +1207,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'toil_to_accrue' => 1,
       'duration' => 200,
       'expiry_date' => CRM_Utils_Date::processDate('2016-01-30'),
-    ]);
+    ], true);
 
     $balanceChange = $this->findToilRequestBalanceChange($toilRequest->id);
 
@@ -1277,7 +1277,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'toil_to_accrue' => 1,
       'duration' => 200,
       'expiry_date' => CRM_Utils_Date::processDate('-10 days'),
-    ]);
+    ], true);
 
     $numberOfCreatedRecords = LeaveBalanceChange::createExpiryRecords();
     $this->assertEquals(1, $numberOfCreatedRecords);
@@ -1311,7 +1311,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'expiry_date' => CRM_Utils_Date::processDate('2016-02-17'),
       'toil_to_accrue' => 1,
       'duration' => 100
-    ]);
+    ], true);
 
     $toilRequest2 = TOILRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $periodEntitlement->contact_id,
@@ -1321,7 +1321,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'expiry_date' => CRM_Utils_Date::processDate('2016-03-01'),
       'toil_to_accrue' => 2,
       'duration' => 100
-    ]);
+    ], true);
 
     // This leave request overlaps only the brought forward period
     // so it will deduct 1 day from it
@@ -1399,7 +1399,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'expiry_date' => CRM_Utils_Date::processDate('2016-02-26'),
       'toil_to_accrue' => 1,
       'duration' => 100
-    ]);
+    ], true);
 
     // A 7 days Leave Request, overlapping both the TOIL request period and
     // the brought forward
@@ -1512,7 +1512,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'expiry_date' => CRM_Utils_Date::processDate('2016-02-27'),
       'toil_to_accrue' => 1,
       'duration' => 100
-    ]);
+    ], true);
 
     // This Leave Request overlaps both toil and brought forward, but will be
     // deduct only from one of them
@@ -1561,7 +1561,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'toil_to_accrue' => 2,
       'duration' => 200,
       'expiry_date' => CRM_Utils_Date::processDate('-10 days'),
-    ]);
+    ], true);
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $periodEntitlement->contact_id,
@@ -1660,7 +1660,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'toil_to_accrue' => 2,
       'duration' => 120,
       'expiry_date' => CRM_Utils_Date::processDate('+100 days')
-    ]);
+    ], true);
 
     $this->assertEquals(2, LeaveBalanceChange::getAmountForTOILRequest($toilRequest->id));
   }
@@ -1679,7 +1679,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'toil_to_accrue' => 1,
       'duration' => 120,
       'expiry_date' => CRM_Utils_Date::processDate('+100 days')
-    ]);
+    ], true);
 
     TOILRequestFabricator::fabricateWithoutValidation([
       'type_id' => $absenceTypeID,
@@ -1692,7 +1692,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'toil_to_accrue' => 2,
       'duration' => 120,
       'expiry_date' => CRM_Utils_Date::processDate('+100 days')
-    ]);
+    ], true);
 
     TOILRequestFabricator::fabricateWithoutValidation([
       'type_id' => $absenceTypeID,
@@ -1705,7 +1705,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'toil_to_accrue' => 3,
       'duration' => 120,
       'expiry_date' => CRM_Utils_Date::processDate('+100 days')
-    ]);
+    ], true);
 
     $startDate = new DateTime('+3 days');
     $endDate = new DateTime('+6 days');
@@ -1732,7 +1732,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'toil_to_accrue' => 1,
       'duration' => 120,
       'expiry_date' => CRM_Utils_Date::processDate('+100 days')
-    ]);
+    ], true);
 
     TOILRequestFabricator::fabricateWithoutValidation([
       'type_id' => $absenceTypeID,
@@ -1745,7 +1745,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'toil_to_accrue' => 2,
       'duration' => 120,
       'expiry_date' => CRM_Utils_Date::processDate('+100 days')
-    ]);
+    ], true);
 
     TOILRequestFabricator::fabricateWithoutValidation([
       'type_id' => $absenceTypeID2,
@@ -1758,7 +1758,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'toil_to_accrue' => 2,
       'duration' => 120,
       'expiry_date' => CRM_Utils_Date::processDate('+100 days')
-    ]);
+    ], true);
 
     TOILRequestFabricator::fabricateWithoutValidation([
       'type_id' => $absenceTypeID,
@@ -1771,7 +1771,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'toil_to_accrue' => 3,
       'duration' => 120,
       'expiry_date' => CRM_Utils_Date::processDate('+100 days')
-    ]);
+    ], true);
 
     $startDate = new DateTime('+1 day');
     $endDate = new DateTime('+6 days');

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
@@ -916,7 +916,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
   public function testGetBreakdown() {
     $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate();
 
-    $this->createExpiredBroughtForwardBalanceChange($periodEntitlement->id, 8, 3);
+    $this->createExpiredBroughtForwardBalanceChange($periodEntitlement->id, 8, 3, null);
     $this->createLeaveBalanceChange($periodEntitlement->id, 10);
 
     $result = LeavePeriodEntitlement::getBreakdown([

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/AbsenceTypeTest.php
@@ -36,7 +36,7 @@ class CRM_HRLeaveAndAbsences_Service_AbsenceTypeTest extends BaseHeadlessTest {
       'toil_to_accrue' => 2,
       'duration' => 120,
       'expiry_date' => CRM_Utils_Date::processDate('+100 days')
-    ]);
+    ], true);
 
     $toilRequest2 = TOILRequestFabricator::fabricateWithoutValidation([
       'type_id' => $absenceType->id,
@@ -46,7 +46,7 @@ class CRM_HRLeaveAndAbsences_Service_AbsenceTypeTest extends BaseHeadlessTest {
       'toil_to_accrue' => 2,
       'duration' => 120,
       'expiry_date' => CRM_Utils_Date::processDate('2016-12-10')
-    ]);
+    ], true);
 
     //assert the records exist first before updating absence type
     $balanceChanges = new LeaveBalanceChange();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -604,7 +604,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'toil_to_accrue' => 2,
       'duration' => 300,
       'expiry_date' => CRM_Utils_Date::processDate('+100 days')
-    ]);
+    ], true);
 
     $result = civicrm_api3('LeaveRequest', 'get', ['sequential' => 1]);
     $this->assertCount(3, $result['values']);
@@ -989,7 +989,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'toil_to_accrue' => 8,
       'duration' => 300,
       'expiry_date' => CRM_Utils_Date::processDate('+100 days')
-    ]);
+    ], true);
 
     $result = civicrm_api3('LeaveRequest', 'getFull', [
         'sequential' => 1,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
@@ -76,7 +76,7 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
     if(!$expiredByNoOfDays) {
       $expiredByNoOfDays = 2;
     }
-    LeaveBalanceChange::create([
+    return LeaveBalanceChange::create([
       'type_id' => $this->getBalanceChangeTypeValue('Brought Forward'),
       'source_id' => $entitlementID,
       'source_type' => 'entitlement',
@@ -128,6 +128,8 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
    *    The start date of the leave request
    * @param null|string $toDate
    *    The end date of the leave request. If null, it means it starts and ends at the same date
+   * 
+   * @return \CRM_HRLeaveAndAbsences_BAO_LeaveRequest
    */
   public function createLeaveRequestBalanceChange($typeID, $contactID, $status, $fromDate, $toDate = null) {
     $fromDate = new DateTime($fromDate);
@@ -139,7 +141,7 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
       $toDate = new DateTime($toDate);
     }
 
-    LeaveRequestFabricator::fabricateWithoutValidation([
+    return LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => $typeID,
       'contact_id' => $contactID,
       'status_id' => $status,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
@@ -74,6 +74,10 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
       $expiryDate = date('YmdHis', strtotime("-{$expiry} day"));
     }
 
+    if ($expiry == null) {
+      $expiryDate = null;
+    }
+
     $this->createEntitlementBalanceChange(
       $entitlementID,
       $amount,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
@@ -65,25 +65,23 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
     );
   }
 
-  public function createExpiredBroughtForwardBalanceChange($entitlementID, $amount, $expiredAmount, $expiry = null) {
-    $this->createEntitlementBalanceChange(
-      $entitlementID,
-      $amount,
-      $this->getBalanceChangeTypeValue('Brought Forward')
-    );
-
-    $broughtForwardBalanceChangeID = $this->getLastIdInTable(LeaveBalanceChange::getTableName());
-
-    if($expiry instanceof DateTime){
+  public function createExpiredBroughtForwardBalanceChange($entitlementID, $amount, $expiredAmount, $expiry = 2) {
+    if ($expiry instanceof DateTime) {
       $expiryDate = $expiry->format('YmdHis');
     }
 
-    if(!$expiry || is_int($expiry)) {
-      if(!$expiry){
-        $expiry = 2;
-      }
+    if (is_int($expiry)) {
       $expiryDate = date('YmdHis', strtotime("-{$expiry} day"));
     }
+
+    $this->createEntitlementBalanceChange(
+      $entitlementID,
+      $amount,
+      $this->getBalanceChangeTypeValue('Brought Forward'),
+      $expiryDate
+    );
+
+    $broughtForwardBalanceChangeID = $this->getLastIdInTable(LeaveBalanceChange::getTableName());
 
     return LeaveBalanceChange::create([
       'type_id' => $this->getBalanceChangeTypeValue('Brought Forward'),

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
@@ -96,7 +96,7 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
       'toil_to_accrue' => $toilToAccrue,
       'duration' => 200,
       'expiry_date' => $expiryDate
-    ]);
+    ], true);
 
     $toilBalanceChange = $this->findToilRequestBalanceChange($toilRequest->id);
     return LeaveBalanceChangeFabricator::fabricate([


### PR DESCRIPTION
This PR fixes an issue with expired TOIL/Brought Forward Leave Balance Changes.

**Problem:**
It's possible to create Leave Requests for dates in the past. That can affect the number of expired Brought Forward/TOIL days. 
Example: 
Absence Period: 2016-01-01 to 2016-12-31
Brought Forward expired in 2016-03-01
Brought Forward amount: 5 days
Number of days taken before expiry date: 2
Number of expired days: 3
Then, after the expiry date, a new LeaveRequest single day leave request is added for the date of 2016-02-15. Since it represents a leave taken before the expiry date, we must recalculate the number of expired days, which will become 2 instead of 3).

Currently the system does not support this, because the expiry calculation is done daily by a scheduled job and doesn't take into consideration those records already expired.

**Solution**
This PR fixes the problem by checking it there will be an impact on any expired Brought Forward/TOIL when saving an approved LeaveRequest for a past date. When there are expired Brought Forward/TOIL to be impacted, the number of expired days is recalculated right after the LeaveRequest is saved. Note that only expired Brought Forward/TOIL linked to the leave request contact  and with same absence type as that on the leave request is affected. Also the expired TOIL/Brought Forward must have expiry date greater than the LeaveRequest date.
