### PR TITLE
PCHR-2113: hrvisa activity handling fixes

### DIFF
--- a/hrvisa/CRM/HRVisa/Activity.php
+++ b/hrvisa/CRM/HRVisa/Activity.php
@@ -105,4 +105,3 @@ class CRM_HRVisa_Activity {
     } // end of if for immgration info check
   }
 }
-?>

--- a/hrvisa/CRM/HRVisa/Activity.php
+++ b/hrvisa/CRM/HRVisa/Activity.php
@@ -63,15 +63,11 @@ class CRM_HRVisa_Activity {
         'activity_type_id' => $activityTypeId,
         'sequential' => 1,
       );
-      // note : using filter 'activity_type_id' in combination with 'contact_id' filter doesn't work
       $activities = civicrm_api3('activity', 'get', $activityGetParams);
 
       $activityId = NULL;
       $count = 0;
       foreach($activities['values'] as $val) {
-        if ($val['activity_type_id'] != $activityTypeId || !array_key_exists('targets', $val)) {
-          continue;
-        }
         $activityId = $val['id'];
         $count++;
       }

--- a/hrvisa/tests/phpunit/CRM/HRVisa/ActivityTest.php
+++ b/hrvisa/tests/phpunit/CRM/HRVisa/ActivityTest.php
@@ -153,18 +153,15 @@ class CRM_HRVisa_ActivityTest extends CiviUnitTestCase implements HeadlessInterf
       'activity_type_id' => $activityTypeId,
       'sequential' => 1,
     );
-    // note : using filter 'activity_type_id' in combination with 'contact_id' filter doesn't work
     $activities = civicrm_api3('activity', 'get', $activityGetParams);
 
     $activityId = NULL;
     $count = 0;
     foreach($activities['values'] as $val) {
-      if ($val['activity_type_id'] != $activityTypeId || !array_key_exists('targets', $val)) {
-        continue;
-      }
       $activityId = $val['id'];
       $count++;
     }
+
     return array($count, $activityId);
   }
 

--- a/hrvisa/tests/phpunit/CRM/HRVisa/ActivityTest.php
+++ b/hrvisa/tests/phpunit/CRM/HRVisa/ActivityTest.php
@@ -2,21 +2,23 @@
 
 use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
 
 /**
  * Class CRM_HRVisa_ActivityTest
  *
  * @group headless
  */
-class CRM_HRVisa_ActivityTest extends CiviUnitTestCase implements HeadlessInterface , TransactionalInterface {
+class CRM_HRVisa_ActivityTest extends PHPUnit_Framework_TestCase implements HeadlessInterface , TransactionalInterface {
 
   protected $customFields;
 
   public function setUpHeadless() {
-    // check phpunitPopulateDB() to know why org.civicrm.hrdemog is installed here
     return \Civi\Test::headless()
       ->installMe(__DIR__)
+      // hrdemog is necessary because it creates the Immigration fields used by the tests
       ->install('org.civicrm.hrdemog')
+      ->install('uk.co.compucorp.civicrm.hrcore')
       ->apply();
   }
 
@@ -37,21 +39,6 @@ class CRM_HRVisa_ActivityTest extends CiviUnitTestCase implements HeadlessInterf
     $this->createLoggedInUser();
   }
 
-  protected static function _populateDB($perClass = FALSE, &$object = NULL) {
-    self::phpunitPopulateDB();
-
-    //also create 'Visa Expiration' activity type
-    $params = array(
-      'weight' => 1,
-      'label' => 'Visa Expiration',
-      'filter' => 0,
-      'is_active' => 1,
-      'is_default' => 0,
-    );
-    civicrm_api3('activity_type', 'create', $params);
-    return TRUE;
-  }
-
   /**
    * CASE 1 : is_visa_required = TRUE, and 2 migration records,
    * activity of type 'Visa Expiration' created with target contact as
@@ -59,7 +46,7 @@ class CRM_HRVisa_ActivityTest extends CiviUnitTestCase implements HeadlessInterf
    */
   public function testSyncScenario1() {
     // create a test individual
-    $cid = $this->individualCreate();
+    $cid = ContactFabricator::fabricate()['id'];
     // is visa required = 1
     $caseOneStartDate = date('YmdHis');
     $caseOneEndDate = date('YmdHis', strtotime('+1 year'));
@@ -76,13 +63,13 @@ class CRM_HRVisa_ActivityTest extends CiviUnitTestCase implements HeadlessInterf
       "{$this->customFields['Immigration:End_Date']}:-2" => $caseOneEndDate2,
       "{$this->customFields['Immigration:Visa_Number']}:-2" => '4111111111111111'
     );
-    $this->callAPISuccess('custom_value', 'create', $caseOneParams);
+    civicrm_api3('custom_value', 'create', $caseOneParams);
     // sync activity with contact of above details
     CRM_HRVisa_Activity::sync($cid);
 
     // calling a common function for getting activity a particular target contact and activity type
     // this will return activity id and number of activities found
-    list($count, $activityId) = self::_getTargetContactActivity($cid);
+    list($count, $activityId) = self::getTargetContactActivity($cid);
     $caseOneActivityGetParams = array('id' => $activityId);
     $caseOneActivity = civicrm_api3('activity', 'get', $caseOneActivityGetParams);
 
@@ -100,7 +87,7 @@ class CRM_HRVisa_ActivityTest extends CiviUnitTestCase implements HeadlessInterf
    */
   public function testSyncScenario2() {
     // create a test individual
-    $cid = $this->individualCreate();
+    $cid = ContactFabricator::fabricate()['id'];
     $startDate = date('YmdHis');
     $endDate = date('YmdHis', strtotime('+1 year'));
     $params = array(
@@ -111,13 +98,13 @@ class CRM_HRVisa_ActivityTest extends CiviUnitTestCase implements HeadlessInterf
       "{$this->customFields['Immigration:End_Date']}:-1" => $endDate,
       "{$this->customFields['Immigration:Visa_Number']}:-1" => '4111111111111111',
     );
-    $this->callAPISuccess('custom_value', 'create', $params);
+    civicrm_api3('custom_value', 'create', $params);
     // sync activity with contact of above details
     CRM_HRVisa_Activity::sync($cid);
 
     // calling a common function for getting activity a particular target contact and activity type
     // this will return activity id and number of activities found
-    list($count, $activityId) = self::_getTargetContactActivity($cid);
+    list($count, $activityId) = self::getTargetContactActivity($cid);
     $activityGetParams = array('id' => $activityId);
     $activity = civicrm_api3('activity', 'get', $activityGetParams);
 
@@ -133,7 +120,7 @@ class CRM_HRVisa_ActivityTest extends CiviUnitTestCase implements HeadlessInterf
       'entity_id' => $cid,
       $this->customFields['Extended_Demographics:Is_Visa_Required']  => 0,
     );
-    $this->callAPISuccess('custom_value', 'create', $params);
+    civicrm_api3('custom_value', 'create', $params);
 
     // sync activity with contact of above details
     CRM_HRVisa_Activity::sync($cid);
@@ -144,7 +131,7 @@ class CRM_HRVisa_ActivityTest extends CiviUnitTestCase implements HeadlessInterf
     $this->assertEquals(CRM_Core_OptionGroup::getValue('activity_status', 'Cancelled', 'name'), $activity['values'][$activity['id']]['status_id'], 'in line ' . __LINE__ . ' Status of \'Visa Expiration\' activity should be \'Cancelled\' but wrongly is ' . $activity['values'][$activity['id']]['status_id']);
   }
 
-  private function _getTargetContactActivity($contactId) {
+  private function getTargetContactActivity($contactId) {
     $activityTypeId = CRM_Core_OptionGroup::getValue('activity_type', 'Visa Expiration', 'name');
     // to check if visa expiration activity exists for the input target_contact_id
     $activityGetParams = array(
@@ -164,19 +151,20 @@ class CRM_HRVisa_ActivityTest extends CiviUnitTestCase implements HeadlessInterf
     return array($count, $activityId);
   }
 
-  /**
-   * Helper function to load data into DB between iterations of the unit-test
-   */
-  private static function phpunitPopulateDB() {
-    $import = new CRM_Utils_Migrate_Import();
-    $import->run(
-      CRM_Extension_System::singleton()->getMapper()->keyToBasePath('org.civicrm.hrvisa')
-      . '/xml/auto_install.xml'
-    );
-    // this had to be done as demographics consists of is_visa_required field (used in unit test)
-    $import->run(
-      CRM_Extension_System::singleton()->getMapper()->keyToBasePath('org.civicrm.hrdemog')
-      . '/xml/auto_install.xml'
-    );
+  private function createLoggedInUser() {
+    $params = [
+      'first_name' => 'Logged In',
+      'last_name' => 'User ' . rand(),
+      'contact_type' => 'Individual',
+    ];
+    $contact = ContactFabricator::fabricate($params);
+    civicrm_api3('UFMatch', 'create', [
+      'contact_id' => $contact['id'],
+      'uf_name' => 'superman',
+      'uf_id' => 6,
+    ]);
+
+    $session = CRM_Core_Session::singleton();
+    $session->set('userID', $contact['id']);
   }
 }

--- a/hrvisa/tests/phpunit/CRM/HRVisa/ActivityTest.php
+++ b/hrvisa/tests/phpunit/CRM/HRVisa/ActivityTest.php
@@ -20,7 +20,7 @@ class CRM_HRVisa_ActivityTest extends CiviUnitTestCase implements HeadlessInterf
       ->apply();
   }
 
-  function setUp() {
+  public function setUp() {
     // call after parent invocation as fields populated in parent
     $customFields = array(
       'Extended_Demographics:Is_Visa_Required' => 'Is_Visa_Required',
@@ -37,15 +37,10 @@ class CRM_HRVisa_ActivityTest extends CiviUnitTestCase implements HeadlessInterf
     $this->createLoggedInUser();
   }
 
-  function tearDown()
-  {
-
-  }
-
   protected static function _populateDB($perClass = FALSE, &$object = NULL) {
     self::phpunitPopulateDB();
 
-    //also create 'Visa Expiration' actvity type
+    //also create 'Visa Expiration' activity type
     $params = array(
       'weight' => 1,
       'label' => 'Visa Expiration',
@@ -53,14 +48,16 @@ class CRM_HRVisa_ActivityTest extends CiviUnitTestCase implements HeadlessInterf
       'is_active' => 1,
       'is_default' => 0,
     );
-    $result = civicrm_api3('activity_type', 'create', $params);
+    civicrm_api3('activity_type', 'create', $params);
     return TRUE;
   }
 
-  // CASE 1 : is_visa_required = TRUE, and 2 migration records,
-  // activity of type 'Visa Expiration' created with target contact as
-  // the one whose record is being edited.
-  function testSyncScenario1() {
+  /**
+   * CASE 1 : is_visa_required = TRUE, and 2 migration records,
+   * activity of type 'Visa Expiration' created with target contact as
+   * the one whose record is being edited.
+   */
+  public function testSyncScenario1() {
     // create a test individual
     $cid = $this->individualCreate();
     // is visa required = 1
@@ -83,7 +80,7 @@ class CRM_HRVisa_ActivityTest extends CiviUnitTestCase implements HeadlessInterf
     // sync activity with contact of above details
     CRM_HRVisa_Activity::sync($cid);
 
-    // calling a common function for getting acivity a particular target contact and acitvity type
+    // calling a common function for getting activity a particular target contact and activity type
     // this will return activity id and number of activities found
     list($count, $activityId) = self::_getTargetContactActivity($cid);
     $caseOneActivityGetParams = array('id' => $activityId);
@@ -96,10 +93,12 @@ class CRM_HRVisa_ActivityTest extends CiviUnitTestCase implements HeadlessInterf
 
   }
 
-  // CASE 2 : is_visa_required = TRUE, one migration record.
-  // later is_visa_required = FALSE,
-  // activity status set to 'Cancelled' from 'Scheduled'
-  function testSyncSncenario2() {
+  /**
+   * CASE 2 : is_visa_required = TRUE, one migration record.
+   * later is_visa_required = FALSE,
+   * activity status set to 'Cancelled' from 'Scheduled'
+   */
+  public function testSyncScenario2() {
     // create a test individual
     $cid = $this->individualCreate();
     $startDate = date('YmdHis');
@@ -116,7 +115,7 @@ class CRM_HRVisa_ActivityTest extends CiviUnitTestCase implements HeadlessInterf
     // sync activity with contact of above details
     CRM_HRVisa_Activity::sync($cid);
 
-    // calling a common function for getting acivity a particular target contact and acitvity type
+    // calling a common function for getting activity a particular target contact and activity type
     // this will return activity id and number of activities found
     list($count, $activityId) = self::_getTargetContactActivity($cid);
     $activityGetParams = array('id' => $activityId);
@@ -145,7 +144,7 @@ class CRM_HRVisa_ActivityTest extends CiviUnitTestCase implements HeadlessInterf
     $this->assertEquals(CRM_Core_OptionGroup::getValue('activity_status', 'Cancelled', 'name'), $activity['values'][$activity['id']]['status_id'], 'in line ' . __LINE__ . ' Status of \'Visa Expiration\' activity should be \'Cancelled\' but wrongly is ' . $activity['values'][$activity['id']]['status_id']);
   }
 
-  function _getTargetContactActivity($contactId) {
+  private function _getTargetContactActivity($contactId) {
     $activityTypeId = CRM_Core_OptionGroup::getValue('activity_type', 'Visa Expiration', 'name');
     // to check if visa expiration activity exists for the input target_contact_id
     $activityGetParams = array(


### PR DESCRIPTION
One of the features of the hrvisa extension is to check for expired visas and, in case this is a required document and the existing one is expired, it creates Activities to "notify" the user that it has to be updated.

In order to do this, it first checks if such Activity already exists (to avoid spamming the user with duplicated activities) and it does that by looking for activities where the Contact of the expired visa is the target. This check was done by inspecting the `targets` property returned by the API, but since the changes introduced by https://github.com/civicrm/civicrm-core/pull/9841, `targets` is not returned anymore and the code was failing.

To fix this, I first thought about replacing `targets` with something else, but then I realized that this check is not required at all. Looking at the code, there was this comment: 

> note : using filter 'activity_type_id' in combination with 'contact_id' filter doesn't work

It means, the check was only added because it was not possible, by the time the code was created back in 2013, to get an activity by both the type and the contact. Fortunately, this is not the case anymore. The API works just fine now, so I completely remove the check, which fixed the error.

Finally, I did some cleanup to fix some typos and remove the dependency on CiviUnitTestCase, which we're not using anymore on the new tests.