### PR TITLE
PCHR-1501: Get absence types that are only active

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Page/JobContractTab.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Page/JobContractTab.php
@@ -129,6 +129,7 @@ class CRM_Hrjobcontract_Page_JobContractTab extends CRM_Core_Page {
 
     $absenceTypeResult = civicrm_api3('HRAbsenceType', 'get', array(
         'sequential' => 1,
+        'is_active' => 1,
         'return' => 'id,title',
     ));
 


### PR DESCRIPTION
### Issue: 
Currently, All absence types are fetched and displayed in UI. Both in Contract Summary and New Contract Modal Tab.

### Solution:
1. We need to modify file `hrjobcontract/CRM/Hrjobcontract/Page/JobContractTab.php` file to display only active absence types as follows.
```
    absenceTypeResult = civicrm_api3('HRAbsenceType', 'get', array(
        'sequential' => 1,
        'return' => 'id,title',
    ));
```
To following to get only the active absence types.

```
    absenceTypeResult = civicrm_api3('HRAbsenceType', 'get', array(
        'sequential' => 1,
        'is_active' => 1,
        'return' => 'id,title',
    ));
```

### Screenshots:
1. Disabling the Absence type: "Vacation"
<img width="1342" alt="screen shot 2017-03-13 at 4 40 12 pm" src="https://cloud.githubusercontent.com/assets/6307362/23851954/a122dad6-080d-11e7-8176-60e4ccc67288.png">

2. Vacation is not displayed in Contract Summary
<img width="1175" alt="screen shot 2017-03-13 at 4 41 03 pm" src="https://cloud.githubusercontent.com/assets/6307362/23851964/ac0dd630-080d-11e7-9fd2-3d74520f9bf8.png">

3. Vacation is not displayed in New Contract leave Tab
<img width="934" alt="screen shot 2017-03-13 at 4 41 20 pm" src="https://cloud.githubusercontent.com/assets/6307362/23851970/b210dcc6-080d-11e7-8356-38ea8412f335.png">

