### PR TITLE
PCHR-1968: Fix ACL issues with Contact.getLeaveManagees API Endpoint

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/Contact/Getleavemanagees.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/Contact/Getleavemanagees.php
@@ -29,6 +29,8 @@ function _civicrm_api3_contact_getleavemanagees_spec(&$spec) {
  * @throws API_Exception
  */
 function civicrm_api3_contact_getleavemanagees($params) {
+  // We need to set check_permissions to false so as to disable default Civi ACL checks for
+  // this endpoint. ACL checks needed are already in the ContactSelect Query class.
   $params['check_permissions'] = false;
   $leaveManagerService = new CRM_HRLeaveAndAbsences_Service_LeaveManager();
   $query = new CRM_HRLeaveAndAbsences_API_Query_ContactSelect($params, $leaveManagerService);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/Contact/Getleavemanagees.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/Contact/Getleavemanagees.php
@@ -29,6 +29,7 @@ function _civicrm_api3_contact_getleavemanagees_spec(&$spec) {
  * @throws API_Exception
  */
 function civicrm_api3_contact_getleavemanagees($params) {
+  $params['check_permissions'] = false;
   $leaveManagerService = new CRM_HRLeaveAndAbsences_Service_LeaveManager();
   $query = new CRM_HRLeaveAndAbsences_API_Query_ContactSelect($params, $leaveManagerService);
   return civicrm_api3_create_success($query->run(), $params);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ContactTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ContactTest.php
@@ -33,7 +33,7 @@ class api_v3_ContactTest extends BaseHeadlessTest {
     ]);
 
     $this->registerCurrentLoggedInContactInSession($this->manager['id']);
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API'];
   }
 
   public function testGetLeaveManageesDoesNotReturnDeceasedORDeletedContacts() {
@@ -45,7 +45,7 @@ class api_v3_ContactTest extends BaseHeadlessTest {
     $this->setContactAsLeaveApproverOf($this->manager, $contact3, null, null, true, 'has leaves approved by');
     $this->setContactAsLeaveApproverOf($this->manager, $contact4, null, null, true, 'has things managed by');
 
-    $result = civicrm_api3('Contact', 'getleavemanagees', ['managed_by' => $this->manager['id']]);
+    $result = $this->callGetLeaveManagees(['managed_by' => $this->manager['id']]);
 
     //only the two contacts who are neither deleted nor deceased is returned
     $this->assertEquals(2, $result['count']);
@@ -58,7 +58,7 @@ class api_v3_ContactTest extends BaseHeadlessTest {
   public function testGetLeaveManageesDoesNotReturnFilteredOutFields() {
     $this->setContactAsLeaveApproverOf($this->manager, $this->contact1, null, null, true, 'has things managed by');
 
-    $result = civicrm_api3('Contact', 'getleavemanagees', ['managed_by' => $this->manager['id']]);
+    $result = $this->callGetLeaveManagees(['managed_by' => $this->manager['id']]);
 
     //filtered out fields are hash, created_date, modified_date
     $this->assertEquals(1, $result['count']);
@@ -72,10 +72,11 @@ class api_v3_ContactTest extends BaseHeadlessTest {
   public function testGetLeaveManageesDoesNotReturnFilteredOutFieldsWhenFilteredOutFieldsArePartOfFieldsToReturn() {
     $this->setContactAsLeaveApproverOf($this->manager, $this->contact2, null, null, true, 'has things managed by');
 
-    $result = civicrm_api3('Contact', 'getleavemanagees', [
+    $params = [
       'managed_by' => $this->manager['id'],
       'return' => ['id', 'hash', 'display_name', 'created_date', 'modified_date']
-    ]);
+    ];
+    $result = $this->callGetLeaveManagees($params);
 
     //filtered put fields are hash, created_at, modified_at
     $this->assertEquals(1, $result['count']);
@@ -94,7 +95,10 @@ class api_v3_ContactTest extends BaseHeadlessTest {
     $this->setContactAsLeaveApproverOf($this->manager, $this->contact1, null, null, true, 'has leaves approved by');
     $this->setContactAsLeaveApproverOf($manager2, $contact3, null, null, true, 'has leaves approved by');
 
-    $result = civicrm_api3('Contact', 'getleavemanagees', ['managed_by' => $this->manager['id']]);
+    //even though the logged in manager does not have 'edit all contacts' or 'view all contacts' permission
+    //the manager is able to view results even with check_permissions set to true because
+    // the Contact.getleavemanagees api changes this value to false.
+    $result = $this->callGetLeaveManageesWithCheckPermissionsOn(['managed_by' => $this->manager['id']]);
 
     $this->assertEquals(2, $result['count']);
     $this->assertEquals($result['values'][$this->contact1['id']]['id'], $this->contact1['id']);
@@ -151,7 +155,8 @@ class api_v3_ContactTest extends BaseHeadlessTest {
     $this->setContactAsLeaveApproverOf($manager2, $this->contact2, null, null, true, 'has things managed by');
     $this->setContactAsLeaveApproverOf($manager2, $this->contact1, null, null, true, 'has leaves approved by');
 
-    $result = civicrm_api3('Contact', 'getleavemanagees', ['managed_by' => $manager2['id']]);
+    //the logged in manager can't access the the managees of another manager.
+    $result = $this->callGetLeaveManagees(['managed_by' => $manager2['id']]);
 
     //No result will be returned because a manager is not allowed to access the managees of another manager
     $this->assertEquals(0, $result['count']);
@@ -160,15 +165,37 @@ class api_v3_ContactTest extends BaseHeadlessTest {
   public function testGetLeaveManageesReturnsResultsWhenALoggedInAdminIsTryingToAccessTheManageesOfAManager() {
     $adminID = 1;
     $this->registerCurrentLoggedInContactInSession($adminID);
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer leave and absences'];
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API', 'administer leave and absences'];
 
     $this->setContactAsLeaveApproverOf($this->manager, $this->contact2, null, null, true, 'has things managed by');
     $this->setContactAsLeaveApproverOf($this->manager, $this->contact1, null, null, true, 'has leaves approved by');
 
-    $result = civicrm_api3('Contact', 'getleavemanagees', ['managed_by' => $this->manager['id']]);
+    $result = $this->callGetLeaveManageesWithCheckPermissionsOn(['managed_by' => $this->manager['id']]);
 
     $this->assertEquals(2, $result['count']);
     $this->assertEquals($result['values'][$this->contact1['id']]['id'], $this->contact1['id']);
     $this->assertEquals($result['values'][$this->contact2['id']]['id'], $this->contact2['id']);
+  }
+
+  public function testGetLeaveManageesReturnsEmptyResultsWhenStaffMemberIsTryingToAccessTheManageesOfAManager() {
+    $staffID = 1;
+    $this->registerCurrentLoggedInContactInSession($staffID);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API'];
+
+    $this->setContactAsLeaveApproverOf($this->manager, $this->contact2, null, null, true, 'has things managed by');
+    $this->setContactAsLeaveApproverOf($this->manager, $this->contact1, null, null, true, 'has leaves approved by');
+
+    $result = $this->callGetLeaveManagees(['managed_by' => $this->manager['id']]);
+
+    $this->assertEquals(0, $result['count']);
+  }
+
+  private function callGetLeaveManagees($params, $checkPermissions = false) {
+    $params['check_permissions'] = $checkPermissions;
+    return civicrm_api3('Contact', 'getleavemanagees', $params);
+  }
+
+  private function callGetLeaveManageesWithCheckPermissionsOn($params) {
+    return $this->callGetLeaveManagees($params, true);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
@@ -13,6 +13,7 @@ require_once 'helpers/WorkPatternHelpersTrait.php';
 require_once 'helpers/LeaveManagerHelpersTrait.php';
 require_once 'helpers/SessionHelpersTrait.php';
 require_once 'helpers/LeaveRequestStatusMatrixHelpersTrait.php';
+require_once 'helpers/ApiHelpersTrait.php';
 
 /**
  * Call the "cv" command.

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/ApiHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/ApiHelpersTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+trait CRM_HRLeaveAndAbsences_ApiHelpersTrait {
+
+  private function callAPI($entity, $action, $params, $checkPermissions = true) {
+    $params['check_permissions'] = $checkPermissions;
+    return civicrm_api3($entity, $action, $params);
+  }
+
+  private function callAPIWithCheckPermissionsOff($entity, $action, $params) {
+    return $this->callAPI($entity, $action, $params, false);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/SessionHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/SessionHelpersTrait.php
@@ -11,4 +11,8 @@ trait CRM_HRLeaveAndAbsences_SessionHelpersTrait {
     $session = CRM_Core_Session::singleton();
     $session->set('userID', null);
   }
+
+  private function setPermissions(array $permissions = []) {
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = $permissions;
+  }
 }


### PR DESCRIPTION
This PR fixes ACL issues with Contact.getLeaveManagees API endpoint.

Currently the API returns an empty result set for users without 'edit all contacts' or 'view all contacts' permissions.

To fix this, the Contact.getLeaveManagees is modified to ignore the default civicrm ACL checks by setting check_permissions parameter to false.
The 'ACL' needed for this endpoint was already implemented in the ContactSelect Query class:

- A Leave Approver only gets to see his/her managees and can't view the managees of another Manager.
- An Admin can view the managees of any Manager.
- A staff member can't view managees of any manager.

Some of the tests were modified to set check_permissions to true just to be sure that civicrm 'ACL' checks will be ignored. 
