### PR TITLE
PCHR-1917: Create LeaveRequest.deleteAttachment API

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestAttachment.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestAttachment.php
@@ -1,0 +1,75 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
+
+class CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachment {
+
+  /**
+   * Uses the Attachment API to delete an attachment associated with a LeaveRequest.
+   * This method also implement some checks to ensure that only the LeaveRequest Approver
+   * or an Admin can delete attachments for a leave request
+   *
+   * @param array $params
+   *
+   * @throws UnexpectedValueException
+   * @throws InvalidArgumentException
+   *
+   * @return array
+   */
+  public function delete($params) {
+    $params['sequential'] = 1;
+    $attachment = $this->callAttachmentAPI('get', $params);
+
+    if ($attachment['count'] > 0) {
+      $leaveRequest = LeaveRequest::findById($attachment['values'][0]['entity_id']);
+      $leaveManagerService = new LeaveManagerService();
+
+      if ($leaveManagerService->currentUserIsAdmin() || $leaveManagerService->currentUserIsLeaveManagerOf($leaveRequest->contact_id)) {
+        return $this->callAttachmentAPI('delete', $params);
+      }
+
+      throw new UnexpectedValueException('You must either be an L&A admin or an approver to this leave request to be able to delete the attachment');
+    }
+
+    throw new InvalidArgumentException('Attachment does not exist or has been deleted already!');
+  }
+
+  /**
+   * Helper function used to format the parameters
+   * into a format expected by the Attachment.create, Attachment.delete and Attachment.get API
+   *
+   * @param array $params
+   *
+   * @return array
+   */
+  private function prepareParametersForAttachmentPayload($params) {
+    $params['entity_table'] = CRM_HRLeaveAndAbsences_BAO_LeaveRequest::getTableName();
+
+    if (!empty($params['leave_request_id'])) {
+      $params['entity_id'] = $params['leave_request_id'];
+      unset($params['leave_request_id']);
+    }
+
+    if (!empty($params['attachment_id'])) {
+      $params['id'] = $params['attachment_id'];
+      unset($params['attachment_id']);
+    }
+
+    return $params;
+  }
+
+  /**
+   * Helper function to make calls to the Attachment API.
+   *
+   * @param string $action
+   * @param array $params
+   *
+   * @return array
+   */
+  private function callAttachmentAPI($action, $params) {
+    $params = $this->prepareParametersForAttachmentPayload($params);
+
+    return civicrm_api3('Attachment', $action, $params);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -622,3 +622,41 @@ function _civicrm_api3_leave_request_filter_attachment_fields(&$item) {
   $item['attachment_id'] = $item['id'];
   unset($item['id']);
 }
+
+/**
+ * LeaveRequest.deleteAttachment API spec
+ *
+ * @param array $spec
+ */
+function _civicrm_api3_leave_request_deleteattachment_spec(&$spec) {
+  $spec['leave_request_id'] = [
+    'name' => 'leave_request_id',
+    'type' => CRM_Utils_Type::T_INT,
+    'title' => 'LeaveRequest ID',
+    'description' => 'The Leave Request ID to delete attachments for',
+    'api.required' => 1
+  ];
+
+  $spec['attachment_id'] = [
+    'name' => 'attachment_id',
+    'type' => CRM_Utils_Type::T_INT,
+    'title' => 'Attachment ID',
+    'description' => 'The ID of the attachment to delete',
+    'api.required' => 1
+  ];
+}
+
+/**
+ * LeaveRequest.deleteAttachment API
+ *
+ * Uses the LeaveRequestAttachment Service
+ * to delete attachment associated with a LeaveRequest.
+ *
+ * @param array $params
+ *
+ * @return array
+ */
+function civicrm_api3_leave_request_deleteattachment($params) {
+  $leaveRequestAttachmentService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachment();
+  return $leaveRequestAttachmentService->delete($params);
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestAttachmentTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestAttachmentTest.php
@@ -1,0 +1,154 @@
+<?php
+
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachment as LeaveRequestAttachmentService;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachmentTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachmentTest extends BaseHeadlessTest {
+
+  use CRM_HRLeaveAndAbsences_LeaveManagerHelpersTrait;
+  use CRM_HRLeaveAndAbsences_SessionHelpersTrait;
+  use CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait;
+
+  private $leaveRequestAttachmentService;
+
+  private $leaveContact;
+
+  public function setUp() {
+    CRM_Core_DAO::executeQuery('SET foreign_key_checks = 0;');
+
+    $this->leaveRequestAttachmentService = new LeaveRequestAttachmentService();
+    $this->leaveContact = 1;
+  }
+
+  public function tearDown() {
+    CRM_Core_DAO::executeQuery('SET foreign_key_checks = 1;');
+  }
+
+  /**
+   * @expectedException UnexpectedValueException
+   * @expectedExceptionMessage You must either be an L&A admin or an approver to this leave request to be able to delete the attachment
+   */
+  public function testDeleteShouldThrowAnExceptionWhenLoggedInUserIsNotAnAdminOrLeaveApprover() {
+    $contactID = 1;
+    $params = $this->getDefaultLeaveRequestParams();
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+    // Register contact in session and make sure that no permission is set
+    $this->registerCurrentLoggedInContactInSession($contactID);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
+
+    $attachment = $this->createAttachmentForLeaveRequest(['entity_id' => $leaveRequest->id]);
+    $this->leaveRequestAttachmentService->delete(['leave_request_id' => $leaveRequest->id, 'attachment_id' => $attachment['id']]);
+  }
+
+  public function testDeleteShouldDeleteAttachmentWhenLoggedInUserIsAnAdmin() {
+    $adminID = 2;
+    $params = $this->getDefaultLeaveRequestParams();
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    // Register contact in session and set permission to admin
+    $this->registerCurrentLoggedInContactInSession($adminID);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer leave and absences'];
+
+    $attachment = $this->createAttachmentForLeaveRequest(['entity_id' => $leaveRequest->id]);
+    $attachment2 = $this->createAttachmentForLeaveRequest(['entity_id' => $leaveRequest->id]);
+
+    //confirm that two attachments exist for the leave request before deletion
+    $attachmentList = $this->getAttachmentForLeaveRequest(['entity_id' => $leaveRequest->id]);
+    $this->assertEquals($attachmentList['count'], 2);
+
+    $result = $this->leaveRequestAttachmentService->delete(['leave_request_id' => $leaveRequest->id, 'attachment_id' => $attachment['id']]);
+
+    $expected = [
+      'is_error' => 0,
+      'version' => 3,
+      'count' => 0,
+      'values' => [],
+    ];
+    $this->assertEquals($expected, $result);
+
+    $attachmentList = $this->getAttachmentForLeaveRequest(['entity_id' => $leaveRequest->id]);
+    $this->assertEquals($attachmentList['count'], 1);
+    $this->assertEquals($attachmentList['values'][0]['id'], $attachment2['id']);
+  }
+
+  public function testDeleteShouldDeleteAttachmentWhenLoggedInUserIsTheLeaveApprover() {
+    $manager = ContactFabricator::fabricate();
+    $leaveContact = ContactFabricator::fabricate();
+    $params = $this->getDefaultLeaveRequestParams(['contact_id' => $leaveContact['id']]);
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    // Set logged in user as manager of Contact who requested leave
+    $this->registerCurrentLoggedInContactInSession($manager['id']);
+    $this->setContactAsLeaveApproverOf($manager, $leaveContact);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
+
+    $attachment = $this->createAttachmentForLeaveRequest(['entity_id' => $leaveRequest->id]);
+
+    //confirm that only one attachment exist for the leave request before deletion
+    $attachmentList = $this->getAttachmentForLeaveRequest(['entity_id' => $leaveRequest->id]);
+    $this->assertEquals($attachmentList['count'], 1);
+    $result = $this->leaveRequestAttachmentService->delete(['leave_request_id' => $leaveRequest->id, 'attachment_id' => $attachment['id']]);
+
+    $expected = [
+      'is_error' => 0,
+      'version' => 3,
+      'count' => 0,
+      'values' => [],
+    ];
+
+    $this->assertEquals($expected, $result);
+    $attachmentList = $this->getAttachmentForLeaveRequest(['entity_id' => $leaveRequest->id]);
+    $this->assertEquals($attachmentList['count'], 0);
+  }
+
+  public function testDeleteShouldThrowAnExceptionWhenAttachmentHasBeenDeletedBefore() {
+    $adminID = 2;
+    $params = $this->getDefaultLeaveRequestParams();
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    // Register contact in session and set permission to admin
+    $this->registerCurrentLoggedInContactInSession($adminID);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer leave and absences'];
+
+    $attachment = $this->createAttachmentForLeaveRequest(['entity_id' => $leaveRequest->id]);
+
+    $this->leaveRequestAttachmentService->delete(['leave_request_id' => $leaveRequest->id, 'attachment_id' => $attachment['id']]);
+
+    //try delete attachment again
+    $this->setExpectedException('InvalidArgumentException', 'Attachment does not exist or has been deleted already!');
+    $this->leaveRequestAttachmentService->delete(['leave_request_id' => $leaveRequest->id, 'attachment_id' => $attachment['id']]);
+  }
+
+  /**
+   * @expectedException InvalidArgumentException
+   * @expectedExceptionMessage Attachment does not exist or has been deleted already!
+   */
+  public function testDeleteShouldThrowAnExceptionWhenAttachmentDoesNotExist() {
+    $adminID = 2;
+    $leaveRequestID = 1;
+
+    // Register contact in session and set permission to admin
+    $this->registerCurrentLoggedInContactInSession($adminID);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer leave and absences'];
+
+    $this->leaveRequestAttachmentService->delete(['leave_request_id' => $leaveRequestID, 'attachment_id' => 1]);
+  }
+
+  private function getDefaultLeaveRequestParams($params = []) {
+    $defaultParams =  [
+      'contact_id' => $this->leaveContact,
+      'type_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'from_date_type' => 1,
+      'to_date_type' => 1
+    ];
+    return array_merge($defaultParams, $params);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -2659,4 +2659,20 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $this->assertEquals($result, $expectedResult);
   }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage Mandatory key(s) missing from params array: leave_request_id
+   */
+  public function testDeleteAttachmentShouldThrowAnExceptionIfLeaveRequestIDIsMissing() {
+    civicrm_api3('LeaveRequest', 'deleteattachment', ['attachment_id' => 1]);
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage Mandatory key(s) missing from params array: attachment_id
+   */
+  public function testDeleteAttachmentShouldThrowAnExceptionIfAttachmentIDIsMissing() {
+    civicrm_api3('LeaveRequest', 'deleteattachment', ['leave_request_id' => 1]);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestHelpersTrait.php
@@ -47,11 +47,22 @@ trait CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait {
       'name' => 'LeaveRequestSampleFile.txt',
       'mime_type' => 'text/plain',
       'content' => '',
-      'sequential' => 1
+      'sequential' => 1,
     ];
     $payload = array_merge($defaultParams, $params);
     $result =  civicrm_api3('Attachment', 'create', $payload);
 
     return $result['values'][0];
+  }
+
+  protected function getAttachmentForLeaveRequest($params) {
+    $defaultParams = [
+      'entity_table' => LeaveRequest::getTableName(),
+      'sequential' => 1
+    ];
+    $payload = array_merge($defaultParams, $params);
+    $result =  civicrm_api3('Attachment', 'get', $payload);
+
+    return $result;
   }
 }


### PR DESCRIPTION
This PR creates the LeaveRequest.deleteAttachment API endpoint.
The API uses the delete method exposed by the newly created LeaveRequestAttachment Service.
Also only Leave Approvers and admins can delete attachments from a Leave Request.

Sample Request
```php
$result = civicrm_api3('LeaveRequest', 'deleteattachment', array(
  'sequential' => 1,
  'leave_request_id' => 1,
  'attachment_id' => 1,
));
```
Response
```json
{
    "is_error": 1,
    "version": 3,
    "count" : 0,
    "values: [],
}
```

**Note** that this API only works currently when called in php/smarty but not via REST. When called via REST the check_permissions parameter is set to true and cannot be overriden and triggers some checks in core.  There is a blocker in core that prevents an attachment from being created or deleted due to this [HERE](https://github.com/civicrm/civicrm-core/blob/master/Civi/API/Subscriber/DynamicFKAuthorization.php#L226). Core tries to check if the entity associated with the attachment can be created/modified using the parameters sent to the Attachment API. However we have some BAO level validations on Leave and Absence Extension which prevents this check from going through and a validation error is thrown.

Also note that a PR for CORE also currently blocks the creation of attachments for entities other than core entities. [HERE](https://github.com/civicrm/civicrm-core/pull/9875)

For the purpose of this PR since the tests call the API within PHP with check_permissions set to false, the tests passed successfully but a solution needs to be found for this issue because when creating attachments using the internal callback, Core manually sets check_permission to be true [HERE](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Page/AJAX/Attachment.php#L101).