### PR TITLE
PCHR-2001: Add absence tab to L&A extension

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/AbsenceTab.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/AbsenceTab.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * CRM_HRLeaveAndAbsences_Page_AbsenceTab
+ */
+class CRM_HRLeaveAndAbsences_Page_AbsenceTab extends  CRM_Core_Page {
+  public function run() {
+    CRM_Utils_System::setTitle(ts('Absence'));
+    parent::run();
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -333,6 +333,29 @@ function hrleaveandabsences_civicrm_postInstall() {
   _hrleaveandabsences_set_has_leave_approved_by_as_default_relationship_type();
 }
 
+/**
+ * Implementation of hook_civicrm_tabset.
+ *
+ * This is a way for this extension to add its own tabs to
+ * the core tabs interface used for contacts, contributions and events.
+ *
+ * @param string $tabsetName
+ * @param array $tabs
+ * @param array $context
+ */
+function hrleaveandabsences_civicrm_tabset($tabsetName, &$tabs, $context) {
+  //check if the tabset is Contact Summary Page
+  if ($tabsetName == 'civicrm/contact/view') {
+    $contactId = $context['contact_id'];
+    $tabs[] = [
+      'id'        => 'absence',
+      'url'       => CRM_Utils_System::url('civicrm/contact/view/absence', ['cid' => $contactId]),
+      'title'     => ts('Absence'),
+      'weight'    => 10
+    ];
+  }
+}
+
 //----------------------------------------------------------------------------//
 //                               Helper Functions                             //
 //----------------------------------------------------------------------------//

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsenceTab.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsenceTab.tpl
@@ -1,0 +1,10 @@
+<section data-leave-absences-absence-tab>
+  <ui-view></ui-view>
+</section>
+{literal}
+  <script type="text/javascript">
+    document.addEventListener('absenceTabReady', function () {
+      angular.bootstrap(document.querySelector('[data-leave-absences-absence-tab]'), ['absence-tab']);
+    });
+  </script>
+{/literal}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/Menu/hrleaveandabsences.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/Menu/hrleaveandabsences.xml
@@ -42,4 +42,10 @@
     <title>General Settings</title>
     <access_arguments>administer leave and absences</access_arguments>
   </item>
+  <item>
+    <path>civicrm/contact/view/absence</path>
+    <page_callback>CRM_HRLeaveAndAbsences_Page_AbsenceTab</page_callback>
+    <title>Absence</title>
+    <access_arguments>access leave and absences</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
In this PR, The L&A extension adds an Absence tab to the contacts summary page using hook_civicrm_tabset hook.
It also adds the page for the Absence tab.

![mrs alexia adams - civihr 1 6 demo 2017-03-03 12-45-24](https://cloud.githubusercontent.com/assets/6951813/23550066/6b9535d6-000f-11e7-8fdf-9d723fb44ff1.png)
