### PR TITLE
AI-109: Fix styleguide error

### DIFF
--- a/org.civicrm.styleguide/styleguide.civix.php
+++ b/org.civicrm.styleguide/styleguide.civix.php
@@ -278,7 +278,7 @@ function _styleguide_civix_insert_navigation_menu(&$menu, $path, $item) {
     $first = array_shift($path);
     foreach ($menu as $key => &$entry) {
       if ($entry['attributes']['name'] == $first) {
-        if (!$entry['child']) $entry['child'] = array();
+        if (empty($entry['child'])) $entry['child'] = array();
         $found = _styleguide_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
       }
     }

--- a/org.civicrm.styleguide/styleguide.civix.php
+++ b/org.civicrm.styleguide/styleguide.civix.php
@@ -278,7 +278,7 @@ function _styleguide_civix_insert_navigation_menu(&$menu, $path, $item) {
     $first = array_shift($path);
     foreach ($menu as $key => &$entry) {
       if ($entry['attributes']['name'] == $first) {
-        if (empty($entry['child'])) $entry['child'] = array();
+        if (!$entry['child']) $entry['child'] = array();
         $found = _styleguide_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
       }
     }

--- a/org.civicrm.styleguide/styleguide.php
+++ b/org.civicrm.styleguide/styleguide.php
@@ -130,6 +130,9 @@ function styleguide_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_navigationMenu
  */
 function styleguide_civicrm_navigationMenu(&$menu) {
+  foreach ($menu as $key => $menu_item) {
+    if(empty($menu_item['child'])) $menu[$key]['child'] = array();
+  }
   _styleguide_civix_insert_navigation_menu($menu, 'Support/Developer', array(
     'label' => ts('Style Guide', array('domain' => 'org.civicrm.styleguide')),
     'name' => 'developer_styleguide',


### PR DESCRIPTION
Loop over current defined menus and initializ 'child' index for the menu items that doesn't has the index defined. 

Before:
![ai-109](https://cloud.githubusercontent.com/assets/2423218/25045602/5e36f0ca-212d-11e7-9f04-fa39f8cd4f0b.png)

After:
![screen shot 2017-04-14 at 4 14 48 pm](https://cloud.githubusercontent.com/assets/2423218/25045628/72c01a80-212d-11e7-860d-6bbec131bd79.png)
