### PR TITLE
PCHR-1421: Multiple credentials support for Backstop JS

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/login.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/login.js
@@ -1,11 +1,12 @@
 'use strict';
 
-module.exports = function (casper) {
+module.exports = function (casper, scenario) {
   var config = require('../site-config');
   var loginFormSelector = 'form#user-login-form';
+  var credentials = config.credentials[scenario.credentials || 'default'];
 
   casper
-    .echo('Logging in before starting...', 'INFO')
+    .echo('Logging in with ' + (scenario.credentials || 'default') + ' credentials before starting ...', 'INFO')
     .thenOpen(config.url + '/welcome-page', function () {
       casper.then(function () {
         casper.waitForSelector(loginFormSelector, function () {
@@ -14,7 +15,7 @@ module.exports = function (casper) {
           }, function () {
             casper.echo('Login form visible and timeout reached!', 'RED_BAR');
           }, 5000);
-          casper.fill(loginFormSelector, config.credentials, true);
+          casper.fill(loginFormSelector, credentials, true);
         }, function () {
           casper.echo('Login form not found!', 'RED_BAR');
         }, 8000);

--- a/uk.co.compucorp.civicrm.hrcore/gulpfile.js
+++ b/uk.co.compucorp.civicrm.hrcore/gulpfile.js
@@ -14,7 +14,11 @@ var Promise = require('es6-promise').Promise;
   var files = { config: 'site-config.json', tpl: 'backstop.tpl.json' };
   var configTpl = {
     "url": "http://%{site-host}",
-    "credentials": { "name": "%{user-name}", "pass": "%{user-password}" }
+    "credentials": {
+      "default": {"name": "%{user-name}", "pass": "%{user-password}"},
+      "manager": {"name": "admin", "pass": "admin"},
+      "staff": {"name": "civihr_staff", "pass": "civihr_staff"}
+    }
   };
 
   gulp.task('backstopjs:reference', function (done) {


### PR DESCRIPTION
## Overview
Previously backstop js supported a single logon information, so if the test suite requires different logon information for different scenario's it was not possible to achieve the same in the single test run. In this PR the ability to specify individual logon information for each scenario has been added.

## Technical Details
1. Backstop will use `default`(existing) logon information, if no `credentials`is mentioned in the scenario.
2. If a scenario needs a different logon information than the default one, it needs to be specified in the scenario JSON itself, example
```
{
  "scenarios": [
    {
      "label": "<label>",
      "url": "<url>",
      "onReadyScript": "<file name>",
      "credentials": "<manager/staff/etc>"
    }
  ]
}

