### PR TITLE
PCHR-1826: Hide Option Value Edit Field

### DIFF
--- a/hrcase/CRM/HRCase/Upgrader.php
+++ b/hrcase/CRM/HRCase/Upgrader.php
@@ -341,11 +341,16 @@ class CRM_HRCase_Upgrader extends CRM_HRCase_Upgrader_Base {
   private function up1402_removedUnusedManagedEntities($caseTypes, $activityTypes) {
     $entitiesToRemove['civicase:act:Background Check'] = 'OptionValue';
 
+    $allActivityTypes = [];
+    foreach ($activityTypes as $componentActivities) {
+      $allActivityTypes = array_merge($allActivityTypes, $componentActivities);
+    }
+
     foreach (array_merge($caseTypes, ['Appraisal', 'Probation']) as $caseType) {
       $entitiesToRemove[$caseType] = 'CaseType';
     }
 
-    foreach ($activityTypes as $extension) {
+    foreach ($allActivityTypes as $extension) {
       foreach ($extension as $activityType) {
         $entitiesToRemove['civitask:act:' . $activityType] = 'OptionValue';
       }

--- a/hrui/hrui.php
+++ b/hrui/hrui.php
@@ -64,6 +64,12 @@ function hrui_civicrm_pageRun($page) {
   CRM_Core_Resources::singleton()->addStyleFile('org.civicrm.hrui', 'css/hrui.css');
 }
 
+/**
+ * Implements hook_civicrm_buildForm().
+ *
+ * @param string $formName
+ * @param CRM_Core_Form $form
+ */
 function hrui_civicrm_buildForm($formName, &$form) {
   CRM_Core_Resources::singleton()->addStyleFile('org.civicrm.hrui', 'css/hrui.css');
 
@@ -92,6 +98,10 @@ function hrui_civicrm_buildForm($formName, &$form) {
 
       CRM_Core_Session::setStatus($message, $title, 'no-popup crm-error', ['expires' => 0]);
     }
+  }
+
+  if ($formName === 'CRM_Admin_Form_Options') {
+    $form->removeElement('value');
   }
 }
 

--- a/hrui/hrui.php
+++ b/hrui/hrui.php
@@ -100,7 +100,7 @@ function hrui_civicrm_buildForm($formName, &$form) {
     }
   }
 
-  if ($formName === 'CRM_Admin_Form_Options') {
+  if ($formName === 'CRM_Admin_Form_Options' && $form->elementExists('value')) {
     $form->removeElement('value');
   }
 }

--- a/hrui/tests/phpunit/CRM/HRUI/HelperTest.php
+++ b/hrui/tests/phpunit/CRM/HRUI/HelperTest.php
@@ -13,11 +13,6 @@ class CRM_HRUI_HelperTest extends \PHPUnit_Framework_TestCase implements Headles
 
   use HRUITrait;
 
-  protected $requiredExtensions = [
-    'uk.co.compucorp.civicrm.tasksassignments',
-    'org.civicrm.hrcase'
-  ];
-
   /**
    * @return CiviEnvBuilder
    */
@@ -27,7 +22,6 @@ class CRM_HRUI_HelperTest extends \PHPUnit_Framework_TestCase implements Headles
       ->install('org.civicrm.hrident')
       ->install('uk.co.compucorp.civicrm.tasksassignments')
       ->installMe(__DIR__)
-      ->install($this->requiredExtensions)
       ->apply();
   }
 

--- a/hrui/tests/phpunit/CRM/HRUI/HelperTest.php
+++ b/hrui/tests/phpunit/CRM/HRUI/HelperTest.php
@@ -62,9 +62,11 @@ class CRM_HRUI_HelperTest extends \PHPUnit_Framework_TestCase implements Headles
    * @return int
    */
   private function createContact($firstName, $lastName) {
-    $params = ['first_name' => $firstName, 'last_name' => $lastName];
-
-    return ContactMaker::fabricate($params)['id'];
+    return ContactMaker::fabricate([
+        'first_name' => $firstName,
+        'last_name' => $lastName
+      ]
+    )['id'];
   }
 
 }

--- a/hrui/tests/phpunit/CRM/HRUI/HelperTest.php
+++ b/hrui/tests/phpunit/CRM/HRUI/HelperTest.php
@@ -63,10 +63,9 @@ class CRM_HRUI_HelperTest extends \PHPUnit_Framework_TestCase implements Headles
    */
   private function createContact($firstName, $lastName) {
     return ContactMaker::fabricate([
-        'first_name' => $firstName,
-        'last_name' => $lastName
-      ]
-    )['id'];
+      'first_name' => $firstName,
+      'last_name' => $lastName
+    ])['id'];
   }
 
 }

--- a/hrui/tests/phpunit/HRUITrait.php
+++ b/hrui/tests/phpunit/HRUITrait.php
@@ -8,17 +8,19 @@ trait HrUITrait {
   /**
    * Creates a single (Individuals) contact from the provided data.
    *
-   * @param array $params should contain first_name and last_name
-   * @return int return the contact ID
-   * @throws \CiviCRM_API3_Exception
+   * @param $firstName
+   * @param $lastName
+   *
+   * @return mixed
    */
-  protected function createContact($params) {
+  protected function createContact($firstName, $lastName) {
     $result = civicrm_api3('Contact', 'create', array(
       'contact_type' => "Individual",
-      'first_name' => $params['first_name'],
-      'last_name' => $params['last_name'],
-      'display_name' => $params['first_name'] . ' ' . $params['last_name'],
+      'first_name' => $firstName,
+      'last_name' => $lastName,
+      'display_name' => $firstName . ' ' . $lastName,
     ));
+
     return $result['id'];
   }
 
@@ -35,11 +37,27 @@ trait HrUITrait {
       'return' => array("id"),
       'name_a_b' => $relationship_type,
     ));
+
     civicrm_api3('Relationship', 'create', array(
       'contact_id_a' => $contactA,
       'contact_id_b' => $contactB,
       'relationship_type_id' => $relationshipType['id'],
     ));
+  }
+
+  /**
+   * @param $labelAtoB
+   * @param $labelBtoA
+   *
+   * @return array
+   */
+  protected function createRelationshipType($labelAtoB, $labelBtoA) {
+    return civicrm_api3('RelationshipType', 'create', [
+      'name_a_b' => $labelAtoB,
+      'name_b_a' => $labelBtoA,
+      'contact_type_a' => 'Individual',
+      'contact_type_b' => 'Individual',
+    ]);
   }
 
 }

--- a/hrui/tests/phpunit/HRUITrait.php
+++ b/hrui/tests/phpunit/HRUITrait.php
@@ -4,26 +4,6 @@
  * A trait with helper methods to be reused among this extension's tests
  */
 trait HrUITrait {
-
-  /**
-   * Creates a single (Individuals) contact from the provided data.
-   *
-   * @param $firstName
-   * @param $lastName
-   *
-   * @return mixed
-   */
-  protected function createContact($firstName, $lastName) {
-    $result = civicrm_api3('Contact', 'create', array(
-      'contact_type' => "Individual",
-      'first_name' => $firstName,
-      'last_name' => $lastName,
-      'display_name' => $firstName . ' ' . $lastName,
-    ));
-
-    return $result['id'];
-  }
-
   /**
    * Creates a relationship between two contacts
    *
@@ -33,30 +13,15 @@ trait HrUITrait {
    * @throws \CiviCRM_API3_Exception
    */
   protected function createRelationship($contactA, $contactB, $relationship_type) {
-    $relationshipType = civicrm_api3('RelationshipType', 'getsingle', array(
-      'return' => array("id"),
+    $relationshipType = civicrm_api3('RelationshipType', 'getsingle', [
+      'return' => ['id'],
       'name_a_b' => $relationship_type,
-    ));
+    ]);
 
-    civicrm_api3('Relationship', 'create', array(
+    civicrm_api3('Relationship', 'create', [
       'contact_id_a' => $contactA,
       'contact_id_b' => $contactB,
       'relationship_type_id' => $relationshipType['id'],
-    ));
-  }
-
-  /**
-   * @param $labelAtoB
-   * @param $labelBtoA
-   *
-   * @return array
-   */
-  protected function createRelationshipType($labelAtoB, $labelBtoA) {
-    return civicrm_api3('RelationshipType', 'create', [
-      'name_a_b' => $labelAtoB,
-      'name_b_a' => $labelBtoA,
-      'contact_type_a' => 'Individual',
-      'contact_type_b' => 'Individual',
     ]);
   }
 

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -77,18 +77,6 @@ function hrcore_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
 }
 
 /**
- * Implements hook_civicrm_buildForm().
- *
- * @param string $formName
- * @param CRM_Core_Form $form
- */
-function hrcore_civicrm_buildForm($formName, &$form) {
-  if ($formName === 'CRM_Admin_Form_Options') {
-    $form->removeElement('value');
-  }
-}
-
-/**
  * Implements hook_civicrm_managed().
  *
  * Generate a list of entities to create/deactivate/delete when this module

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -77,6 +77,18 @@ function hrcore_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
 }
 
 /**
+ * Implements hook_civicrm_buildForm().
+ *
+ * @param string $formName
+ * @param CRM_Core_Form $form
+ */
+function hrcore_civicrm_buildForm($formName, &$form) {
+  if ($formName === 'CRM_Admin_Form_Options') {
+    $form->removeElement('value');
+  }
+}
+
+/**
  * Implements hook_civicrm_managed().
  *
  * Generate a list of entities to create/deactivate/delete when this module
@@ -114,7 +126,7 @@ function hrcore_civicrm_caseTypes(&$caseTypes) {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
  */
 function hrcore_civicrm_angularModules(&$angularModules) {
-_hrcore_civix_civicrm_angularModules($angularModules);
+  _hrcore_civix_civicrm_angularModules($angularModules);
 }
 
 /**


### PR DESCRIPTION
## Overview
All option values have a "value" field which acts like their ID. If this value is changed it could cause major problems since it acts like a database foreign key. For example changing the "value" for an absence type would change all absences created in the system that point to that absence type. The aim of this PR is to hide the option to edit the value.

## Before
From the admin option edit screen (/civicrm/admin/options) you can change the value.
![selection_181](https://cloud.githubusercontent.com/assets/6374064/25617555/bd8ff3e4-2f3a-11e7-9e9d-510a25fed1fa.png)

## After
From the admin option edit screen (/civicrm/admin/options) the value field is not displayed.

![selection_180](https://cloud.githubusercontent.com/assets/6374064/25617540/ac229cc4-2f3a-11e7-86ba-88776f9092a0.png)

- [x] Tests Pass