### PR TITLE
PCHR-2161: Fix issues with Leave Days amount is not saved correctly on a Work Pattern

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/WorkDay.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/DAO/WorkDay.php
@@ -117,9 +117,9 @@ class CRM_HRLeaveAndAbsences_DAO_WorkDay extends CRM_Core_DAO
    */
   public $break;
   /**
-   * The proportion of a days leave that will be deducted if this day is taken as leave.
+   * One of the values of the Leave Days Amount option group
    *
-   * @var int unsigned
+   * @var string
    */
   public $leave_days;
   /**
@@ -221,9 +221,15 @@ class CRM_HRLeaveAndAbsences_DAO_WorkDay extends CRM_Core_DAO
         ) ,
         'leave_days' => array(
           'name' => 'leave_days',
-          'type' => CRM_Utils_Type::T_INT,
+          'type' => CRM_Utils_Type::T_STRING,
           'title' => ts('Leave Days') ,
-          'description' => 'The proportion of a days leave that will be deducted if this day is taken as leave.',
+          'description' => 'One of the values of the Leave Days Amount option group',
+          'maxlength' => 512,
+          'size' => CRM_Utils_Type::HUGE,
+          'pseudoconstant' => array(
+            'optionGroupName' => 'hrleaveandabsences_leave_days_amounts',
+            'optionEditPath' => 'civicrm/admin/options/hrleaveandabsences_leave_days_amounts',
+          )
         ) ,
         'number_of_hours' => array(
           'name' => 'number_of_hours',

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_install.sql
@@ -202,7 +202,7 @@ CREATE TABLE `civicrm_hrleaveandabsences_work_day` (
      `time_from` char(5)    COMMENT 'The start time of this work day. This field is a char because CiviCRM can\'t handle TIME fields.',
      `time_to` char(5)    COMMENT 'The end time of this work day. This field is a char because CiviCRM can\'t handle TIME fields.',
      `break` decimal(20,2)    COMMENT 'The amount of break time (in hours) allowed for this day. ',
-     `leave_days` int unsigned    COMMENT 'The proportion of a days leave that will be deducted if this day is taken as leave.',
+     `leave_days` varchar(512)    COMMENT 'One of the values of the Leave Days Amount option group',
      `number_of_hours` decimal(20,2)    COMMENT 'This is the number of hours between time_from and time_to minus break',
      `week_id` int unsigned NOT NULL   COMMENT 'The Work Week this Day belongs to',
     PRIMARY KEY ( `id` ),

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkDayTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkDayTest.php
@@ -183,34 +183,25 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends BaseHeadlessTest {
     $this->assertSame((string)$workDayTypes['weekend'], WorkDay::getWeekendTypeValue());
   }
 
-  public function testCreateWorkDayWithLeaveDaysFromLeaveDaysAmountOptionGroup() {
-    $leaveDayAmounts = array_flip(WorkDay::buildOptions('leave_days', 'validate'));
-    $dayOfTheWeek = 1;
-
-    //Just testing different leave amount for at most seven days since its not possible to have more
-    //than seven days for a particular work week ID.
-    foreach($leaveDayAmounts as $leaveDay) {
-      $this->createBasicWorkDay(['day_of_the_week' => $dayOfTheWeek, 'leave_days' => $leaveDay]);
-      if($dayOfTheWeek == 7) {
-        break;
-      }
-      $dayOfTheWeek++;
-    }
+  public function testCreateWorkDayWithWithRandomDecimalValuesAsLeaveDays() {
+    $leaveDayAmounts = [0.5, 1.5, 2.5];
+    $this->createBasicWorkDay(['day_of_the_week' => 1, 'leave_days' => $leaveDayAmounts[0]]);
+    $this->createBasicWorkDay(['day_of_the_week' => 2, 'leave_days' => $leaveDayAmounts[1]]);
+    $this->createBasicWorkDay(['day_of_the_week' => 3, 'leave_days' => $leaveDayAmounts[2]]);
 
     $workDays = new WorkDay();
     $workDays->week_id = $this->workWeek->id;
     $workDays->find();
 
-    $this->assertEquals($workDays->N, $dayOfTheWeek);
+    //Three Work days were created
+    $this->assertEquals($workDays->N, 3);
 
     while($workDays->fetch()) {
       $leaveDays[] = $workDays->leave_days;
     }
 
     //compare that the leave day amount we created the work days with is the same as what is in the db
-    $leaveDayAmounts = array_slice($leaveDayAmounts, 0, $dayOfTheWeek);
     sort($leaveDays);
-    sort($leaveDayAmounts);
     $this->assertEquals($leaveDays, $leaveDayAmounts);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/WorkDay.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/schema/CRM/HRLeaveAndAbsences/WorkDay.xml
@@ -70,10 +70,14 @@
 
   <field>
     <name>leave_days</name>
-    <type>int unsigned</type>
+    <type>varchar</type>
+    <length>512</length>
     <label>Leave days</label>
-    <comment>The proportion of a days leave that will be deducted if this day is taken as leave.</comment>
+    <comment>One of the values of the Leave Days Amount option group</comment>
     <add>4.4</add>
+    <pseudoconstant>
+      <optionGroupName>hrleaveandabsences_leave_days_amounts</optionGroupName>
+    </pseudoconstant>
   </field>
 
   <field>


### PR DESCRIPTION
## Overview
When saving/editing a Work Pattern, it's possible to set the Leave Days amount for a working day. Currently, if you select any amount other than 1 Day, the saved amount will be incorrect.


## Before
When saving/editing the leave day amount for a working day in a Work Pattern other than 1 Day, the saved amount will be incorrect.
The reason for this is that the column for leave_days in the Work Day table is integer and some of the leave day values are float e.g 0.5 for Half day. When these values are saved, they get rounded up to integers in the database i.e 0.5 becomes 1 and 1.5 becomes 2.

## After
This PR fixes that by changing the leave_days column to VARCHAR and also binding the column to the leave_days_amount option group. The obvious solution would have been to change to change the column type to decimal but since its linked to the leave_days_amount option group, the column has to be VARCHAR to be same as the option value column type storing the leave day amounts.

When saving/editing the leave day amount for a working day in a Work Pattern, It gets saved correctly.


- [X] Tests Pass
