### PR TITLE
PCHR-1980: Add upgrade method to add 'other task' task type

### DIFF
--- a/hrcase/CRM/HRCase/DefaultCaseAndActivityTypes.php
+++ b/hrcase/CRM/HRCase/DefaultCaseAndActivityTypes.php
@@ -26,6 +26,7 @@ class CRM_HRCase_DefaultCaseAndActivityTypes {
       'Probation appraisal (start probation workflow)',
       'Confirm End of Probation Date',
       'Start Probation workflow',
+      'Other Task',
     ],
     'CiviDocument' => [
       'Government Photo ID',

--- a/hrcase/CRM/HRCase/Upgrader.php
+++ b/hrcase/CRM/HRCase/Upgrader.php
@@ -142,6 +142,16 @@ class CRM_HRCase_Upgrader extends CRM_HRCase_Upgrader_Base {
    * Upgrader to add new default task type: 'Other Task'
    */
   public function upgrade_1403() {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'component_id' => "CiviTask",
+      'name' => "Other Task",
+      'option_group_id' => "activity_type",
+    ]);
+
+    if ($result['is_error'] || $result['count'] != 0) {
+      return true;
+    }
+
     civicrm_api3('OptionValue', 'create', [
       'option_group_id' => "activity_type",
       'component_id' => "CiviTask",

--- a/hrcase/CRM/HRCase/Upgrader.php
+++ b/hrcase/CRM/HRCase/Upgrader.php
@@ -139,6 +139,20 @@ class CRM_HRCase_Upgrader extends CRM_HRCase_Upgrader_Base {
   }
 
   /**
+   * Upgrader to add new default task type: 'Other Task'
+   */
+  public function upgrade_1403() {
+    civicrm_api3('OptionValue', 'create', [
+      'option_group_id' => "activity_type",
+      'component_id' => "CiviTask",
+      'label' => "Other Task",
+      'name' => "Other Task",
+    ]);
+
+    return true;
+  }
+
+  /**
    * Replaces (Case) keyword and (Open Case) keyword with (Assignment) keyword
    * and (Created New Assignment) keyword respectively and vise versa for
    * civicrm default activity types labels when installing/uninstalling the extension.

--- a/hrcase/CRM/HRCase/Upgrader.php
+++ b/hrcase/CRM/HRCase/Upgrader.php
@@ -141,7 +141,7 @@ class CRM_HRCase_Upgrader extends CRM_HRCase_Upgrader_Base {
   /**
    * Upgrader to add new default task type: 'Other Task'
    */
-  public function upgrade_1403() {
+  public function upgrade_1430() {
     $result = civicrm_api3('OptionValue', 'get', [
       'component_id' => "CiviTask",
       'name' => "Other Task",


### PR DESCRIPTION
## Overview

To give a more generic option for task types a 'Other Task' type will be added


### Notes

- I'm not sure if it should also be added to CRM_HRCase_DefaultCaseAndActivityTypes::$defaultActivityTypes and would like to hear from the reviewer what they think. If it is added here the upgrade will need to be changed since 'create' will create a duplicate.