### PR TITLE
PCHR-2044: Extend LeaveRequest.get and LeaveRequest.getFull API to support the 'unassigned' Parameter

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
@@ -90,7 +90,7 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
     ];
 
     if($hasUnassignedAsFalse) {
-      $conditions[] = implode(' AND ', $this->hasActiveLeaveManagerCondition());
+      $conditions = array_merge($conditions, $this->hasActiveLeaveManagerCondition());
     }
 
     if($hasUnassignedAsTrue) {
@@ -108,7 +108,7 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
       if(!isset($this->params['unassigned'])) {
         $activeLeaveManagerCondition = $this->hasActiveLeaveManagerCondition();
         $activeLeaveManagerCondition[] = "r.contact_id_b = {$managerID}";
-        $conditions[] = implode(' AND ', $activeLeaveManagerCondition);
+        $conditions = array_merge($conditions, $activeLeaveManagerCondition);
       }
     }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
@@ -288,7 +288,6 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
   }
 
   /**
-   *
    * Returns the conditions needed to add to the Where clause for
    * contacts that have active leave managers
    *

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -114,8 +114,7 @@ function _civicrm_api3_leave_request_get_spec(&$spec) {
  * @throws CiviCRM_API3_Exception
  */
 function civicrm_api3_leave_request_get($params) {
-  $settingsManager = Civi::service('hrleaveandabsences.settings_manager');
-  $query = new CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect($params, $settingsManager);
+  $query = new CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect($params);
   return civicrm_api3_create_success($query->run(), $params, '', 'get');
 }
 
@@ -165,8 +164,7 @@ function _civicrm_api3_leave_request_getfull_spec(&$spec) {
  * @throws CiviCRM_API3_Exception
  */
 function civicrm_api3_leave_request_getfull($params) {
-  $settingsManager = Civi::service('hrleaveandabsences.settings_manager');
-  $query = new CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect($params, $settingsManager);
+  $query = new CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect($params);
   $query->setReturnFullDetails(true);
 
   return civicrm_api3_create_success($query->run(), $params, '', 'getfull');

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -91,6 +91,15 @@ function _civicrm_api3_leave_request_get_spec(&$spec) {
     'type'         => CRM_Utils_Type::T_BOOLEAN,
     'api.required' => 0
   ];
+
+  $spec['unassigned'] = [
+    'name' => 'unassigned',
+    'title' => 'Unassigned only?',
+    'description' => 'Include only Leave Requests of contacts without active leave managers?',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+    'api.default' => FALSE,
+    'api.required' => 0,
+  ];
 }
 
 /**
@@ -148,6 +157,15 @@ function _civicrm_api3_leave_request_getfull_spec(&$spec) {
     'description'  => ts('When true, only expired expired requests will be returned. Otherwise, only the non-expired ones will be returned'),
     'type'         => CRM_Utils_Type::T_BOOLEAN,
     'api.required' => 0
+  ];
+
+  $spec['unassigned'] = [
+    'name' => 'unassigned',
+    'title' => 'Unassigned only?',
+    'description' => 'Include only Leave Requests of contacts without active leave managers?',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+    'api.default' => FALSE,
+    'api.required' => 0,
   ];
 }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -97,7 +97,6 @@ function _civicrm_api3_leave_request_get_spec(&$spec) {
     'title' => 'Unassigned only?',
     'description' => 'Include only Leave Requests of contacts without active leave managers?',
     'type' => CRM_Utils_Type::T_BOOLEAN,
-    'api.default' => FALSE,
     'api.required' => 0,
   ];
 }
@@ -164,7 +163,6 @@ function _civicrm_api3_leave_request_getfull_spec(&$spec) {
     'title' => 'Unassigned only?',
     'description' => 'Include only Leave Requests of contacts without active leave managers?',
     'type' => CRM_Utils_Type::T_BOOLEAN,
-    'api.default' => FALSE,
     'api.required' => 0,
   ];
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -1509,6 +1509,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     // No results will be returned because the unassigned parameter has a true value
     // and a manager can only see contacts assigned to him that he manages, the unassigned parameter negates that.
+    // We need to set check permissions to true here so that civi can add
+    // the appropriate ACL clause to the LeaveRequest queries
     $result = civicrm_api3('LeaveRequest', 'get', ['unassigned' => true, 'check_permissions' => true]);
     $resultGetFull = civicrm_api3('LeaveRequest', 'getFull', ['unassigned' => true, 'check_permissions' => true]);
 
@@ -1564,7 +1566,9 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
 
     // Only staffMember1 is actively managed by the Leave Manager
-    // therefore only leave requests for staffMember1 is returned
+    // therefore only leave requests for staffMember1 is returned.
+    // We need to set check permissions to true here so that civi can add
+    // the appropriate ACL clause to the LeaveRequest queries
     $result = civicrm_api3('LeaveRequest', 'get', ['unassigned' => false, 'check_permissions' => true]);
     $resultGetFull = civicrm_api3('LeaveRequest', 'getFull', ['unassigned' => false, 'check_permissions' => true]);
 
@@ -1582,35 +1586,18 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ]);
 
     $manager1 = ContactFabricator::fabricate();
-
-    $staffMember1 = ContactFabricator::fabricate();
     $staffMember2 = ContactFabricator::fabricate();
-
-    HRJobContractFabricator::fabricate(
-      ['contact_id' => $staffMember1['id']],
-      ['period_start_date' => '2016-01-01']
-    );
 
     HRJobContractFabricator::fabricate(
       ['contact_id' => $staffMember2['id']],
       ['period_start_date' => '2015-10-01']
     );
 
-    // Set Leave Approvers for staffMembers 1 and 2.
+    // Set Leave Approver for staffMembers
     // staffMember2 does not have an active leave manager relationship
-    $this->setContactAsLeaveApproverOf($manager1, $staffMember1, null, null, true, 'has Leaves Approved By');
     $this->setContactAsLeaveApproverOf($manager1, $staffMember2, '2016-01-01', '2016-12-28', true, 'has Leaves Managed By');
 
-    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
-      'contact_id' => $staffMember1['id'],
-      'type_id' => 1,
-      'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
-      'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
-      'from_date_type' => 1,
-      'to_date_type' => 1
-    ], true);
-
-    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
+    LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember2['id'],
       'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-01-05'),


### PR DESCRIPTION
This PR extends LeaveRequest.get and LeaveRequest.getFull API endpoints to support the 'unassigned' Boolean Parameter.

The 'unassigned' parameter returns Leave Requests for contacts without active Leave managers, when false, it returns Leave Requests for contacts with active Leave managers for LeaveRequest.get and LeaveRequest.getFull
When the parameter is absent, LeaveRequest.get and LeaveRequest.getFull returns Leave Requests for all contacts irrespective of whether they have an active Leave manager or not.

Note that contacts without Leave managers and contacts having an inactive relationship with leave managers both fall under the category of contacts without active leave managers.

Different tests were also added to ensure that ACL's and other existing parameters on the API's were respected.