### PR TITLE
PCHR-2203: Fix dropdown for My/Manager Leave

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/manager-leave/components/manager-leave-container.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/manager-leave/components/manager-leave-container.html
@@ -1,13 +1,12 @@
 <div class="manager-leave-page">
   <div class="button-container">
-    <div class="btn-group">
+    <div class="btn-group" uib-dropdown>
       <button type="button" class="btn btn-primary" leave-request-popup leave-type="leave" for-staff="true"
         contact-id="managerLeave.contactId">Record New Absence</button>
-      <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split"
-              data-toggle="dropdown">
+      <button type="button" class="btn btn-primary dropdown-toggle-split" uib-dropdown-toggle>
         <span class="caret"></span>
       </button>
-      <ul class="dropdown-menu">
+      <ul class="dropdown-menu" uib-dropdown-menu>
         <li><a leave-request-popup contact-id="managerLeave.contactId" leave-type="sickness" for-staff="true" href="#">
           Record Sickness</a></li>
         <li><a leave-request-popup contact-id="managerLeave.contactId" leave-type="toil" for-staff="true" href="#">

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/my-leave/components/my-leave-container.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/my-leave/components/my-leave-container.html
@@ -1,12 +1,11 @@
 <div class="my-leave-page">
   <div class="button-container">
-    <div class="btn-group">
+    <div class="btn-group" uib-dropdown>
       <button type="button" class="btn btn-primary" leave-request-popup leave-type="leave" contact-id="myleave.contactId">Record New Absence</button>
-      <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split"
-              data-toggle="dropdown">
+      <button type="button" class="btn btn-primary dropdown-toggle-split" uib-dropdown-toggle>
         <span class="caret"></span>
       </button>
-      <ul class="dropdown-menu">
+      <ul class="dropdown-menu" uib-dropdown-menu>
         <li><a leave-request-popup contact-id="myleave.contactId" leave-type="sickness" href="#">Record Sickness</a></li>
         <li><a leave-request-popup contact-id="myleave.contactId" leave-type="toil" href="#">Record Overtime</a></li>
       </ul>


### PR DESCRIPTION
## Overview
After syncing 1.7 with 1.6, the dropdown on the "Record New Absence" is not opening anymore and the "Record Sickness" and "Record Overtime" options are not accessible

## After
My Leave
![2203 my leave](https://cloud.githubusercontent.com/assets/5058867/25572105/35d50498-2e55-11e7-89c3-aaabe65a5a83.gif)

Manager Leave
![2203 manager leave](https://cloud.githubusercontent.com/assets/5058867/25572106/3c8a7bba-2e55-11e7-980a-db2cec4e053c.gif)


## Technical Details
Not exactly sure why the dropdowns stopped working after 1.7 sync. As other dropdowns with `uib-dropdown` is working fine, added the same for `My Leave`& `Manager Leave`.
