### PR TITLE
PCHR-2047: Hide delete option on work pattern list and form for a WorkPattern that cannot be deleted

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/WorkPattern.php
@@ -4,6 +4,7 @@ require_once 'CRM/Core/Form.php';
 
 use CRM_HRLeaveAndAbsences_BAO_WorkDay as WorkDay;
 use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
+use CRM_HRLeaveAndAbsences_Service_WorkPattern as WorkPatternService;
 
 /**
  * Form controller class
@@ -424,7 +425,7 @@ class CRM_HRLeaveAndAbsences_Form_WorkPattern extends CRM_Core_Form
             [ 'type' => 'cancel', 'name' => ts('Cancel') ],
         ];
 
-        if($this->_action & CRM_Core_Action::UPDATE) {
+        if($this->_action & CRM_Core_Action::UPDATE && ($this->canDelete())) {
             $buttons[] = [ 'type' => 'delete', 'name' => ts('Delete') ];
         }
 
@@ -589,5 +590,15 @@ class CRM_HRLeaveAndAbsences_Form_WorkPattern extends CRM_Core_Form
       }
 
       return $numberOfHours;
+    }
+
+    /**
+     * Checks whether a WorkPattern object can be deleted.
+     *
+     * @return bool
+     */
+    private function canDelete() {
+      $workPattern = new WorkPatternService();
+      return !$workPattern->workPatternHasEverBeenUsed($this->_id);
     }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/WorkPattern.php
@@ -425,7 +425,7 @@ class CRM_HRLeaveAndAbsences_Form_WorkPattern extends CRM_Core_Form
             [ 'type' => 'cancel', 'name' => ts('Cancel') ],
         ];
 
-        if($this->_action & CRM_Core_Action::UPDATE && ($this->canDelete())) {
+        if($this->_action & CRM_Core_Action::UPDATE && $this->canDelete()) {
             $buttons[] = [ 'type' => 'delete', 'name' => ts('Delete') ];
         }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/WorkPattern.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_HRLeaveAndAbsences_Service_WorkPattern as WorkPatternService;
+
 class CRM_HRLeaveAndAbsences_Page_WorkPattern extends CRM_Core_Page_Basic {
 
   private $links = array();
@@ -27,8 +29,13 @@ class CRM_HRLeaveAndAbsences_Page_WorkPattern extends CRM_Core_Page_Basic {
         $rows[$object->id]['number_of_hours'] = ts('Various');
       }
 
+      $links = $this->links();
+
+      if ($this->canNotDelete($object->id)) {
+         unset($links[CRM_Core_Action::DELETE]);
+      }
       $rows[$object->id]['action'] = CRM_Core_Action::formLink(
-          $this->links(),
+          $links,
           $this->calculateLinksMask($object),
           ['id' => $object->id]
       );
@@ -169,5 +176,17 @@ class CRM_HRLeaveAndAbsences_Page_WorkPattern extends CRM_Core_Page_Basic {
     }
 
     return $mask;
+  }
+
+  /**
+   * Checks whether a WorkPattern object cannot be deleted.
+   *
+   * @param int $workPatternID
+   *
+   * @return bool
+   */
+  private function canNotDelete($workPatternID) {
+    $workPattern = new WorkPatternService();
+    return $workPattern->workPatternHasEverBeenUsed($workPatternID);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/WorkPattern.php
@@ -6,8 +6,14 @@ class CRM_HRLeaveAndAbsences_Page_WorkPattern extends CRM_Core_Page_Basic {
 
   private $links = array();
 
+  /**
+   * @var \CRM_HRLeaveAndAbsences_Service_WorkPattern
+   */
+  private $workPatternService;
+
   public function run() {
     CRM_Utils_System::setTitle(ts('Work Patterns'));
+    $this->workPatternService = new WorkPatternService();
     parent::run();
   }
 
@@ -29,13 +35,8 @@ class CRM_HRLeaveAndAbsences_Page_WorkPattern extends CRM_Core_Page_Basic {
         $rows[$object->id]['number_of_hours'] = ts('Various');
       }
 
-      $links = $this->links();
-
-      if ($this->canNotDelete($object->id)) {
-         unset($links[CRM_Core_Action::DELETE]);
-      }
       $rows[$object->id]['action'] = CRM_Core_Action::formLink(
-          $links,
+          $this->links(),
           $this->calculateLinksMask($object),
           ['id' => $object->id]
       );
@@ -175,6 +176,10 @@ class CRM_HRLeaveAndAbsences_Page_WorkPattern extends CRM_Core_Page_Basic {
       $mask -= CRM_Core_Action::BASIC;
     }
 
+    if($this->canNotDelete($workPattern->id)) {
+      $mask -= CRM_Core_Action::DELETE;
+    }
+
     return $mask;
   }
 
@@ -186,7 +191,6 @@ class CRM_HRLeaveAndAbsences_Page_WorkPattern extends CRM_Core_Page_Basic {
    * @return bool
    */
   private function canNotDelete($workPatternID) {
-    $workPattern = new WorkPatternService();
-    return $workPattern->workPatternHasEverBeenUsed($workPatternID);
+    return $this->workPatternService->workPatternHasEverBeenUsed($workPatternID);
   }
 }


### PR DESCRIPTION
This PR hides the delete option on the Work Pattern list and form for a  WorkPattern that cannot be deleted.

![work patterns - civihr 1 6 demo 2017-03-17 18-13-35](https://cloud.githubusercontent.com/assets/6951813/24055226/8d2a336e-0b3f-11e7-8d7f-e0ffbe3cc02d.png)

![work patterns - civihr 1 6 demo 2017-03-17 18-14-58](https://cloud.githubusercontent.com/assets/6951813/24055230/93d3a916-0b3f-11e7-85b0-d821511988e6.png)

![work patterns - civihr 1 6 demo 2017-03-17 18-15-34](https://cloud.githubusercontent.com/assets/6951813/24055240/9b1ceaf2-0b3f-11e7-9948-d4d5e21b9b86.png)

