### PR TITLE
PCHR-2202:  Colour is reset when enabling/disabling an Absence Type from the list

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -73,7 +73,9 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
       $params['weight'] = self::getMaxWeight() + 1;
     }
 
-    $params['color'] = strtoupper($params['color']);
+    if (!empty($params['color'])) {
+      $params['color'] = strtoupper($params['color']);
+    }
 
     unset($params['is_reserved']);
 


### PR DESCRIPTION
## Overview
When an action is performed on an Absence Type from the Absence Type listing page such as disabling/enabling or setting an absence type as default, the absence type loses the initial colour it had before the action was taken.

## Before
The reason for the colour of the Absence type being reset is that the AbsenceType BAO create method modifies the colour using this condition before it get saved in the database.
```php
$params['color'] = strtoupper($params['color']);
```
When an absence type is disabled, the payload to the Absence Type create API looks like this:
```php
    civicrm_api3('AbsenceType', 'create', [
      'id' => 1,
      'is_active' => 0
    ]);
```
When being disabled/enabled, the colour parameter is not present but the colour parameter gets to be modified and ends up being set to null.

![absencelistbefore2](https://cloud.githubusercontent.com/assets/6951813/25619422/b5a9eb14-2f42-11e7-8c83-5c534dfe3474.gif)

## After
The condition to modify the colour parameter gets wrapped in an IF statement.

![absencelistafter1](https://cloud.githubusercontent.com/assets/6951813/25619787/06c9c90a-2f44-11e7-9d63-e3c4bd3d67e3.gif)

- [X] Tests Pass
