### PR TITLE
AI-22: Fix select2 fields

### DIFF
--- a/org.civicrm.bootstrapcivicrm/js/enable-select2.js
+++ b/org.civicrm.bootstrapcivicrm/js/enable-select2.js
@@ -14,8 +14,14 @@ CRM.$(function() {
    * during DOM changes
    */
   var observer = new MutationObserver(debounce(function() {
-    CRM.$('select:visible:not([class^="ui-datepicker"])').select2();
-  }, 500));
+    CRM.$('select:visible:not([class^="ui-datepicker"])')
+      .select2({
+        containerCss: {
+          display: 'inline-block'
+        }
+      })
+      .on('change', clearSelect2);
+  }, 50));
 
   observer.observe(document.querySelector('body'), {
     childList: true,
@@ -32,5 +38,22 @@ CRM.$(function() {
         fn.apply(me, args);
       }, delay);
     };
+  }
+
+  /**
+   * Walk through all select fields and hide it
+   * if there isn't any option
+  */
+  function clearSelect2() {
+    window.setTimeout(function() {
+      CRM.$('select').each(function(idx, item) {
+        var id = '#s2id_' + CRM.$(item).attr('id');
+        var optionsLength = CRM.$(item).find('option').length;
+
+        if (optionsLength === 0) {
+          CRM.$(id).remove();
+        }
+      });
+    }, 50);
   }
 });


### PR DESCRIPTION
- Change select2 element display property to `inline-block` instead of `inline`
- Add a callback to hide all select fields that haven't an option

**Before**

![kapture 2017-02-22 at 17 48 08](https://cloud.githubusercontent.com/assets/1280255/23231581/1958419e-f927-11e6-9f78-726251c01d02.gif)


**After**

![kapture 2017-02-22 at 17 46 33](https://cloud.githubusercontent.com/assets/1280255/23231509/e327eade-f926-11e6-88f6-4ab3bceba150.gif)
