### PR TITLE
PCHR-2209: Fix bug with requesting TOIL when current Entitlement Balance is Zero

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -2196,7 +2196,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
     ]);
 
-    $this->assertInstanceOf(LeaveRequest::class, $leaveRequest);
+    $this->assertNotNull($leaveRequest->id);
   }
 
   public function testToilCanBeAccruedWhenTheToilRequestHasNoWorkingDay() {
@@ -2244,6 +2244,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
     ]);
 
-    $this->assertInstanceOf(LeaveRequest::class, $toilRequest);
+    $this->assertNotNull($toilRequest->id);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -2151,4 +2151,99 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       $this->assertNotEmpty($email['headers']);
     }
   }
+
+  public function testToilCanBeAccruedWhenTheCurrentBalanceForPeriodEntitlementIsZero() {
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+    ]);
+
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'title' => 'Type 1',
+      'allow_accruals_request' => true,
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceType->id,
+      'contact_id' => 1,
+      'period_id' => $period->id
+    ]);
+
+    $periodStartDate = date('2016-01-01');
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $periodEntitlement->contact_id],
+      ['period_start_date' => $periodStartDate]
+    );
+
+    $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $periodEntitlement->contact_id,
+      'pattern_id' => $workPattern->id
+    ]);
+
+    $this->assertEquals(0, $periodEntitlement->getBalance());
+
+    $leaveRequest = LeaveRequest::create([
+      'type_id' => $absenceType->id,
+      'contact_id' => $periodEntitlement->contact_id,
+      'status_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('today'),
+      'from_date_type' => 1,
+      'to_date' => CRM_Utils_Date::processDate('tomorrow'),
+      'to_date_type' => 1,
+      'toil_to_accrue' => 3,
+      'toil_duration' => 120,
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
+    ]);
+
+    $this->assertInstanceOf(LeaveRequest::class, $leaveRequest);
+  }
+
+  public function testToilCanBeAccruedWhenTheToilRequestHasNoWorkingDay() {
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-1 day'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days'),
+    ]);
+
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'title' => 'Type 1',
+      'allow_accruals_request' => true,
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceType->id,
+      'contact_id' => 1,
+      'period_id' => $period->id
+    ]);
+
+    $periodStartDate = date('2016-01-01');
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $periodEntitlement->contact_id],
+      ['period_start_date' => $periodStartDate]
+    );
+
+    $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $periodEntitlement->contact_id,
+      'pattern_id' => $workPattern->id
+    ]);
+
+    $this->assertEquals(0, $periodEntitlement->getBalance());
+
+    $toilRequest = LeaveRequest::create([
+      'type_id' => $absenceType->id,
+      'contact_id' => $periodEntitlement->contact_id,
+      'status_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('saturday'),
+      'from_date_type' => 1,
+      'to_date' => CRM_Utils_Date::processDate('sunday'),
+      'to_date_type' => 1,
+      'toil_to_accrue' => 2,
+      'toil_duration' => 120,
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
+    ]);
+
+    $this->assertInstanceOf(LeaveRequest::class, $toilRequest);
+  }
 }


### PR DESCRIPTION
## Overview
When trying to accrue TOIL for an absence type whose current balance is Zero for that period, It returns an error that the Leave Request Balance change is greater that the remaining balance for the absence type. This error is actually valid for a leave request especially if the absence type does not allow overuse but employee should be able to accrue TOIL even if current balance is Zero provided the other validations for accruing TOIL passes.

This PR also fixes an issue whereby TOIL can not be accrued when there is no working day for the TOIL request. Since an employee may want to accrue TOIL for days that are non-working days.

## Before
Trying to accrue TOIL when the current balance change for the absence type for the period is Zero returns an error.

Trying to accrue TOIL when the TOIL request has no working day returns an error.

## After
TOIL can be accrued even when the current balance for the absence type for the period is Zero provided all the other TOIL validations pass.

TOIL can be accrued even when the TOIL request has no working day provided all the other TOIL validations pass.

- [X] Tests Pass
