### PR TITLE
PCHR-1892: Cleanup orphan contract leave

### DIFF
--- a/hrabsence/CRM/HRAbsence/BAO/HRAbsenceType.php
+++ b/hrabsence/CRM/HRAbsence/BAO/HRAbsenceType.php
@@ -88,10 +88,8 @@ class CRM_HRAbsence_BAO_HRAbsenceType extends CRM_HRAbsence_DAO_HRAbsenceType {
   private static function createActivityType($activityTypes, $params, $isDebit) {
     $weight = count($activityTypes["values"]);
     if ($isDebit) {
-      $valueId = $params['debit_activity_type_id'];
       $valueLabel = $params['title'];
     } else {
-      $valueId = $params['credit_activity_type_id'];
       $valueLabel = ts('%1 (Credit)', array(1 => $params["title"]));
     }
 

--- a/hrabsence/CRM/HRAbsence/BAO/HRAbsenceType.php
+++ b/hrabsence/CRM/HRAbsence/BAO/HRAbsenceType.php
@@ -267,7 +267,7 @@ class CRM_HRAbsence_BAO_HRAbsenceType extends CRM_HRAbsence_DAO_HRAbsenceType {
   private static function deleteLeaveEntitlements($absenceTypeId) {
     $result = civicrm_api3('HRJobLeave', 'get', [
       'leave_type' => $absenceTypeId,
-      'jobcontract_revision_id' => array('>' => 0),
+      'jobcontract_revision_id' => ['>' => 0],
       'options' => ['limit' => 0]
     ]);
     foreach ($result['values'] as $currentLeave) {

--- a/hrabsence/CRM/HRAbsence/BAO/HRAbsenceType.php
+++ b/hrabsence/CRM/HRAbsence/BAO/HRAbsenceType.php
@@ -266,17 +266,16 @@ class CRM_HRAbsence_BAO_HRAbsenceType extends CRM_HRAbsence_DAO_HRAbsenceType {
    */
   private static function deleteLeaveEntitlements($absenceTypeId) {
     $result = civicrm_api3('HRJobLeave', 'get', [
-      'sequential' => 1,
       'leave_type' => $absenceTypeId,
-      'jobcontract_revision_id' => array('>' => 0)
+      'jobcontract_revision_id' => array('>' => 0),
+      'options' => ['limit' => 0]
     ]);
     foreach ($result['values'] as $currentLeave) {
-      $result = civicrm_api3('HRJobLeave', 'delete', [
+      civicrm_api3('HRJobLeave', 'delete', [
         'id' => $currentLeave['id'],
       ]);
     }
   }
-
 
   /**
    * Get the total duration for given 'Source Absence ID'

--- a/hrabsence/CRM/HRAbsence/Upgrader.php
+++ b/hrabsence/CRM/HRAbsence/Upgrader.php
@@ -562,7 +562,9 @@ class CRM_HRAbsence_Upgrader extends CRM_HRAbsence_Upgrader_Base {
   public function upgrade_1402() {
     $deleteQuery = "DELETE FROM civicrm_hrjobcontract_leave WHERE leave_type NOT IN (
       SELECT id FROM civicrm_hrabsence_type
-    );";
+    )";
     CRM_Core_DAO::executeQuery($deleteQuery);
+
+    return true;
   }
 }

--- a/hrabsence/CRM/HRAbsence/Upgrader.php
+++ b/hrabsence/CRM/HRAbsence/Upgrader.php
@@ -551,4 +551,18 @@ class CRM_HRAbsence_Upgrader extends CRM_HRAbsence_Upgrader_Base {
 
     return TRUE;
   }
+
+  /**
+   * Previously when a leave type was deleted it was only deleting the first 25 civicrm_hrjobcontract_leave
+   * entries for that type. This upgrade is to remove legacy data where civicrm_hrjobcontract_leave points to a
+   * civicrm_hrabsence_type that does not exist
+   *
+   * @see https://compucorp.atlassian.net/browse/PCHR-1892
+   */
+  public function upgrade_1402() {
+    $deleteQuery = "DELETE FROM civicrm_hrjobcontract_leave WHERE leave_type NOT IN (
+      SELECT id FROM civicrm_hrabsence_type
+    );";
+    CRM_Core_DAO::executeQuery($deleteQuery);
+  }
 }


### PR DESCRIPTION
## Problem

A leave type can be deleted only if it has no approved absences related to it. However if the leave type is used only in a contract then it can be deleted. In a [related PR](https://github.com/civicrm/civihr/pull/1290) this was fixed by deleting all entries in `civicrm_hrjobcontract_leave` related to the deleted type. The problem here was that the API call to fetch them was being limited to 25 entries.

## Solution

- Remove the limit on the `civicrm_api3('HRJobLeave', 'get')` API call
- Add an upgrader to remove all entries from `civicrm_hrjobcontract_leave` that do not have a related entry in `civicrm_hrabsence_type`

### Notes

- I removed `sequential` from the API call since it's not relevant