### PR TITLE
PCHR-2055: Disallow Duplicate Absence Types

### DIFF
--- a/hrabsence/CRM/HRAbsence/Form/AbsenceType.php
+++ b/hrabsence/CRM/HRAbsence/Form/AbsenceType.php
@@ -103,7 +103,7 @@ class CRM_HRAbsence_Form_AbsenceType extends CRM_Core_Form {
    $this->add('checkbox', 'allow_debits', ts('Allow Debits?'), CRM_Core_DAO::getAttribute('CRM_HRAbsence_DAO_HRAbsenceType', 'allow_debits'));
     $this->add('checkbox', 'is_active', ts('Enabled?'), CRM_Core_DAO::getAttribute('CRM_HRAbsence_DAO_HRAbsenceType', 'is_active'));
 
-    $this->addFormRule(array('CRM_HRAbsence_Form_AbsenceType', 'formRule'), $this);
+    $this->addFormRule([$this, 'formRule']);
   }
 
   /**
@@ -113,22 +113,23 @@ class CRM_HRAbsence_Form_AbsenceType extends CRM_Core_Form {
    *  An array of fields from the form
    * @param array $files
    *  An array of uploaded files
-   * @param self $self
-   *  An instance of this class
    * @return array
    *   An array of errors
    */
-  public static function formRule($fields, $files, $self) {
+  public function formRule($fields, $files) {
     $errors = [];
     if (!array_key_exists('allow_debits', $fields) && !array_key_exists('allow_credits', $fields)) {
       $errors['allow_debits'] = $errors['allow_credits'] = ts("Please choose either 'Allow Debits' and/or 'Allow Credits'");
     }
 
     $title = CRM_Utils_Array::value('title', $fields);
-    if ($self->getAction() === CRM_Core_Action::ADD) {
+    $isCreation = $this->getAction() === CRM_Core_Action::ADD;
+
+    if ($isCreation) {
       $existing = civicrm_api3('HRAbsenceType', 'get', ['name' => $title]);
       if (isset($existing['count']) && $existing['count'] > 0) {
-        $errors['title'] = ts("An absence type with title '%1' already exists", [1 => $title]);
+        $errorMessage = "An absence type with title '%1' already exists";
+        $errors['title'] = ts($errorMessage, [1 => $title]);
       }
     }
 

--- a/hrabsence/CRM/HRAbsence/Form/AbsenceType.php
+++ b/hrabsence/CRM/HRAbsence/Form/AbsenceType.php
@@ -125,10 +125,14 @@ class CRM_HRAbsence_Form_AbsenceType extends CRM_Core_Form {
     $title = CRM_Utils_Array::value('title', $fields);
     $isCreation = $this->getAction() === CRM_Core_Action::ADD;
 
+    $getCount = function ($field, $val) {
+      return civicrm_api3('HRAbsenceType', 'getcount', [$field => $val]);
+    };
+
     if ($isCreation) {
-      $existing = civicrm_api3('HRAbsenceType', 'get', ['name' => $title]);
-      if (isset($existing['count']) && $existing['count'] > 0) {
-        $errorMessage = "An absence type with title '%1' already exists";
+      $count = $getCount('title', $title) + $getCount('name', $title);
+      if ($count > 0) {
+        $errorMessage = "An absence type with title or name '%1' already exists";
         $errors['title'] = ts($errorMessage, [1 => $title]);
       }
     }

--- a/hrabsence/CRM/HRAbsence/Form/AbsenceType.php
+++ b/hrabsence/CRM/HRAbsence/Form/AbsenceType.php
@@ -106,11 +106,32 @@ class CRM_HRAbsence_Form_AbsenceType extends CRM_Core_Form {
     $this->addFormRule(array('CRM_HRAbsence_Form_AbsenceType', 'formRule'), $this);
   }
 
-  static function formRule($fields, $files, $self) {
-    $errors = array();
+  /**
+   * Used in validation from addFormRule
+   *
+   * @param array $fields
+   *  An array of fields from the form
+   * @param array $files
+   *  An array of uploaded files
+   * @param self $self
+   *  An instance of this class
+   * @return array
+   *   An array of errors
+   */
+  public static function formRule($fields, $files, $self) {
+    $errors = [];
     if (!array_key_exists('allow_debits', $fields) && !array_key_exists('allow_credits', $fields)) {
       $errors['allow_debits'] = $errors['allow_credits'] = ts("Please choose either 'Allow Debits' and/or 'Allow Credits'");
     }
+
+    $title = CRM_Utils_Array::value('title', $fields);
+    if ($self->getAction() === CRM_Core_Action::ADD) {
+      $existing = civicrm_api3('HRAbsenceType', 'get', ['name' => $title]);
+      if (isset($existing['count']) && $existing['count'] > 0) {
+        $errors['title'] = ts("An absence type with title '%1' already exists", [1 => $title]);
+      }
+    }
+
     return $errors;
   }
 


### PR DESCRIPTION
## Problem

Creating two absence types with the same name is permitted, but they will use the same activity_type_id. When one is deleted the activity type for it is also deleted. The whole system becomes unusable and the following error is displayed:

![screenshot from 2017-03-09 11-53-28](https://cloud.githubusercontent.com/assets/6374064/24463794/b801db32-149f-11e7-8d9f-a34e69b8dd5f.png)

## Solution

Add a rule to check for absence types with duplicate names, but only when creating a new type

## Notes

- I wasn't sure which was the best option for checking if it's a 'create' or 'update'. I used the `$self->getAction()` but I'm open to changing it to a `isset($fields['id'])` if that makes more sense.