### PR TITLE
PCHR-1978: Fix period_id list in backbone views

### DIFF
--- a/hrabsence/js/models.js
+++ b/hrabsence/js/models.js
@@ -322,7 +322,18 @@ CRM.HRAbsenceApp.module('Models', function(Models, HRAbsenceApp, Backbone, Mario
       //activity_type_id: 3,
 
       // period_id: int or array(int); optional
-      period_id: _.last(_.keys(CRM.absenceApp.periods)),
+      period_id: (function () {
+        var today = moment();
+
+        var current = _.find(CRM.absenceApp.periods, function (period, id) {
+          var start = moment(period.start_date);
+          var end = moment(period.end_date);
+
+          return today.isBetween(start, end, 'day');
+        });
+
+        return current ? [current.id] : [_.last(_.keys(CRM.absenceApp.periods))];
+      }()),
 
       target_contact_id: CRM.absenceApp.contactId,
 


### PR DESCRIPTION
# Problem
The default value of `period_id` of the `AbsenceCriteria` model was simply the string of the last period's id.
```js
period_id: _.last(_.keys(CRM.absenceApp.periods)),
```

This created a problem as the views' templates are looping through `period_id` via `_.each`

```
<% _.each(active_period_ids, function(periodId) { %>
```
By providing a multi-digit id, for example "10", instead of an array would result in the `periodId` param of the callback being "1", and "0" (since it loops through the string's characters) which would obviously result in an error

# Solution
The default `period_id` is now always an array, and, if found, it is also the id of the current period, rather than of the last one in the list