### PR TITLE
PCHR-2058: Remove old entitlement calculation when updating leave on a contract

### DIFF
--- a/hrjobcontract/api/v3/HRJobLeave.php
+++ b/hrjobcontract/api/v3/HRJobLeave.php
@@ -93,23 +93,5 @@ function civicrm_api3_h_r_job_leave_replace($params) {
     }
     $result =  _civicrm_hrjobcontract_api3_replace(_civicrm_get_entity_name(_civicrm_api3_get_BAO(__FUNCTION__)), $params, $validRevisionId);
 
-    if (!empty($params['values'])) {
-      $firstLeaveEntry = CRM_Utils_Array::first($params['values']);
-
-      $jobContractId = isset($firstLeaveEntry['jobcontract_id']) ? $firstLeaveEntry['jobcontract_id'] : null;
-      if (!$jobContractId && isset($firstLeaveEntry['jobcontract_revision_id'])) {
-        $revision = civicrm_api3('HRJobContractRevision', 'get', array(
-          'sequential' => 1,
-          'id' => $firstLeaveEntry['jobcontract_revision_id'],
-        ));
-        $revisionData = CRM_Utils_Array::first($revision['values']);
-        $jobContractId = $revisionData['jobcontract_id'];
-      }
-
-      if ($jobContractId) {
-        CRM_HRAbsence_BAO_HRAbsenceEntitlement::recalculateAbsenceEntitlement($jobContractId);
-      }
-    }
-
     return $result;
 }


### PR DESCRIPTION
Whenever the leave information on a contract was updated, the entitlement for the contract period was recalculated. This was done using the `recalculateAbsenceEntitlement` method of the `CRM_HRAbsence_BAO_HRAbsenceEntitlement` BAO, from the `hrabsence` extension.

This recalculation isn't necessary anymore, because now, after updating a contract, the user is redirected to the Entitlement Calculation page.

The piece of code has to be removed though, because it will cause errors if we try to save/create a contract while the `hrabsence` extension is disabled.

**Note**: There are still some parts of the hrjobcontract (and other extensions) that call method and APIs of the hrabsence, but these will not cause errors on any of the main functionalities of the system (adding contracts, job roles, tasks, vacacies etc). They will be removed later, on another PR