### PR TITLE
PCHR-2124: Remove styleguide backstop scenario + misc

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/contact-summary.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/contact-summary.js
@@ -6,8 +6,9 @@ module.exports = (function () {
   return page.extend({
 
     /**
-     * [openManageRightsModal description]
-     * @return {[type]} [description]
+     * Opens the "contact access rights" modal
+     *
+     * @return {Promise} resolves with the modal page object
      */
     openManageRightsModal: function () {
       var casper = this.casper;
@@ -22,9 +23,10 @@ module.exports = (function () {
     },
 
     /**
-     * [openTab description]
-     * @param  {[type]}   tabId [description]
-     * @return {[type]}         [description]
+     * Opens one of the contact summary tabs
+     *
+     * @param  {string} tabId
+     * @return {object} resolves with the tab page object
      */
     openTab: function (tabId) {
       var casper = this.casper;
@@ -42,8 +44,7 @@ module.exports = (function () {
     },
 
     /**
-     * [showActions description]
-     * @return {[type]} [description]
+     * Shows the dropdown of the "Actions" button in the contact summary page
      */
     showActions: function () {
       var casper = this.casper;

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/documents.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/documents.js
@@ -7,7 +7,9 @@ module.exports = (function () {
   return page.extend({
 
     /**
-     * [addDocument description]
+     * Opens the modal to add a documents
+     *
+     * @return {Promise} resolves with the document modal page object
      */
     addDocument: function () {
       var casper = this.casper;
@@ -21,8 +23,9 @@ module.exports = (function () {
     },
 
     /**
-     * [advancedFilters description]
-     * @return {[type]} [description]
+     * Shows the advanced filters
+     *
+     * @return {object}
      */
     advancedFilters: function () {
       var casper = this.casper;
@@ -36,8 +39,9 @@ module.exports = (function () {
     },
 
     /**
-     * [documentActions description]
-     * @return {[type]} [description]
+     * Shows the dropdown of the actions available on any given document
+     *
+     * @return {object}
      */
     documentActions: function () {
       var casper = this.casper;
@@ -50,8 +54,9 @@ module.exports = (function () {
     },
 
     /**
-     * [openDocument description]
-     * @return {[type]} [description]
+     * Opens a document
+     *
+     * @return {Promise} resolves with the document modal page object
      */
     openDocument: function () {
       var casper = this.casper;
@@ -69,8 +74,7 @@ module.exports = (function () {
     },
 
     /**
-     * [selectDates description]
-     * @return {[type]} [description]
+     * Shows the "select dates" filter
      */
     selectDates: function () {
       var casper = this.casper;
@@ -82,8 +86,7 @@ module.exports = (function () {
     },
 
     /**
-     * [waitForReady description]
-     * @return {[type]} [description]
+     * Waits until the specified select is visible on the page
      */
     waitForReady: function () {
       var casper = this.casper;

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/assignment.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/assignment.js
@@ -4,7 +4,9 @@ module.exports = (function () {
   return modal.extend({
 
     /**
-     * [addDocument description]
+     * Clicks the "add document" button
+     *
+     * @return {object}
      */
     addDocument: function () {
       var casper = this.casper;
@@ -17,7 +19,9 @@ module.exports = (function () {
     },
 
     /**
-     * [addTask description]
+     * Clicks the "add task" button
+     *
+     * @return {object}
      */
     addTask: function () {
       var casper = this.casper;
@@ -30,8 +34,9 @@ module.exports = (function () {
     },
 
     /**
-     * [pickDate description]
-     * @return {[type]} [description]
+     * Opens a date picker
+     *
+     * @return {object}
      */
     pickDate: function () {
       var casper = this.casper;
@@ -45,8 +50,9 @@ module.exports = (function () {
     },
 
     /**
-     * [selectType description]
-     * @return {[type]} [description]
+     * Selects an assignment type, so that the rest of the modal is shown
+     *
+     * @return {object}
      */
     selectType: function () {
       var casper = this.casper;

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/contact-access-rights.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/contact-access-rights.js
@@ -4,8 +4,9 @@ module.exports = (function () {
   return modal.extend({
 
     /**
-     * [openDropdown description]
-     * @return {[type]} [description]
+     * Opens a ui-select dropdown
+     *
+     * @return {object}
      */
     openDropdown: function (name) {
       casper.then(function () {

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/document.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/document.js
@@ -4,8 +4,9 @@ module.exports = (function () {
   return modal.extend({
 
     /**
-     * [pickDueDate description]
-     * @return {[type]} [description]
+     * Opens the "due date" datepicker
+     *
+     * @return {object}
      */
     pickDueDate: function () {
       var casper = this.casper;
@@ -19,9 +20,10 @@ module.exports = (function () {
     },
 
     /**
-     * [showField description]
-     * @param  {[type]} fieldName [description]
-     * @return {[type]}           [description]
+     * Shows the given field
+     *
+     * @param  {string} fieldName
+     * @return {object}
      */
     showField: function (fieldName) {
       var casper = this.casper;
@@ -34,8 +36,9 @@ module.exports = (function () {
     },
 
     /**
-     * [selectAssignee description]
-     * @return {[type]} [description]
+     * Selects an assignee for the document
+     *
+     * @return {object}
      */
     selectAssignee: function () {
       var casper = this.casper;
@@ -49,8 +52,9 @@ module.exports = (function () {
     },
 
     /**
-     * [selectType description]
-     * @return {[type]} [description]
+     * Selects the type of document
+     *
+     * @return {object}
      */
     selectType: function () {
       var casper = this.casper;
@@ -64,8 +68,9 @@ module.exports = (function () {
     },
 
     /**
-     * [showMore description]
-     * @return {[type]} [description]
+     * Expands fully the modal
+     *
+     * @return {object}
      */
     showMore: function () {
       var casper = this.casper;

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/job-contract.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/job-contract.js
@@ -4,9 +4,9 @@ module.exports = (function () {
   return modal.extend({
 
     /**
-     * [selectTab description]
-     * @param  {[type]} tabTitle [description]
-     * @return {[type]}          [description]
+     * Selects the tab with the given title
+     *
+     * @param  {string} tabTitle
      */
     selectTab: function (tabTitle) {
       var casper = this.casper;

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/task.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/task.js
@@ -4,8 +4,9 @@ module.exports = (function () {
   return modal.extend({
 
     /**
-     * [pickDate description]
-     * @return {[type]} [description]
+     * Opens a date picker
+     *
+     * @return {object}
      */
     pickDate: function () {
       var casper = this.casper;
@@ -19,9 +20,10 @@ module.exports = (function () {
     },
 
     /**
-     * [showField description]
-     * @param  {[type]} fieldName [description]
-     * @return {[type]}           [description]
+     * Shows a given field
+     *
+     * @param  {string} fieldName
+     * @return {object}
      */
     showField: function (fieldName) {
       var casper = this.casper;
@@ -34,8 +36,9 @@ module.exports = (function () {
     },
 
     /**
-     * [selectAssignee description]
-     * @return {[type]} [description]
+     * Selects the task's assignee
+     *
+     * @return {object}
      */
     selectAssignee: function () {
       var casper = this.casper;
@@ -49,8 +52,9 @@ module.exports = (function () {
     },
 
     /**
-     * [selectType description]
-     * @return {[type]} [description]
+     * Select the task type
+     *
+     * @return {object}
      */
     selectType: function () {
       var casper = this.casper;

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/page.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/page.js
@@ -20,6 +20,24 @@ function closeAnyModal() {
   return this;
 }
 
+/**
+ * [closeNotifications description]
+ * @return {[type]} [description]
+ */
+function closeNotifications() {
+  var casper = this.casper;
+  var notificationSelector = 'a.ui-notify-cross.ui-notify-close';
+
+  casper.then(function () {
+    if (casper.exists(notificationSelector)) {
+      casper.click(notificationSelector);
+      casper.wait(500);
+    }
+  });
+
+  return this;
+}
+
 
 module.exports = {
 
@@ -40,6 +58,7 @@ module.exports = {
 
     if (clearDialogs) {
       closeAnyModal.call(this);
+      closeNotifications.call(this);
     }
 
     return this;

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/page.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/page.js
@@ -3,8 +3,9 @@ var Promise = require('es6-promise').Promise;
 var customCasperJS = require('../utils/custom-casperjs');
 
 /**
- * [closeAnyModal description]
- * @return {[type]} [description]
+ * Closes any modal currently open
+ *
+ * @return {object}
  */
 function closeAnyModal() {
   var casper = this.casper;
@@ -21,8 +22,9 @@ function closeAnyModal() {
 }
 
 /**
- * [closeNotifications description]
- * @return {[type]} [description]
+ * Closes any notification currently open
+ *
+ * @return {object}
  */
 function closeNotifications() {
   var casper = this.casper;
@@ -42,10 +44,14 @@ function closeNotifications() {
 module.exports = {
 
   /**
-   * [init description]
-   * @param  {[type]} casper       [description]
-   * @param  {[type]} clearDialogs [description]
-   * @return {[type]}              [description]
+   * Initializes the page
+   *
+   * Stores a customized version of CasperJS and then wait for a
+   * until a certain "ready" condition is met, if the page is set up to do so
+   *
+   * @param  {object} casper
+   * @param  {boolean} clearDialogs if true it will close modals and notifications
+   * @return {object}
    */
   init: function (casper, clearDialogs) {
     clearDialogs = typeof clearDialogs !== 'undefined' ? !!clearDialogs : true;
@@ -65,17 +71,22 @@ module.exports = {
   },
 
   /**
-   * [extent description]
-   * @param  {[type]} page [description]
-   * @return {[type]}      [description]
+   * Used to extend the main page
+   *
+   * @param  {object} page
+   *   a collection of methods and properties that will extend the main page
+   * @return {object}
    */
   extend: function (page) {
     return _.assign(Object.create(this), page);
   },
 
   /**
-   * [waitForModal description]
-   * @return {[type]} [description]
+   * Makes CasperJS wait until the modal is visible, then it returns the
+   * specified modal object (if any)
+   *
+   * @param {string} name of the modal object
+   * @return {object} the modal object
    */
   waitForModal: function (modalModule) {
     var casper = this.casper;

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/job-contract.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/job-contract.js
@@ -7,8 +7,9 @@ module.exports = (function () {
     tabTitle: 'Job Contract',
 
     /**
-     * [delete description]
-     * @return {[type]} [description]
+     * Clicks on the delete button
+     *
+     * @return {object}
      */
     attemptDelete: function () {
       var casper = this.casper;
@@ -20,9 +21,10 @@ module.exports = (function () {
     },
 
     /**
-     * [openContractModal description]
-     * @param  {[type]} mode [description]
-     * @return {[type]}      [description]
+     * Opens the modal of an already existing contract
+     *
+     * @param  {string} mode "correct" or "revision"
+     * @return {Promise} resolves with the job contract modal object
      */
     openContractModal: function (mode) {
       var param, casper = this.casper;
@@ -38,8 +40,9 @@ module.exports = (function () {
     },
 
     /**
-     * [openNewContractModal description]
-     * @return {[type]}      [description]
+     * Opens the modal for creating a new contract
+     *
+     * @return {Promise} resolves with the job contract modal object
      */
     openNewContractModal: function () {
       var casper = this.casper;
@@ -53,8 +56,9 @@ module.exports = (function () {
     },
 
     /**
-     * [showFullHistory description]
-     * @return {[type]} [description]
+     * Shows the full history of a contract
+     *
+     * @return {object}
      */
     showFullHistory: function () {
       var casper = this.casper;

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/job-roles.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/job-roles.js
@@ -6,8 +6,7 @@ module.exports = (function () {
     tabTitle: 'Job Roles',
 
     /**
-     * [attemptDelete description]
-     * @return {[type]} [description]
+     * Clicks on the delete button
      */
     attemptDelete: function () {
       var casper = this.casper;
@@ -19,8 +18,9 @@ module.exports = (function () {
     },
 
     /**
-     * [edit description]
-     * @return {[type]} [description]
+     * Clicks on the edit button of a job role
+     *
+     * @return {object}
      */
     edit: function () {
       var casper = this.casper;
@@ -34,9 +34,10 @@ module.exports = (function () {
     },
 
     /**
-     * [openDropdown description]
-     * @param  {[type]} name [description]
-     * @return {[type]}      [description]
+     * Opens the ui-select with the given name
+     *
+     * @param  {string} name
+     * @return {object}
      */
     openDropdown: function (name) {
       casper.then(function () {
@@ -50,8 +51,7 @@ module.exports = (function () {
     },
 
     /**
-     * [showAddNew description]
-     * @return {[type]} [description]
+     * Show the form for adding a new job role
      */
     showAddNew: function () {
       var casper = this.casper;
@@ -62,9 +62,10 @@ module.exports = (function () {
     },
 
     /**
-     * [switchToTab description]
-     * @param  {[type]} tabName [description]
-     * @return {[type]}         [description]
+     * Changes active tab
+     *
+     * @param  {string} tabName
+     * @return {object}
      */
     switchToTab: function (tabName) {
       var casper = this.casper;

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/tab.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/tab.js
@@ -4,8 +4,8 @@ module.exports = (function () {
   return page.extend({
 
     /**
-     * [open description]
-     * @return {[type]} [description]
+     * Defines that the tab is ready when the a specific selector is visible
+     * @return {boolean}
      */
     ready: function () {
       return this.casper.visible(this.readySelector);

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tasks.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tasks.js
@@ -13,7 +13,9 @@ module.exports = (function () {
   return page.extend({
 
     /**
-     * [addAssignment description]
+     * Shows the assignment modal
+     *
+     * @return {Promise} resolves with the assignment modal page object
      */
     addAssignment: function () {
       var casper = this.casper;
@@ -27,7 +29,9 @@ module.exports = (function () {
     },
 
     /**
-     * [addTask description]
+     * Shows the task modal
+     *
+     * @return {Promise} resolves with the task modal page object
      */
     addTask: function () {
       var casper = this.casper;
@@ -41,8 +45,9 @@ module.exports = (function () {
     },
 
     /**
-     * [advancedFilters description]
-     * @return {[type]} [description]
+     * Opens the advanced filters
+     *
+     * @return {object}
      */
     advancedFilters: function () {
       var casper = this.casper;
@@ -56,8 +61,10 @@ module.exports = (function () {
     },
 
     /**
-     * [inPlaceEdit description]
-     * @return {[type]} [description]
+     * Shows the given edit-in-place field
+     *
+     * @param {string} fieldName
+     * @return {object}
      */
     inPlaceEdit: function (fieldName) {
       var casper = this.casper;
@@ -71,8 +78,9 @@ module.exports = (function () {
     },
 
     /**
-     * [openTask description]
-     * @return {[type]} [description]
+     * Opens the first task of the list
+     *
+     * @return {Promise} resolves with the task modal page object
      */
     openTask: function () {
       var casper = this.casper;
@@ -86,8 +94,7 @@ module.exports = (function () {
     },
 
     /**
-     * [selectDates description]
-     * @return {[type]} [description]
+     * Shows the "select dates" filter
      */
     selectDates: function () {
       var casper = this.casper;
@@ -99,8 +106,9 @@ module.exports = (function () {
     },
 
     /**
-     * [showMore description]
-     * @return {[type]} [description]
+     * Expands the "show more" area of the first task of the list
+     *
+     * @return {object}
      */
     showMore: function () {
       var casper = this.casper;
@@ -116,8 +124,9 @@ module.exports = (function () {
     },
 
     /**
-     * [taskActions description]
-     * @return {[type]} [description]
+     * Shows the dropdown of the actions available on any given task
+     *
+     * @return {object}
      */
     taskActions: function () {
       var casper = this.casper;
@@ -130,8 +139,7 @@ module.exports = (function () {
     },
 
     /**
-     * [waitForReady description]
-     * @return {[type]} [description]
+     * Waits until the specified select is visible on the page
      */
     waitForReady: function () {
       var casper = this.casper;

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/contact-edit-form.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/contact-edit-form.json
@@ -3,7 +3,7 @@
     {
       "label": "Contact Edit Form",
       "delay": 5000,
-      "url": "index.php?q=civicrm/contact/view&reset=1&cid=205",
+      "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
       "onReadyScript": "contact/contact-edit"
     }
   ]

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/styleguide.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/styleguide.json
@@ -1,9 +1,0 @@
-{
-  "scenarios": [
-    {
-      "label": "Styleguide",
-      "url": "/civicrm/styleguide/bootstrap",
-      "onReadyScript": "close-any-modal"
-    }
-  ]
-}

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ta-documents.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ta-documents.json
@@ -6,11 +6,6 @@
       "onReadyScript": "close-any-modal"
     },
     {
-      "label": "T&A / Documents / Select Dates",
-      "url": "civicrm/tasksassignments/dashboard#/documents",
-      "onReadyScript": "documents/select-dates"
-    },
-    {
       "label": "T&A / Documents / Advanced Filters",
       "url": "civicrm/tasksassignments/dashboard#/documents",
       "onReadyScript": "documents/advanced-filters"
@@ -19,16 +14,6 @@
       "label": "T&A / Documents / Document / Add",
       "url": "civicrm/tasksassignments/dashboard#/documents",
       "onReadyScript": "documents/document/add"
-    },
-    {
-      "label": "T&A / Documents / Document / Actions",
-      "url": "civicrm/tasksassignments/dashboard#/documents",
-      "onReadyScript": "documents/document/actions"
-    },
-    {
-      "label": "T&A / Documents / Document / Open",
-      "url": "civicrm/tasksassignments/dashboard#/documents",
-      "onReadyScript": "documents/document/open"
     },
     {
       "label": "T&A / Documents / Document / Show All Fields",

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/utils/custom-casperjs.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/utils/custom-casperjs.js
@@ -5,8 +5,8 @@ var casper;
 var overrides = {
 
   /**
-   * [click description]
-   * @return {[type]} [description]
+   * Customized version of the default casperjs' click handler
+   * If the given selector doesn't exist, it exits with an error
    */
   click: function () {
     var selector = arguments[0];

--- a/uk.co.compucorp.civicrm.hrcore/gulpfile.js
+++ b/uk.co.compucorp.civicrm.hrcore/gulpfile.js
@@ -17,22 +17,29 @@ var Promise = require('es6-promise').Promise;
     "credentials": { "name": "%{user-name}", "pass": "%{user-password}" }
   };
 
-  gulp.task('backstop:reference', function () {
+  gulp.task('backstopjs:reference', function (done) {
     runBackstopJS('reference').then(function () {
       done();
     });
   });
 
-  gulp.task('backstop:test', function (done) {
+  gulp.task('backstopjs:test', function (done) {
     runBackstopJS('test').then(function () {
       done();
     });
   });
 
-  gulp.task('backstop:report', function () {
-    backstopjs('openReport', { configPath: backstopDir + files.tpl });
+  gulp.task('backstopjs:report', function (done) {
+    runBackstopJS('openReport').then(function () {
+      done();
+    });
   });
 
+  gulp.task('backstopjs:approve', function (done) {
+    runBackstopJS('approve').then(function () {
+      done();
+    });
+  });
 
   /**
    * Checks if the site config file is in the backstopjs folder
@@ -46,7 +53,7 @@ var Promise = require('es6-promise').Promise;
     try {
       fs.readFileSync(backstopDir + files.config);
     } catch (err) {
-      require('fs').writeFileSync(backstopDir + files.config, JSON.stringify(configTpl, null, 2));
+      fs.writeFileSync(backstopDir + files.config, JSON.stringify(configTpl, null, 2));
       check = false;
     }
 


### PR DESCRIPTION
This PR contains the following:

1) Removed the styleguide backstopjs scenario, as now the styleguide extension itself will have that scenario (see [here](https://github.com/compucorp/org.civicrm.styleguide/pull/1))
2) Renamed `backstop:action` tasks in `backstopjs:action`
3) Added `backstopjs:approve` task
4) Now on page ready backstop will close the notification (if any) before taking a screenshot
5) Using the cid = 2 in all scenarios
6) Removed some of the scenarios for the Documents page (T&A), because of [this issue](https://github.com/ariya/phantomjs/issues/11151). PhantomJS has a bug with how it parses dates, and that leads the Documents page to not show any documents, which then leads to errors when CasperJS tries to click on documents that are not there. I don't know of any solutions yet, so i could only removed those scenarios