### PR TITLE
PCHR-2113: Fix warning on the Activity.getAbsences API

### DIFF
--- a/hrabsence/api/v3/Activity/Getabsences.php
+++ b/hrabsence/api/v3/Activity/Getabsences.php
@@ -127,6 +127,7 @@ function civicrm_api3_activity_getabsences($params) {
   $entity = _civicrm_api3_get_BAO(__FUNCTION__);
   $bao = CRM_Core_DAO::executeQuery($select->toSQL(), array(), TRUE, 'CRM_Activity_BAO_Activity');
   $activities = _civicrm_api3_dao_to_array($bao, $params, FALSE, $entity, FALSE);
-  $activities = _civicrm_api3_activity_get_formatResult($params, $activities);
+  $options = _civicrm_api3_get_options_from_params($params, FALSE, 'Activity', 'get');
+  $activities = _civicrm_api3_activity_get_formatResult($params, $activities, $options);
   return civicrm_api3_create_success($activities, $params, $entity, 'getAbsences');
 }


### PR DESCRIPTION
After upgrading to CiviCRM 4.7.18, this error started being displayed on the contact summary page:
![captura de tela de 2017-04-12 17-07-51](https://cloud.githubusercontent.com/assets/388373/24977927/3da88ab4-1fa5-11e7-909c-dca147891141.png)

The was caused by a call to the `getAbsences` custom action of the Activity API. It uses the `_civicrm_api3_activity_get_formatResult` function, which had its signature changed by this commit:
https://github.com/civicrm/civicrm-core/commit/bc4b6f0f5694d1a5b8e2151e6dcf9a394c300df4#diff-7673c7d055caeab2a3ec5d05a1553293R395

Due to this change, any call to this action was resulting in a warning, because `getAbsences` was not passing the new third param added to the function.

This fixes the warning by fetching the options from the `$params` array and passing it to the function.