### PR TITLE
PCHR-1968: Create Contact.getleavemanagees endpoint.

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/ContactSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/ContactSelect.php
@@ -1,0 +1,111 @@
+<?php
+
+use Civi\API\SelectQuery;
+use CRM_Contact_BAO_Relationship as Relationship;
+use CRM_Contact_BAO_RelationshipType as RelationshipType;
+use CRM_Contact_BAO_Contact as Contact;
+
+/**
+ * This class is basically a wrapper around Civi\API\SelectQuery.
+ */
+class CRM_HRLeaveAndAbsences_API_Query_ContactSelect {
+
+  use CRM_HRLeaveAndAbsences_Service_SettingsManagerTrait;
+
+  /**
+   * @var array
+   *   An array of params passed to an API endpoint
+   */
+  private $params;
+
+  /**
+   * @var \Civi\API\SelectQuery
+   *  The SelectQuery instance wrapped by this class
+   */
+  private $query;
+
+  public function __construct($params) {
+    $this->params = $params;
+    $this->buildCustomQuery();
+  }
+
+  /**
+   * Build the custom query.
+   */
+  private function buildCustomQuery() {
+    $customQuery = CRM_Utils_SQL_Select::from(Contact::getTableName() . ' as a');
+
+    $this->addJoins($customQuery);
+    $this->addWhere($customQuery);
+    $this->filterReturnFields();
+
+    $this->query = new SelectQuery(Contact::class, $this->params, false);
+    $this->query->merge($customQuery);
+  }
+
+  /**
+   * Add the conditions to the query.
+   *
+   * This where it is ensured that only contacts managed by the logged-in user
+   * with the approved relationship types are returned.
+   * Also only contacts with is_deleted = 0 and is_deceased = 0 are returned.
+   *
+   * @param \CRM_Utils_SQL_Select $query
+   */
+  private function addWhere(CRM_Utils_SQL_Select $query) {
+    $today = date('Y-m-d');
+    $loggedInUserID = (int) CRM_Core_Session::getLoggedInContactID();
+    $leaveApproverRelationships = $this->getLeaveApproverRelationshipsTypes();
+
+    $whereClauses[] = "(
+      r.is_active = 1 AND
+      rt.is_active = 1 AND
+      rt.id IN(" . implode(',', $leaveApproverRelationships) . ") AND
+      r.contact_id_b = {$loggedInUserID} AND 
+      (r.start_date IS NULL OR r.start_date <= '$today') AND
+      (r.end_date IS NULL OR r.end_date >= '$today')
+    )";
+    $whereClauses[] = 'a.is_deleted = 0 AND a.is_deceased = 0';
+    $whereClauses = implode(' AND ', $whereClauses);
+
+    $query->where($whereClauses);
+  }
+
+  /**
+   * Add the joins required to join Contact with Relationship and RelationshipType.
+   *
+   * @param \CRM_Utils_SQL_Select $query
+   */
+  private function addJoins(CRM_Utils_SQL_Select $query) {
+    $joins[] = 'INNER JOIN ' . Relationship::getTableName() . ' r ON r.contact_id_a = a.id';
+    $joins[] = 'INNER JOIN ' . RelationshipType::getTableName() . ' rt ON rt.id = r.relationship_type_id';
+    $query->join(null, $joins);
+  }
+
+  /**
+   * Executes the query
+   *
+   * @return array
+   */
+  public function run() {
+    return $this->query->run();
+  }
+
+  /**
+   * This function allows some fields to be filtered out of the query results.
+   */
+  private function filterReturnFields() {
+    if (empty($this->params['return'])) {
+      $allFields = Contact::fieldKeys();
+      unset($allFields['created_date'], $allFields['modified_date'], $allFields['hash']);
+      $this->params['return'] = ($allFields);
+    }
+
+    if (!empty($this->params['return'])) {
+      $returnFields = array_flip($this->params['return']);
+      unset($returnFields['created_date'], $returnFields['modified_date'], $returnFields['hash']);
+      $this->params['return'] = array_flip($returnFields);
+    }
+  }
+}
+

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/ContactSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/ContactSelect.php
@@ -98,7 +98,7 @@ class CRM_HRLeaveAndAbsences_API_Query_ContactSelect {
     if (empty($this->params['return'])) {
       $allFields = Contact::fieldKeys();
       unset($allFields['created_date'], $allFields['modified_date'], $allFields['hash']);
-      $this->params['return'] = ($allFields);
+      $this->params['return'] = $allFields;
     }
 
     if (!empty($this->params['return'])) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/Contact/GetLeaveManagees.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/Contact/GetLeaveManagees.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Contact.GetLeaveManagees API
+ *
+ * Returns the list of contacts that are managed by the currently logged in user
+ *
+ * @param array $params
+ *
+ * @return array API result descriptor
+ *
+ * @throws API_Exception
+ */
+function civicrm_api3_contact_getleavemanagees($params) {
+  $query = new CRM_HRLeaveAndAbsences_API_Query_ContactSelect($params);
+  return civicrm_api3_create_success($query->run(), $params);
+}
+

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -119,7 +119,8 @@ function hrleaveandabsences_civicrm_alterAPIPermissions($entity, $action, &$para
     'ismanagedby' => ['leave_request'],
     'isvalid' => ['leave_request', 'sickness_request', 't_o_i_l_request'],
     'getfull' => ['leave_request', 'sickness_request'],
-    'calculatetoilexpirydate' => ['absence_type']
+    'calculatetoilexpirydate' => ['absence_type'],
+    'getleavemanagees' => ['contact']
   ];
 
   foreach ($actionEntities as $action => $entities) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveManagerTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveManagerTest.php
@@ -82,19 +82,19 @@ class CRM_HRLeaveAndAbsences_Service_LeaveManagerTest extends BaseHeadlessTest {
 
   public function testIsContactManagedByWhenThereAreMultipleLeaveApproverRelationshipsAndOnlyOneIsActive() {
     $this->setLeaveApproverRelationshipTypes([
-      'approves leaves for',
-      'manages leaves for'
+      'has leaves approved by',
+      'has leaves managed by'
     ]);
 
     $this->assertFalse($this->leaveManagerService->isContactManagedBy($this->staffMember['id'], $this->manager['id']));
 
-    $this->setContactAsLeaveApproverOf($this->manager, $this->staffMember, null, null, false, 'approves leaves for');
+    $this->setContactAsLeaveApproverOf($this->manager, $this->staffMember, null, null, false, 'has leaves approved by');
 
     // the relationship is of one of the "Leave Approver" types, but it's not active,
     // so this should return false
     $this->assertFalse($this->leaveManagerService->isContactManagedBy($this->staffMember['id'], $this->manager['id']));
 
-    $this->setContactAsLeaveApproverOf($this->manager, $this->staffMember, null, null, true, 'manages leaves for');
+    $this->setContactAsLeaveApproverOf($this->manager, $this->staffMember, null, null, true, 'has leaves managed by');
 
     // this relationship uses another one of the "Leave Approver" types and it's active,
     // so this should return true
@@ -103,14 +103,14 @@ class CRM_HRLeaveAndAbsences_Service_LeaveManagerTest extends BaseHeadlessTest {
 
   public function testIsContactManagedByWhenThereAreMultipleActiveLeaveApproverRelationships() {
     $this->setLeaveApproverRelationshipTypes([
-      'approves leaves for',
-      'manages leaves for'
+      'has leaves approved by',
+      'has leaves managed by'
     ]);
 
     $this->assertFalse($this->leaveManagerService->isContactManagedBy($this->staffMember['id'], $this->manager['id']));
 
-    $this->setContactAsLeaveApproverOf($this->manager, $this->staffMember, null, null, true, 'approves leaves for');
-    $this->setContactAsLeaveApproverOf($this->manager, $this->staffMember, null, null, true, 'manages leaves for');
+    $this->setContactAsLeaveApproverOf($this->manager, $this->staffMember, null, null, true, 'has leaves approved by');
+    $this->setContactAsLeaveApproverOf($this->manager, $this->staffMember, null, null, true, 'has leaves managed by');
 
     $this->assertTrue($this->leaveManagerService->isContactManagedBy($this->staffMember['id'], $this->manager['id']));
   }
@@ -142,7 +142,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveManagerTest extends BaseHeadlessTest {
 
   public function testCurrentUserIsLeaveManagerOfWhenTheCurrentRelationshipIsNotActive() {
     $this->assertFalse($this->leaveManagerService->currentUserIsLeaveManagerOf($this->staffMember['id']));
-    
+
     $this->setContactAsLeaveApproverOf($this->manager, $this->staffMember, null, null, false);
 
     $this->assertFalse($this->leaveManagerService->currentUserIsLeaveManagerOf($this->staffMember['id']));

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ApiPermissionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ApiPermissionTest.php
@@ -44,7 +44,8 @@ class api_v3_ApiPermissionTest extends BaseHeadlessTest {
       ['OptionGroup', 'get'],
       ['OptionValue', 'get'],
       ['LeavePeriodEntitlement', 'get'],
-      ['PublicHoliday', 'get']
+      ['PublicHoliday', 'get'],
+      ['Contact', 'getleavemanagees']
     ];
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ContactTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ContactTest.php
@@ -71,7 +71,7 @@ class api_v3_ContactTest extends BaseHeadlessTest {
     $this->setContactAsLeaveApproverOf($this->manager, $this->contact2, null, null, true, 'has things managed by');
 
     $result = civicrm_api3('Contact', 'getleavemanagees', [
-      'return' => ['id','hash', 'display_name', 'created_date', 'modified_date']
+      'return' => ['id', 'hash', 'display_name', 'created_date', 'modified_date']
     ]);
 
     //filtered put fields are hash, created_at, modified_at
@@ -93,7 +93,7 @@ class api_v3_ContactTest extends BaseHeadlessTest {
 
     $result = civicrm_api3('Contact', 'getleavemanagees');
 
-    //only the two contacts who are managed by the manager are returned
+    //only the two contacts who are managed by the current logged in manager are returned
     $this->assertEquals(2, $result['count']);
     $this->assertEquals($result['values'][$this->contact1['id']]['id'], $this->contact1['id']);
     $this->assertEquals($result['values'][$this->contact1['id']]['display_name'], $this->contact1['display_name']);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ContactTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ContactTest.php
@@ -29,8 +29,8 @@ class api_v3_ContactTest extends BaseHeadlessTest {
     $this->registerCurrentLoggedInContactInSession($this->manager['id']);
 
     $this->setLeaveApproverRelationshipTypes([
-      'approves leaves for',
-      'manages things for',
+      'has leaves approved by',
+      'has things managed by',
     ]);
   }
 
@@ -38,10 +38,10 @@ class api_v3_ContactTest extends BaseHeadlessTest {
     $contact3 = ContactFabricator::fabricate(['is_deleted' => 1]);
     $contact4 = ContactFabricator::fabricate(['is_deceased' => 1]);
 
-    $this->setContactAsLeaveApproverOf($this->manager, $this->contact2, null, null, true, 'manages things for');
-    $this->setContactAsLeaveApproverOf($this->manager, $this->contact1, null, null, true, 'approves leaves for');
-    $this->setContactAsLeaveApproverOf($this->manager, $contact3, null, null, true, 'approves leaves for');
-    $this->setContactAsLeaveApproverOf($this->manager, $contact4, null, null, true, 'manages things for');
+    $this->setContactAsLeaveApproverOf($this->manager, $this->contact2, null, null, true, 'has things managed by');
+    $this->setContactAsLeaveApproverOf($this->manager, $this->contact1, null, null, true, 'has leaves approved by');
+    $this->setContactAsLeaveApproverOf($this->manager, $contact3, null, null, true, 'has leaves approved by');
+    $this->setContactAsLeaveApproverOf($this->manager, $contact4, null, null, true, 'has things managed by');
 
     $result = civicrm_api3('Contact', 'getleavemanagees');
 
@@ -54,7 +54,7 @@ class api_v3_ContactTest extends BaseHeadlessTest {
   }
 
   public function testGetLeaveManageesDoesNotReturnFilteredOutFields() {
-    $this->setContactAsLeaveApproverOf($this->manager, $this->contact1, null, null, true, 'manages things for');
+    $this->setContactAsLeaveApproverOf($this->manager, $this->contact1, null, null, true, 'has things managed by');
 
     $result = civicrm_api3('Contact', 'getleavemanagees');
 
@@ -68,7 +68,7 @@ class api_v3_ContactTest extends BaseHeadlessTest {
   }
 
   public function testGetLeaveManageesDoesNotReturnFilteredOutFieldsWhenFilteredOutFieldsArePartOfFieldsToReturn() {
-    $this->setContactAsLeaveApproverOf($this->manager, $this->contact2, null, null, true, 'manages things for');
+    $this->setContactAsLeaveApproverOf($this->manager, $this->contact2, null, null, true, 'has things managed by');
 
     $result = civicrm_api3('Contact', 'getleavemanagees', [
       'return' => ['id','hash', 'display_name', 'created_date', 'modified_date']
@@ -87,9 +87,9 @@ class api_v3_ContactTest extends BaseHeadlessTest {
     $contact3 = ContactFabricator::fabricate();
     $manager2 = ContactFabricator::fabricate();
 
-    $this->setContactAsLeaveApproverOf($this->manager, $this->contact2, null, null, true, 'manages things for');
-    $this->setContactAsLeaveApproverOf($this->manager, $this->contact1, null, null, true, 'approves leaves for');
-    $this->setContactAsLeaveApproverOf($manager2, $contact3, null, null, true, 'approves leaves for');
+    $this->setContactAsLeaveApproverOf($this->manager, $this->contact2, null, null, true, 'has things managed by');
+    $this->setContactAsLeaveApproverOf($this->manager, $this->contact1, null, null, true, 'has leaves approved by');
+    $this->setContactAsLeaveApproverOf($manager2, $contact3, null, null, true, 'has leaves approved by');
 
     $result = civicrm_api3('Contact', 'getleavemanagees');
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ContactTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ContactTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
+
+
+/**
+ * Class api_v3_LeaveRequestTest
+ *
+ * @group headless
+ */
+class api_v3_ContactTest extends BaseHeadlessTest {
+
+  use CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait;
+  use CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait;
+  use CRM_HRLeaveAndAbsences_LeaveManagerHelpersTrait;
+  use CRM_HRLeaveAndAbsences_SessionHelpersTrait;
+
+  private $manager;
+
+  private $contact1;
+
+  private $contact2;
+
+  public function setUp() {
+    CRM_Core_DAO::executeQuery('SET foreign_key_checks = 0;');
+
+    $this->contact1 = ContactFabricator::fabricate();
+    $this->contact2 = ContactFabricator::fabricate();
+    $this->manager = ContactFabricator::fabricate();
+    $this->registerCurrentLoggedInContactInSession($this->manager['id']);
+
+    $this->setLeaveApproverRelationshipTypes([
+      'approves leaves for',
+      'manages things for',
+    ]);
+  }
+
+  public function testGetLeaveManageesDoesNotReturnDeceasedORDeletedContacts() {
+    $contact3 = ContactFabricator::fabricate(['is_deleted' => 1]);
+    $contact4 = ContactFabricator::fabricate(['is_deceased' => 1]);
+
+    $this->setContactAsLeaveApproverOf($this->manager, $this->contact2, null, null, true, 'manages things for');
+    $this->setContactAsLeaveApproverOf($this->manager, $this->contact1, null, null, true, 'approves leaves for');
+    $this->setContactAsLeaveApproverOf($this->manager, $contact3, null, null, true, 'approves leaves for');
+    $this->setContactAsLeaveApproverOf($this->manager, $contact4, null, null, true, 'manages things for');
+
+    $result = civicrm_api3('Contact', 'getleavemanagees');
+
+    //only the two contacts who are neither deleted nor deceased is returned
+    $this->assertEquals(2, $result['count']);
+    $this->assertEquals($result['values'][$this->contact1['id']]['id'], $this->contact1['id']);
+    $this->assertEquals($result['values'][$this->contact1['id']]['display_name'], $this->contact1['display_name']);
+    $this->assertEquals($result['values'][$this->contact2['id']]['id'], $this->contact2['id']);
+    $this->assertEquals($result['values'][$this->contact2['id']]['display_name'], $this->contact2['display_name']);
+  }
+
+  public function testGetLeaveManageesDoesNotReturnFilteredOutFields() {
+    $this->setContactAsLeaveApproverOf($this->manager, $this->contact1, null, null, true, 'manages things for');;
+
+    $result = civicrm_api3('Contact', 'getleavemanagees');
+
+    //filtered out fields are hash, created_date, modified_date
+    $this->assertEquals(1, $result['count']);
+    $this->assertEquals($result['values'][$this->contact1['id']]['id'], $this->contact1['id']);
+    $this->assertEquals($result['values'][$this->contact1['id']]['display_name'], $this->contact1['display_name']);
+    $this->assertArrayNotHasKey('hash', $result['values'][$this->contact1['id']]);
+    $this->assertArrayNotHasKey('created_date', $result['values'][$this->contact1['id']]);
+    $this->assertArrayNotHasKey('modified_date', $result['values'][$this->contact1['id']]);
+  }
+
+  public function testGetLeaveManageesDoesNotReturnFilteredOutFieldsWhenFilteredOutFieldsArePartOfFieldsToReturn() {
+    $this->setContactAsLeaveApproverOf($this->manager, $this->contact2, null, null, true, 'manages things for');
+
+    $result = civicrm_api3('Contact', 'getleavemanagees', ['return' => ['id','hash', 'display_name', 'created_date', 'modified_date']]);
+
+    //filtered put fields are hash, created_at, modified_at
+    $this->assertEquals(1, $result['count']);
+    $this->assertEquals($result['values'][$this->contact2['id']]['id'], $this->contact2['id']);
+    $this->assertEquals($result['values'][$this->contact2['id']]['display_name'], $this->contact2['display_name']);
+    $this->assertArrayNotHasKey('hash', $result['values'][$this->contact2['id']]);
+    $this->assertArrayNotHasKey('created_date', $result['values'][$this->contact2['id']]);
+    $this->assertArrayNotHasKey('modified_date', $result['values'][$this->contact2['id']]);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeavePeriodEntitlementTest.php
@@ -425,8 +425,8 @@ class api_v3_LeavePeriodEntitlementTest extends BaseHeadlessTest {
 
   public function testGetReturnsOnlyDataLinkedToContactsThatLoggedInUserManagesWhenLoggedInIsALeaveApproverWithOneOfTheAvailableRelationships() {
     $this->setLeaveApproverRelationshipTypes([
-      'approves leaves for',
-      'manages things for',
+      'has leaves approved by',
+      'has things managed by',
     ]);
 
     $manager1 = ContactFabricator::fabricate();
@@ -436,7 +436,7 @@ class api_v3_LeavePeriodEntitlementTest extends BaseHeadlessTest {
     $contact3 = ContactFabricator::fabricate();
 
     $this->setContactAsLeaveApproverOf($manager1, $contact2, null, null, true, 'manage things for');
-    $this->setContactAsLeaveApproverOf($manager2, $contact1, null, null, true, 'approves leaves for');
+    $this->setContactAsLeaveApproverOf($manager2, $contact1, null, null, true, 'has leaves approved by');
     $this->setContactAsLeaveApproverOf($manager2, $contact3, null, null, true, 'manage things for');
 
     $entitlementContact1 = LeavePeriodEntitlementFabricator::fabricate([
@@ -459,14 +459,14 @@ class api_v3_LeavePeriodEntitlementTest extends BaseHeadlessTest {
 
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API'];
 
-    // Manager1 only manages contact2 (though the 'manages things for' relationship),
+    // Manager1 only manages contact2 (though the 'has things managed by' relationship),
     // so only contact2 leave requests will be returned
     $this->registerCurrentLoggedInContactInSession($manager1['id']);
     $result = civicrm_api3('LeavePeriodEntitlement', 'get', ['check_permissions' => true, 'sequential' => 1]);
     $this->assertEquals(1, $result['count']);
     $this->assertEquals($contact2['id'], $result['values'][0]['contact_id']);
 
-    // Manager2 manages contact1 (through the 'approves leaves for' relationship),
+    // Manager2 manages contact1 (through the 'has leaves approved by' relationship),
     // and contact3 (through the 'manage things for' relationship), so the
     // entitlement for both will be returned
     $this->registerCurrentLoggedInContactInSession($manager2['id']);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -2787,8 +2787,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
   public function testGetAndGetFullReturnsOnlyDataLinkedToContactsThatLoggedInUserManagesWhenLoggedInUserIsALeaveApproverWithOneOfTheAvailableRelationships() {
     $this->setLeaveApproverRelationshipTypes([
-      'approves leaves for',
-      'manages things for',
+      'has leaves approved by',
+      'has things managed by',
     ]);
 
     $manager1 = ContactFabricator::fabricate();
@@ -2797,9 +2797,9 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $contact2 = ContactFabricator::fabricate();
     $contact3 = ContactFabricator::fabricate();
 
-    $this->setContactAsLeaveApproverOf($manager1, $contact2, null, null, true, 'manages things for');
-    $this->setContactAsLeaveApproverOf($manager2, $contact1, null, null, true, 'approves leaves for');
-    $this->setContactAsLeaveApproverOf($manager2, $contact3, null, null, true, 'manages leaves for');
+    $this->setContactAsLeaveApproverOf($manager1, $contact2, null, null, true, 'has things managed by');
+    $this->setContactAsLeaveApproverOf($manager2, $contact1, null, null, true, 'has leaves approved by');
+    $this->setContactAsLeaveApproverOf($manager2, $contact3, null, null, true, 'has leaves managed by');
 
     HRJobContractFabricator::fabricate(
       [ 'contact_id' => $contact2['id'] ],
@@ -2857,7 +2857,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API'];
 
-    // Manager1 only manages contact2 (though the 'manages things for' relationship),
+    // Manager1 only manages contact2 (though the 'has things managed by' relationship),
     // so only contact2 leave requests will be returned
     $this->registerCurrentLoggedInContactInSession($manager1['id']);
     $result = civicrm_api3('LeaveRequest', 'get', ['check_permissions' => true, 'sequential' => 1]);
@@ -2868,7 +2868,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals(1, $result['count']);
     $this->assertEquals($contact2['id'], $result['values'][0]['contact_id']);
 
-    // Manager2 manages contact1 (through the 'approves leaves for' relationship),
+    // Manager2 manages contact1 (through the 'has leaves approved by' relationship),
     // and contact3 (through the 'manage things for' relationship), so leave
     // requests from both should be returned
     $this->registerCurrentLoggedInContactInSession($manager2['id']);


### PR DESCRIPTION
This PR creates the Contact.getleavemanagees API endpoint.
This endpoint returns a list of contacts managed by the current logged in user. That is, all the contacts the logged in user manages with any of the relationships defined in the Leave and Absences general settings page.  Deceased and deleted contacts (i.e where is_deleted = 1 or is_deceased = 1 are not returned).

**Sample request:**
```php
$result = civicrm_api3('Contact', 'getleavemanagees');
```

**Sample Response:**
```php
{
  "is_error": 0,
  "version": 3,
  "count": 1,
  "values": {
    "437": {
      "id": "437",
      "contact_type": "Individual",
      "do_not_email": "0",
      "do_not_phone": "0",
      "do_not_mail": "0",
      "do_not_sms": "0",
      "do_not_trade": "0",
      "is_opt_out": "0",
      "sort_name": "John Doe",
      "display_name": "John Doe",
      "preferred_mail_format": "Both",
      "first_name": "John",
      "last_name": "Doe",
      "email_greeting_id": "1",
      "email_greeting_display": "Dear John",
      "postal_greeting_id": "1",
      "postal_greeting_display": "Dear John",
      "addressee_id": "1",
      "addressee_display": "John Doe",
      "is_deceased": "0"
    }
  }
}
```