### PR TITLE
PCHR-2085: Contract Date Fallback for Role Import

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/MapField.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/MapField.php
@@ -166,7 +166,7 @@ class CRM_Hrjobroles_Import_Form_MapField extends CRM_Import_Form_MapField {
 
             $js .= "{$formName}['mapper[$i][3]'].style.display = 'none';\n";
             $defaults["mapper[$i]"] = array(
-              $mappingHeader[0],
+              isset($mappingHeader[0]) ? $mappingHeader[0] : "",
               (isset($locationId)) ? $locationId : "",
               (isset($phoneType)) ? $phoneType : "",
             );

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Parser/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Parser/HrJobRoles.php
@@ -147,7 +147,6 @@ class CRM_Hrjobroles_Import_Parser_HrJobRoles extends CRM_Hrjobroles_Import_Pars
     $session = CRM_Core_Session::singleton();
     $dateType = $session->get('dateTypes');
 
-    /** @var object $contractDetails */
     $contractDetails = NULL;
     if (!empty($params['job_contract_id']))  {
       $contractDetails = CRM_Hrjobcontract_BAO_HRJobContract::checkContract($params['job_contract_id']);

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Parser/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Parser/HrJobRoles.php
@@ -147,6 +147,7 @@ class CRM_Hrjobroles_Import_Parser_HrJobRoles extends CRM_Hrjobroles_Import_Pars
     $session = CRM_Core_Session::singleton();
     $dateType = $session->get('dateTypes');
 
+    /** @var object $contractDetails */
     $contractDetails = NULL;
     if (!empty($params['job_contract_id']))  {
       $contractDetails = CRM_Hrjobcontract_BAO_HRJobContract::checkContract($params['job_contract_id']);
@@ -323,10 +324,9 @@ class CRM_Hrjobroles_Import_Parser_HrJobRoles extends CRM_Hrjobroles_Import_Pars
         unset($params['hrjc_role_percent_pay_funder']);
       }
 
-      // check if job role start and end dates if exist matches or within contract start and end dates
-
-      $contractStartDate = CRM_Utils_Date::formatDate($contractDetails->period_start_date, $dateType);
-      $contractEndDate = CRM_Utils_Date::formatDate($contractDetails->period_end_date, $dateType);
+      // use contract dates as fallback if job role dates not set
+      $contractStartDate = $contractDetails->period_start_date;
+      $contractEndDate = $contractDetails->period_end_date;
 
       if (!empty($params['hrjc_role_start_date'])) {
         $roleStartDate = CRM_Utils_Date::formatDate($params['hrjc_role_start_date'], $dateType);

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Parser/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Parser/HrJobRoles.php
@@ -325,8 +325,8 @@ class CRM_Hrjobroles_Import_Parser_HrJobRoles extends CRM_Hrjobroles_Import_Pars
       }
 
       // use contract dates as fallback if job role dates not set
-      $contractStartDate = $contractDetails->period_start_date;
-      $contractEndDate = $contractDetails->period_end_date;
+      $contractStartDate = CRM_Utils_Date::formatDate($contractDetails->period_start_date, 1);
+      $contractEndDate = CRM_Utils_Date::formatDate($contractDetails->period_end_date, 1);
 
       if (!empty($params['hrjc_role_start_date'])) {
         $roleStartDate = CRM_Utils_Date::formatDate($params['hrjc_role_start_date'], $dateType);

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
@@ -182,7 +182,7 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
    * ];
    *
    * @param array $contracts
-   * @param string $date Y-m-d format of a date for which we calculate the result 
+   * @param string $date Y-m-d format of a date for which we calculate the result
    *
    * @return array
    */
@@ -329,7 +329,7 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
 
   /**
    * Get Length of Service value in days for specific Contact ID.
-   * 
+   *
    * @param type $contactId
    * @return int
    */
@@ -349,7 +349,7 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
   /**
    * Get an assotiative array of days, months and years counted for
    * specific Contact ID.
-   * 
+   *
    * @param int contactId
    * @return array
    */
@@ -369,10 +369,11 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
    * Check Job Contract if exist   .
    *
    * @param Integer $contractID
-   * @return array|0 ( return 0 if not exist or an array contain some contract details if exist )
+   * @return object|int
+   *  0 if not exist or an object containing contract details
    */
   public static function checkContract($contractID) {
-    if ( !CRM_Utils_Rule::positiveInteger($contractID))  {
+    if (!CRM_Utils_Rule::positiveInteger($contractID)) {
       return 0;
     }
     $queryParam = array(1 => array($contractID, 'Integer'));
@@ -380,6 +381,7 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
               left join civicrm_hrjobcontract_details chrjcd on chrjcr.id=chrjcd.jobcontract_revision_id
               where  chrjcr.jobcontract_id = %1 order by chrjcr.id desc limit 1";
     $result = CRM_Core_DAO::executeQuery($query, $queryParam);
+
     return $result->fetch() ? $result : 0;
   }
 
@@ -578,20 +580,20 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
   }
 
   /**
-   * Returns the current revision for current contract for the contact, if it 
+   * Returns the current revision for current contract for the contact, if it
    * exists. The current contract is either:
-   * 
-   * - The one where current revision effective_date is on or before the current 
-   *   date and effective_end_date is either greater than the current date or 
+   *
+   * - The one where current revision effective_date is on or before the current
+   *   date and effective_end_date is either greater than the current date or
    *   null/empty.
    * - The one where effective_date for the revision is in the future.
    *
    * Also note:
    * 1) two contracts for the same contact can't overlap.
-   * 2) two revisions for the same contract can't have the same effective date 
+   * 2) two revisions for the same contract can't have the same effective date
    *
    * @param int $contactID
-   * 
+   *
    * @return array|null
    */
   public static function getCurrentContract($contactID)  {

--- a/hrjobcontract/api/v3/jobcontract_utils.php
+++ b/hrjobcontract/api/v3/jobcontract_utils.php
@@ -7,7 +7,7 @@
 
 /**
  * Returns entity name by given BAO / DAO class name.
- * 
+ *
  * @param String $baoName
  * @return String
  */
@@ -34,7 +34,7 @@ function _civicrm_get_table_name($className)
 /**
  * Sets $params array to point at valid revision of given $params['jobcontract_id']
  * Job Contract.
- * 
+ *
  * @param array $params
  * @param String $table
  */
@@ -56,7 +56,7 @@ function _civicrm_hrjobcontract_api3_set_current_revision(array &$params, $table
  * Creates new revision for given Job Contract Id.
  * If there is no previous revision the function creates new blank revision.
  * Otherwise the function creates new revision with previous entity values.
- * 
+ *
  * @param int $jobContractId
  */
 function _civicrm_hrjobcontract_api3_create_revision($jobContractId)
@@ -74,7 +74,7 @@ function _civicrm_hrjobcontract_api3_create_revision($jobContractId)
             'status' => 0,
         ));
     }*/
-    
+
     //$currentRevision = _civicrm_hrjobcontract_api3_get_latest_revision((int)$jobContractId);
     $currentRevision = _civicrm_hrjobcontract_api3_get_current_revision(array('jobcontract_id' => (int)$jobContractId));
     if (empty($currentRevision))
@@ -87,17 +87,17 @@ function _civicrm_hrjobcontract_api3_create_revision($jobContractId)
     }
     //$currentRevision['values']['status'] = 1; // TODO: status
     $result = civicrm_api3('HRJobContractRevision', 'create', $currentRevision['values']);
-    
+
     return $result;
 }
 
 /**
  * Returns current revision. If current revision is for a past contract, and its
  * terms are changed by future revisions, it will return the latest revision.
- * 
+ *
  * @param array $params
  *   Parameter array passed by API call
- * 
+ *
  * @return mixed
  *   Returns either:
  *   - Array with contents of revision if one is found
@@ -118,16 +118,20 @@ function _civicrm_hrjobcontract_api3_get_current_revision($params) {
         'id', 'details_revision_id.id', 'jobcontract_id', 'editor_uid',
         'created_date', 'effective_date', 'effective_end_date', 'modified_date',
         'details_revision_id', 'health_revision_id', 'hour_revision_id',
-        'leave_revision_id', 'pay_revision_id', 'pension_revision_id', 
-        'role_revision_id', 'deleted', 'editor_name', 
+        'leave_revision_id', 'pay_revision_id', 'pension_revision_id',
+        'role_revision_id', 'deleted', 'editor_name',
         'details_revision_id.period_end_date'
       ],
     ]);
-    $contractEnd = $revision['values'][0]['details_revision_id.period_end_date'];
-    $revisionEndDate = $revision['values'][0]['effective_end_date'];
+
+    $first = isset($revision['values'][0]) ? $revision['values'][0] : NULL;
+    if ($first) {
+      $contractEnd = CRM_Utils_Array::value('details_revision_id.period_end_date', $first);
+      $revisionEndDate = CRM_Utils_Array::value('effective_end_date', $first);
+    }
 
     if (
-      empty($revision['values']) 
+      empty($revision['values'])
       || (!empty($revisionEndDate) && !empty($contractEnd) && strtotime($contractEnd) <= time())
     ) {
       $revision = civicrm_api3('HRJobContractRevision', 'get', array(
@@ -197,7 +201,7 @@ function _civicrm_hrjobcontract_api3_custom_get($bao_name, &$params, $returnAsSu
 {
     $bao = new $bao_name();
     $callbacks = array();
-    
+
     $fields = $bao::fields();
     foreach ($fields as $field)
     {
@@ -352,7 +356,7 @@ function _civicrm_hrjobcontract_api3_deletecontract($params) {
     {
         throw new Exception("Cannot find Job Contract with given id (" . $params['id'] . ").");
     }
-    
+
     $revisions = civicrm_api('HRJobContractRevision', 'get', array('sequential' => 1, 'options' => array('limit' => 0), 'version' => 3, 'jobcontract_id' => $params['id']));
     foreach ($revisions['values'] as $revision)
     {
@@ -360,7 +364,7 @@ function _civicrm_hrjobcontract_api3_deletecontract($params) {
     }
     civicrm_api3('HRJobContract', 'create', array('version' => 3, 'id' => $contract['id'], 'deleted' => 1));
     CRM_Hrjobcontract_JobContractDates::removeDates($contract['id']);
-    
+
     return 1;
   }
   catch(PEAR_Exception $e) {


### PR DESCRIPTION
## Problem

When importing job roles the logic should be that if the role start / end are not set then use the related contract start / end. However currently for imports with no role start / end dates the dates are undefined after import.

This is caused by improper formatting of the existing contract dates, which is done by `CRM_Utils_Date::formatDate`. It takes a $dateType argument which refers to the format of the date being passed in. Currently we are using the $dateType the user selects for their import file. However, for the existing contract dates we do not want to use this. We should use the $dateType that matches the format of dates stored in the database, i.e. YYYY-mm-dd.

## Solution

Change the formatting of the contract dates to use the correct $dateType.

## Notes
- I encountered some undefined errors during the test import. I think it's important that we fix these warnings and I would recommend all developers to have the same php.ini settings for error reporting
- I'm using type-hinting, for example on [this line](https://github.com/civicrm/civihr/compare/PCHR-2085-use-contract-date-for-role-import?expand=1#diff-0b10d27247ff6ffc7bfc5598a88c589cR150). I prefer not to have any warnings in my code, but I'm open to discussion on this.
- My IDE is trimming whitespace in files ever since I enabled the editorconfig plugin. I know it's annoying to have these extra changes to look at. If people are doing things different normally just tell me and I'll try to turn it off.
- I didn't find any documentation on the $dateType and to be honest, it's a mess looking at their functions. If you know where I can find documentation on this please let me know.
