### PR TITLE
PCHR-2200: Fix Uncaught Exception When Attempting to Create an Absence Period With Same Title

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
@@ -67,6 +67,8 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
         'This Absence Period overlaps with another existing Period'
       );
     }
+
+    self::validateAbsencePeriodTitle($params);
   }
 
   /**
@@ -99,6 +101,34 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
     if($startDate >= $endDate) {
       throw new InvalidAbsencePeriodException(
         'Start Date should be less than End Date'
+      );
+    }
+  }
+
+  /**
+   * Checks if another absence period exists with same title as
+   * the absence period being created/updated and throws an exception if found.
+   *
+   * @param array $params
+   *
+   * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidAbsencePeriodException
+   */
+  private static function validateAbsencePeriodTitle($params) {
+    $title = !empty($params['title']) ? $params['title'] : '';
+    $absencePeriod = new self();
+    $absencePeriod->title = $title;
+    $absencePeriod->find(true);
+
+    if (!$absencePeriod->id) {
+      return;
+    }
+
+    $throwExceptionOnCreate = empty($params['id']);
+    $throwExceptionOnUpdate = !empty($params['id']) && $absencePeriod->id != $params['id'];
+
+    if ($throwExceptionOnCreate || $throwExceptionOnUpdate) {
+      throw new InvalidAbsencePeriodException(
+        'Absence Period with same title already exists!'
       );
     }
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
@@ -111,10 +111,10 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    *
    * @param array $params
    *
-   * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidAbsencePeriodException
+   * @throws InvalidAbsencePeriodException
    */
   private static function validateAbsencePeriodTitle($params) {
-    $title = !empty($params['title']) ? $params['title'] : '';
+    $title = CRM_Utils_Array::value('title', $params);
     $absencePeriod = new self();
     $absencePeriod->title = $title;
     $absencePeriod->find(true);
@@ -123,10 +123,10 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
       return;
     }
 
-    $throwExceptionOnCreate = empty($params['id']);
-    $throwExceptionOnUpdate = !empty($params['id']) && $absencePeriod->id != $params['id'];
+    $isCreate = empty($params['id']);
+    $isSeparateUpdate = !empty($params['id']) && $absencePeriod->id != $params['id'];
 
-    if ($throwExceptionOnCreate || $throwExceptionOnUpdate) {
+    if ($isCreate || $isSeparateUpdate) {
       throw new InvalidAbsencePeriodException(
         'Absence Period with same title already exists!'
       );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
@@ -72,8 +72,8 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseHeadlessTest {
   }
 
   /**
-   * @expectedException PEAR_Exception
-   * @expectedExceptionMessage DB Error: already exists
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidAbsencePeriodException
+   * @expectedExceptionMessage Absence Period with same title already exists!
    */
   public function testPeriodsTitlesShouldBeUnique() {
     AbsencePeriodFabricator::fabricate([
@@ -86,6 +86,25 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseHeadlessTest {
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
     ]);
+  }
+
+  public function testNoExceptionIsThrownWhenUpdatingAnAbsencePeriodWithSameTitle() {
+    $params = [
+      'title'      => 'Period 1',
+      'start_date' => CRM_Utils_Date::processDate('2015-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2015-12-31'),
+    ];
+    $absencePeriod = AbsencePeriodFabricator::fabricate($params);
+
+    //update the absence period
+    $params['id'] = $absencePeriod->id;
+    $params['start_date'] = CRM_Utils_Date::processDate('2015-02-05');
+    try{
+      $absencePeriod = AbsencePeriod::create($params);
+      $this->assertEquals($absencePeriod->start_date, $params['start_date']);
+    }catch(CRM_HRLeaveAndAbsences_Exception_InvalidAbsencePeriodException $e) {
+      $this->fail($e->getMessage());
+    }
   }
 
   /**


### PR DESCRIPTION
## Overview
When attempting to create/update an absence period with same title as an already existing absence period, an error is displayed and the site crashes.

## Before
The title column of the absence period table is a unique field and this is what causes a exception of type `PEAR_Exception`to be thrown. Since the Absence Period form is expecting an error of type `InvalidAbsencePeriodException` to be thrown, the exception does not get to be handled.

![localhost-8900-civicrm-admin-leaveandabsences-periods 2017-05-03 16-51-27](https://cloud.githubusercontent.com/assets/6951813/25669280/f51dce08-3020-11e7-96d1-8e167979f34e.png)
## After

A validation function to check for the existence of an absence period with same title as the one being created/updated was added and an exception of type `InvalidAbsencePeriodException` is thrown if such absence type is found. The exception is caught and the error message displayed appropriately.

![absence periods - civihr 1 6 demo 2017-05-03 16-52-08](https://cloud.githubusercontent.com/assets/6951813/25669325/177f3a7c-3021-11e7-84f6-ea60b373d81f.png)

- [X] Tests Pass
