### PR TITLE
PCHR-2050: Set default CiviCRM permissions for L&A

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -331,6 +331,7 @@ function hrleaveandabsences_civicrm_container(\Symfony\Component\DependencyInjec
  */
 function hrleaveandabsences_civicrm_postInstall() {
   _hrleaveandabsences_set_has_leave_approved_by_as_default_relationship_type();
+  _hrleaveandabsences_set_default_permissions();
 }
 
 /**
@@ -637,5 +638,33 @@ function _hrleaveandabsences_set_has_leave_approved_by_as_default_relationship_t
       'relationship_types_allowed_to_approve_leave',
       [$relationshipType['id']]
     );
+  }
+}
+
+/**
+ * Sets the default CiviCRM permissions for the 3 main roles in CiviHR
+ */
+function _hrleaveandabsences_set_default_permissions() {
+  _hrleaveandabsences_set_roles_permissions(
+    ['civihr_staff', 'civihr_manager', 'civihr_admin'],
+    ['access leave and absences']
+  );
+
+  _hrleaveandabsences_set_roles_permissions(
+    ['civihr_admin'],
+    ['administer leave and absences']
+  );
+}
+
+/**
+ * Grant the given $permissions to the given $roles
+ *
+ * @param array $roles
+ * @param array $permissions
+ */
+function _hrleaveandabsences_set_roles_permissions($roles, $permissions) {
+  foreach($roles as $roleName) {
+    $role = user_role_load_by_name($roleName);
+    user_role_grant_permissions($role->rid, $permissions);
   }
 }


### PR DESCRIPTION
Currently, we need to set the permissions for L&A manually. When we uninstall the extension, these permission get deleted though, and when we install it again the permissions have to be set once more. This is quite problematic for leave and absences, since it's still in development and not using upgraders yet, which forces us to reinstall the extension whenever there are changes in the db structure. 

We're adding this to the postInstall hook so we can have the system automatically set with permission after installing the extension. This is mainly useful for deployments with compubot, while it still have to reinstall the extension.

The roles `civihr_staff`, `civihr_manager` and `civihr_admin` all have the `'access leave and absences'` permissions.

The role `civihr_admin` also have the `'administer leave and absences'` permission.