### PR TITLE
PCHR-459: Removing managed case types from hrcase

### DIFF
--- a/hrcase/CRM/HRCase/Upgrader.php
+++ b/hrcase/CRM/HRCase/Upgrader.php
@@ -16,11 +16,15 @@ class CRM_HRCase_Upgrader extends CRM_HRCase_Upgrader_Base {
     $this->setComponentStatuses([
       'CiviCase' => true,
     ]);
-  }
 
-  public function postInstall() {
-    $this->upgrade_1400();
-    $this->upgrade_1402();
+    // Execute upgrader methods during extension installation
+    $revisions = $this->getRevisions();
+    foreach ($revisions as $revision) {
+      $methodName = 'upgrade_' . $revision;
+      if (is_callable([$this, $methodName])) {
+        $this->{$methodName}();
+      }
+    }
   }
 
   public function uninstall() {

--- a/hrcase/hrcase.php
+++ b/hrcase/hrcase.php
@@ -84,26 +84,6 @@ function hrcase_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
  * is installed, disabled, uninstalled.
  */
 function hrcase_civicrm_managed(&$entities) {
-  // Since there is probably some assignments created under these assignment types ( case types)
-  // and because civicrm managed entity handler is broken for case types and do not work very well
-  // we have to keep this list of assignment types (case types) or otherwise errors will appears.
-  $caseTypes = ['Exiting', 'Joining', 'Appraisal', 'Probation'];
-
-  foreach ($caseTypes as $caseType) {
-    $entities[] = [
-      'name' => $caseType,
-      'entity' => 'CaseType',
-      'module' => 'org.civicrm.hrcase',
-      'params' =>
-        [
-          'version' => 3,
-          'name' => $caseType,
-          'title' => $caseType,
-          'is_active' => 1,
-        ]
-    ];
-  }
-
   return _hrcase_civix_civicrm_managed($entities);
 }
 


### PR DESCRIPTION
Removing all the managed case types from hrcase and keep them to be created manually.

 For existing sites , **civicrm_managed** table should be cleared from any managed Case type record defined by this extension before upgrading civihr ( by running a query like this : 
```php
DELETE FROM civicrm_managed WHERE entity_type = 'CaseType' and name IN ('Exiting', 'Joining', 'Probation', 'Appraisal')
```
).