### PR TITLE
PCHR-1916: Create LeaveRequest.getAttachments API endpoint

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -572,3 +572,53 @@ function civicrm_api3_leave_request_deletecomment($params) {
   return $leaveRequestCommentService->delete($params);
 }
 
+/**
+ * LeaveRequest.getAttachments API spec
+ *
+ * @param array $spec
+ */
+function _civicrm_api3_leave_request_getattachments_spec(&$spec) {
+  $spec['leave_request_id'] = [
+    'name' => 'leave_request_id',
+    'type' => CRM_Utils_Type::T_INT,
+    'title' => 'LeaveRequest ID',
+    'description' => 'The Leave Request ID to fetch attachments for',
+    'api.required' => 1
+  ];
+}
+
+/**
+ * LeaveRequest.getAttachments API
+ *
+ * Uses the Attachment API to fetch attachments associated
+ * with a LeaveRequest.
+ *
+ * @param array $params
+ *
+ * @return array
+ */
+function civicrm_api3_leave_request_getattachments($params) {
+  $params['entity_id'] = $params['leave_request_id'];
+  $params['entity_table'] = CRM_HRLeaveAndAbsences_BAO_LeaveRequest::getTableName();
+
+  $result =  civicrm_api3('Attachment', 'get', $params);
+
+  if ($result['count'] > 0) {
+    array_walk($result['values'], '_civicrm_api3_leave_request_filter_attachment_fields');
+  }
+
+  return $result;
+}
+
+/**
+ * Helper method to filter the returned results from the Attachment.get API
+ * Ensures only relevant fields are returned.
+ *
+ * @param array $item
+ */
+function _civicrm_api3_leave_request_filter_attachment_fields(&$item) {
+  $fields = array_flip(['id', 'name', 'mime_type', 'upload_date', 'url']);
+  $item = array_intersect_key($item, $fields);
+  $item['attachment_id'] = $item['id'];
+  unset($item['id']);
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -2605,4 +2605,58 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals($contact1['id'], $result['values'][0]['contact_id']);
     $this->assertEquals($contact2['id'], $result['values'][1]['contact_id']);
   }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage Mandatory key(s) missing from params array: leave_request_id
+   */
+  public function testGetAttachmentsShouldThrowAnExceptionIfLeaveRequestIDIsMissing() {
+    civicrm_api3('LeaveRequest', 'getattachments');
+  }
+
+  public function testGetAttachments() {
+    $leaveRequestID = 1;
+    $leaveRequestID2 = 2;
+    $attachment1 = $this->createAttachmentForLeaveRequest([
+      'entity_id' => $leaveRequestID,
+      'name' => 'LeaveRequestSampleFile1.txt'
+    ]);
+
+    $attachment2 = $this->createAttachmentForLeaveRequest([
+      'entity_id' => $leaveRequestID,
+      'name' => 'LeaveRequestSampleFile2.txt'
+    ]);
+
+    $attachment3 = $this->createAttachmentForLeaveRequest([
+      'entity_id' => $leaveRequestID2,
+      'name' => 'LeaveRequestSampleFile3.txt'
+    ]);
+
+    $params = ['leave_request_id' => $leaveRequestID, 'sequential' => 1];
+    $result = civicrm_api3('LeaveRequest', 'getAttachments', $params);
+
+    $expectedResult = [
+      'is_error' => 0,
+      'version' => 3,
+      'count' => 2,
+      'values' => [
+        [
+          'name' => $attachment1['name'],
+          'mime_type' => $attachment1['mime_type'],
+          'upload_date' => $attachment1['upload_date'],
+          'url' => $attachment1['url'],
+          'attachment_id' => $attachment1['id']
+        ],
+        [
+          'name' => $attachment2['name'],
+          'mime_type' => $attachment2['mime_type'],
+          'upload_date' => $attachment2['upload_date'],
+          'url' => $attachment2['url'],
+          'attachment_id' => $attachment2['id']
+        ]
+      ]
+    ];
+
+    $this->assertEquals($result, $expectedResult);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestHelpersTrait.php
@@ -40,4 +40,18 @@ trait CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait {
 
     return $this->leaveRequestStatuses;
   }
+
+  protected function createAttachmentForLeaveRequest($params) {
+    $defaultParams = [
+      'entity_table' => LeaveRequest::getTableName(),
+      'name' => 'LeaveRequestSampleFile.txt',
+      'mime_type' => 'text/plain',
+      'content' => '',
+      'sequential' => 1
+    ];
+    $payload = array_merge($defaultParams, $params);
+    $result =  civicrm_api3('Attachment', 'create', $payload);
+
+    return $result['values'][0];
+  }
 }


### PR DESCRIPTION
This PR creates the LeaveRequest.getAttachments API endpoint. 
This API retrieves a list of attachments for a leave request

Given a Leave Request with ID of 1 having some attachments previously uploaded for it:

**Sample Request**
```php
$result = civicrm_api3('LeaveRequest', 'getAttachments', array(
  'leave_request_id' => 1
));
```

**Sample Response**
```json
{

    "is_error": 0,
    "version": 3,
    "count": 2,
    "values": [
        {
            "attachment_id": "1",
            "name": "LeaveRequestSampleFile1.txt",
            "mime_type": "text/plain",
            "upload_date": "2017-02-21 14:29:58",
            "url": "http://localhost:8900/index.php?q=civicrm/file&reset=1&id=1&eid=1"
        },
        {
            "attachment_id": "2",
            "name": "LeaveRequestSampleFile2.txt",
            "mime_type": "text/plain",
            "upload_date": "2017-02-22 13:21:14",
            "url": "http://localhost:8900/index.php?q=civicrm/file&reset=1&id=2&eid=1"
        }
    ]
}
```