### PR TITLE
PCHR-2058: Don't install hrabsence by default when creating a new site with civibuild

### DIFF
--- a/bin/drush-install.sh
+++ b/bin/drush-install.sh
@@ -14,7 +14,6 @@ org.civicrm.hrdemog,\
 org.civicrm.hrident,\
 org.civicrm.hrjobcontract,\
 com.civicrm.hrjobroles,\
-org.civicrm.hrabsence,\
 org.civicrm.hrmed,\
 org.civicrm.hrqual,\
 org.civicrm.hrvisa,\


### PR DESCRIPTION
This PR is related to: https://github.com/compucorp/civihr-employee-portal/pull/287. It removes removes hrabsence from the list of extensions installed by default.