### PR TITLE
PCHR-2201: Manager Leave pagination Fix

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/manager-leave/components/manager-leave-requests.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/manager-leave/components/manager-leave-requests.html
@@ -140,7 +140,7 @@
                       <i class="fa fa-angle-double-left" aria-hidden="true"></i> First
                     </a>
                   </li>
-                  <li ng-click="ctrl.refresh($index)"
+                  <li ng-click="ctrl.refresh(ctrl.pagination.page - 1)"
                       class="active">
                     <a class="pointer">
                       <i class="fa fa-angle-left" aria-hidden="true"></i> Previous
@@ -151,7 +151,7 @@
                       ng-repeat="a in ctrl.getArrayOfSize(ctrl.totalNoOfPages()) track by $index">
                     <a>{{$index + 1}}</a>
                   </li>
-                  <li ng-click="ctrl.refresh($index + 2)"
+                  <li ng-click="ctrl.refresh(ctrl.pagination.page + 1)"
                       class="active">
                     <a class="pointer">
                       Next <i class="fa fa-angle-right" aria-hidden="true"></i>


### PR DESCRIPTION
## Overview
Manager was not navigated to the correct page by using First/Last/Previous/Next buttons

## After
![2201](https://cloud.githubusercontent.com/assets/5058867/25649979/55b6454e-2ff7-11e7-8ed7-63c8b9cf402d.gif)

## Comments
This PR does not include BackstopJS tests as Manager Leave Report section is already covered.

