### PR TITLE
PCHR-1195: Modify the Creation Logic For Public Holidays Leave Request.

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/PublicHolidayLeaveRequestService.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/PublicHolidayLeaveRequestService.php
@@ -2,6 +2,7 @@
 
 use CRM_HRLeaveAndAbsences_Service_JobContract as JobContractService;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest as PublicHolidayLeaveRequestService;
+use CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange as LeaveBalanceChangeService;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation as PublicHolidayLeaveRequestCreation;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion as PublicHolidayLeaveRequestDeletion;
 
@@ -19,7 +20,8 @@ class CRM_HRLeaveAndAbsences_Factory_PublicHolidayLeaveRequestService {
    */
   public static function create() {
     $jobContractService = new JobContractService();
-    $creationLogic = new PublicHolidayLeaveRequestCreation($jobContractService);
+    $leaveBalanceChangeService = new LeaveBalanceChangeService();
+    $creationLogic = new PublicHolidayLeaveRequestCreation($jobContractService, $leaveBalanceChangeService);
     $deletionLogic = new PublicHolidayLeaveRequestDeletion($jobContractService);
 
     return new PublicHolidayLeaveRequestService($creationLogic, $deletionLogic);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChange.php
@@ -108,6 +108,6 @@ class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange {
    * @return float
    */
   public function calculateAmountToBeDeductedForDate(LeaveRequest $leaveRequest, DateTime $date) {
-    return LeaveBalanceChange::calculateAmountForDate($leaveRequest, new DateTime($date));
+    return LeaveBalanceChange::calculateAmountForDate($leaveRequest, $date);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChange.php
@@ -95,4 +95,19 @@ class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange {
   public function recalculateExpiredBalanceChangesForLeaveRequestPastDates(LeaveRequest $leaveRequest) {
     LeaveBalanceChange::recalculateExpiredBalanceChangesForLeaveRequestPastDates($leaveRequest);
   }
+
+  /**
+   * This method uses calculateAmountForDate method of LeaveBalanceChange BAO to
+   * calculates the amount to be deducted for a leave taken by the given contact
+   * on the given date.
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_LeaveRequest $leaveRequest
+   *  The LeaveRequest which the $date belongs to
+   * @param \DateTime $date
+   *
+   * @return float
+   */
+  public function calculateAmountToBeDeductedForDate(LeaveRequest $leaveRequest, DateTime $date) {
+    return LeaveBalanceChange::calculateAmountForDate($leaveRequest, new DateTime($date));
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/PublicHolidayLeaveRequest.php
@@ -8,7 +8,6 @@ use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation as PublicHo
 class CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest {
 
   use CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait;
-  use CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait;
 
   /**
    * This Fabricator is a bit different than the others, because a Public Holiday

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/PublicHolidayLeaveRequest.php
@@ -2,14 +2,13 @@
 
 use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
 use CRM_HRLeaveAndAbsences_Service_JobContract as JobContractService;
+use CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange as LeaveBalanceChangeService;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation as PublicHolidayLeaveRequestCreation;
-use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
-use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
-use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange as LeaveBalanceChangeFabricator;
 
 class CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest {
 
   use CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait;
+  use CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait;
 
   /**
    * This Fabricator is a bit different than the others, because a Public Holiday
@@ -22,8 +21,13 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest {
    * @param int $contactID
    * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
    */
-  public static function fabricate($contactID, PublicHoliday $publicHoliday) {
-    $creationLogic = new PublicHolidayLeaveRequestCreation(new JobContractService());
+  public static function fabricate($contactID, PublicHoliday $publicHoliday, $mockBalanceChangeService = null) {
+    $leaveBalanceChangeService = new LeaveBalanceChangeService();
+
+    if ($mockBalanceChangeService) {
+      $leaveBalanceChangeService = $mockBalanceChangeService;
+    }
+    $creationLogic = new PublicHolidayLeaveRequestCreation(new JobContractService(), $leaveBalanceChangeService);
     $creationLogic->createForContact($contactID, $publicHoliday);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -646,7 +646,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('Y-m-d', strtotime('+30 days'));
-    PublicHolidayLeaveRequestFabricator::fabricate($entitlement->contact_id, $publicHoliday);
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($entitlement->contact_id, $publicHoliday);
 
     // Balance excluding the days deducted from the leave request
     $excludePublicHolidays = true;
@@ -675,11 +675,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
     $publicHoliday1 = new PublicHoliday();
     $publicHoliday1->date = date('Y-m-d', strtotime('+30 days'));
-    PublicHolidayLeaveRequestFabricator::fabricate($entitlement->contact_id, $publicHoliday1);
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($entitlement->contact_id, $publicHoliday1);
 
     $publicHoliday2 = new PublicHoliday();
     $publicHoliday2->date = date('Y-m-d', strtotime('+47 days'));
-    PublicHolidayLeaveRequestFabricator::fabricate($entitlement->contact_id, $publicHoliday2);
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($entitlement->contact_id, $publicHoliday2);
 
     // Balance excluding the days deducted from the leave request
     $includePublicHolidaysOnly = true;
@@ -715,7 +715,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
     $publicHoliday1 = new PublicHoliday();
     $publicHoliday1->date = date('Y-m-d', strtotime('+30 days'));
-    PublicHolidayLeaveRequestFabricator::fabricate($entitlement->contact_id, $publicHoliday1);
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($entitlement->contact_id, $publicHoliday1);
 
     // Balance excluding the days deducted from the leave request
     $excludePublicHolidays = true;
@@ -2422,7 +2422,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'effective_date' => $periodStartDate->format('YmdHis')
     ]);
 
-    //create a public holidays on on of the days
+    //create a public holiday on a working day ('2016-08-04'), thursday of second week
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('2016-08-04');
     PublicHolidayLeaveRequestFabricator::fabricate($contract['contact_id'], $publicHoliday);
@@ -2472,6 +2472,46 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'effective_date' => $periodStartDate->format('YmdHis')
     ]);
 
+    //create a public holiday on a working day ('2016-08-03')
+    $publicHoliday = new PublicHoliday();
+    $publicHoliday->date = date('2016-08-03');
+    PublicHolidayLeaveRequestFabricator::fabricate($contract['contact_id'], $publicHoliday);
+
+    $leaveRequest = new LeaveRequest();
+    $leaveRequest->contact_id = $contract['contact_id'];
+
+    //(2016-07-29) is a friday and a working day
+    $amount = LeaveBalanceChange::calculateAmountForDate($leaveRequest, new DateTime('2016-07-29'));
+    $this->assertEquals(-1, $amount);
+
+    //(2016-07-31) is a Sunday  and a non-working day
+    $amount = LeaveBalanceChange::calculateAmountForDate($leaveRequest, new DateTime('2016-07-31'));
+    $this->assertEquals(0, $amount);
+
+    //(2016-08-01) is a monday and a working day
+    $amount = LeaveBalanceChange::calculateAmountForDate($leaveRequest, new DateTime('2016-08-01'));
+    $this->assertEquals(-1, $amount);
+
+    //(2016-08-02) is a tuesday which is a working day.
+    $amount = LeaveBalanceChange::calculateAmountForDate($leaveRequest, new DateTime('2016-08-02'));
+    $this->assertEquals(-1, $amount);
+
+    //(2016-08-03) is a Wednesday which is  a working day but a public holiday was created on this date
+    $amount = LeaveBalanceChange::calculateAmountForDate($leaveRequest, new DateTime('2016-08-03'));
+    $this->assertEquals(0, $amount);
+  }
+
+  public function testCalculateAmountForDateForAContactUsingTheDefaultWorkPattern() {
+    $periodStartDate = new DateTime('2016-01-01');
+
+    $contract = HRJobContractFabricator::fabricate(
+      [ 'contact_id' => 1 ],
+      [ 'period_start_date' => $periodStartDate->format('Y-m-d') ]
+    );
+
+    // Working days: monday through friday
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
+
     //create a public holidays on on of the days
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('2016-08-03');
@@ -2480,23 +2520,23 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $leaveRequest = new LeaveRequest();
     $leaveRequest->contact_id = $contract['contact_id'];
 
-    //2016-07-29 is a friday and a working day
+    //(2016-07-29) is a friday and a working day
     $amount = LeaveBalanceChange::calculateAmountForDate($leaveRequest, new DateTime('2016-07-29'));
     $this->assertEquals(-1, $amount);
 
-    //2016-07-31 is a Sunday  and a non-working day
+    //(2016-07-31) is a Sunday and a non-working day
     $amount = LeaveBalanceChange::calculateAmountForDate($leaveRequest, new DateTime('2016-07-31'));
     $this->assertEquals(0, $amount);
 
-    // (2016-08-01) is a the monday and a working day
+    //(2016-08-01) is a monday and a working day
     $amount = LeaveBalanceChange::calculateAmountForDate($leaveRequest, new DateTime('2016-08-01'));
     $this->assertEquals(-1, $amount);
 
-    // (2016-08-02) is a tuesday which is a working day.
+    //(2016-08-02) is a tuesday which is a working day.
     $amount = LeaveBalanceChange::calculateAmountForDate($leaveRequest, new DateTime('2016-08-02'));
     $this->assertEquals(-1, $amount);
 
-    //(2016-08-03) is a Wednesday which is  a working day but a public holiday was created form this date
+    //(2016-08-03) is a Wednesday which is a working day but a public holiday was created on this date
     $amount = LeaveBalanceChange::calculateAmountForDate($leaveRequest, new DateTime('2016-08-03'));
     $this->assertEquals(0, $amount);
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
@@ -22,6 +22,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
   use CRM_HRLeaveAndAbsences_ContractHelpersTrait;
   use CRM_HRLeaveAndAbsences_LeavePeriodEntitlementHelpersTrait;
+  use CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait;
 
   /**
    * @var CRM_HRLeaveAndAbsences_BAO_AbsenceType
@@ -49,7 +50,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     $publicHoliday = $this->instantiatePublicHoliday('2016-01-01');
 
-    PublicHolidayLeaveRequestFabricator::fabricate($periodEntitlement->contact_id, $publicHoliday);
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($periodEntitlement->contact_id, $publicHoliday);
 
     $this->assertEquals(-1, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
 
@@ -115,9 +116,9 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     $publicHoliday3 = PublicHolidayFabricator::fabricateWithoutValidation([
       'date' => CRM_Utils_Date::processDate('+2 years')
     ]);
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday1);
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday2);
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday3);
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact['id'], $publicHoliday1);
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact['id'], $publicHoliday2);
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact['id'], $publicHoliday3);
 
     $this->assertEquals(-3, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
 
@@ -158,9 +159,9 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     // The Fabricator will create the leave request even for public holidays in
     // the past
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday1);
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday2);
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday3);
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact['id'], $publicHoliday1);
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact['id'], $publicHoliday2);
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact['id'], $publicHoliday3);
 
     $this->assertEquals(-3, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
 
@@ -201,9 +202,9 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     // The Fabricator will create the leave request even for public holidays in
     // the past
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday1);
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday2);
-    PublicHolidayLeaveRequestFabricator::fabricate($contact['id'], $publicHoliday3);
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact['id'], $publicHoliday1);
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact['id'], $publicHoliday2);
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact['id'], $publicHoliday3);
 
     $this->assertEquals(-3, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -259,7 +259,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('Y-m-d', strtotime('+40 days'));
 
-    PublicHolidayLeaveRequestFabricator::fabricate($periodEntitlement->contact_id, $publicHoliday);
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($periodEntitlement->contact_id, $publicHoliday);
 
     // Passing the public_holiday param, it will sum the balance only for the
     // public holidays

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
@@ -3,8 +3,10 @@
 use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
+use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange as LeaveBalanceChangeFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest as PublicHolidayLeaveRequestFabricator;
 
 trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
 
@@ -227,5 +229,31 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
       ->method('createForLeaveRequest');
 
     return $leaveBalanceChangeService;
+  }
+
+  public function createLeaveBalanceChangeServiceForPublicHolidayLeaveRequestMock() {
+    $leaveBalanceChangeService = $this->getMockBuilder(CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange::class)
+      ->setMethods(['calculateAmountToBeDeductedForDate'])
+      ->getMock();
+
+    $leaveBalanceChangeService->expects($this->any())
+      ->method('calculateAmountToBeDeductedForDate')
+      ->will($this->returnValue(-1));
+
+    return $leaveBalanceChangeService;
+  }
+
+  /**
+   * Fabricates a Public Holiday leave request with the balance change amount as -1
+   * Without this method, most of the tests will need to have a work pattern assigned to
+   * the contact or have a default work pattern and will need to be mindful of which day is a
+   * working day or not for the public holiday balance change to be successfully created.
+   *
+   * @param int$contactID
+   * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
+   */
+  public function fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contactID, PublicHoliday $publicHoliday) {
+    $balanceChangeServiceMock = $this->createLeaveBalanceChangeServiceForPublicHolidayLeaveRequestMock();
+    PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday, $balanceChangeServiceMock);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
@@ -249,7 +249,7 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
    * the contact or have a default work pattern and will need to be mindful of which day is a
    * working day or not for the public holiday balance change to be successfully created.
    *
-   * @param int$contactID
+   * @param int $contactID
    * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
    */
   public function fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contactID, PublicHoliday $publicHoliday) {


### PR DESCRIPTION
This PR makes some modifications to the way the balance change for a public holiday is created when creating a public holiday leave request using the Public Holiday Leave Request creation service. 

**Before:**
The calculation for the number of days to be deducted for a public holiday is always -1 day.

**Now:**
Instead of always deducting -1 day, it  deducts the amount specified by the Work Pattern of the contact (which could either be the default work pattern or the work pattern assigned to the contact effective for the public holiday date).