### PR TITLE
PCHR-2081: Add non-EEA joining timeline

### DIFF
--- a/hrcase/CRM/HRCase/DefaultCaseAndActivityTypes.php
+++ b/hrcase/CRM/HRCase/DefaultCaseAndActivityTypes.php
@@ -1,9 +1,10 @@
 <?php
-// This file declares a managed database record of type "CaseType" and "OptionValue".
-// The record will be automatically inserted, updated, or deleted from the
-// database as appropriate. For more details, see "hook_civicrm_managed" at:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/Hook+Reference
-
+/**
+ * This file declares a managed database record of type "CaseType" and "OptionValue".
+ * The record will be automatically inserted, updated, or deleted from the
+ * database as appropriate. For more details, see "hook_civicrm_managed" at:
+ * http://wiki.civicrm.org/confluence/display/CRMDOC/Hook+Reference
+ */
 class CRM_HRCase_DefaultCaseAndActivityTypes {
 
   private static $defaultActivityTypes = [
@@ -46,7 +47,7 @@ class CRM_HRCase_DefaultCaseAndActivityTypes {
 
           'activitySets' => [
             [
-              'name'   => 'standard_timeline',
+              'name' => 'standard_timeline',
               'label' => 'Standard Timeline',
               'timeline' => 1,
               'activityTypes' => [
@@ -54,30 +55,35 @@ class CRM_HRCase_DefaultCaseAndActivityTypes {
                   'name' => 'Schedule Exit Interview',
                   'reference_offset' => -10,
                   'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
                   'reference_select' => 'newest'
                 ],
                 [
                   'name' => 'Get "No Dues" certification',
                   'reference_offset' => -7,
                   'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
                   'reference_select' => 'newest'
                 ],
                 [
                   'name' => 'Conduct Exit Interview',
                   'reference_offset' => -3,
                   'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
                   'reference_select' => 'newest'
                 ],
                 [
                   'name' => 'Revoke Access to Database',
                   'reference_offset' => 0,
                   'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
                   'reference_select' => 'newest'
                 ],
                 [
                   'name' => 'Block work email ID',
                   'reference_offset' => 0,
                   'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
                   'reference_select' => 'newest'
                 ]
               ]
@@ -114,7 +120,7 @@ class CRM_HRCase_DefaultCaseAndActivityTypes {
 
           'activitySets' => [
             [
-              'name'   => 'standard_timeline',
+              'name' => 'standard_timeline',
               'label' => 'Standard Timeline',
               'timeline' => 1,
               'activityTypes' => [
@@ -122,56 +128,171 @@ class CRM_HRCase_DefaultCaseAndActivityTypes {
                   'name' => 'Schedule joining date',
                   'reference_offset' => -10,
                   'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
                   'reference_select' => 'newest'
                 ],
                 [
                   'name' => 'Issue appointment letter',
                   'reference_offset' => -10,
                   'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
                   'reference_select' => 'newest'
                 ],
                 [
                   'name' => 'Fill Employee Details Form',
                   'reference_offset' => -10,
                   'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
                   'reference_select' => 'newest'
                 ],
                 [
                   'name' => 'Submission of ID/Residence proofs and photos',
                   'reference_offset' => -10,
                   'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
                   'reference_select' => 'newest'
                 ],
                 [
                   'name' => 'Enter employee data in CiviHR',
                   'reference_offset' => -7,
                   'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
                   'reference_select' => 'newest'
                 ],
                 [
                   'name' => 'Program and work induction by program supervisor',
                   'reference_offset' => -10,
                   'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
                   'reference_select' => 'newest'
                 ],
                 [
                   'name' => 'Group Orientation to organization, values, policies',
                   'reference_offset' => 7,
                   'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
                   'reference_select' => 'newest'
                 ],
                 [
                   'name' => 'Confirm End of Probation Date',
                   'reference_offset' => 30,
                   'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
                   'reference_select' => 'newest'
                 ],
                 [
                   'name' => 'Start Probation workflow',
                   'reference_offset' => 30,
                   'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
                   'reference_select' => 'newest'
-                ]
+                ],
+                [
+                  'name' => 'P45',
+                  'reference_offset' => -10,
+                  'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
+                  'reference_select' => 'newest'
+                ],
+                [
+                  'name' => 'Passport',
+                  'reference_offset' => -10,
+                  'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
+                  'reference_select' => 'newest'
+                ],
+              ]
+            ],
+
+            [
+              'name' => 'non_eea_timeline',
+              'label' => 'Non EEA Staff Member Timeline',
+              'timeline' => 2,
+              'activityTypes' => [
+                [
+                  'name' => 'Schedule joining date',
+                  'reference_offset' => -10,
+                  'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
+                  'reference_select' => 'newest'
+                ],
+                [
+                  'name' => 'Issue appointment letter',
+                  'reference_offset' => -10,
+                  'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
+                  'reference_select' => 'newest'
+                ],
+                [
+                  'name' => 'Fill Employee Details Form',
+                  'reference_offset' => -10,
+                  'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
+                  'reference_select' => 'newest'
+                ],
+                [
+                  'name' => 'Submission of ID/Residence proofs and photos',
+                  'reference_offset' => -10,
+                  'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
+                  'reference_select' => 'newest'
+                ],
+                [
+                  'name' => 'Enter employee data in CiviHR',
+                  'reference_offset' => -7,
+                  'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
+                  'reference_select' => 'newest'
+                ],
+                [
+                  'name' => 'Program and work induction by program supervisor',
+                  'reference_offset' => -10,
+                  'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
+                  'reference_select' => 'newest'
+                ],
+                [
+                  'name' => 'Group Orientation to organization, values, policies',
+                  'reference_offset' => 7,
+                  'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
+                  'reference_select' => 'newest'
+                ],
+                [
+                  'name' => 'Confirm End of Probation Date',
+                  'reference_offset' => 30,
+                  'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
+                  'reference_select' => 'newest'
+                ],
+                [
+                  'name' => 'Start Probation workflow',
+                  'reference_offset' => 30,
+                  'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
+                  'reference_select' => 'newest'
+                ],
+                [
+                  'name' => 'P45',
+                  'reference_offset' => -10,
+                  'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
+                  'reference_select' => 'newest'
+                ],
+                [
+                  'name' => 'Passport',
+                  'reference_offset' => -10,
+                  'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
+                  'reference_select' => 'newest'
+                ],
+                [
+                  'name' => 'Visa',
+                  'reference_offset' => -10,
+                  'reference_activity' => 'Open Case',
+                  'status' => 'Scheduled',
+                  'reference_select' => 'newest'
+                ],
               ]
             ]
           ],

--- a/hrcase/CRM/HRCase/DefaultCaseAndActivityTypes.php
+++ b/hrcase/CRM/HRCase/DefaultCaseAndActivityTypes.php
@@ -8,23 +8,34 @@
 class CRM_HRCase_DefaultCaseAndActivityTypes {
 
   private static $defaultActivityTypes = [
-    'Schedule Exit Interview',
-    'Get "No Dues" certification',
-    'Conduct Exit Interview',
-    'Revoke Access to Database',
-    'Block work email ID',
-    'Background Check',
-    'References Check',
-    'Schedule joining date',
-    'Issue appointment letter',
-    'Fill Employee Details Form',
-    'Submission of ID/Residence proofs and photos',
-    'Program and work induction by program supervisor',
-    'Enter employee data in CiviHR',
-    'Group Orientation to organization, values, policies',
-    'Probation appraisal (start probation workflow)',
-    'Confirm End of Probation Date',
-    'Start Probation workflow'
+    'CiviTask' => [
+      'Schedule Exit Interview',
+      'Get "No Dues" certification',
+      'Conduct Exit Interview',
+      'Revoke Access to Database',
+      'Block work email ID',
+      'Background Check',
+      'References Check',
+      'Schedule joining date',
+      'Issue appointment letter',
+      'Fill Employee Details Form',
+      'Submission of ID/Residence proofs and photos',
+      'Program and work induction by program supervisor',
+      'Enter employee data in CiviHR',
+      'Group Orientation to organization, values, policies',
+      'Probation appraisal (start probation workflow)',
+      'Confirm End of Probation Date',
+      'Start Probation workflow',
+    ],
+    'CiviDocument' => [
+      'Government Photo ID',
+      'Driving licence',
+      'Identity card',
+      'Certificate of sponsorship (COS)',
+      'P45',
+      'Passport',
+      'VISA',
+    ]
   ];
 
   private static $defaultCaseTypes = [

--- a/hrcase/CRM/HRCase/DefaultCaseAndActivityTypes.php
+++ b/hrcase/CRM/HRCase/DefaultCaseAndActivityTypes.php
@@ -287,7 +287,7 @@ class CRM_HRCase_DefaultCaseAndActivityTypes {
                   'reference_select' => 'newest'
                 ],
                 [
-                  'name' => 'Visa',
+                  'name' => 'VISA',
                   'reference_offset' => -10,
                   'reference_activity' => 'Open Case',
                   'status' => 'Scheduled',

--- a/hrcase/CRM/HRCase/Upgrader.php
+++ b/hrcase/CRM/HRCase/Upgrader.php
@@ -116,9 +116,22 @@ class CRM_HRCase_Upgrader extends CRM_HRCase_Upgrader_Base {
     $this->up1402_removeUnusedCaseTypes();
     //Removes CiviCase activity types which should belong to CiviTask component
     $this->removeActivityTypesList($defaultActivityTypes, 'CiviCase');
-    $this->up1402_createDefaultCaseTypes($defaultCaseTypes);
+    $this->createOrUpdateDefaultCaseTypes($defaultCaseTypes);
     $this->up1402_createDefaultActivityTypes($defaultActivityTypes);
     $this->changeActivityTypeComponent('Open Case', 'CiviCase', 'CiviTask');
+
+    return TRUE;
+  }
+
+  /**
+   * Resets all default case types discarding any customization to match new
+   * activity workflow
+   *
+   * will be 1404
+   */
+  public function upgrade_1412() {
+    $defaultTypes = CRM_HRCase_DefaultCaseAndActivityTypes::getDefaultCaseTypes();
+    $this->createOrUpdateDefaultCaseTypes($defaultTypes);
 
     return TRUE;
   }
@@ -329,10 +342,12 @@ class CRM_HRCase_Upgrader extends CRM_HRCase_Upgrader_Base {
    * Creates/Updates default case types to be shipped
    * with this extension
    *
+   * WARNING: Resets activity types for an assignment, discarding customization
+   *
    * @param array $defaultCaseTypes
    *   A list of case types with their related data
    */
-  private function up1402_createDefaultCaseTypes($defaultCaseTypes) {
+  private function createOrUpdateDefaultCaseTypes($defaultCaseTypes) {
     foreach ($defaultCaseTypes as $caseType) {
       $type = civicrm_api3('CaseType', 'get', [
         'sequential' => 1,

--- a/hrcase/CRM/HRCase/Upgrader.php
+++ b/hrcase/CRM/HRCase/Upgrader.php
@@ -126,10 +126,8 @@ class CRM_HRCase_Upgrader extends CRM_HRCase_Upgrader_Base {
   /**
    * Resets all default case types discarding any customization to match new
    * activity workflow
-   *
-   * will be 1404
    */
-  public function upgrade_1412() {
+  public function upgrade_1404() {
     $defaultTypes = CRM_HRCase_DefaultCaseAndActivityTypes::getDefaultCaseTypes();
     $this->createOrUpdateDefaultCaseTypes($defaultTypes);
 

--- a/hrcase/CRM/HRCase/Upgrader.php
+++ b/hrcase/CRM/HRCase/Upgrader.php
@@ -32,23 +32,23 @@ class CRM_HRCase_Upgrader extends CRM_HRCase_Upgrader_Base {
   public function uninstall() {
     self::activityTypesWordReplacement(true);
     self::removeRelationshipTypes();
-    self::removeCaseTypesWithData(array_column(CRM_HRCase_DefaultCaseAndActivityTypes::getDefaultCaseTypes(), 'name'));
-    $this->removeActivityTypesList(CRM_HRCase_DefaultCaseAndActivityTypes::getDefaultActivityTypes(), 'CiviTask');
+    self::removeCaseTypesWithData(array_column(DefaultCaseAndActivityTypes::getDefaultCaseTypes(), 'name'));
+    $this->removeActivityTypesList(DefaultCaseAndActivityTypes::getDefaultActivityTypes(), 'CiviTask');
   }
 
   public function enable() {
     self::toggleRelationshipTypes(1);
-    self::toggleCaseTypes(array_column(CRM_HRCase_DefaultCaseAndActivityTypes::getDefaultCaseTypes(), 'name'), 1);
-    self::toggleCaseTypes(CRM_HRCase_DefaultCaseAndActivityTypes::getDefaultCiviCRMCaseTypes(), 0);
-    self::toggleActivityTypes(CRM_HRCase_DefaultCaseAndActivityTypes::getDefaultActivityTypes(), 1);
+    self::toggleCaseTypes(array_column(DefaultCaseAndActivityTypes::getDefaultCaseTypes(), 'name'), 1);
+    self::toggleCaseTypes(DefaultCaseAndActivityTypes::getDefaultCiviCRMCaseTypes(), 0);
+    self::toggleActivityTypes(DefaultCaseAndActivityTypes::getDefaultActivityTypes(), 1);
     $this->changeActivityTypeComponent('Open Case', 'CiviCase', 'CiviTask');
   }
 
   public function disable() {
     self::toggleRelationshipTypes(0);
-    self::toggleCaseTypes(array_column(CRM_HRCase_DefaultCaseAndActivityTypes::getDefaultCaseTypes(), 'name'), 0);
-    self::toggleCaseTypes(CRM_HRCase_DefaultCaseAndActivityTypes::getDefaultCiviCRMCaseTypes(), 1);
-    self::toggleActivityTypes(CRM_HRCase_DefaultCaseAndActivityTypes::getDefaultActivityTypes(), 0);
+    self::toggleCaseTypes(array_column(DefaultCaseAndActivityTypes::getDefaultCaseTypes(), 'name'), 0);
+    self::toggleCaseTypes(DefaultCaseAndActivityTypes::getDefaultCiviCRMCaseTypes(), 1);
+    self::toggleActivityTypes(DefaultCaseAndActivityTypes::getDefaultActivityTypes(), 0);
     $this->changeActivityTypeComponent('Open Case', 'CiviTask', 'CiviCase');
   }
 
@@ -111,15 +111,15 @@ class CRM_HRCase_Upgrader extends CRM_HRCase_Upgrader_Base {
    * @return bool
    */
   public function upgrade_1402() {
-    $defaultCaseTypes = CRM_HRCase_DefaultCaseAndActivityTypes::getDefaultCaseTypes();
-    $defaultActivityTypes = CRM_HRCase_DefaultCaseAndActivityTypes::getDefaultActivityTypes();
+    $defaultCaseTypes = DefaultCaseAndActivityTypes::getDefaultCaseTypes();
+    $defaultActivityTypes = DefaultCaseAndActivityTypes::getDefaultActivityTypes();
 
     $this->up1402_removedUnusedManagedEntities(array_column($defaultCaseTypes, 'name'), $defaultActivityTypes);
     $this->up1402_removeUnusedCaseTypes();
     //Removes CiviCase activity types which should belong to CiviTask component
     $this->removeActivityTypesList($defaultActivityTypes, 'CiviCase');
     $this->createOrUpdateDefaultCaseTypes($defaultCaseTypes);
-    $this->createOrUpdateActivityTypes($defaultActivityTypes);
+    $this->createActivityTypes($defaultActivityTypes);
     $this->changeActivityTypeComponent('Open Case', 'CiviCase', 'CiviTask');
 
     return TRUE;
@@ -132,7 +132,7 @@ class CRM_HRCase_Upgrader extends CRM_HRCase_Upgrader_Base {
   public function upgrade_1429() {
     $defaultActivityTypes = DefaultCaseAndActivityTypes::getDefaultActivityTypes();
     $defaultCaseTypes = DefaultCaseAndActivityTypes::getDefaultCaseTypes();
-    $this->createOrUpdateActivityTypes($defaultActivityTypes);
+    $this->createActivityTypes($defaultActivityTypes);
     $this->createOrUpdateDefaultCaseTypes($defaultCaseTypes);
 
     return TRUE;
@@ -298,6 +298,7 @@ class CRM_HRCase_Upgrader extends CRM_HRCase_Upgrader_Base {
     foreach ($activityTypes as $componentActivities) {
       $allActivityTypes = array_merge($allActivityTypes, $componentActivities);
     }
+
     civicrm_api3('OptionValue', 'get', [
           'name' => ['IN' => $allActivityTypes],
           'component_id' => $componentName,
@@ -378,7 +379,7 @@ class CRM_HRCase_Upgrader extends CRM_HRCase_Upgrader_Base {
    * @param array $defaultActivityTypes
    *   A list of activity types grouped by component name
    */
-  private function createOrUpdateActivityTypes($defaultActivityTypes) {
+  private function createActivityTypes($defaultActivityTypes) {
     foreach ($defaultActivityTypes as $componentName => $componentActivities) {
       foreach ($componentActivities as $activityType) {
         $type = civicrm_api3('OptionValue', 'get', [


### PR DESCRIPTION
## Problem

- The "Joining" process for non-European citizens can differ, but this is not reflected in the joining tasks.
- Default tasks do not have a default status
- There are no documents attached to the default Joining timelines

## Solution

- Add a new "Non-EEA" joining timeline
- Add the default status of "Scheduled" for all default tasks
- Add the required documents to each Joining timeline