### PR TITLE
PCHR-2048: Don't allow deleting an Absence Type that has been used.

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -105,22 +105,12 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
   /**
    * Deletes the AbsenceType with the given ID.
    *
-   * A reserved AbsenceType cannot be deleted. If the given ID is from a
-   * reserved type, and exception will be thrown.
-   *
    * @param int $id The ID of the AbsenceType to be deleted
-   *
-   * @throws \CRM_HRLeaveAndAbsences_Exception_OperationNotAllowedException
    */
   public static function del($id) {
     $absenceType = new CRM_HRLeaveAndAbsences_DAO_AbsenceType();
     $absenceType->id = $id;
     $absenceType->find(true);
-
-    if($absenceType->is_reserved) {
-      throw new CRM_HRLeaveAndAbsences_Exception_OperationNotAllowedException('Reserved types cannot be deleted!');
-    }
-
     $absenceType->delete();
 
     if($absenceType->must_take_public_holiday_as_leave) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/AbsenceType.php
@@ -38,7 +38,6 @@ class CRM_HRLeaveAndAbsences_Service_AbsenceType {
    * @return boolean
    */
   public function absenceTypeHasEverBeenUsed($absenceTypeID) {
-
     if ($this->absenceTypeIsLinkedToLeaveRequest($absenceTypeID)) {
       return true;
     }
@@ -53,13 +52,12 @@ class CRM_HRLeaveAndAbsences_Service_AbsenceType {
    * @param int $absenceTypeID
    *
    * @throws CRM_HRLeaveAndAbsences_Exception_OperationNotAllowedException
-   * @throws UnexpectedValueException
    */
   public function delete($absenceTypeID) {
     $absenceType = AbsenceType::findById($absenceTypeID);
 
     if ($this->absenceTypeHasEverBeenUsed($absenceType->id)) {
-      throw new UnexpectedValueException('Absence type cannot be deleted because it is linked to one or more leave requests');
+      throw new OperationNotAllowedException('Absence type cannot be deleted because it is linked to one or more leave requests');
     }
 
     if($absenceType->is_reserved) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/AbsenceType.php
@@ -3,6 +3,7 @@
 use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use CRM_HRLeaveAndAbsences_Exception_OperationNotAllowedException as OperationNotAllowedException;
 
 class CRM_HRLeaveAndAbsences_Service_AbsenceType {
 
@@ -27,5 +28,63 @@ class CRM_HRLeaveAndAbsences_Service_AbsenceType {
     $currentPeriod = AbsencePeriod::getCurrentPeriod();
     $startDate = new DateTime($currentPeriod->start_date);
     LeaveRequest::deleteAllNonExpiredTOILRequestsForAbsenceType($absenceType->id, $startDate);
+  }
+
+  /**
+   * Checks if an absenceType has ever been used for a leave request
+   *
+   * @param int $absenceTypeID
+   *
+   * @return boolean
+   */
+  public function absenceTypeHasEverBeenUsed($absenceTypeID) {
+
+    if ($this->absenceTypeIsLinkedToLeaveRequest($absenceTypeID)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Deletes the AbsenceType with the given id.
+   * Checks first to see if the absence type can be deleted or not.
+   *
+   * @param int $absenceTypeID
+   *
+   * @throws CRM_HRLeaveAndAbsences_Exception_OperationNotAllowedException
+   * @throws UnexpectedValueException
+   */
+  public function delete($absenceTypeID) {
+    $absenceType = AbsenceType::findById($absenceTypeID);
+
+    if ($this->absenceTypeHasEverBeenUsed($absenceType->id)) {
+      throw new UnexpectedValueException('Absence type cannot be deleted because it is linked to one or more leave requests');
+    }
+
+    if($absenceType->is_reserved) {
+      throw new OperationNotAllowedException('Reserved types cannot be deleted!');
+    }
+
+    AbsenceType::del($absenceType->id);
+  }
+
+  /**
+   * Checks if an absenceType is linked to at least one leave request
+   *
+   * @param int $absenceTypeID
+   *
+   * @return boolean
+   */
+  private function absenceTypeIsLinkedToLeaveRequest($absenceTypeID) {
+    $leaveRequest = new LeaveRequest();
+    $leaveRequest->type_id = $absenceTypeID;
+    $leaveRequest->find();
+
+    if ($leaveRequest->N > 0) {
+      return true;
+    }
+
+    return false;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/AbsenceType.php
@@ -22,4 +22,27 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType extends
     return AbsenceType::create($params);
   }
 
+  /**
+   * Since we cannot create reserved types through the API,
+   * we have this helper method to insert one directly in
+   * the database
+   */
+  public static function createReservedType() {
+    $title = 'Title ' . microtime();
+    $query = "
+      INSERT INTO
+        civicrm_hrleaveandabsences_absence_type(title, color, default_entitlement, allow_request_cancelation, is_reserved, weight)
+        VALUES('{$title}', '#000000', 0, 1, 1, 1)
+    ";
+    CRM_Core_DAO::executeQuery($query);
+
+    $query = "SELECT id FROM civicrm_hrleaveandabsences_absence_type WHERE title = '{$title}'";
+    $dao = CRM_Core_DAO::executeQuery($query);
+    if($dao->N == 1) {
+      $dao->fetch();
+      return $dao->id;
+    }
+
+    return null;
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/AbsenceType.php
@@ -27,22 +27,13 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType extends
    * we have this helper method to insert one directly in
    * the database
    */
-  public static function createReservedType() {
-    $title = 'Title ' . microtime();
-    $query = "
-      INSERT INTO
-        civicrm_hrleaveandabsences_absence_type(title, color, default_entitlement, allow_request_cancelation, is_reserved, weight)
-        VALUES('{$title}', '#000000', 0, 1, 1, 1)
-    ";
+  public static function fabricateReservedType($params = []) {
+    $absenceType = self::fabricate($params);
+    $absenceTypeTable = AbsenceType::getTableName();
+
+    $query = "UPDATE {$absenceTypeTable} SET is_reserved = 1 WHERE id = {$absenceType->id}";
     CRM_Core_DAO::executeQuery($query);
 
-    $query = "SELECT id FROM civicrm_hrleaveandabsences_absence_type WHERE title = '{$title}'";
-    $dao = CRM_Core_DAO::executeQuery($query);
-    if($dao->N == 1) {
-      $dao->fetch();
-      return $dao->id;
-    }
-
-    return null;
+    return $absenceType;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/AbsenceType.php
@@ -31,7 +31,11 @@ function civicrm_api3_absence_type_create($params) {
  * @throws API_Exception
  */
 function civicrm_api3_absence_type_delete($params) {
-  return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  civicrm_api3_verify_mandatory($params, NULL, ['id']);
+  $absenceTypeService = new CRM_HRLeaveAndAbsences_Service_AbsenceType();
+  $absenceTypeService->delete($params['id']);
+
+  return civicrm_api3_create_success(true);
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -336,17 +336,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     $this->assertEquals(0, $entity->is_reserved);
   }
 
-  /**
-   * @expectedException CRM_HRLeaveAndAbsences_Exception_OperationNotAllowedException
-   * @expectedExceptionMessage Reserved types cannot be deleted!
-   */
-  public function testShouldNotBeAllowedToDeleteReservedTypes() {
-    $id = $this->createReservedType();
-    $this->assertNotNull($id);
-    AbsenceType::del($id);
-  }
-
-  public function testShouldBeAllowedToDeleteNonReservedTypes() {
+  public function testDeleteCanDeleteAbsenceType() {
     $entity = AbsenceTypeFabricator::fabricate();
     $this->assertNotNull($entity->id);
     AbsenceType::del($entity->id);
@@ -583,30 +573,6 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
       [77, 9, true],
       [12, 31, true],
     ];
-  }
-
-  /**
-   * Since we cannot create reserved types through the API,
-   * we have this helper method to insert one directly in
-   * the database
-   */
-  private function createReservedType() {
-    $title = 'Title ' . microtime();
-    $query = "
-      INSERT INTO
-        civicrm_hrleaveandabsences_absence_type(title, color, default_entitlement, allow_request_cancelation, is_reserved, weight)
-        VALUES('{$title}', '#000000', 0, 1, 1, 1)
-    ";
-    CRM_Core_DAO::executeQuery($query);
-
-    $query = "SELECT id FROM civicrm_hrleaveandabsences_absence_type WHERE title = '{$title}'";
-    $dao = CRM_Core_DAO::executeQuery($query);
-    if($dao->N == 1) {
-      $dao->fetch();
-      return $dao->id;
-    }
-
-    return null;
   }
 
   public function testAbsenceTypeHasIsSickFlagAsFalseByDefault() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/AbsenceTypeTest.php
@@ -100,7 +100,7 @@ class CRM_HRLeaveAndAbsences_Service_AbsenceTypeTest extends BaseHeadlessTest {
   }
 
   /**
-   * @expectedException UnexpectedValueException
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_OperationNotAllowedException
    * @expectedExceptionMessage Absence type cannot be deleted because it is linked to one or more leave requests
    */
   public function testDeleteThrowsExceptionWhenDeletingAnAbsenceTypeThatIsLinkedToALeaveRequest() {
@@ -150,17 +150,6 @@ class CRM_HRLeaveAndAbsences_Service_AbsenceTypeTest extends BaseHeadlessTest {
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'from_date_type' => 1,
       'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
-      'to_date_type' => 1,
-      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
-    ], true);
-
-    LeaveRequestFabricator::fabricateWithoutValidation([
-      'type_id' => $absenceTypeID,
-      'contact_id' => 1,
-      'status_id' => 3,
-      'from_date' => CRM_Utils_Date::processDate('2016-01-02'),
-      'from_date_type' => 1,
-      'to_date' => CRM_Utils_Date::processDate('2016-01-02'),
       'to_date_type' => 1,
       'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
     ], true);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/AbsenceTypeTest.php
@@ -18,6 +18,12 @@ class CRM_HRLeaveAndAbsences_Service_AbsenceTypeTest extends BaseHeadlessTest {
 
   use CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait;
 
+  private $absenceTypeService;
+
+  public function setUp() {
+    $this->absenceTypeService = new AbsenceTypeService();
+  }
+
   public function testPostUpdateActionDeletesTOILRequestsWhenTOILGetsDisabled() {
     $absenceType = AbsenceTypeFabricator::fabricate([
       'allow_accruals_request' => true,
@@ -71,8 +77,7 @@ class CRM_HRLeaveAndAbsences_Service_AbsenceTypeTest extends BaseHeadlessTest {
       'color' => '#000000'
     ]);
 
-    $absenceTypeService = new AbsenceTypeService();
-    $absenceTypeService->postUpdateActions($updatedAbsenceType);
+    $this->absenceTypeService->postUpdateActions($updatedAbsenceType);
 
     //confirm the balance change for the expired TOIL balance was not deleted
     $balanceChange = new LeaveBalanceChange();
@@ -92,5 +97,79 @@ class CRM_HRLeaveAndAbsences_Service_AbsenceTypeTest extends BaseHeadlessTest {
     $leaveRequestDate->find(true);
     $this->assertEquals($leaveRequestDate->N, 1);
     $this->assertEquals($leaveRequestDate->date, '2016-03-10');
+  }
+
+  /**
+   * @expectedException UnexpectedValueException
+   * @expectedExceptionMessage Absence type cannot be deleted because it is linked to one or more leave requests
+   */
+  public function testDeleteThrowsExceptionWhenDeletingAnAbsenceTypeThatIsLinkedToALeaveRequest() {
+    $absenceTypeID = 1;
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => 1,
+      'status_id' => 3,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'from_date_type' => 1,
+      'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'to_date_type' => 1,
+      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
+    ], true);
+
+    $this->absenceTypeService->delete($absenceTypeID);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_OperationNotAllowedException
+   * @expectedExceptionMessage Reserved types cannot be deleted!
+   */
+  public function testDeleteThrowsExceptionWhenDeletingAnAbsenceTypeThatIsReserved() {
+    $absenceTypeID = AbsenceTypeFabricator::createReservedType();
+    $this->absenceTypeService->delete($absenceTypeID);
+  }
+
+  public function testDeleteCanDeleteAnAbsenceTypeThatIsNotUsedOrReserved() {
+    $absenceType = AbsenceTypeFabricator::fabricate();
+    $this->absenceTypeService->delete($absenceType->id);
+
+    try {
+      AbsenceType::findById($absenceType->id);
+    } catch(Exception $e) {
+      return;
+    }
+    $this->fail("Expected to not find the AbsenceType with {$absenceType->id}, but it was found");
+  }
+
+  public function testAbsenceTypeHasEverBeenUsedReturnsTrueWhenAbsenceTypeIsLinkedToLeaveRequest() {
+    $absenceTypeID = 1;
+
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => 1,
+      'status_id' => 3,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'from_date_type' => 1,
+      'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'to_date_type' => 1,
+      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
+    ], true);
+
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => 1,
+      'status_id' => 3,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-02'),
+      'from_date_type' => 1,
+      'to_date' => CRM_Utils_Date::processDate('2016-01-02'),
+      'to_date_type' => 1,
+      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
+    ], true);
+
+    $this->assertTrue($this->absenceTypeService->absenceTypeHasEverBeenUsed($absenceTypeID));
+  }
+
+  public function testAbsenceTypeHasEverBeenUsedReturnsFalseWhenAbsenceTypeIsNotLinkedToLeaveRequest() {
+    $absenceTypeID = 1;
+    $this->assertFalse($this->absenceTypeService->absenceTypeHasEverBeenUsed($absenceTypeID));
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/AbsenceTypeTest.php
@@ -124,8 +124,8 @@ class CRM_HRLeaveAndAbsences_Service_AbsenceTypeTest extends BaseHeadlessTest {
    * @expectedExceptionMessage Reserved types cannot be deleted!
    */
   public function testDeleteThrowsExceptionWhenDeletingAnAbsenceTypeThatIsReserved() {
-    $absenceTypeID = AbsenceTypeFabricator::createReservedType();
-    $this->absenceTypeService->delete($absenceTypeID);
+    $absenceType = AbsenceTypeFabricator::fabricateReservedType();
+    $this->absenceTypeService->delete($absenceType->id);
   }
 
   public function testDeleteCanDeleteAnAbsenceTypeThatIsNotUsedOrReserved() {


### PR DESCRIPTION
This PR changes the way an AbsenceType is deleted:
An Absence that has at least one leave request for it is not allowed to be deleted.

The logic for this is implemented in the AbsenceType service. Also existing logic in the `del` method of the AbsenceType BAO is moved to the delete method of the AbsenceType service.