### PR TITLE
PCHR-1868:  Modify LeaveRequest.AddComment API and Comment.create 

### DIFF
--- a/uk.co.compucorp.civicrm.hrcomments/CRM/HRComments/BAO/Comment.php
+++ b/uk.co.compucorp.civicrm.hrcomments/CRM/HRComments/BAO/Comment.php
@@ -155,11 +155,17 @@ class CRM_HRComments_BAO_Comment extends CRM_HRComments_DAO_Comment {
    */
   private static function validateCommentCreatedAtDateDuringAnUpdate($params) {
     if (isset($params['id']) && !empty($params['created_at'])) {
-      throw new InvalidCommentException(
-        'You cannot update the created_at date of a comment',
-        'comment_cannot_update_created_at',
-        'created_at'
-      );
+      $comment = self::findById($params['id']);
+      $commentDate = new DateTime($comment->created_at);
+      $createdAt = new DateTime($params['created_at']);
+
+      if ($commentDate != $createdAt) {
+        throw new InvalidCommentException(
+          'You cannot update the created_at date of a comment',
+          'comment_cannot_update_created_at',
+          'created_at'
+        );
+      }
     }
   }
 

--- a/uk.co.compucorp.civicrm.hrcomments/tests/phpunit/CRM/HRComments/BAO/CommentTest.php
+++ b/uk.co.compucorp.civicrm.hrcomments/tests/phpunit/CRM/HRComments/BAO/CommentTest.php
@@ -130,12 +130,13 @@ class CRM_HRComments_BAO_CommentTest extends BaseHeadlessTest  {
    * @expectedException CRM_HRComments_Exception_InvalidCommentException
    * @expectedExceptionMessage You cannot update the created_at date of a comment
    */
-  public function testValidateParamsThrowsAnExceptionWhenTryingToUpdateTheCreatedAtDateForAComment() {
+  public function testValidateParamsThrowsAnExceptionWhenTryingToChangeTheCreatedAtDateForACommentDuringAnUpdate() {
     $comment = Comment::create([
       'entity_id' => 1,
       'entity_name' => 'LeaveRequest',
       'text' => 'This is a sample comment',
       'contact_id' => 1,
+      'created_at' => CRM_Utils_Date::processDate('2016-01-01 10:09:11')
     ]);
 
     Comment::validateParams([
@@ -144,7 +145,7 @@ class CRM_HRComments_BAO_CommentTest extends BaseHeadlessTest  {
       'entity_name' => $comment->entity_name,
       'text' => $comment->text,
       'contact_id' => $comment->contact_id,
-      'created_at' => CRM_Utils_Date::processDate('2016-01-01'),
+      'created_at' => CRM_Utils_Date::processDate('2016-01-01 10:09:15'),
     ]);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -472,7 +472,7 @@ function _civicrm_api3_leave_request_addcomment_spec(&$spec) {
 
   $spec['created_at'] = [
     'name' => 'created_at',
-    'type' => CRM_Utils_Type::T_TIME,
+    'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
     'title' => 'Created at',
     'description' => 'Date and time the Comment was created',
     'api.required' => 0

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -469,6 +469,14 @@ function _civicrm_api3_leave_request_addcomment_spec(&$spec) {
     'FKClassName'  => 'CRM_Contact_DAO_Contact',
     'FKApiName'    => 'Contact',
   ];
+
+  $spec['created_at'] = [
+    'name' => 'created_at',
+    'type' => CRM_Utils_Type::T_TIME,
+    'title' => 'Created at',
+    'description' => 'Date and time the Comment was created',
+    'api.required' => 0
+  ];
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestCommentTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestCommentTest.php
@@ -58,6 +58,37 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestCommentTest extends BaseHeadles
     $this->assertEquals($expected, $result['values']);
   }
 
+  public function testAddCanCreateCommentForLeaveRequestWhenCreatedAtIsPartOfTheParametersPassed() {
+    $created_at = new DateTime('2016-10-10 09:20:43');
+    $params = [
+      'leave_request_id' => 1,
+      'text' => 'Random Commenter',
+      'contact_id' => 1,
+      'created_at' => $created_at->format('Y-m-d H:i:s'),
+      'sequential' => 1
+    ];
+
+    $result = $this->leaveRequestCommentService->add($params);
+
+    $comment = new Comment();
+    $comment->find();
+    $this->assertEquals(1, $comment->N);
+    $comment->fetch();
+
+
+    $expected = [
+      [
+        'comment_id' => $comment->id,
+        'leave_request_id' => $comment->entity_id,
+        'text' => $comment->text,
+        'contact_id' => $comment->contact_id,
+        "created_at"=> $created_at->format('YmdHis')
+      ]
+    ];
+
+    $this->assertEquals($expected, $result['values']);
+  }
+
   public function testAddCannotUpdateCommentForLeaveRequest() {
     $params = [
       'leave_request_id' => 1,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestCommentTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestCommentTest.php
@@ -75,14 +75,13 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestCommentTest extends BaseHeadles
     $this->assertEquals(1, $comment->N);
     $comment->fetch();
 
-
     $expected = [
       [
         'comment_id' => $comment->id,
         'leave_request_id' => $comment->entity_id,
         'text' => $comment->text,
         'contact_id' => $comment->contact_id,
-        "created_at"=> $created_at->format('YmdHis')
+        'created_at'=> $created_at->format('YmdHis')
       ]
     ];
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -2252,6 +2252,19 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
   /**
    * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage created_at is not a valid date: 2016-06-01 10:20:90
+   */
+  public function testAddCommentShouldThrowAnExceptionWhenCreatedAtIsNotAProperDateTimeFormat() {
+    civicrm_api3('LeaveRequest', 'addcomment', [
+      'leave_request_id' => 1,
+      'text' => 'Random Commenter',
+      'contact_id' => 1,
+      'created_at' => '2016-06-01 10:20:90'
+    ]);
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
    * @expectedExceptionMessage Mandatory key(s) missing from params array: text
    */
   public function testAddCommentShouldThrowAnExceptionIfTextIsMissing() {


### PR DESCRIPTION
This PR modifies the Create method of the Comment Entity BAO. 
The changes are as follows:

- The create method now allows the created_at date parameter to be passed when creating a new comment although this is still disallowed when updating a comment.
- As a security check for allowing this (1st change), a new comment will not be allowed to be created when the created_at date is less than the created_at date of the last comment for that entity.

The created_at is also added as an optional parameter for the LeaveRequest.addComment API endpoint.