### PR TITLE
Add Timeout For Fetching en_GB Translation Files

### DIFF
--- a/bin/drush-install.sh
+++ b/bin/drush-install.sh
@@ -41,10 +41,12 @@ org.civicrm.styleguide
 # It expect one parameter ($1) which points to civicrm absolute path
 function set_default_localisation_settings() {
   LOC_FILE="en_US"
-  if wget -q "https://download.civicrm.org/civicrm-l10n-core/mo/en_GB/civicrm.mo" > /dev/null; then
+  if wget -q -t 3 --timeout=60 "https://download.civicrm.org/civicrm-l10n-core/mo/en_GB/civicrm.mo" > /dev/null; then
     mkdir -p $1/l10n/en_GB/LC_MESSAGES/
     mv civicrm.mo $1/l10n/en_GB/LC_MESSAGES/civicrm.mo
     LOC_FILE="en_GB"
+  else
+    echo "Could not download en_GB translation file";
   fi
 
   UKID=$(drush cvapi Country.getsingle return="id" iso_code="GB" | grep -oh '[0-9]*')


### PR DESCRIPTION
## Problem

If download.civicrm.org is down the `drush_install.sh` script will hang indefinitely

## Solution

Add a timeout on the `wget` call, limiting the number of tries to 3 and the timeout each time to 60 seconds