### PR TITLE
PCHR-2142: Fix error when running Public Holiday Updates Scheduled Job

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/RequestNotificationTemplate.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/RequestNotificationTemplate.php
@@ -16,7 +16,7 @@ class CRM_HRLeaveAndAbsences_Factory_RequestNotificationTemplate {
    *
    * @param \CRM_HRLeaveAndAbsences_BAO_LeaveRequest $leaveRequest
    *
-   * @return \CRM_HRLeaveAndAbsences_Mail_Template_BaseRequestNotification|boolean
+   * @return \CRM_HRLeaveAndAbsences_Mail_Template_BaseRequestNotification|null
    */
   public function create(LeaveRequest $leaveRequest) {
     $leaveRequestCommentService = new LeaveRequestCommentService();
@@ -32,7 +32,7 @@ class CRM_HRLeaveAndAbsences_Factory_RequestNotificationTemplate {
         return new TOILRequestNotificationTemplate($leaveRequestCommentService);
         break;
       default:
-        return false;
+        return null;
     }
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/RequestNotificationTemplate.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/RequestNotificationTemplate.php
@@ -16,7 +16,7 @@ class CRM_HRLeaveAndAbsences_Factory_RequestNotificationTemplate {
    *
    * @param \CRM_HRLeaveAndAbsences_BAO_LeaveRequest $leaveRequest
    *
-   * @return \CRM_HRLeaveAndAbsences_Mail_Template_BaseRequestNotification
+   * @return \CRM_HRLeaveAndAbsences_Mail_Template_BaseRequestNotification|boolean
    */
   public function create(LeaveRequest $leaveRequest) {
     $leaveRequestCommentService = new LeaveRequestCommentService();
@@ -31,6 +31,8 @@ class CRM_HRLeaveAndAbsences_Factory_RequestNotificationTemplate {
       case LeaveRequest::REQUEST_TYPE_TOIL:
         return new TOILRequestNotificationTemplate($leaveRequestCommentService);
         break;
+      default:
+        return false;
     }
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Message.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Message.php
@@ -79,31 +79,32 @@ class CRM_HRLeaveAndAbsences_Mail_Message {
     if (is_null($this->requestTemplate)) {
       $this->requestTemplate = $this->requestTemplateFactory->create($this->leaveRequest);
     }
-
     return $this->requestTemplate;
   }
 
   /**
    * Gets the template parameters for the Leave Request template
    *
-   * @return array|boolean
+   * @return array|null
    */
   public function getTemplateParameters() {
     if (!$this->isValidTemplate()) {
-      return false;
+      return null;
     }
+
     return $this->getTemplate()->getTemplateParameters($this->leaveRequest);
   }
 
   /**
    * Gets the template ID for the Leave Request template
    *
-   * @return int|boolean
+   * @return int|null
    */
   public function getTemplateID() {
     if (!$this->isValidTemplate()) {
-      return false;
+      return null;
     }
+
     return $this->getTemplate()->getTemplateID();
   }
 
@@ -191,8 +192,7 @@ class CRM_HRLeaveAndAbsences_Mail_Message {
   }
 
   /**
-   * Checks whether the template is a valid template and extends the
-   * BaseRequestNotificationTemplate class.
+   * Checks whether the template is a valid template or not.
    *
    * @return bool
    */

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Message.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Message.php
@@ -2,6 +2,7 @@
 
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_BAO_NotificationReceiver as NotificationReceiver;
+use CRM_HRLeaveAndAbsences_Mail_Template_BaseRequestNotification as BaseRequestNotificationTemplate;
 use CRM_HRLeaveAndAbsences_Factory_RequestNotificationTemplate as RequestNotificationTemplateFactory;
 
 class CRM_HRLeaveAndAbsences_Mail_Message {
@@ -85,18 +86,24 @@ class CRM_HRLeaveAndAbsences_Mail_Message {
   /**
    * Gets the template parameters for the Leave Request template
    *
-   * @return array
+   * @return array|boolean
    */
   public function getTemplateParameters() {
+    if (!$this->isValidTemplate()) {
+      return false;
+    }
     return $this->getTemplate()->getTemplateParameters($this->leaveRequest);
   }
 
   /**
    * Gets the template ID for the Leave Request template
    *
-   * @return int
+   * @return int|boolean
    */
   public function getTemplateID() {
+    if (!$this->isValidTemplate()) {
+      return false;
+    }
     return $this->getTemplate()->getTemplateID();
   }
 
@@ -181,5 +188,15 @@ class CRM_HRLeaveAndAbsences_Mail_Message {
    */
   private function getNotificationReceivers() {
     return NotificationReceiver::getReceiversIDsForAbsenceType($this->leaveRequest->type_id);
+  }
+
+  /**
+   * Checks whether the template is a valid template and extends the
+   * BaseRequestNotificationTemplate class.
+   *
+   * @return bool
+   */
+  private function isValidTemplate() {
+    return $this->getTemplate() instanceof BaseRequestNotificationTemplate;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestMailNotificationSender.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestMailNotificationSender.php
@@ -17,15 +17,19 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestMailNotificationSender {
   public function send(Message $message) {
 
     $recipientEmails = $message->getRecipientEmails();
+    $templateID = $message->getTemplateID();
+    $templateParameters = $message->getTemplateParameters();
+    $contactID = $message->getLeaveContactID();
+    $fromEmail = $message->getFromEmail();
     $status = [];
     foreach($recipientEmails as $recipient) {
 
       $mailSent =
         MessageTemplate::sendTemplate([
-          'messageTemplateID' => $message->getTemplateID(),
-          'contactId' => $message->getLeaveContactID(),
-          'tplParams' => $message->getTemplateParameters(),
-          'from' => $message->getFromEmail(),
+          'messageTemplateID' => $templateID,
+          'contactId' => $contactID,
+          'tplParams' => $templateParameters,
+          'from' => $fromEmail,
           'toName' => $recipient['api.Contact.get']['values'][0]['display_name'],
           'toEmail' => $recipient['email'],
         ])[0];

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestMailNotificationSender.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestMailNotificationSender.php
@@ -22,8 +22,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestMailNotificationSender {
     $contactID = $message->getLeaveContactID();
     $fromEmail = $message->getFromEmail();
     $status = [];
-    foreach($recipientEmails as $recipient) {
 
+    foreach($recipientEmails as $recipient) {
       $mailSent =
         MessageTemplate::sendTemplate([
           'messageTemplateID' => $templateID,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -15,6 +15,7 @@
 use CRM_HRLeaveAndAbsences_Factory_PublicHolidayLeaveRequestService as PublicHolidayLeaveRequestServiceFactory;
 use CRM_HRLeaveAndAbsences_Service_AbsenceType as AbsenceTypeService;
 use CRM_HRLeaveAndAbsences_Mail_Message as Message;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestMailNotificationSender as LeaveRequestMailNotificationSenderService;
 use CRM_HRLeaveAndAbsences_Factory_RequestNotificationTemplate as RequestNotificationTemplateFactory;
 
@@ -608,6 +609,9 @@ function _hrleaveandabsences_civicrm_post_absencetype($op, $objectId, &$objectRe
  * @param object $objectRef
  */
 function _hrleaveandabsences_civicrm_post_leaverequest($op, $objectId, &$objectRef) {
+  if ($objectRef->request_type == LeaveRequest::REQUEST_TYPE_PUBLIC_HOLIDAY) {
+    return;
+  }
 
   try {
     //get the message for the leave request

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -609,14 +609,14 @@ function _hrleaveandabsences_civicrm_post_absencetype($op, $objectId, &$objectRe
  * @param object $objectRef
  */
 function _hrleaveandabsences_civicrm_post_leaverequest($op, $objectId, &$objectRef) {
-  if ($objectRef->request_type == LeaveRequest::REQUEST_TYPE_PUBLIC_HOLIDAY) {
-    return;
-  }
-
   try {
     //get the message for the leave request
     $leaveRequestTemplateFactory = new RequestNotificationTemplateFactory();
     $message = new Message($objectRef, $leaveRequestTemplateFactory);
+
+    if (!$message->getTemplateID()) {
+      return;
+    }
 
     //send the email
     $leaveMailSenderService = new LeaveRequestMailNotificationSenderService();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Factory/RequestMailNotificationTemplateTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Factory/RequestMailNotificationTemplateTest.php
@@ -27,6 +27,14 @@ class CRM_HRLeaveAndAbsences_Factory_RequestMailNotificationServiceTest extends 
     $this->assertInstanceOf($expectedClass, $template);
   }
 
+  public function testCreateReturnsFalseWhenThereIsNoTemplateForTheRequestType() {
+    $leaveRequest = new LeaveRequest();
+    $leaveRequest->request_type = LeaveRequest::REQUEST_TYPE_PUBLIC_HOLIDAY;
+    $template = $this->leaveRequestTemplateFactory->create($leaveRequest);
+
+    $this->assertFalse($template);
+  }
+
   public function requestTemplateFactoryDataProvider() {
     return [
       [LeaveRequest::REQUEST_TYPE_LEAVE, 'CRM_HRLeaveAndAbsences_Mail_Template_LeaveRequestNotification'],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Factory/RequestMailNotificationTemplateTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Factory/RequestMailNotificationTemplateTest.php
@@ -27,12 +27,12 @@ class CRM_HRLeaveAndAbsences_Factory_RequestMailNotificationServiceTest extends 
     $this->assertInstanceOf($expectedClass, $template);
   }
 
-  public function testCreateReturnsFalseWhenThereIsNoTemplateForTheRequestType() {
+  public function testCreateReturnsNullWhenThereIsNoTemplateForTheRequestType() {
     $leaveRequest = new LeaveRequest();
     $leaveRequest->request_type = LeaveRequest::REQUEST_TYPE_PUBLIC_HOLIDAY;
     $template = $this->leaveRequestTemplateFactory->create($leaveRequest);
 
-    $this->assertFalse($template);
+    $this->assertNull($template);
   }
 
   public function requestTemplateFactoryDataProvider() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
@@ -171,7 +171,7 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
     $this->assertNotNull($recipientEmails);
   }
 
-  public function testGetTemplateParametersReturnsFalseWhenThereIsNoTemplateForARequestType() {
+  public function testGetTemplateParametersReturnsNullWhenThereIsNoTemplateForARequestType() {
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => 1,
       'contact_id' =>$this->leaveContact['id'],
@@ -181,10 +181,10 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
     ], false);
 
     $message = new Message($leaveRequest, $this->leaveRequestTemplateFactory);
-    $this->assertFalse($message->getTemplateParameters());
+    $this->assertNull($message->getTemplateParameters());
   }
 
-  public function testGetTemplateIDReturnsFalseWhenThereIsNoTemplateForARequestType() {
+  public function testGetTemplateIDReturnsNullWhenThereIsNoTemplateForARequestType() {
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => 1,
       'contact_id' =>$this->leaveContact['id'],
@@ -194,6 +194,6 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
     ], false);
 
     $message = new Message($leaveRequest, $this->leaveRequestTemplateFactory);
-    $this->assertFalse($message->getTemplateID());
+    $this->assertNull($message->getTemplateID());
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
@@ -170,4 +170,30 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
     //to fetch from L&A general settings
     $this->assertNotNull($recipientEmails);
   }
+
+  public function testGetTemplateParametersReturnsFalseWhenThereIsNoTemplateForARequestType() {
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => 1,
+      'contact_id' =>$this->leaveContact['id'],
+      'from_date' => CRM_Utils_Date::processDate('tomorrow'),
+      'to_date' => CRM_Utils_Date::processDate('tomorrow'),
+      'request_type' => 'test_request_type'
+    ], false);
+
+    $message = new Message($leaveRequest, $this->leaveRequestTemplateFactory);
+    $this->assertFalse($message->getTemplateParameters());
+  }
+
+  public function testGetTemplateIDReturnsFalseWhenThereIsNoTemplateForARequestType() {
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => 1,
+      'contact_id' =>$this->leaveContact['id'],
+      'from_date' => CRM_Utils_Date::processDate('tomorrow'),
+      'to_date' => CRM_Utils_Date::processDate('tomorrow'),
+      'request_type' => 'test_request_type'
+    ], false);
+
+    $message = new Message($leaveRequest, $this->leaveRequestTemplateFactory);
+    $this->assertFalse($message->getTemplateID());
+  }
 }


### PR DESCRIPTION
## Overview
When a Leave Request is created/updated, Email notifications are sent out. However a Public holiday leave request is a special kind of leave request in that it is created by the system itself and not by a user. While running the Public Holiday scheduled job to create a leave request, I found an error in the Logs. This error is thrown because the system could not find an Email template for the Public Holiday Leave Request type. This PR makes sure that for Public Holiday leave requests, notifications are not sent since we are not supposed to send notifications for a Public Holiday Leave request

## Before
When running the Public Holiday Updates Schedule Jobs, this error is found in the Logs, 
`Call to a member function getTemplateID() on null in .../civihr/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Message.php on line 100`.
The reason for this is that no Email template exists for a Public Holiday leave request.
## After
The Public Holiday Updates Scheduled Job runs smoothly without any error in the logs

---

- [x] Tests Pass
