### PR TITLE
PCHR-1064:  Fix Issues With Redirecting back to Return URL after Saving On Confirm Calculations Page

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
@@ -380,7 +380,10 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
     $returnUrl = isset($_GET['returnUrl']) ? urldecode($_GET['returnUrl']) : '';
     $vars = [];
     parse_str(parse_url($returnUrl, PHP_URL_QUERY), $vars);
-    if (!empty($vars['q']) && $this->isValidReturnPath($vars['q'])) {
+    //q will not exist in $vars for sites with clean Urls enabled
+    $url = empty($vars['q']) ? $returnUrl : $vars['q'];
+    //we need to trim preceding slash when clean url is enabled
+    if (!empty($url) && $this->isValidReturnPath(ltrim($url, '/'))) {
       $returnUrl = filter_var($returnUrl, FILTER_SANITIZE_URL);
       $session->set('ManageEntitlementsReturnUrl', $returnUrl);
     }


### PR DESCRIPTION
Redirecting back to return URL after saving on Confirm Calculations page works fine for sites without clean URL enabled as the function responsible for saving the returnUrl relies on the q string parameter in the URL. However for sites with clean Url enabled, the q parameter does not exist.

This PR fixes this issue and makes sure that the redirection works for cases when clean Url is enabled or is not