### PR TITLE
PCHR-1968: Modify Contact.getleavemanagees API

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/ContactSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/ContactSelect.php
@@ -46,22 +46,22 @@ class CRM_HRLeaveAndAbsences_API_Query_ContactSelect {
   /**
    * Add the conditions to the query.
    *
-   * This where it is ensured that only contacts managed by the logged-in user
-   * with the approved relationship types are returned.
+   * This where it is ensured that only contacts managed by the contactID
+   * passed in via the managed_by parameter with the approved relationship types are returned.
    * Also only contacts with is_deleted = 0 and is_deceased = 0 are returned.
    *
    * @param \CRM_Utils_SQL_Select $query
    */
   private function addWhere(CRM_Utils_SQL_Select $query) {
     $today = date('Y-m-d');
-    $loggedInUserID = (int) CRM_Core_Session::getLoggedInContactID();
+    $managerID = $this->params['managed_by'];
     $leaveApproverRelationships = $this->getLeaveApproverRelationshipsTypes();
 
     $whereClauses[] = "(
       r.is_active = 1 AND
       rt.is_active = 1 AND
       rt.id IN(" . implode(',', $leaveApproverRelationships) . ") AND
-      r.contact_id_b = {$loggedInUserID} AND 
+      r.contact_id_b = {$managerID} AND 
       (r.start_date IS NULL OR r.start_date <= '$today') AND
       (r.end_date IS NULL OR r.end_date >= '$today')
     )";

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/Contact/Getleavemanagees.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/Contact/Getleavemanagees.php
@@ -29,7 +29,8 @@ function _civicrm_api3_contact_getleavemanagees_spec(&$spec) {
  * @throws API_Exception
  */
 function civicrm_api3_contact_getleavemanagees($params) {
-  $query = new CRM_HRLeaveAndAbsences_API_Query_ContactSelect($params);
+  $leaveManagerService = new CRM_HRLeaveAndAbsences_Service_LeaveManager();
+  $query = new CRM_HRLeaveAndAbsences_API_Query_ContactSelect($params, $leaveManagerService);
   return civicrm_api3_create_success($query->run(), $params);
 }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/Contact/Getleavemanagees.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/Contact/Getleavemanagees.php
@@ -1,6 +1,23 @@
 <?php
 
 /**
+ * Contact.GetLeaveManagees API specification
+ *
+ * @param array $spec
+ */
+function _civicrm_api3_contact_getleavemanagees_spec(&$spec) {
+  $spec['managed_by'] = [
+    'name' => 'managed_by',
+    'title' => 'Managed By',
+    'description' => 'Only information for contacts managed by the contact with the given ID are returned',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 1,
+    'FKClassName'  => 'CRM_Contact_DAO_Contact',
+    'FKApiName'    => 'Contact',
+  ];
+}
+
+/**
  * Contact.GetLeaveManagees API
  *
  * Returns the list of contacts that are managed by the currently logged in user

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ContactTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ContactTest.php
@@ -23,10 +23,9 @@ class api_v3_ContactTest extends BaseHeadlessTest {
   public function setUp() {
     CRM_Core_DAO::executeQuery('SET foreign_key_checks = 0;');
 
-    $this->contact1 = ContactFabricator::fabricate();
-    $this->contact2 = ContactFabricator::fabricate();
+    $this->contact1 = ContactFabricator::fabricate(['first_name' => 'ContactA']);
+    $this->contact2 = ContactFabricator::fabricate(['first_name' => 'ContactB']);
     $this->manager = ContactFabricator::fabricate();
-    $this->registerCurrentLoggedInContactInSession($this->manager['id']);
 
     $this->setLeaveApproverRelationshipTypes([
       'has leaves approved by',
@@ -43,7 +42,7 @@ class api_v3_ContactTest extends BaseHeadlessTest {
     $this->setContactAsLeaveApproverOf($this->manager, $contact3, null, null, true, 'has leaves approved by');
     $this->setContactAsLeaveApproverOf($this->manager, $contact4, null, null, true, 'has things managed by');
 
-    $result = civicrm_api3('Contact', 'getleavemanagees');
+    $result = civicrm_api3('Contact', 'getleavemanagees', ['managed_by' => $this->manager['id']]);
 
     //only the two contacts who are neither deleted nor deceased is returned
     $this->assertEquals(2, $result['count']);
@@ -56,7 +55,7 @@ class api_v3_ContactTest extends BaseHeadlessTest {
   public function testGetLeaveManageesDoesNotReturnFilteredOutFields() {
     $this->setContactAsLeaveApproverOf($this->manager, $this->contact1, null, null, true, 'has things managed by');
 
-    $result = civicrm_api3('Contact', 'getleavemanagees');
+    $result = civicrm_api3('Contact', 'getleavemanagees', ['managed_by' => $this->manager['id']]);
 
     //filtered out fields are hash, created_date, modified_date
     $this->assertEquals(1, $result['count']);
@@ -71,6 +70,7 @@ class api_v3_ContactTest extends BaseHeadlessTest {
     $this->setContactAsLeaveApproverOf($this->manager, $this->contact2, null, null, true, 'has things managed by');
 
     $result = civicrm_api3('Contact', 'getleavemanagees', [
+      'managed_by' => $this->manager['id'],
       'return' => ['id', 'hash', 'display_name', 'created_date', 'modified_date']
     ]);
 
@@ -83,7 +83,7 @@ class api_v3_ContactTest extends BaseHeadlessTest {
     $this->assertArrayNotHasKey('modified_date', $result['values'][$this->contact2['id']]);
   }
 
-  public function testGetLeaveManageesOnlyReturnsContactsManagedByTheCurrentLoggedInManager() {
+  public function testGetLeaveManageesOnlyReturnsContactsManagedByTheContactPassedInManagedByParameter() {
     $contact3 = ContactFabricator::fabricate();
     $manager2 = ContactFabricator::fabricate();
 
@@ -91,13 +91,45 @@ class api_v3_ContactTest extends BaseHeadlessTest {
     $this->setContactAsLeaveApproverOf($this->manager, $this->contact1, null, null, true, 'has leaves approved by');
     $this->setContactAsLeaveApproverOf($manager2, $contact3, null, null, true, 'has leaves approved by');
 
-    $result = civicrm_api3('Contact', 'getleavemanagees');
+    $result = civicrm_api3('Contact', 'getleavemanagees', ['managed_by' => $this->manager['id']]);
 
-    //only the two contacts who are managed by the current logged in manager are returned
     $this->assertEquals(2, $result['count']);
     $this->assertEquals($result['values'][$this->contact1['id']]['id'], $this->contact1['id']);
     $this->assertEquals($result['values'][$this->contact1['id']]['display_name'], $this->contact1['display_name']);
     $this->assertEquals($result['values'][$this->contact2['id']]['id'], $this->contact2['id']);
     $this->assertEquals($result['values'][$this->contact2['id']]['display_name'], $this->contact2['display_name']);
+  }
+
+  public function testGetLeaveManageesCanBeFilteredByDifferentFields() {
+
+    $this->setContactAsLeaveApproverOf($this->manager, $this->contact2, null, null, true, 'has things managed by');
+    $this->setContactAsLeaveApproverOf($this->manager, $this->contact1, null, null, true, 'has leaves approved by');
+
+    $result = civicrm_api3('Contact', 'getleavemanagees', [
+      'managed_by' => $this->manager['id'],
+      'id' => $this->contact1['id'],
+      'display_name' => $this->contact1['display_name'],
+      'sort_name' => $this->contact1['sort_name']
+    ]);
+
+    $this->assertEquals(1, $result['count']);
+    $this->assertEquals($result['values'][$this->contact1['id']]['id'], $this->contact1['id']);
+
+    //filter results by the display_name field
+    $result = civicrm_api3('Contact', 'getleavemanagees', [
+      'managed_by' => $this->manager['id'],
+      'display_name' => $this->contact2['display_name'],
+    ]);
+
+    $this->assertEquals(1, $result['count']);
+    $this->assertEquals($result['values'][$this->contact2['id']]['id'], $this->contact2['id']);
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage Mandatory key(s) missing from params array: managed_by
+   */
+  public function testGetLeaveManageesThrowsAnExceptionWhenManagedByParameterIsNotPresent() {
+    civicrm_api3('Contact', 'getleavemanagees');
   }
 }


### PR DESCRIPTION
This PR modifies the Contact.getleavemanagees API.

A new required parameter: 'managed_by' is added.  Previously the API returns contacts information for contacts managed by the currently logged in user. The API has been modified to now return contact information for contacts managed by the given contactID passed in via the managed_by parameter.
