### PR TITLE
PCHR-2046:  Don't allow deleting a Work Pattern that has ever been used by a contact

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/WorkPattern.php
@@ -17,7 +17,7 @@ class CRM_HRLeaveAndAbsences_Service_WorkPattern {
    */
   public function workPatternHasEverBeenUsed($workPatternID) {
     if ($this->isDefaultWorkPattern($workPatternID) ||
-      $this->workPatternIsLinkedToAContactWorkPattern($workPatternID))
+      $this->workPatternIsLinkedToAContact($workPatternID))
     {
       return true;
     }
@@ -63,7 +63,7 @@ class CRM_HRLeaveAndAbsences_Service_WorkPattern {
    *
    * @return boolean
    */
-  private function workPatternIsLinkedToAContactWorkPattern($workPatternID) {
+  private function workPatternIsLinkedToAContact($workPatternID) {
     $contactWorkPattern = new ContactWorkPattern();
     $contactWorkPattern->pattern_id = $workPatternID;
     $contactWorkPattern->find();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/WorkPattern.php
@@ -1,0 +1,77 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
+use CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern as ContactWorkPattern;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Service_WorkPattern
+ */
+class CRM_HRLeaveAndAbsences_Service_WorkPattern {
+
+  /**
+   * Checks If a work pattern has ever been used by a contact
+   *
+   * @param int $workPatternID
+   *
+   * @return boolean
+   */
+  public function workPatternHasEverBeenUsed($workPatternID) {
+    if ($this->isDefaultWorkPattern($workPatternID) ||
+      $this->workPatternIsLinkedToAContactWorkPattern($workPatternID))
+    {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Deletes the WorkPattern with the given id.
+   * Checks first to see if the work pattern can be deleted or not.
+   *
+   * @param int $workPatternID
+   */
+  public function delete($workPatternID) {
+    if ($this->workPatternHasEverBeenUsed($workPatternID)) {
+      throw new UnexpectedValueException('Work pattern cannot be deleted because it is used by one or more contacts');
+    }
+
+    WorkPattern::del($workPatternID);
+  }
+
+  /**
+   * Checks if the work pattern is the default work pattern
+   *
+   * @param int $workPatternID
+   *
+   * @return boolean
+   */
+  private function isDefaultWorkPattern($workPatternID) {
+    $workPattern = WorkPattern::findById($workPatternID);
+
+    if ($workPattern->is_default) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Checks if the work pattern is linked to at least one contact work pattern
+   *
+   * @param int $workPatternID
+   *
+   * @return boolean
+   */
+  private function workPatternIsLinkedToAContactWorkPattern($workPatternID) {
+    $contactWorkPattern = new ContactWorkPattern();
+    $contactWorkPattern->pattern_id = $workPatternID;
+    $contactWorkPattern->find();
+
+    if ($contactWorkPattern->N > 0) {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/WorkPattern.php
@@ -31,7 +31,11 @@ function civicrm_api3_work_pattern_create($params) {
  * @throws API_Exception
  */
 function civicrm_api3_work_pattern_delete($params) {
-  return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  civicrm_api3_verify_mandatory($params, NULL, ['id']);
+  $workPatternService = new CRM_HRLeaveAndAbsences_Service_WorkPattern();
+  $workPatternService->delete($params['id']);
+
+  return civicrm_api3_create_success(true);
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/WorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/WorkPatternTest.php
@@ -29,7 +29,7 @@ class CRM_HRLeaveAndAbsences_Service_WorkPatternTest extends BaseHeadlessTest {
     $this->assertTrue($this->workPatternService->workPatternHasEverBeenUsed($workPattern->id));
   }
 
-  public function testWorkPatternHasEverBeenUsedReturnsTrueWhenWorkPatternIsLinkedToAContactWorkPattern() {
+  public function testWorkPatternHasEverBeenUsedReturnsTrueWhenWorkPatternIsLinkedToAContact() {
     $workPattern = WorkPatternFabricator::fabricate(['is_default' => 0]);
 
     ContactWorkPatternFabricator::fabricate([
@@ -39,7 +39,7 @@ class CRM_HRLeaveAndAbsences_Service_WorkPatternTest extends BaseHeadlessTest {
     $this->assertTrue($this->workPatternService->workPatternHasEverBeenUsed($workPattern->id));
   }
 
-  public function testWorkPatternHasEverBeenUsedReturnsFalseWhenWorkPatternIsNotTheDefaultAndWorkPatternIsNotLinkedToAContactWorkPattern() {
+  public function testWorkPatternHasEverBeenUsedReturnsFalseWhenWorkPatternIsNotTheDefaultAndWorkPatternIsNotLinkedToAContact() {
     $workPattern = WorkPatternFabricator::fabricate(['is_default' => 0]);
     $this->assertFalse($this->workPatternService->workPatternHasEverBeenUsed($workPattern->id));
   }
@@ -48,8 +48,22 @@ class CRM_HRLeaveAndAbsences_Service_WorkPatternTest extends BaseHeadlessTest {
    * @expectedException UnexpectedValueException
    * @expectedExceptionMessage Work pattern cannot be deleted because it is used by one or more contacts
    */
-  public function testDeleteThrowsAnExceptionWhenAttemptingToDeleteAWorkPatternThatHasBeenUsed() {
+  public function testDeleteThrowsAnExceptionWhenAttemptingToDeleteADefaultWorkPattern() {
     $workPattern = WorkPatternFabricator::fabricate(['is_default' => 1]);
+    $this->workPatternService->delete($workPattern->id);
+  }
+
+  /**
+   * @expectedException UnexpectedValueException
+   * @expectedExceptionMessage Work pattern cannot be deleted because it is used by one or more contacts
+   */
+  public function testDeleteThrowsAnExceptionWhenAttemptingToDeleteAWorkPatternThatIsLinkedToAContact() {
+    $workPattern = WorkPatternFabricator::fabricate(['is_default' => 0]);
+
+    ContactWorkPatternFabricator::fabricate([
+      'pattern_id' => $workPattern->id,
+    ]);
+
     $this->workPatternService->delete($workPattern->id);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/WorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/WorkPatternTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern as WorkPatternFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_ContactWorkPattern as ContactWorkPatternFabricator;
+use CRM_HRLeaveAndAbsences_Service_WorkPattern as WorkPatternService;
+
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Service_WorkPatternTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_Service_WorkPatternTest extends BaseHeadlessTest {
+
+  private $workPatternService;
+
+  public function setUp() {
+    CRM_Core_DAO::executeQuery('SET foreign_key_checks = 0;');
+    $this->workPatternService = new WorkPatternService();
+  }
+
+  public function tearDown() {
+    CRM_Core_DAO::executeQuery('SET foreign_key_checks = 1;');
+  }
+
+  public function testWorkPatternHasEverBeenUsedReturnsTrueWhenWorkPatternIsTheDefaultWorkPattern() {
+    $workPattern = WorkPatternFabricator::fabricate(['is_default' => 1]);
+    $this->assertTrue($this->workPatternService->workPatternHasEverBeenUsed($workPattern->id));
+  }
+
+  public function testWorkPatternHasEverBeenUsedReturnsTrueWhenWorkPatternIsLinkedToAContactWorkPattern() {
+    $workPattern = WorkPatternFabricator::fabricate(['is_default' => 0]);
+
+    ContactWorkPatternFabricator::fabricate([
+      'pattern_id' => $workPattern->id,
+    ]);
+
+    $this->assertTrue($this->workPatternService->workPatternHasEverBeenUsed($workPattern->id));
+  }
+
+  public function testWorkPatternHasEverBeenUsedReturnsFalseWhenWorkPatternIsNotTheDefaultAndWorkPatternIsNotLinkedToAContactWorkPattern() {
+    $workPattern = WorkPatternFabricator::fabricate(['is_default' => 0]);
+    $this->assertFalse($this->workPatternService->workPatternHasEverBeenUsed($workPattern->id));
+  }
+
+  /**
+   * @expectedException UnexpectedValueException
+   * @expectedExceptionMessage Work pattern cannot be deleted because it is used by one or more contacts
+   */
+  public function testDeleteThrowsAnExceptionWhenAttemptingToDeleteAWorkPatternThatHasBeenUsed() {
+    $workPattern = WorkPatternFabricator::fabricate(['is_default' => 1]);
+    $this->workPatternService->delete($workPattern->id);
+  }
+
+  public function testDeleteCanDeleteAWorkPatternThatIsNotUsed() {
+    $workPattern = WorkPatternFabricator::fabricate(['is_default' => 0]);
+    $this->workPatternService->delete($workPattern->id);
+
+    try {
+      WorkPattern::findById($workPattern->id);
+    } catch(Exception $e) {
+      return;
+    }
+    $this->fail("Expected to not find the WorkPattern with {$workPattern->id}, but it was found");
+  }
+}


### PR DESCRIPTION
This PR changes the way a WorkPattern is deleted:

A WorkPattern that fulfils any of the following criteria is not allowed to be deleted, instead an exception is thrown.

- If the WorkPattern is the default one
- If there's at least one ContactWorkPattern where the pattern_id is the ID of the WorkPattern being deleted.

A new WorkPattern service is created to implement these new changes