### PR TITLE
PCHR-2139: Fix path to org.civicrm.shoreditch theme in jobroles module

### DIFF
--- a/com.civicrm.hrjobroles/css/hrjobroles.css
+++ b/com.civicrm.hrjobroles/css/hrjobroles.css
@@ -2809,7 +2809,6 @@
   text-decoration: none;
 }
 #hrjobroles a:focus {
-  outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
@@ -4197,7 +4196,6 @@
 #hrjobroles input[type="file"]:focus,
 #hrjobroles input[type="radio"]:focus,
 #hrjobroles input[type="checkbox"]:focus {
-  outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
@@ -4743,7 +4741,6 @@ fieldset[disabled]
   user-select: none;
 }
 #hrjobroles .btn:focus, #hrjobroles .btn.focus, #hrjobroles .btn:active:focus, #hrjobroles .btn:active.focus, #hrjobroles .btn.active:focus, #hrjobroles .btn.active.focus {
-  outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }

--- a/com.civicrm.hrjobroles/scss/hrjobroles/modules/_civihr-ui-select.scss
+++ b/com.civicrm.hrjobroles/scss/hrjobroles/modules/_civihr-ui-select.scss
@@ -9,8 +9,8 @@ $gray-lighter:           #F3F6F7;
 $input-border-radius:    0;
 
 // Include the original ui-select css + the civihr-ui-select dropdown theme
-@import "../../../civihr/org.civicrm.shoreditch/scss/bootstrap/vendor/ui-select/ui-select";
-@import "../../../civihr/org.civicrm.shoreditch/scss/bootstrap/components/civihr-ui-select/civihr-ui-select";
+@import "../../../org.civicrm.shoreditch/scss/bootstrap/vendor/ui-select/ui-select";
+@import "../../../org.civicrm.shoreditch/scss/bootstrap/components/civihr-ui-select/civihr-ui-select";
 
 // Customizations specific for Job Roles
 .ui-select-bootstrap {


### PR DESCRIPTION
### Issue:
Currently, the path to `org.civicrm.shoreditch` theme is incorrect in `com.civicrm.hrjobroles` module in `com.civicrm.hrjobroles/scss/hrjobroles/modules/_civihr-ui-select.scss` as follows:
```
// Include the original ui-select css + the civihr-ui-select dropdown theme
@import "../../../civihr/org.civicrm.shoreditch/scss/bootstrap/vendor/ui-select/ui-select";
@import "../../../civihr/org.civicrm.shoreditch/scss/bootstrap/components/civihr-ui-select/civihr-ui-select";
```

### Solution:
As a part of this ticket, the path to `org.civicrm.shoreditch ` theme is fixed in file `com.civicrm.hrjobroles/scss/hrjobroles/modules/_civihr-ui-select.scss` in `com.civicrm.hrjobroles` Module as follows:
```
// Include the original ui-select css + the civihr-ui-select dropdown theme
@import "../../../org.civicrm.shoreditch/scss/bootstrap/vendor/ui-select/ui-select";
@import "../../../org.civicrm.shoreditch/scss/bootstrap/components/civihr-ui-select/civihr-ui-select";
```
Since, `org.civicrm.shoreditch` is now not a part of `civihr` directory.

And ran backstopjs tests to verify everything is working fine.
