### PR TITLE
PCHR-2197: Apply correct margin to .email

### DIFF
--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/components/_email.scss
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/components/_email.scss
@@ -1,7 +1,7 @@
 $email-heading-line-height: 40px;
 
 .email {
-  @include margin(40px);
+  @include margin(40px 0);
 }
 
 .email-date {


### PR DESCRIPTION
When using the `margin` mixin, the margin was erroneously set to 40px instead of 40px 0, resulting in the email being decentered horizontally