### PR TITLE
PCHR-2113: Make CiviHR 1.7 compatible with CiviCRM 4.7.18

### DIFF
--- a/uk.co.compucorp.civicrm.hrcomments/CRM/HRComments/API/Query/CommentSelect.php
+++ b/uk.co.compucorp.civicrm.hrcomments/CRM/HRComments/API/Query/CommentSelect.php
@@ -1,10 +1,10 @@
 <?php
 
-use Civi\API\SelectQuery;
+use Civi\API\Api3SelectQuery;
 use CRM_HRComments_BAO_Comment as Comment;
 
 /**
- * This class is basically a wrapper around Civi\API\SelectQuery.
+ * This class is basically a wrapper around Civi\API\Api3SelectQuery.
  */
 class CRM_HRComments_API_Query_CommentSelect {
 
@@ -15,7 +15,7 @@ class CRM_HRComments_API_Query_CommentSelect {
   private $params;
 
   /**
-   * @var \Civi\API\SelectQuery
+   * @var \Civi\API\Api3SelectQuery
    *  The SelectQuery instance wrapped by this class
    */
   private $query;
@@ -33,7 +33,10 @@ class CRM_HRComments_API_Query_CommentSelect {
 
     $this->addWhere($customQuery);
     $this->filterReturnFields();
-    $this->query = new SelectQuery(Comment::class, $this->params, false);
+
+    $checkPermissions = !empty($this->params['check_permissions']);
+    $this->query = new Api3SelectQuery('Comment', $checkPermissions);
+    $this->query->where = $this->params;
     $this->query->merge($customQuery);
   }
 

--- a/uk.co.compucorp.civicrm.hrcomments/CRM/HRComments/API/Query/CommentSelect.php
+++ b/uk.co.compucorp.civicrm.hrcomments/CRM/HRComments/API/Query/CommentSelect.php
@@ -34,9 +34,7 @@ class CRM_HRComments_API_Query_CommentSelect {
     $this->addWhere($customQuery);
     $this->filterReturnFields();
 
-    $checkPermissions = !empty($this->params['check_permissions']);
-    $this->query = new Api3SelectQuery('Comment', $checkPermissions);
-    $this->query->where = $this->params;
+    $this->buildSelectQuery();
     $this->query->merge($customQuery);
   }
 
@@ -133,5 +131,26 @@ class CRM_HRComments_API_Query_CommentSelect {
     );
 
     return $conditions;
+  }
+
+  /**
+   * Build the internal Api3SelectQuery object based on the instance's params.
+   */
+  private function buildSelectQuery() {
+    $checkPermissions = !empty($this->params['check_permissions']);
+    $this->query = new Api3SelectQuery('Comment', $checkPermissions);
+    $options = _civicrm_api3_get_options_from_params($this->params);
+
+    if ($options['is_count']) {
+      $this->query->select = ['count_rows'];
+    }
+    else {
+      $this->query->select = array_keys(array_filter($options['return']));
+      $this->query->orderBy = $options['sort'];
+    }
+
+    $this->query->limit = $options['limit'];
+    $this->query->offset = $options['offset'];
+    $this->query->where = $this->params;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/ContactSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/ContactSelect.php
@@ -1,13 +1,13 @@
 <?php
 
-use Civi\API\SelectQuery;
+use Civi\API\Api3SelectQuery;
 use CRM_Contact_BAO_Relationship as Relationship;
 use CRM_Contact_BAO_RelationshipType as RelationshipType;
 use CRM_Contact_BAO_Contact as Contact;
 use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
 
 /**
- * This class is basically a wrapper around Civi\API\SelectQuery.
+ * This class is basically a wrapper around Civi\API\Api3SelectQuery.
  */
 class CRM_HRLeaveAndAbsences_API_Query_ContactSelect {
 
@@ -25,7 +25,7 @@ class CRM_HRLeaveAndAbsences_API_Query_ContactSelect {
   private $leaveManagerService;
 
   /**
-   * @var \Civi\API\SelectQuery
+   * @var \Civi\API\Api3SelectQuery
    *  The SelectQuery instance wrapped by this class
    */
   private $query;
@@ -52,7 +52,9 @@ class CRM_HRLeaveAndAbsences_API_Query_ContactSelect {
     $this->addWhere($customQuery);
     $this->filterReturnFields();
 
-    $this->query = new SelectQuery(Contact::class, $this->params, false);
+    $checkPermissions = !empty($this->params['check_permissions']);
+    $this->query = new Api3SelectQuery('Contact', $checkPermissions);
+    $this->query->where = $this->params;
     $this->query->merge($customQuery);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/ContactSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/ContactSelect.php
@@ -1,13 +1,14 @@
 <?php
 
-use Civi\API\Api3SelectQuery;
 use CRM_Contact_BAO_Relationship as Relationship;
 use CRM_Contact_BAO_RelationshipType as RelationshipType;
 use CRM_Contact_BAO_Contact as Contact;
+use CRM_HRLeaveAndAbsences_API_Query_Select as SelectQuery;
 use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
 
 /**
- * This class is basically a wrapper around Civi\API\Api3SelectQuery.
+ * Uses CRM_HRLeaveAndAbsences_API_Query_Select to tweak select queries to
+ * Contacts and inject custom conditions to it
  */
 class CRM_HRLeaveAndAbsences_API_Query_ContactSelect {
 
@@ -25,7 +26,7 @@ class CRM_HRLeaveAndAbsences_API_Query_ContactSelect {
   private $leaveManagerService;
 
   /**
-   * @var \Civi\API\Api3SelectQuery
+   * @var \CRM_HRLeaveAndAbsences_API_Query_Select
    *  The SelectQuery instance wrapped by this class
    */
   private $query;
@@ -52,9 +53,7 @@ class CRM_HRLeaveAndAbsences_API_Query_ContactSelect {
     $this->addWhere($customQuery);
     $this->filterReturnFields();
 
-    $checkPermissions = !empty($this->params['check_permissions']);
-    $this->query = new Api3SelectQuery('Contact', $checkPermissions);
-    $this->query->where = $this->params;
+    $this->query = new SelectQuery('Contact', $this->params);
     $this->query->merge($customQuery);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
@@ -1,6 +1,6 @@
 <?php
 
-use Civi\API\SelectQuery;
+use Civi\API\Api3SelectQuery;
 use CRM_Contact_BAO_Relationship as Relationship;
 use CRM_Contact_BAO_RelationshipType as RelationshipType;
 use CRM_Hrjobcontract_BAO_HRJobContract as HRJobContract;
@@ -11,9 +11,9 @@ use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
 
 /**
- * This class is basically a wrapper around Civi\API\SelectQuery.
+ * This class is basically a wrapper around Civi\API\Api3SelectQuery.
  *
- * It's supposed to work just like SelectQuery, but it will automatically join
+ * It's supposed to work just like Api3SelectQuery, but it will automatically join
  * the LeaveRequest with its LeaveRequestDates and LeaveBalanceChange, allowing
  * us to filter the results based on balance change details, like returning only
  * Public Holiday Leave Requests.
@@ -29,7 +29,7 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
   private $params;
 
   /**
-   * @var \Civi\API\SelectQuery
+   * @var \Civi\API\Api3SelectQuery
    *  The SelectQuery instance wrapped by this class
    */
   private $query;
@@ -58,7 +58,9 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
     $this->addWhere($customQuery);
     $this->addGroupBy($customQuery);
 
-    $this->query = new SelectQuery(LeaveRequest::class, $this->params, false);
+    $checkPermissions = !empty($this->params['check_permissions']);
+    $this->query = new Api3SelectQuery('LeaveRequest', $checkPermissions);
+    $this->query->where = $this->params;
     $this->query->merge($customQuery);
   }
 
@@ -202,12 +204,12 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
 
   /**
    * Adds the balance_change and dates to the Leave Requests array returned by
-   * the SelectQuery.
+   * the Api3SelectQuery.
    *
    * This is not the best code in terms of performance, since it will trigger
    * two SQL queries for each returned Leave Request (one to get the balance, and
    * another one to get the dates). But, since we want the query to work just
-   * like LeaveRequest.get (including all the params and options) and the SelectQuery
+   * like LeaveRequest.get (including all the params and options) and the Api3SelectQuery
    * class is not much flexible regarding returning calculated fields (the balance
    * change is the sum of the amount of all balance changes) and related records,
    * this is how it will work for now.

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/Select.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/Select.php
@@ -1,0 +1,49 @@
+<?php
+
+use Civi\API\Api3SelectQuery;
+
+/**
+ * This class is just a wrapper around Civi\API\Api3SelectQuery.
+ *
+ * It introduces a new constructor which accepts the API params and then uses it
+ * to prepare the internal query properties.
+ */
+class CRM_HRLeaveAndAbsences_API_Query_Select extends Api3SelectQuery {
+
+  /**
+   * CRM_HRLeaveAndAbsences_API_Query_Select constructor.
+   *
+   * @param string $entity
+   *   An entity name like Contact, LeaveRequest, etc
+   * @param array $params
+   *   The API params array
+   */
+  public function __construct($entity, $params) {
+    $checkPermissions = !empty($params['check_permissions']);
+    parent::__construct($entity, $checkPermissions);
+    $this->setupQueryFromParams($params);
+  }
+
+  /**
+   * Setup things like limit, order, offset and fields to return
+   *
+   * @param array $params
+   */
+  private function setupQueryFromParams($params) {
+    $this->where = $params;
+
+    $options = _civicrm_api3_get_options_from_params($params);
+
+    if ($options['is_count']) {
+      $this->select = ['count_rows'];
+    }
+    else {
+      $this->select  = array_keys(array_filter($options['return']));
+      $this->orderBy = $options['sort'];
+    }
+
+    $this->limit = $options['limit'];
+    $this->offset = $options['offset'];
+  }
+
+}


### PR DESCRIPTION
Up until now, CiviHR 1.7 was based on CiviCRM 4.7.9. This PR updates it to follow the changes introduced since then and make it compatible with 4.7.18.

The only problem found was related to the usage of the `SelectQuery` class, used to create some custom get* APIs (e.g. `LeaveRequest.getFull`, `Contact.getManagess`, etc). On civicrm/civicrm-core#7725, a lot of changes to support APIv4 were introduced, including changes to this class, which now is abstract and cannot be instantiated, breaking any code which was using the `SelectQuery` class.

To fix this, the *Select classes now use the Api3SelectQuery class instead. For L&A, a new `CRM_HRLeaveAndAbsences_API_Query_Select` was added. It extends `Api3SelectQuery`, but introduces a new constructor which accepts the params array. Internally, it uses this array to set all the necessary properties. This new class is now used by `ContactSelect` and `LeaveRequestSelect`, exactly where `SelectQuery` was being used before.

For hrcomments, a similar approach was used, but instead of adding a new class, a new method was added.