### PR TITLE
PCHR-1108: Fix Issues with being unable to save and override New Proposed Entitlement

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -546,6 +546,23 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
   }
 
   /**
+   * Deletes the LeaveBalanceChanges for a LeavePeriodEntitlement
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement $leavePeriodEntitlement
+   */
+  public static function deleteForLeavePeriodEntitlement(LeavePeriodEntitlement $leavePeriodEntitlement) {
+    $leaveBalanceChangeTable = self::getTableName();
+    $query = "DELETE FROM {$leaveBalanceChangeTable} WHERE source_id = %1 AND source_type = %2";
+
+    $params = [
+      1 => [$leavePeriodEntitlement->id, 'Integer'],
+      2 => [self::SOURCE_ENTITLEMENT, 'String']
+    ];
+
+    CRM_Core_DAO::executeQuery($query, $params);
+  }
+
+  /**
    * Deletes the LeaveBalanceChanges linked to all of the LeaveRequestDates of
    * the given LeaveRequest
    *

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
@@ -253,14 +253,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
 
     //The original pro-rata calculation already factors in public holidays
     //since public holiday balance changes are saved differently, we need to deduct it from the pro rata
-    $adjustedProRata = $calculation->getProRata() - $calculation->getNumberOfPublicHolidaysInEntitlement();
-
-
     LeaveBalanceChange::create([
       'type_id' => $balanceChangeTypes['Leave'],
       'source_id' => $periodEntitlement->id,
       'source_type' => LeaveBalanceChange::SOURCE_ENTITLEMENT,
-      'amount' => $adjustedProRata
+      'amount' => $calculation->getProRata() - $calculation->getNumberOfPublicHolidaysInEntitlement()
     ]);
 
 
@@ -306,13 +303,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
   }
 
   /**
-   * Saves the Entitlement Calculation Public Holiday as Leave Requests and
-   * Balance Changes.
+   * Saves the Entitlement Calculation Public Holiday as Balance Changes
    *
-   * On Balance Change, of type "Public Holiday", will be created with the amount
-   * equals to the number of Public Holidays in the entitlement. Next, for each of
-   * the Public Holidays, a LeaveRequest will be created, including it's respective
-   * LeaveRequestDates and LeaveBalanceChanges.
+   * Leave Balance Change of type "Public Holiday" will be created with the amount
+   * equals to the number of Public Holidays in the entitlement.
    *
    * @param \CRM_HRLeaveAndAbsences_Service_EntitlementCalculation $calculation
    * @param \CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement $periodEntitlement

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
@@ -325,8 +325,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
     LeavePeriodEntitlement $periodEntitlement
   ) {
     $balanceChangeTypes = array_flip(LeaveBalanceChange::buildOptions('type_id'));
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id'));
-    $leaveRequestDateTypes  = array_flip(LeaveRequest::buildOptions('from_date_type'));
 
     $publicHolidays = $calculation->getPublicHolidaysInEntitlement();
 
@@ -337,28 +335,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
         'source_type' => LeaveBalanceChange::SOURCE_ENTITLEMENT,
         'amount'      => count($publicHolidays)
       ]);
-
-      foreach ($publicHolidays as $publicHoliday) {
-        $leaveRequest = LeaveRequest::create([
-          'type_id'        => $periodEntitlement->type_id,
-          'contact_id'     => $periodEntitlement->contact_id,
-          'status_id'      => $leaveRequestStatuses['Admin Approved'],
-          'from_date'      => CRM_Utils_Date::processDate($publicHoliday->date),
-          'to_date'        => CRM_Utils_Date::processDate($publicHoliday->date),
-          'from_date_type' => $leaveRequestDateTypes['All Day'],
-          'to_date_type'   => $leaveRequestDateTypes['All Day'],
-          'request_type'   => LeaveRequest::REQUEST_TYPE_PUBLIC_HOLIDAY
-        ]);
-
-        $requestDate  = LeaveRequestDate::getDatesForLeaveRequest($leaveRequest->id)[0];
-
-        LeaveBalanceChange::create([
-          'type_id'        => $balanceChangeTypes['Public Holiday'],
-          'amount'         => -1,
-          'source_id'      => $requestDate->id,
-          'source_type'    => LeaveBalanceChange::SOURCE_LEAVE_REQUEST_DAY
-        ]);
-      }
     }
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
@@ -184,6 +184,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
       $absencePeriodID = $calculation->getAbsencePeriod()->id;
       $absenceTypeID = $calculation->getAbsenceType()->id;
       $contactID = $calculation->getContact()['id'];
+      self::deleteBalanceChangesForLeavePeriodEntitlement($absencePeriodID, $absenceTypeID, $contactID);
       self::deleteLeavePeriodEntitlement($absencePeriodID, $absenceTypeID, $contactID);
 
       $periodEntitlement = self::create(self::buildLeavePeriodParamsFromCalculation(
@@ -359,6 +360,23 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
     ];
 
     CRM_Core_DAO::executeQuery($query, $params);
+  }
+
+  /**
+   * Deletes the LeaveBalanceChanges for a LeavePeriodEntitlement
+   *
+   * @param int $absencePeriodID
+   * @param int $absenceTypeID
+   * @param int $contactID
+   */
+  private static function deleteBalanceChangesForLeavePeriodEntitlement($absencePeriodID, $absenceTypeID, $contactID) {
+    $leavePeriodEntitlement = new self();
+    $leavePeriodEntitlement->period_id = $absencePeriodID;
+    $leavePeriodEntitlement->type_id = $absenceTypeID;
+    $leavePeriodEntitlement->contact_id = $contactID;
+    $leavePeriodEntitlement->find(true);
+
+    LeaveBalanceChange::deleteForLeavePeriodEntitlement($leavePeriodEntitlement);
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveBalanceChange.php
@@ -60,13 +60,6 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange {
     ]);
   }
 
-  public static function fabricateForLeavePeriodEntitlement(LeavePeriodEntitlement $leavePeriodEntitlement) {
-    return self::fabricate([
-      'source_id' => $leavePeriodEntitlement->id,
-      'source_type' => LeaveBalanceChange::SOURCE_ENTITLEMENT,
-    ]);
-  }
-
   private static function getTypeId($typeLabel) {
     if(is_null(self::$balanceChangeTypes)) {
       self::$balanceChangeTypes = array_flip(LeaveBalanceChange::buildOptions('type_id'));

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveBalanceChange.php
@@ -3,6 +3,7 @@
 use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
+use CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement as LeavePeriodEntitlement;
 
 class CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange {
 
@@ -56,6 +57,13 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange {
     return self::fabricate([
       'source_id' => $leaveRequestDate->id,
       'source_type' => LeaveBalanceChange::SOURCE_LEAVE_REQUEST_DAY,
+    ]);
+  }
+
+  public static function fabricateForLeavePeriodEntitlement(LeavePeriodEntitlement $leavePeriodEntitlement) {
+    return self::fabricate([
+      'source_id' => $leavePeriodEntitlement->id,
+      'source_type' => LeaveBalanceChange::SOURCE_ENTITLEMENT,
     ]);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -2540,5 +2540,29 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $amount = LeaveBalanceChange::calculateAmountForDate($leaveRequest, new DateTime('2016-08-03'));
     $this->assertEquals(0, $amount);
   }
+
+  public function testCanDeleteTheBalanceChangesForALeavePeriodEntitlement() {
+    $leavePeriodEntitlement = $this->createLeavePeriodEntitlement();
+
+    LeaveBalanceChangeFabricator::fabricateForLeavePeriodEntitlement($leavePeriodEntitlement);
+    LeaveBalanceChangeFabricator::fabricateForLeavePeriodEntitlement($leavePeriodEntitlement);
+    LeaveBalanceChangeFabricator::fabricateForLeavePeriodEntitlement($leavePeriodEntitlement);
+
+    $record = $this->getBalanceChangesForPeriodEntitlement($leavePeriodEntitlement);
+    $this->assertEquals(3, $record->N);
+
+    LeaveBalanceChange::deleteForLeavePeriodEntitlement($leavePeriodEntitlement);
+
+    $record = $this->getBalanceChangesForPeriodEntitlement($leavePeriodEntitlement);
+    $this->assertEquals(0, $record->N);
+  }
+
+  private function getBalanceChangesForPeriodEntitlement($leavePeriodEntitlement) {
+    $record = new LeaveBalanceChange();
+    $record->source_id = $leavePeriodEntitlement->id;
+    $record->source_type = LeaveBalanceChange::SOURCE_ENTITLEMENT;
+    $record->find();
+    return $record;
+  }
 }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -2544,9 +2544,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   public function testCanDeleteTheBalanceChangesForALeavePeriodEntitlement() {
     $leavePeriodEntitlement = $this->createLeavePeriodEntitlement();
 
-    LeaveBalanceChangeFabricator::fabricateForLeavePeriodEntitlement($leavePeriodEntitlement);
-    LeaveBalanceChangeFabricator::fabricateForLeavePeriodEntitlement($leavePeriodEntitlement);
-    LeaveBalanceChangeFabricator::fabricateForLeavePeriodEntitlement($leavePeriodEntitlement);
+    $params = ['source_id' => $leavePeriodEntitlement->id, 'source_type' => LeaveBalanceChange::SOURCE_ENTITLEMENT];
+    LeaveBalanceChangeFabricator::fabricate($params);
+    LeaveBalanceChangeFabricator::fabricate($params);
+    LeaveBalanceChangeFabricator::fabricate($params);
 
     $record = $this->getBalanceChangesForPeriodEntitlement($leavePeriodEntitlement);
     $this->assertEquals(3, $record->N);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
@@ -382,9 +382,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
     // 10 + 1 + 3 (Pro Rata + Brought Forward + No. Public Holidays)
     $this->assertEquals(14, $periodEntitlement->getEntitlement());
 
-    //No leave request should be created
-    $this->assertEquals(0, $periodEntitlement->getLeaveRequestBalance());
-
     $balanceChangeTypes = array_flip(LeaveBalanceChange::buildOptions('type_id'));
 
     $breakDownBalanceChanges = LeaveBalanceChange::getBreakdownBalanceChangesForEntitlement($periodEntitlement->id);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
@@ -382,8 +382,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
     // 10 + 1 + 3 (Pro Rata + Brought Forward + No. Public Holidays)
     $this->assertEquals(14, $periodEntitlement->getEntitlement());
 
-    //The 3 days deducted because of the Public Holidays
-    $this->assertEquals(-3, $periodEntitlement->getLeaveRequestBalance());
+    //No leave request should be created
+    $this->assertEquals(0, $periodEntitlement->getLeaveRequestBalance());
 
     $balanceChangeTypes = array_flip(LeaveBalanceChange::buildOptions('type_id'));
 


### PR DESCRIPTION
This PR fixes issues with Inability to save and override the 'New Proposed Period Entitlement' column on the confirm calculations page.

The was fixed once the code for creating public holiday leave requests when creating balance changes for public holidays after saving entitlements on the confirm calculations page was removed. (This code was never needed and has been removed).
It turned out that the public holiday leave requests were created without passing the false (don't run validation) parameter to the LeaveRequest BAO create method thereby causing validation errors which prevented the all the methods in the transaction to successfully execute..

Some other issues/cleanup was also done:

Removing old balance changes related to a LeavePeriodEntitlement after it gets overridden/re-saved and a new LeavePeriodEntitlement is created in its place.

Some changes to creating LeaveBalanceChanges for LeavePeriodEntitlement after saving on the confirm calculations page. Currently the proRata amount is used to create the balance change, but proRata actually includes public holiday days View Code Here (i.e when the job leave allows this) and we are also creating LeaveBalance changes for the Public Holidays separately.
This resulted in duplication and causing the numbers not to add up. So the number of public holiday is deducted from the proRata before saving the balance change.