### PR TITLE
PCHR-2049: Hide the delete option/button on the Absence Type list and edit form for an Absence Type that cannot be deleted/

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_HRLeaveAndAbsences_Service_AbsenceType as AbsenceTypeService;
+
 require_once 'CRM/Core/Form.php';
 
 /**
@@ -39,6 +41,7 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form
         $this->addFieldsRules();
 
         $this->addButtons($this->getAvailableButtons());
+        $this->assign('canDeleteType', $this->canDelete());
         $this->assign('deleteUrl', $this->getDeleteUrl());
         $this->assign('availableColors', json_encode(CRM_HRLeaveAndAbsences_BAO_AbsenceType::getAvailableColors()));
 
@@ -306,5 +309,15 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form
             null,
             false
         );
+    }
+
+    /**
+     * Checks whether an AbsenceType object can be deleted.
+     *
+     * @return bool
+     */
+    private function canDelete() {
+      $absenceTypeService = new AbsenceTypeService();
+      return !$absenceTypeService->absenceTypeHasEverBeenUsed($this->_id);
     }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/AbsenceType.php
@@ -1,11 +1,19 @@
 <?php
 
+use CRM_HRLeaveAndAbsences_Service_AbsenceType as AbsenceTypeService;
+
 class CRM_HRLeaveAndAbsences_Page_AbsenceType extends CRM_Core_Page_Basic {
 
   private $links = array();
 
+  /**
+   * @var \CRM_HRLeaveAndAbsences_Service_AbsenceType
+   */
+  private $absenceTypeService;
+
   public function run() {
     CRM_Utils_System::setTitle(ts('Leave/Absence Types'));
+    $this->absenceTypeService = new AbsenceTypeService();
     parent::run();
   }
 
@@ -141,7 +149,7 @@ class CRM_HRLeaveAndAbsences_Page_AbsenceType extends CRM_Core_Page_Basic {
   private function calculateLinksMask($absenceType) {
     $mask = array_sum(array_keys($this->links()));
 
-    if($absenceType->is_reserved) {
+    if($this->canNotDelete($absenceType)) {
       $mask -= CRM_Core_Action::DELETE;
     }
 
@@ -156,5 +164,17 @@ class CRM_HRLeaveAndAbsences_Page_AbsenceType extends CRM_Core_Page_Basic {
     }
 
     return $mask;
+  }
+
+  /**
+   * Checks whether an AbsenceType object cannot be deleted.
+   *
+   * @param CRM_HRLeaveAndAbsences_BAO_AbsenceType $absenceType
+   *
+   * @return bool
+   */
+  private function canNotDelete($absenceType) {
+    return $this->absenceTypeService->absenceTypeHasEverBeenUsed($absenceType->id)
+           || $absenceType->is_reserved;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
@@ -254,16 +254,28 @@
 
                 function initDeleteButton() {
                     $('.crm-button-type-delete').on('click', function(e) {
-                        e.preventDefault();
-                        CRM.confirm({
+                      e.preventDefault();
+                      {/literal}
+                      {if $canDeleteType}
+                      {literal}
+                          CRM.confirm({
                             title: ts('Delete Leave/Absence type'),
                             message: ts('Are you sure you want to delete this leave/absence type?'),
                             options: {
-                                yes: ts('Yes'),
-                                no: ts('No')
+                              yes: ts('Yes'),
+                              no: ts('No')
                             }
-                        })
-                        .on('crmConfirm:yes', deleteCallback);
+                          })
+                          .on('crmConfirm:yes', deleteCallback);
+                      {/literal}
+                      {else}
+                      {literal}
+                          CRM.alert("This leave/absence type is in use and cannot be deleted. Please disable it instead.",
+                                    'Delete Leave/Absence type', 'error');
+                      {/literal}
+                      {/if}
+                      {literal}
+
                     });
                 }
 


### PR DESCRIPTION
This PR hides the delete option on the Absence Type listing page for an Absence Type that cannot be deleted(either a used or reserved absence type) . For used Absence Types(  [#1662](https://github.com/civicrm/civihr/pull/1662)), the delete button is shown on the edit form but when the button is clicked it displays an error message that the absence type should be disabled and can't be deleted.


![leave-absence types - civihr 1 6 demo 2017-03-22 19-20-07](https://cloud.githubusercontent.com/assets/6951813/24214423/bfe1fc34-0f35-11e7-98d7-3d557554eb80.png)

**Screenshot when trying to delete a used absence type on the edit form:**

![leave-absence types - civihr 1 6 demo 2017-03-22 19-21-13](https://cloud.githubusercontent.com/assets/6951813/24214450/d32a52b4-0f35-11e7-8182-cd029141a838.png)

