### PR TITLE
PCHR-1197: Fix issues with Creating a Contract when no Absence Type with MTPHL exists

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -109,6 +109,11 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
    */
   public function createForContact($contactID, PublicHoliday $publicHoliday) {
     $absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
+
+    if (!$absenceType) {
+      return;
+    }
+
     $this->create($contactID, $absenceType, $publicHoliday);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -385,6 +385,20 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $this->assertEquals(1, $this->countNumberOfLeaveRequests($contact2['id'], $date->format('Ymd')));
   }
 
+  public function testCreateForContactDoesNotCreatePublicHolidayLeaveRequestsWhenNoAbsenceTypeWithMustTakePublicHolidayAsLeaveRequestExist() {
+    //We need to delete any absence type already created
+    $tableName = AbsenceType::getTableName();
+    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+
+    AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 0]);
+    $contactID = 2;
+    $publicHoliday = new PublicHoliday();
+    $publicHoliday->date = CRM_Utils_Date::processDate('first monday of this year');
+
+    $this->creationLogic->createForContact($contactID, $publicHoliday);
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday));
+  }
+
   private function countNumberOfPublicHolidayBalanceChanges() {
     $balanceChangeTypes = array_flip(LeaveBalanceChange::buildOptions('type_id'));
 


### PR DESCRIPTION
## Problem
When trying to create a new contract and no Absence Type with  'Must take Public holiday as leave request' exists, an exception is thrown and the contract cannot be created.

## Solution
This PR fixes the issue by exiting the function for creating the Public Holiday Leave requests once an Absence Type with  'Must take Public holiday as leave request' does not exist.