### PR TITLE
PCHR-2198: Responsive email templates for TOIL Request

### DIFF
--- a/uk.co.compucorp.civicrm.hremails/email-templates/dist/leave-request.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/dist/leave-request.html
@@ -43,6 +43,11 @@
     padding-right: 16px !important;
   }
 
+  table.body .columns .columns {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
   table.body .collapse .columns {
     padding-left: 0 !important;
     padding-right: 0 !important;
@@ -50,6 +55,11 @@
 
   th.small-12 {
     display: inline-block !important;
+    width: 100% !important;
+  }
+
+  .columns th.small-12 {
+    display: block !important;
     width: 100% !important;
   }
 }
@@ -61,9 +71,14 @@
 }
 
 @media only screen and (max-width: 596px) {
-  .request-data dt {
-    float: none !important;
-    width: auto !important;
+  .request-data-key {
+    padding-bottom: 0 !important;
+  }
+}
+
+@media only screen and (min-width: 597px) {
+  .request-data .row .columns {
+    padding-bottom: 10px !important;
   }
 }{/literal}</style>
   </head>
@@ -99,24 +114,53 @@
                       </tr>
                     </table>
 
-                    <table class="callout" style="Margin-bottom: 16px; border-collapse: collapse; border-spacing: 0; margin-bottom: 16px; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner request-data" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
-                      <dl style="Margin: 0; margin: 0;">
-                        <dt style="color: #4D5663; float: left; font-weight: 600; width: 150px;">{ts}Status:{/ts}</dt>
-                        <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{$leaveStatus}</dd>
-                        <dt style="color: #4D5663; float: left; font-weight: 600; width: 150px;">{ts}Staff Member:{/ts}</dt>
-                        <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{contact.display_name}</dd>
-                        {if $leaveRequest->from_date eq $leaveRequest->to_date}
-                          <dt style="color: #4D5663; float: left; font-weight: 600; width: 150px;">Date:</dt>
-                          <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</dd>
-                        {else}
-                          <dt style="color: #4D5663; float: left; font-weight: 600; width: 150px;">{ts}From Date:{/ts}</dt>
-                          <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</dd>
-                          <dt style="color: #4D5663; float: left; font-weight: 600; width: 150px;">{ts}To Date:{/ts}</dt>
-                          <dd style="Margin-left: 0; margin-left: 0;">{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</dd>
-                        {/if}
-                      </dl>
+                    <table class="callout" style="Margin-bottom: 0 !important; border-collapse: collapse; border-spacing: 0; margin-bottom: 0 !important; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner request-data" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
+                      <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                        <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <span style="color: #4D5663; font-weight: 600;">{ts}Status:{/ts}</span>
+                        </th></tr></table></th>
+                        <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <span>{$leaveStatus}</span>
+                        </th></tr></table></th>
+                      </tr></tbody></table>
+                      <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                        <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <span style="color: #4D5663; font-weight: 600;">{ts}Staff Member:{/ts}</span>
+                        </th></tr></table></th>
+                        <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <span>{contact.display_name}</span>
+                        </th></tr></table></th>
+                      </tr></tbody></table>
+                      {if $leaveRequest->from_date eq $leaveRequest->to_date}
+                        <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                          <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span style="color: #4D5663; font-weight: 600;">Date:</span>
+                          </th></tr></table></th>
+                          <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                          </th></tr></table></th>
+                        </tr></tbody></table>
+                      {else}
+                        <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                          <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span style="color: #4D5663; font-weight: 600;">{ts}From Date:{/ts}</span>
+                          </th></tr></table></th>
+                          <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                          </th></tr></table></th>
+                        </tr></tbody></table>
+                        <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                          <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 0 !important; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span style="color: #4D5663; font-weight: 600;">{ts}To Date:{/ts}</span>
+                          </th></tr></table></th>
+                          <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 0 !important; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
+                          </th></tr></table></th>
+                        </tr></tbody></table>
+                      {/if}
                     </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
-                    <table class="button expanded alert" style="Margin: 0 0 16px 0; border-collapse: collapse; border-spacing: 0; margin: 0 0 16px 0; padding: 0; text-align: left; vertical-align: top; width: 100% !important;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #E6807F; border: 0px solid #E6807F; border-collapse: collapse !important; color: #FFF; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;"><center data-parsed="" style="min-width: 0; width: 100%;"><a href="{$leaveRequestLink}" align="center" class="float-center" style="Margin: 0; border: 0 solid #E6807F; border-radius: 3px; color: #FFF; display: inline-block; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 8px 16px 8px 16px; padding-left: 0; padding-right: 0; text-align: center; text-decoration: none; width: 100%;">View This Request</a></center></td></tr></table></td>
+                    <table class="spacer" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td height="16px" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; hyphens: auto; line-height: 16px; margin: 0; mso-line-height-rule: exactly; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">&#xA0;</td></tr></tbody></table>
+                    <table class="button expanded alert" style="Margin: 0 0 16px 0; border-collapse: collapse; border-spacing: 0; margin: 0 0 16px 0; padding: 0; text-align: left; vertical-align: top; width: 100% !important;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; width: 100%; word-wrap: break-word;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #E6807F; border: 0px solid #E6807F; border-collapse: collapse !important; color: #FFF; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 8px 16px 8px 16px; text-align: left; vertical-align: top; width: 100%; word-wrap: break-word;"><center data-parsed="" style="min-width: 0; width: 100%;"><a href="{$leaveRequestLink}" align="center" class="float-center" style="Margin: 0; border: 0 solid #E6807F; border-radius: 3px; color: #FFF; display: inline-block; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; padding-left: 0; padding-right: 0; text-align: center; text-decoration: none; width: 100%;">View This Request</a></center></td></tr></table></td>
 <td class="expander" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; vertical-align: top; visibility: hidden; width: 0; word-wrap: break-word;"></td></tr></table>
                     {if $leaveComments}
                       <hr style="Margin: 20px auto; border: 0; border-top: 1px solid #D3DEE2; height: 0; margin: 20px auto;">
@@ -128,18 +172,24 @@
                         </tr>
                       </table>
 
-                      <table class="callout" style="Margin-bottom: 16px; border-collapse: collapse; border-spacing: 0; margin-bottom: 16px; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner callout-no-padding" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left; width: 100%;">
+                      <table class="callout" style="Margin-bottom: 0 !important; border-collapse: collapse; border-spacing: 0; margin-bottom: 0 !important; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner callout-no-padding" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left; width: 100%;">
                         <div class="request-comments">
                           {foreach from=$leaveComments item=value key=label}
-                            <div class="request-comment" style="border-bottom: 1px solid #E8EEF0; padding: 20px;">
-                              <div class="request-comment-header" style="Margin-bottom: 10px; color: #4D5663; font-weight: 600; margin-bottom: 10px;">
-                                <span class="request-comment-author">{$value.commenter}:</span>
-                                <span class="request-comment-datetime">{$value.created_at|crmDate}</span>
-                              </div>
-                              <div class="request-comment-body">
-                                {$value.text}
-                              </div>
-                            </div>
+                            <table class="request-comment" style="border-bottom: 1px solid #E8EEF0; border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+                              <tbody>
+                                <tr style="padding: 0; text-align: left; vertical-align: top;">
+                                  <td class="request-comment-header" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #4D5663; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: 600; hyphens: auto; line-height: 1.53846; margin: 0; padding: 20px; padding-bottom: 10px; text-align: left; vertical-align: top; word-wrap: break-word;">
+                                    <span class="request-comment-author">{$value.commenter}:</span>
+                                    <span class="request-comment-datetime">{$value.created_at|crmDate}</span>
+                                  </td>
+                                </tr>
+                                <tr style="padding: 0; text-align: left; vertical-align: top;">
+                                  <td class="request-comment-body" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 20px; padding-top: 0; text-align: left; vertical-align: top; word-wrap: break-word;">
+                                    {$value.text}
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
                           {/foreach}
                         </div>
                       </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
@@ -154,7 +204,7 @@
                         </tr>
                       </table>
 
-                      <table class="callout" style="Margin-bottom: 16px; border-collapse: collapse; border-spacing: 0; margin-bottom: 16px; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
+                      <table class="callout" style="Margin-bottom: 0 !important; border-collapse: collapse; border-spacing: 0; margin-bottom: 0 !important; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
                         <div class="request-attachments">
                           {foreach from=$leaveFiles item=value key=label}
                             <div class="request-attachment" style="Margin-bottom: 10px; margin-bottom: 10px;">
@@ -164,8 +214,7 @@
                         </div>
                       </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
                     {/if}
-                  </th>
-<th class="expander" style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table></th>
+                  </th></tr></table></th>
                 </tr></tbody></table>
                 <table class="row collapse" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                   <th class="small-12 large-12 columns first last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0; padding-right: 0; text-align: left; width: 588px;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">

--- a/uk.co.compucorp.civicrm.hremails/email-templates/dist/leave-request.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/dist/leave-request.html
@@ -117,46 +117,62 @@
                     <table class="callout" style="Margin-bottom: 0 !important; border-collapse: collapse; border-spacing: 0; margin-bottom: 0 !important; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner request-data" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
                       <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                         <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                          <span style="color: #4D5663; font-weight: 600;">{ts}Status:{/ts}</span>
+                          <span style="color: #4D5663; font-weight: 600;">
+                            {ts}Status:{/ts}
+                          </span>
                         </th></tr></table></th>
                         <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                           <span>{$leaveStatus}</span>
                         </th></tr></table></th>
                       </tr></tbody></table>
+
                       <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                         <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                          <span style="color: #4D5663; font-weight: 600;">{ts}Staff Member:{/ts}</span>
+                          <span style="color: #4D5663; font-weight: 600;">
+                            {ts}Staff Member:{/ts}
+                          </span>
                         </th></tr></table></th>
                         <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                           <span>{contact.display_name}</span>
                         </th></tr></table></th>
                       </tr></tbody></table>
+
+
                       {if $leaveRequest->from_date eq $leaveRequest->to_date}
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span style="color: #4D5663; font-weight: 600;">Date:</span>
+                            <span style="color: #4D5663; font-weight: 600;">
+                              {ts}Date:{/ts}
+                            </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                            <span>{$fromDate|truncate:10:\&#x27;\&#x27;|crmDate} {$fromDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
+
                       {else}
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span style="color: #4D5663; font-weight: 600;">{ts}From Date:{/ts}</span>
+                            <span style="color: #4D5663; font-weight: 600;">
+                              {ts}From Date:{/ts}
+                            </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                            <span>{$fromDate|truncate:10:\&#x27;\&#x27;|crmDate} {$fromDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
+
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 0 !important; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span style="color: #4D5663; font-weight: 600;">{ts}To Date:{/ts}</span>
+                            <span style="color: #4D5663; font-weight: 600;">
+                              {ts}To Date:{/ts}
+                            </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 0 !important; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
+                            <span>{$toDate|truncate:10:\&#x27;\&#x27;|crmDate} {$toDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
+
                       {/if}
                     </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
                     <table class="spacer" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td height="16px" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; hyphens: auto; line-height: 16px; margin: 0; mso-line-height-rule: exactly; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">&#xA0;</td></tr></tbody></table>
@@ -190,6 +206,7 @@
                                 </tr>
                               </tbody>
                             </table>
+
                           {/foreach}
                         </div>
                       </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
@@ -208,8 +225,9 @@
                         <div class="request-attachments">
                           {foreach from=$leaveFiles item=value key=label}
                             <div class="request-attachment" style="Margin-bottom: 10px; margin-bottom: 10px;">
-                              <span class="request-attachment-name" style="color: #4D5663; font-weight: 600;">{$value.name}</span>: Added on {$value.upload_date|crmDate}
+                              <span class="request-attachment-name" style="color: #4D5663; font-weight: 600;">{$value.name}</span>: Added on {$value.created_at|crmDate}
                             </div>
+
                           {/foreach}
                         </div>
                       </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/dist/toil-request.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/dist/toil-request.html
@@ -117,56 +117,75 @@
                     <table class="callout" style="Margin-bottom: 0 !important; border-collapse: collapse; border-spacing: 0; margin-bottom: 0 !important; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner request-data" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
                       <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                         <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                          <span style="color: #4D5663; font-weight: 600;">{ts}Status:{/ts}</span>
+                          <span style="color: #4D5663; font-weight: 600;">
+                            {ts}Status:{/ts}
+                          </span>
                         </th></tr></table></th>
                         <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                           <span>{$leaveStatus}</span>
                         </th></tr></table></th>
                       </tr></tbody></table>
+
                       <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                         <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                          <span style="color: #4D5663; font-weight: 600;">{ts}Staff Member:{/ts}</span>
+                          <span style="color: #4D5663; font-weight: 600;">
+                            {ts}Staff Member:{/ts}
+                          </span>
                         </th></tr></table></th>
                         <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                           <span>{contact.display_name}</span>
                         </th></tr></table></th>
                       </tr></tbody></table>
+
+
                       {if $leaveRequest->from_date eq $leaveRequest->to_date}
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span style="color: #4D5663; font-weight: 600;">Date:</span>
+                            <span style="color: #4D5663; font-weight: 600;">
+                              {ts}Date:{/ts}
+                            </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                            <span>{$fromDate|truncate:10:\&#x27;\&#x27;|crmDate} {$fromDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
+
                       {else}
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span style="color: #4D5663; font-weight: 600;">{ts}From Date:{/ts}</span>
+                            <span style="color: #4D5663; font-weight: 600;">
+                              {ts}From Date:{/ts}
+                            </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                            <span>{$fromDate|truncate:10:\&#x27;\&#x27;|crmDate} {$fromDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
+
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span style="color: #4D5663; font-weight: 600;">{ts}To Date:{/ts}</span>
+                            <span style="color: #4D5663; font-weight: 600;">
+                              {ts}To Date:{/ts}
+                            </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
+                            <span>{$toDate|truncate:10:\&#x27;\&#x27;|crmDate} {$toDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
+
                       {/if}
+
                       <table class="row request-data-toil" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                         <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 0 !important; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                          <!-- div is necessary because of Outlook's rendering problems -->
-                          <div style="border: 1px solid #FFF; color: #4D5663; font-weight: 600; padding: 10px 0;">{ts}No. TOIL Days Requested:{/ts}</div>
+                          <div style="border: 1px solid #FFF; color: #4D5663; font-weight: 600; padding: 10px 0;">
+                            {ts}No. TOIL Days Requested:{/ts}
+                          </div>
                         </th></tr></table></th>
                         <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 0 !important; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                          <span style="border: 1px solid #FFF; border-color: #727E8A; display: inline-block; padding: 10px 0; text-align: center; width: 100px;">{$leaveRequest->toil_to_accrue}{if $leaveRequest->toil_to_accrue > 1}days{else}day{/if}</span>
+                          <span style="border: 1px solid #FFF; border-color: #727E8A; display: inline-block; padding: 10px 0; text-align: center; width: 100px;">{$leaveRequest-&gt;toil_to_accrue} {if $leaveRequest-&gt;toil_to_accrue &gt; 1}days{else}day{/if}</span>
                         </th></tr></table></th>
                       </tr></tbody></table>
+
                     </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
                     <table class="spacer" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td height="16px" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; hyphens: auto; line-height: 16px; margin: 0; mso-line-height-rule: exactly; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">&#xA0;</td></tr></tbody></table>
                     <table class="button expanded alert" style="Margin: 0 0 16px 0; border-collapse: collapse; border-spacing: 0; margin: 0 0 16px 0; padding: 0; text-align: left; vertical-align: top; width: 100% !important;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; width: 100%; word-wrap: break-word;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #E6807F; border: 0px solid #E6807F; border-collapse: collapse !important; color: #FFF; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 8px 16px 8px 16px; text-align: left; vertical-align: top; width: 100%; word-wrap: break-word;"><center data-parsed="" style="min-width: 0; width: 100%;"><a href="{$leaveRequestLink}" align="center" class="float-center" style="Margin: 0; border: 0 solid #E6807F; border-radius: 3px; color: #FFF; display: inline-block; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; padding-left: 0; padding-right: 0; text-align: center; text-decoration: none; width: 100%;">View This Request</a></center></td></tr></table></td>
@@ -199,6 +218,7 @@
                                 </tr>
                               </tbody>
                             </table>
+
                           {/foreach}
                         </div>
                       </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
@@ -217,8 +237,9 @@
                         <div class="request-attachments">
                           {foreach from=$leaveFiles item=value key=label}
                             <div class="request-attachment" style="Margin-bottom: 10px; margin-bottom: 10px;">
-                              <span class="request-attachment-name" style="color: #4D5663; font-weight: 600;">{$value.name}</span>: Added on {$value.upload_date|crmDate}
+                              <span class="request-attachment-name" style="color: #4D5663; font-weight: 600;">{$value.name}</span>: Added on {$value.created_at|crmDate}
                             </div>
+
                           {/foreach}
                         </div>
                       </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/dist/toil-request.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/dist/toil-request.html
@@ -43,6 +43,11 @@
     padding-right: 16px !important;
   }
 
+  table.body .columns .columns {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
   table.body .collapse .columns {
     padding-left: 0 !important;
     padding-right: 0 !important;
@@ -50,6 +55,11 @@
 
   th.small-12 {
     display: inline-block !important;
+    width: 100% !important;
+  }
+
+  .columns th.small-12 {
+    display: block !important;
     width: 100% !important;
   }
 }
@@ -61,9 +71,14 @@
 }
 
 @media only screen and (max-width: 596px) {
-  .request-data dt {
-    float: none !important;
-    width: auto !important;
+  .request-data-key {
+    padding-bottom: 0 !important;
+  }
+}
+
+@media only screen and (min-width: 597px) {
+  .request-data .row .columns {
+    padding-bottom: 10px !important;
   }
 }{/literal}</style>
   </head>
@@ -99,28 +114,62 @@
                       </tr>
                     </table>
 
-                    <table class="callout" style="Margin-bottom: 16px; border-collapse: collapse; border-spacing: 0; margin-bottom: 16px; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner request-data request-data-large" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
-                      <dl style="Margin: 0; margin: 0;">
-                        <dt style="color: #4D5663; float: left; font-weight: 600; width: 200px;">{ts}Status:{/ts}</dt>
-                        <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{$leaveStatus}</dd>
-                        <dt style="color: #4D5663; float: left; font-weight: 600; width: 200px;">{ts}Staff Member:{/ts}</dt>
-                        <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{contact.display_name}</dd>
-                        {if $leaveRequest->from_date eq $leaveRequest->to_date}
-                          <dt style="color: #4D5663; float: left; font-weight: 600; width: 200px;">Date:</dt>
-                          <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</dd>
-                        {else}
-                          <dt style="color: #4D5663; float: left; font-weight: 600; width: 200px;">{ts}From Date:{/ts}</dt>
-                          <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</dd>
-                          <dt style="color: #4D5663; float: left; font-weight: 600; width: 200px;">{ts}To Date:{/ts}</dt>
-                          <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</dd>
-                        {/if}
-                        <div class="request-data-toil" style="line-height: 2.5;">
-                          <dt style="color: #4D5663; float: left; font-weight: 600; width: 200px;">{ts}No. TOIL Days Requested:{/ts}</dt>
-                          <dd style="Margin-left: 0; margin-left: 0;"><span style="border: 1px solid #727E8A; display: inline-block; text-align: center; width: 100px;">{$leaveRequest->toil_to_accrue}{if $leaveRequest->toil_to_accrue > 1}days{else}day{/if}</span></dd>
-                        </div>
-                      </dl>
+                    <table class="callout" style="Margin-bottom: 0 !important; border-collapse: collapse; border-spacing: 0; margin-bottom: 0 !important; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner request-data" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
+                      <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                        <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <span style="color: #4D5663; font-weight: 600;">{ts}Status:{/ts}</span>
+                        </th></tr></table></th>
+                        <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <span>{$leaveStatus}</span>
+                        </th></tr></table></th>
+                      </tr></tbody></table>
+                      <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                        <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <span style="color: #4D5663; font-weight: 600;">{ts}Staff Member:{/ts}</span>
+                        </th></tr></table></th>
+                        <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <span>{contact.display_name}</span>
+                        </th></tr></table></th>
+                      </tr></tbody></table>
+                      {if $leaveRequest->from_date eq $leaveRequest->to_date}
+                        <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                          <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span style="color: #4D5663; font-weight: 600;">Date:</span>
+                          </th></tr></table></th>
+                          <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                          </th></tr></table></th>
+                        </tr></tbody></table>
+                      {else}
+                        <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                          <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span style="color: #4D5663; font-weight: 600;">{ts}From Date:{/ts}</span>
+                          </th></tr></table></th>
+                          <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                          </th></tr></table></th>
+                        </tr></tbody></table>
+                        <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                          <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span style="color: #4D5663; font-weight: 600;">{ts}To Date:{/ts}</span>
+                          </th></tr></table></th>
+                          <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
+                          </th></tr></table></th>
+                        </tr></tbody></table>
+                      {/if}
+                      <table class="row request-data-toil" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                        <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 0 !important; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <!-- div is necessary because of Outlook's rendering problems -->
+                          <div style="border: 1px solid #FFF; color: #4D5663; font-weight: 600; padding: 10px 0;">{ts}No. TOIL Days Requested:{/ts}</div>
+                        </th></tr></table></th>
+                        <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 0 !important; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <span style="border: 1px solid #FFF; border-color: #727E8A; display: inline-block; padding: 10px 0; text-align: center; width: 100px;">{$leaveRequest->toil_to_accrue}{if $leaveRequest->toil_to_accrue > 1}days{else}day{/if}</span>
+                        </th></tr></table></th>
+                      </tr></tbody></table>
                     </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
-                    <table class="button expanded alert" style="Margin: 0 0 16px 0; border-collapse: collapse; border-spacing: 0; margin: 0 0 16px 0; padding: 0; text-align: left; vertical-align: top; width: 100% !important;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #E6807F; border: 0px solid #E6807F; border-collapse: collapse !important; color: #FFF; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;"><center data-parsed="" style="min-width: 0; width: 100%;"><a href="{$leaveRequestLink}" align="center" class="float-center" style="Margin: 0; border: 0 solid #E6807F; border-radius: 3px; color: #FFF; display: inline-block; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 8px 16px 8px 16px; padding-left: 0; padding-right: 0; text-align: center; text-decoration: none; width: 100%;">View This Request</a></center></td></tr></table></td>
+                    <table class="spacer" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td height="16px" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; hyphens: auto; line-height: 16px; margin: 0; mso-line-height-rule: exactly; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">&#xA0;</td></tr></tbody></table>
+                    <table class="button expanded alert" style="Margin: 0 0 16px 0; border-collapse: collapse; border-spacing: 0; margin: 0 0 16px 0; padding: 0; text-align: left; vertical-align: top; width: 100% !important;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; width: 100%; word-wrap: break-word;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #E6807F; border: 0px solid #E6807F; border-collapse: collapse !important; color: #FFF; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 8px 16px 8px 16px; text-align: left; vertical-align: top; width: 100%; word-wrap: break-word;"><center data-parsed="" style="min-width: 0; width: 100%;"><a href="{$leaveRequestLink}" align="center" class="float-center" style="Margin: 0; border: 0 solid #E6807F; border-radius: 3px; color: #FFF; display: inline-block; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; padding-left: 0; padding-right: 0; text-align: center; text-decoration: none; width: 100%;">View This Request</a></center></td></tr></table></td>
 <td class="expander" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; vertical-align: top; visibility: hidden; width: 0; word-wrap: break-word;"></td></tr></table>
                     {if $leaveComments}
                       <hr style="Margin: 20px auto; border: 0; border-top: 1px solid #D3DEE2; height: 0; margin: 20px auto;">
@@ -132,18 +181,24 @@
                         </tr>
                       </table>
 
-                      <table class="callout" style="Margin-bottom: 16px; border-collapse: collapse; border-spacing: 0; margin-bottom: 16px; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner callout-no-padding" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left; width: 100%;">
+                      <table class="callout" style="Margin-bottom: 0 !important; border-collapse: collapse; border-spacing: 0; margin-bottom: 0 !important; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner callout-no-padding" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left; width: 100%;">
                         <div class="request-comments">
                           {foreach from=$leaveComments item=value key=label}
-                            <div class="request-comment" style="border-bottom: 1px solid #E8EEF0; padding: 20px;">
-                              <div class="request-comment-header" style="Margin-bottom: 10px; color: #4D5663; font-weight: 600; margin-bottom: 10px;">
-                                <span class="request-comment-author">{$value.commenter}:</span>
-                                <span class="request-comment-datetime">{$value.created_at|crmDate}</span>
-                              </div>
-                              <div class="request-comment-body">
-                                {$value.text}
-                              </div>
-                            </div>
+                            <table class="request-comment" style="border-bottom: 1px solid #E8EEF0; border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+                              <tbody>
+                                <tr style="padding: 0; text-align: left; vertical-align: top;">
+                                  <td class="request-comment-header" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #4D5663; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: 600; hyphens: auto; line-height: 1.53846; margin: 0; padding: 20px; padding-bottom: 10px; text-align: left; vertical-align: top; word-wrap: break-word;">
+                                    <span class="request-comment-author">{$value.commenter}:</span>
+                                    <span class="request-comment-datetime">{$value.created_at|crmDate}</span>
+                                  </td>
+                                </tr>
+                                <tr style="padding: 0; text-align: left; vertical-align: top;">
+                                  <td class="request-comment-body" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 20px; padding-top: 0; text-align: left; vertical-align: top; word-wrap: break-word;">
+                                    {$value.text}
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
                           {/foreach}
                         </div>
                       </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
@@ -158,7 +213,7 @@
                         </tr>
                       </table>
 
-                      <table class="callout" style="Margin-bottom: 16px; border-collapse: collapse; border-spacing: 0; margin-bottom: 16px; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
+                      <table class="callout" style="Margin-bottom: 0 !important; border-collapse: collapse; border-spacing: 0; margin-bottom: 0 !important; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
                         <div class="request-attachments">
                           {foreach from=$leaveFiles item=value key=label}
                             <div class="request-attachment" style="Margin-bottom: 10px; margin-bottom: 10px;">
@@ -168,8 +223,7 @@
                         </div>
                       </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
                     {/if}
-                  </th>
-<th class="expander" style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table></th>
+                  </th></tr></table></th>
                 </tr></tbody></table>
                 <table class="row collapse" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                   <th class="small-12 large-12 columns first last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0; padding-right: 0; text-align: left; width: 588px;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">

--- a/uk.co.compucorp.civicrm.hremails/email-templates/dist/toil-request.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/dist/toil-request.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+  <head>
+
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>CiviHR TOIL Request</title>
+    <style>{literal}@media only screen {
+  html {
+    min-height: 100%;
+    background: #E8EEF0;
+  }
+}
+
+@media only screen and (max-width: 596px) {
+  .small-text-left {
+    text-align: left !important;
+  }
+}
+
+@media only screen and (max-width: 596px) {
+  table.body img {
+    width: auto;
+    height: auto;
+  }
+
+  table.body center {
+    min-width: 0 !important;
+  }
+
+  table.body .container {
+    width: 95% !important;
+  }
+
+  table.body .columns {
+    height: auto !important;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+
+  table.body .collapse .columns {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  th.small-12 {
+    display: inline-block !important;
+    width: 100% !important;
+  }
+}
+
+@media only screen and (max-width: 596px) {
+  .email-date {
+    line-height: normal !important;
+  }
+}
+
+@media only screen and (max-width: 596px) {
+  .request-data dt {
+    float: none !important;
+    width: auto !important;
+  }
+}{/literal}</style>
+  </head>
+  <body style="-moz-box-sizing: border-box; -ms-text-size-adjust: 100%; -webkit-box-sizing: border-box; -webkit-text-size-adjust: 100%; Margin: 0; box-sizing: border-box; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; min-width: 100%; padding: 0; text-align: left; width: 100% !important;">
+    <span class="preheader" style="color: #E8EEF0; display: none !important; font-size: 1px; line-height: 1px; max-height: 0px; max-width: 0px; mso-hide: all !important; opacity: 0; overflow: hidden; visibility: hidden;"></span>
+    <table class="body" style="Margin: 0; background: #E8EEF0; border-collapse: collapse; border-spacing: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; height: 100%; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+      <tr style="padding: 0; text-align: left; vertical-align: top;">
+        <td class="center" align="center" valign="top" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">
+          <center class="email" data-parsed="" style="Margin: 40px 0; margin: 40px 0; min-width: 580px; width: 100%;">
+            <!-- header -->
+            <table align="center" class="container email-heading float-center" style="Margin: 0 auto; background: transparent; border-collapse: collapse; border-spacing: 0; float: none; margin: 0 auto; padding: 0; text-align: center; vertical-align: top; width: 580px;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">
+              <table class="row collapse" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                <th class="small-12 large-6 columns first" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0; padding-right: 0; text-align: left; width: 298px;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                  <h1 class="email-title" style="Margin: 0; Margin-bottom: 0; border-left: 5px solid #42AFCB; color: #4D5663; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 18px; font-weight: 500; line-height: 40px; margin: 0; margin-bottom: 0; padding: 0; padding-left: 15px; text-align: left; word-wrap: normal;">CiviHR TOIL Request</h1>
+                </th></tr></table></th>
+                <th class="small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0; padding-right: 0; text-align: left; width: 298px;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                  <p class="email-date small-text-left text-right" style="Margin: 0; Margin-bottom: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 40px; margin: 0; margin-bottom: 0; padding: 0; text-align: right;">{$currentDateTime->format("D d F Y")}</p>
+                </th></tr></table></th>
+              </tr></tbody></table>
+            </td></tr></tbody></table>
+            <table class="spacer float-center" style="Margin: 0 auto; border-collapse: collapse; border-spacing: 0; float: none; margin: 0 auto; padding: 0; text-align: center; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td height="16px" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; hyphens: auto; line-height: 16px; margin: 0; mso-line-height-rule: exactly; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">&#xA0;</td></tr></tbody></table>
+            <!-- body -->
+            <table align="center" class="container float-center" style="Margin: 0 auto; background: transparent; border-collapse: collapse; border-spacing: 0; float: none; margin: 0 auto; padding: 0; text-align: center; vertical-align: top; width: 580px;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">
+
+              <div class="request">
+                <table class="row collapse" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                  <th class="small-12 large-12 columns first last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0; padding-right: 0; text-align: left; width: 588px;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                    <table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+                      <tr style="padding: 0; text-align: left; vertical-align: top;">
+                        <td class="callout-header" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #F3F6F7; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 15px 20px; text-align: left; vertical-align: top; word-wrap: break-word;">
+                          <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">Leave Request Type</h2>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <table class="callout" style="Margin-bottom: 16px; border-collapse: collapse; border-spacing: 0; margin-bottom: 16px; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner request-data request-data-large" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
+                      <dl style="Margin: 0; margin: 0;">
+                        <dt style="color: #4D5663; float: left; font-weight: 600; width: 200px;">{ts}Status:{/ts}</dt>
+                        <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{$leaveStatus}</dd>
+                        <dt style="color: #4D5663; float: left; font-weight: 600; width: 200px;">{ts}Staff Member:{/ts}</dt>
+                        <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{contact.display_name}</dd>
+                        {if $leaveRequest->from_date eq $leaveRequest->to_date}
+                          <dt style="color: #4D5663; float: left; font-weight: 600; width: 200px;">Date:</dt>
+                          <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</dd>
+                        {else}
+                          <dt style="color: #4D5663; float: left; font-weight: 600; width: 200px;">{ts}From Date:{/ts}</dt>
+                          <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</dd>
+                          <dt style="color: #4D5663; float: left; font-weight: 600; width: 200px;">{ts}To Date:{/ts}</dt>
+                          <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</dd>
+                        {/if}
+                        <div class="request-data-toil" style="line-height: 2.5;">
+                          <dt style="color: #4D5663; float: left; font-weight: 600; width: 200px;">{ts}No. TOIL Days Requested:{/ts}</dt>
+                          <dd style="Margin-left: 0; margin-left: 0;"><span style="border: 1px solid #727E8A; display: inline-block; text-align: center; width: 100px;">{$leaveRequest->toil_to_accrue}{if $leaveRequest->toil_to_accrue > 1}days{else}day{/if}</span></dd>
+                        </div>
+                      </dl>
+                    </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
+                    <table class="button expanded alert" style="Margin: 0 0 16px 0; border-collapse: collapse; border-spacing: 0; margin: 0 0 16px 0; padding: 0; text-align: left; vertical-align: top; width: 100% !important;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #E6807F; border: 0px solid #E6807F; border-collapse: collapse !important; color: #FFF; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;"><center data-parsed="" style="min-width: 0; width: 100%;"><a href="{$leaveRequestLink}" align="center" class="float-center" style="Margin: 0; border: 0 solid #E6807F; border-radius: 3px; color: #FFF; display: inline-block; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 8px 16px 8px 16px; padding-left: 0; padding-right: 0; text-align: center; text-decoration: none; width: 100%;">View This Request</a></center></td></tr></table></td>
+<td class="expander" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; vertical-align: top; visibility: hidden; width: 0; word-wrap: break-word;"></td></tr></table>
+                    {if $leaveComments}
+                      <hr style="Margin: 20px auto; border: 0; border-top: 1px solid #D3DEE2; height: 0; margin: 20px auto;">
+                      <table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+                        <tr style="padding: 0; text-align: left; vertical-align: top;">
+                          <td class="callout-header" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #F3F6F7; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 15px 20px; text-align: left; vertical-align: top; word-wrap: break-word;">
+                            <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">Request comments</h2>
+                          </td>
+                        </tr>
+                      </table>
+
+                      <table class="callout" style="Margin-bottom: 16px; border-collapse: collapse; border-spacing: 0; margin-bottom: 16px; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner callout-no-padding" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left; width: 100%;">
+                        <div class="request-comments">
+                          {foreach from=$leaveComments item=value key=label}
+                            <div class="request-comment" style="border-bottom: 1px solid #E8EEF0; padding: 20px;">
+                              <div class="request-comment-header" style="Margin-bottom: 10px; color: #4D5663; font-weight: 600; margin-bottom: 10px;">
+                                <span class="request-comment-author">{$value.commenter}:</span>
+                                <span class="request-comment-datetime">{$value.created_at|crmDate}</span>
+                              </div>
+                              <div class="request-comment-body">
+                                {$value.text}
+                              </div>
+                            </div>
+                          {/foreach}
+                        </div>
+                      </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
+                    {/if}
+                    {if $leaveFiles}
+                      <hr style="Margin: 20px auto; border: 0; border-top: 1px solid #D3DEE2; height: 0; margin: 20px auto;">
+                      <table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+                        <tr style="padding: 0; text-align: left; vertical-align: top;">
+                          <td class="callout-header" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #F3F6F7; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 15px 20px; text-align: left; vertical-align: top; word-wrap: break-word;">
+                            <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">Other files recorded in this request</h2>
+                          </td>
+                        </tr>
+                      </table>
+
+                      <table class="callout" style="Margin-bottom: 16px; border-collapse: collapse; border-spacing: 0; margin-bottom: 16px; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
+                        <div class="request-attachments">
+                          {foreach from=$leaveFiles item=value key=label}
+                            <div class="request-attachment" style="Margin-bottom: 10px; margin-bottom: 10px;">
+                              <span class="request-attachment-name" style="color: #4D5663; font-weight: 600;">{$value.name}</span>: Added on {$value.upload_date|crmDate}
+                            </div>
+                          {/foreach}
+                        </div>
+                      </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
+                    {/if}
+                  </th>
+<th class="expander" style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table></th>
+                </tr></tbody></table>
+                <table class="row collapse" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                  <th class="small-12 large-12 columns first last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0; padding-right: 0; text-align: left; width: 588px;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                    <table class="spacer" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td height="16px" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; hyphens: auto; line-height: 16px; margin: 0; mso-line-height-rule: exactly; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">&#xA0;</td></tr></tbody></table>
+                    <img class="text-center email-logo" src="https://civihr.org/sites/default/files/email-logo.png" style="-ms-interpolation-mode: bicubic; Margin: 0 auto; clear: both; display: block; float: none; margin: 0 auto; max-width: 100%; outline: none; text-align: center; text-decoration: none; width: 100px;">
+                  </th>
+<th class="expander" style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table></th>
+                </tr></tbody></table>
+              </div>
+
+            </td></tr></tbody></table>
+          </center>
+        </td>
+      </tr>
+    </table>
+    <!-- prevent Gmail on iOS font size manipulation -->
+   <div style="display:none; white-space:nowrap; font:15px courier; line-height:0;"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </div>
+  </body>
+</html>
+

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/components/_request.scss
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/components/_request.scss
@@ -15,12 +15,17 @@
 
 
 .request-comment {
-  padding: $callout-padding;
+
+  &-body {
+    padding: $callout-padding;
+    padding-top: 0;
+  }
 
   &-header {
-    @include margin(10px, bottom);
     color: $gray-darker;
     font-weight: 600;
+    padding: $callout-padding;
+    padding-bottom: $callout-padding/2
   }
 }
 

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/components/_request.scss
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/components/_request.scss
@@ -39,30 +39,34 @@
 
 .request-data {
 
-  dl {
-    @include margin(0);
-  }
+  &-key {
 
-  dt {
-    color: $gray-darker;
-    float: left;
-    font-weight: 600;
-    width: 150px;
-  }
+    span {
+      color: $gray-darker;
+      font-weight: 600;
+    }
 
-  dd {
-    @include margin(0, left);
-
-    &:not(:last-child) {
-      @include margin(10px, bottom);
+    // Mobile only: remove vertical margin between the key and the value
+    @media only screen and (max-width: #{$global-breakpoint}) {
+      padding-bottom: 0 !important;
     }
   }
 
-  @media only screen and (max-width: #{$global-breakpoint}) {
+  .row {
 
-    dt {
-      float: none !important;
-      width: auto !important;
+    // Mobile / Desktop: Remove bottom margin on the last row
+    &:last-child {
+
+      .columns {
+        padding-bottom: 0 !important;
+      }
+    }
+
+    // Desktop only: reduce the vergical margin between rows
+    @media only screen and (min-width: #{$global-breakpoint + 1}) {
+      .columns {
+        padding-bottom: 10px !important;
+      }
     }
   }
 }

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/components/_request.scss
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/components/_request.scss
@@ -61,3 +61,22 @@
     }
   }
 }
+
+.request-data-large {
+
+  dt {
+    width: 200px;
+  }
+}
+
+
+.request-data-toil {
+  line-height: 2.5;
+
+  span {
+    border: 1px solid $medium-gray;
+    display: inline-block;
+    text-align: center;
+    width: 100px;
+  }
+}

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/components/_request.scss
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/components/_request.scss
@@ -41,6 +41,7 @@
 
   &-key {
 
+    div,
     span {
       color: $gray-darker;
       font-weight: 600;
@@ -71,21 +72,24 @@
   }
 }
 
-.request-data-large {
-
-  dt {
-    width: 200px;
-  }
-}
-
-
 .request-data-toil {
-  line-height: 2.5;
 
+  div,
   span {
-    border: 1px solid $medium-gray;
-    display: inline-block;
-    text-align: center;
-    width: 100px;
+    padding: 10px 0;
+
+    // trick necessary for Outlook, otherwise the div doesn't get
+    // rendered with the padding
+    border: 1px solid $callout-background;
+  }
+
+  .request-data-value {
+
+    span {
+      border-color: $medium-gray;
+      display: inline-block;
+      text-align: center;
+      width: 100px;
+    }
   }
 }

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/components/_request.scss
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/components/_request.scss
@@ -25,7 +25,7 @@
     color: $gray-darker;
     font-weight: 600;
     padding: $callout-padding;
-    padding-bottom: $callout-padding/2
+    padding-bottom: $callout-padding/2;
   }
 }
 
@@ -65,6 +65,7 @@
 
     // Desktop only: reduce the vergical margin between rows
     @media only screen and (min-width: #{$global-breakpoint + 1}) {
+
       .columns {
         padding-bottom: 10px !important;
       }

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/leave-request.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/leave-request.html
@@ -27,21 +27,7 @@ request-type: Leave
         <callout class="callout-no-padding">
           <div class="request-comments">
             {foreach from=$leaveComments item=value key=label}
-              <table class="request-comment">
-                <tbody>
-                  <tr>
-                    <td class="request-comment-header">
-                      <span class="request-comment-author">{$value.commenter}:</span>
-                      <span class="request-comment-datetime">{$value.created_at|crmDate}</span>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="request-comment-body">
-                      {$value.text}
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
+              {{> request-comment commenter="{$value.commenter}" createdAt="{$value.created_at|crmDate}" text="{$value.text}"}}
             {/foreach}
           </div>
         </callout>
@@ -52,9 +38,7 @@ request-type: Leave
         <callout>
           <div class="request-attachments">
             {foreach from=$leaveFiles item=value key=label}
-              <div class="request-attachment">
-                <span class="request-attachment-name">{$value.name}</span>: Added on {$value.upload_date|crmDate}
-              </div>
+              {{> request-attachment name="{$value.name}" uploadDate="{$value.created_at|crmDate}"}}
             {/foreach}
           </div>
         </callout>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/leave-request.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/leave-request.html
@@ -9,48 +9,14 @@ request-type: Leave
     <columns>
       {{> callout-header title="Leave Request Type"}}
       <callout class="request-data">
-        <row>
-          <columns class="request-data-key" large="3">
-            <span>{ts}Status:{/ts}</span>
-          </columns>
-          <columns class="request-data-value">
-            <span>{$leaveStatus}</span>
-          </columns>
-        </row>
-        <row>
-          <columns class="request-data-key" large="3">
-            <span>{ts}Staff Member:{/ts}</span>
-          </columns>
-          <columns class="request-data-value">
-            <span>{contact.display_name}</span>
-          </columns>
-        </row>
+        {{> request-data key="Status" value="{$leaveStatus}"}}
+        {{> request-data key="Staff Member" value="{contact.display_name}"}}
+
         {if $leaveRequest->from_date eq $leaveRequest->to_date}
-          <row>
-            <columns class="request-data-key" large="3">
-              <span>Date:</span>
-            </columns>
-            <columns class="request-data-value">
-              <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
-            </columns>
-          </row>
+          {{> request-data key="Date" value="{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}"}}
         {else}
-          <row>
-            <columns class="request-data-key" large="3">
-              <span>{ts}From Date:{/ts}</span>
-            </columns>
-            <columns class="request-data-value">
-              <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
-            </columns>
-          </row>
-          <row>
-            <columns class="request-data-key" large="3">
-              <span>{ts}To Date:{/ts}</span>
-            </columns>
-            <columns class="request-data-value">
-              <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
-            </columns>
-          </row>
+          {{> request-data key="From Date" value="{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}"}}
+          {{> request-data key="To Date" value="{$toDate|truncate:10:\'\'|crmDate} {$toDateType}"}}
         {/if}
       </callout>
       <spacer></spacer>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/leave-request.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/leave-request.html
@@ -42,6 +42,8 @@ request-type: Leave
             <columns class="request-data-value">
               <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
             </columns>
+          </row>
+          <row>
             <columns class="request-data-key" large="3">
               <span>{ts}To Date:{/ts}</span>
             </columns>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/leave-request.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/leave-request.html
@@ -32,15 +32,21 @@ request-type: Leave
         <callout class="callout-no-padding">
           <div class="request-comments">
             {foreach from=$leaveComments item=value key=label}
-              <div class="request-comment">
-                <div class="request-comment-header">
-                  <span class="request-comment-author">{$value.commenter}:</span>
-                  <span class="request-comment-datetime">{$value.created_at|crmDate}</span>
-                </div>
-                <div class="request-comment-body">
-                  {$value.text}
-                </div>
-              </div>
+              <table class="request-comment">
+                <tbody>
+                  <tr>
+                    <td class="request-comment-header">
+                      <span class="request-comment-author">{$value.commenter}:</span>
+                      <span class="request-comment-datetime">{$value.created_at|crmDate}</span>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="request-comment-body">
+                      {$value.text}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
             {/foreach}
           </div>
         </callout>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/leave-request.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/leave-request.html
@@ -45,10 +45,5 @@ request-type: Leave
       {/if}
     </columns>
   </row>
-  <row class="collapse">
-    <columns>
-      <spacer></spacer>
-      <img class="text-center email-logo" src="https://civihr.org/sites/default/files/email-logo.png">
-    </columns>
-  </row>
+  {{> la-footer}}
 </div>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/leave-request.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/leave-request.html
@@ -25,6 +25,7 @@ request-type: Leave
           {/if}
         </dl>
       </callout>
+      <spacer></spacer>
       <button href="{$leaveRequestLink}" class="expanded alert">View This Request</button>
       {if $leaveComments}
         <hr>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/leave-request.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/leave-request.html
@@ -9,21 +9,47 @@ request-type: Leave
     <columns>
       {{> callout-header title="Leave Request Type"}}
       <callout class="request-data">
-        <dl>
-          <dt>{ts}Status:{/ts}</dt>
-          <dd>{$leaveStatus}</dd>
-          <dt>{ts}Staff Member:{/ts}</dt>
-          <dd>{contact.display_name}</dd>
-          {if $leaveRequest->from_date eq $leaveRequest->to_date}
-            <dt>Date:</dt>
-            <dd>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</dd>
-          {else}
-            <dt>{ts}From Date:{/ts}</dt>
-            <dd>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</dd>
-            <dt>{ts}To Date:{/ts}</dt>
-            <dd>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</dd>
-          {/if}
-        </dl>
+        <row>
+          <columns class="request-data-key" large="3">
+            <span>{ts}Status:{/ts}</span>
+          </columns>
+          <columns class="request-data-value">
+            <span>{$leaveStatus}</span>
+          </columns>
+        </row>
+        <row>
+          <columns class="request-data-key" large="3">
+            <span>{ts}Staff Member:{/ts}</span>
+          </columns>
+          <columns class="request-data-value">
+            <span>{contact.display_name}</span>
+          </columns>
+        </row>
+        {if $leaveRequest->from_date eq $leaveRequest->to_date}
+          <row>
+            <columns class="request-data-key" large="3">
+              <span>Date:</span>
+            </columns>
+            <columns class="request-data-value">
+              <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+            </columns>
+          </row>
+        {else}
+          <row>
+            <columns class="request-data-key" large="3">
+              <span>{ts}From Date:{/ts}</span>
+            </columns>
+            <columns class="request-data-value">
+              <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+            </columns>
+            <columns class="request-data-key" large="3">
+              <span>{ts}To Date:{/ts}</span>
+            </columns>
+            <columns class="request-data-value">
+              <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
+            </columns>
+          </row>
+        {/if}
       </callout>
       <spacer></spacer>
       <button href="{$leaveRequestLink}" class="expanded alert">View This Request</button>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/toil-request.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/toil-request.html
@@ -42,6 +42,8 @@ request-type: TOIL
             <columns class="request-data-value">
               <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
             </columns>
+          </row>
+          <row>
             <columns class="request-data-key" large="3">
               <span>{ts}To Date:{/ts}</span>
             </columns>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/toil-request.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/toil-request.html
@@ -8,27 +8,59 @@ request-type: TOIL
   <row class="collapse">
     <columns>
       {{> callout-header title="Leave Request Type"}}
-      <callout class="request-data request-data-large">
-        <dl>
-          <dt>{ts}Status:{/ts}</dt>
-          <dd>{$leaveStatus}</dd>
-          <dt>{ts}Staff Member:{/ts}</dt>
-          <dd>{contact.display_name}</dd>
-          {if $leaveRequest->from_date eq $leaveRequest->to_date}
-            <dt>Date:</dt>
-            <dd>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</dd>
-          {else}
-            <dt>{ts}From Date:{/ts}</dt>
-            <dd>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</dd>
-            <dt>{ts}To Date:{/ts}</dt>
-            <dd>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</dd>
-          {/if}
-          <div class="request-data-toil">
-            <dt>{ts}No. TOIL Days Requested:{/ts}</dt>
-            <dd><span>{$leaveRequest->toil_to_accrue}{if $leaveRequest->toil_to_accrue > 1}days{else}day{/if}</span></dd>
-          </div>
-        </dl>
+      <callout class="request-data">
+        <row>
+          <columns class="request-data-key" large="3">
+            <span>{ts}Status:{/ts}</span>
+          </columns>
+          <columns class="request-data-value">
+            <span>{$leaveStatus}</span>
+          </columns>
+        </row>
+        <row>
+          <columns class="request-data-key" large="3">
+            <span>{ts}Staff Member:{/ts}</span>
+          </columns>
+          <columns class="request-data-value">
+            <span>{contact.display_name}</span>
+          </columns>
+        </row>
+        {if $leaveRequest->from_date eq $leaveRequest->to_date}
+          <row>
+            <columns class="request-data-key" large="3">
+              <span>Date:</span>
+            </columns>
+            <columns class="request-data-value">
+              <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+            </columns>
+          </row>
+        {else}
+          <row>
+            <columns class="request-data-key" large="3">
+              <span>{ts}From Date:{/ts}</span>
+            </columns>
+            <columns class="request-data-value">
+              <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+            </columns>
+            <columns class="request-data-key" large="3">
+              <span>{ts}To Date:{/ts}</span>
+            </columns>
+            <columns class="request-data-value">
+              <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
+            </columns>
+          </row>
+        {/if}
+        <row class="request-data-toil">
+          <columns class="request-data-key" large="4">
+            <!-- div is necessary because of Outlook's rendering problems -->
+            <div>{ts}No. TOIL Days Requested:{/ts}</div>
+          </columns>
+          <columns class="request-data-value">
+            <span>{$leaveRequest->toil_to_accrue}{if $leaveRequest->toil_to_accrue > 1}days{else}day{/if}</span>
+          </columns>
+        </row>
       </callout>
+      <spacer></spacer>
       <button href="{$leaveRequestLink}" class="expanded alert">View This Request</button>
       {if $leaveComments}
         <hr>
@@ -36,15 +68,21 @@ request-type: TOIL
         <callout class="callout-no-padding">
           <div class="request-comments">
             {foreach from=$leaveComments item=value key=label}
-              <div class="request-comment">
-                <div class="request-comment-header">
-                  <span class="request-comment-author">{$value.commenter}:</span>
-                  <span class="request-comment-datetime">{$value.created_at|crmDate}</span>
-                </div>
-                <div class="request-comment-body">
-                  {$value.text}
-                </div>
-              </div>
+              <table class="request-comment">
+                <tbody>
+                  <tr>
+                    <td class="request-comment-header">
+                      <span class="request-comment-author">{$value.commenter}:</span>
+                      <span class="request-comment-datetime">{$value.created_at|crmDate}</span>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="request-comment-body">
+                      {$value.text}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
             {/foreach}
           </div>
         </callout>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/toil-request.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/toil-request.html
@@ -9,58 +9,23 @@ request-type: TOIL
     <columns>
       {{> callout-header title="Leave Request Type"}}
       <callout class="request-data">
-        <row>
-          <columns class="request-data-key" large="4">
-            <span>{ts}Status:{/ts}</span>
-          </columns>
-          <columns class="request-data-value">
-            <span>{$leaveStatus}</span>
-          </columns>
-        </row>
-        <row>
-          <columns class="request-data-key" large="4">
-            <span>{ts}Staff Member:{/ts}</span>
-          </columns>
-          <columns class="request-data-value">
-            <span>{contact.display_name}</span>
-          </columns>
-        </row>
+        {{> request-data key="Status" value="{$leaveStatus}" keySize="4"}}
+        {{> request-data key="Staff Member" value="{contact.display_name}" keySize="4"}}
+
         {if $leaveRequest->from_date eq $leaveRequest->to_date}
-          <row>
-            <columns class="request-data-key" large="4">
-              <span>Date:</span>
-            </columns>
-            <columns class="request-data-value">
-              <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
-            </columns>
-          </row>
+          {{> request-data key="Date" value="{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}" keySize="4"}}
         {else}
-          <row>
-            <columns class="request-data-key" large="4">
-              <span>{ts}From Date:{/ts}</span>
-            </columns>
-            <columns class="request-data-value">
-              <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
-            </columns>
-          </row>
-          <row>
-            <columns class="request-data-key" large="4">
-              <span>{ts}To Date:{/ts}</span>
-            </columns>
-            <columns class="request-data-value">
-              <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
-            </columns>
-          </row>
+          {{> request-data key="From Date" value="{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}" keySize="4"}}
+          {{> request-data key="To Date" value="{$toDate|truncate:10:\'\'|crmDate} {$toDateType}" keySize="4"}}
         {/if}
-        <row class="request-data-toil">
-          <columns class="request-data-key" large="4">
-            <!-- div is necessary because of Outlook's rendering problems -->
-            <div>{ts}No. TOIL Days Requested:{/ts}</div>
-          </columns>
-          <columns class="request-data-value">
-            <span>{$leaveRequest->toil_to_accrue}{if $leaveRequest->toil_to_accrue > 1}days{else}day{/if}</span>
-          </columns>
-        </row>
+
+        {{> request-data
+          key="No. TOIL Days Requested"
+          value="{$leaveRequest->toil_to_accrue} {if $leaveRequest->toil_to_accrue > 1}days{else}day{/if}"
+          class="request-data-toil"
+          keySize="4"
+          keyTag="div"
+        }}
       </callout>
       <spacer></spacer>
       <button href="{$leaveRequestLink}" class="expanded alert">View This Request</button>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/toil-request.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/toil-request.html
@@ -10,7 +10,7 @@ request-type: TOIL
       {{> callout-header title="Leave Request Type"}}
       <callout class="request-data">
         <row>
-          <columns class="request-data-key" large="3">
+          <columns class="request-data-key" large="4">
             <span>{ts}Status:{/ts}</span>
           </columns>
           <columns class="request-data-value">
@@ -18,7 +18,7 @@ request-type: TOIL
           </columns>
         </row>
         <row>
-          <columns class="request-data-key" large="3">
+          <columns class="request-data-key" large="4">
             <span>{ts}Staff Member:{/ts}</span>
           </columns>
           <columns class="request-data-value">
@@ -27,7 +27,7 @@ request-type: TOIL
         </row>
         {if $leaveRequest->from_date eq $leaveRequest->to_date}
           <row>
-            <columns class="request-data-key" large="3">
+            <columns class="request-data-key" large="4">
               <span>Date:</span>
             </columns>
             <columns class="request-data-value">
@@ -36,7 +36,7 @@ request-type: TOIL
           </row>
         {else}
           <row>
-            <columns class="request-data-key" large="3">
+            <columns class="request-data-key" large="4">
               <span>{ts}From Date:{/ts}</span>
             </columns>
             <columns class="request-data-value">
@@ -44,7 +44,7 @@ request-type: TOIL
             </columns>
           </row>
           <row>
-            <columns class="request-data-key" large="3">
+            <columns class="request-data-key" large="4">
               <span>{ts}To Date:{/ts}</span>
             </columns>
             <columns class="request-data-value">

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/toil-request.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/toil-request.html
@@ -1,0 +1,73 @@
+---
+layout: leave-absences
+subject: CiviHR TOIL Request
+request-type: TOIL
+---
+
+<div class="request">
+  <row class="collapse">
+    <columns>
+      {{> callout-header title="Leave Request Type"}}
+      <callout class="request-data request-data-large">
+        <dl>
+          <dt>{ts}Status:{/ts}</dt>
+          <dd>{$leaveStatus}</dd>
+          <dt>{ts}Staff Member:{/ts}</dt>
+          <dd>{contact.display_name}</dd>
+          {if $leaveRequest->from_date eq $leaveRequest->to_date}
+            <dt>Date:</dt>
+            <dd>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</dd>
+          {else}
+            <dt>{ts}From Date:{/ts}</dt>
+            <dd>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</dd>
+            <dt>{ts}To Date:{/ts}</dt>
+            <dd>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</dd>
+          {/if}
+          <div class="request-data-toil">
+            <dt>{ts}No. TOIL Days Requested:{/ts}</dt>
+            <dd><span>{$leaveRequest->toil_to_accrue}{if $leaveRequest->toil_to_accrue > 1}days{else}day{/if}</span></dd>
+          </div>
+        </dl>
+      </callout>
+      <button href="{$leaveRequestLink}" class="expanded alert">View This Request</button>
+      {if $leaveComments}
+        <hr>
+        {{> callout-header title="Request comments"}}
+        <callout class="callout-no-padding">
+          <div class="request-comments">
+            {foreach from=$leaveComments item=value key=label}
+              <div class="request-comment">
+                <div class="request-comment-header">
+                  <span class="request-comment-author">{$value.commenter}:</span>
+                  <span class="request-comment-datetime">{$value.created_at|crmDate}</span>
+                </div>
+                <div class="request-comment-body">
+                  {$value.text}
+                </div>
+              </div>
+            {/foreach}
+          </div>
+        </callout>
+      {/if}
+      {if $leaveFiles}
+        <hr>
+        {{> callout-header title="Other files recorded in this request"}}
+        <callout>
+          <div class="request-attachments">
+            {foreach from=$leaveFiles item=value key=label}
+              <div class="request-attachment">
+                <span class="request-attachment-name">{$value.name}</span>: Added on {$value.upload_date|crmDate}
+              </div>
+            {/foreach}
+          </div>
+        </callout>
+      {/if}
+    </columns>
+  </row>
+  <row class="collapse">
+    <columns>
+      <spacer></spacer>
+      <img class="text-center email-logo" src="https://civihr.org/sites/default/files/email-logo.png">
+    </columns>
+  </row>
+</div>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/toil-request.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/toil-request.html
@@ -53,10 +53,5 @@ request-type: TOIL
       {/if}
     </columns>
   </row>
-  <row class="collapse">
-    <columns>
-      <spacer></spacer>
-      <img class="text-center email-logo" src="https://civihr.org/sites/default/files/email-logo.png">
-    </columns>
-  </row>
+  {{> la-footer}}
 </div>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/toil-request.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/toil-request.html
@@ -35,21 +35,7 @@ request-type: TOIL
         <callout class="callout-no-padding">
           <div class="request-comments">
             {foreach from=$leaveComments item=value key=label}
-              <table class="request-comment">
-                <tbody>
-                  <tr>
-                    <td class="request-comment-header">
-                      <span class="request-comment-author">{$value.commenter}:</span>
-                      <span class="request-comment-datetime">{$value.created_at|crmDate}</span>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="request-comment-body">
-                      {$value.text}
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
+              {{> request-comment commenter="{$value.commenter}" createdAt="{$value.created_at|crmDate}" text="{$value.text}"}}
             {/foreach}
           </div>
         </callout>
@@ -60,9 +46,7 @@ request-type: TOIL
         <callout>
           <div class="request-attachments">
             {foreach from=$leaveFiles item=value key=label}
-              <div class="request-attachment">
-                <span class="request-attachment-name">{$value.name}</span>: Added on {$value.upload_date|crmDate}
-              </div>
+              {{> request-attachment name="{$value.name}" uploadDate="{$value.created_at|crmDate}"}}
             {/foreach}
           </div>
         </callout>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/partials/la-footer.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/partials/la-footer.html
@@ -1,0 +1,6 @@
+<row class="collapse">
+  <columns>
+    <spacer></spacer>
+    <img class="text-center email-logo" src="https://civihr.org/sites/default/files/email-logo.png">
+  </columns>
+</row>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/partials/request-attachment.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/partials/request-attachment.html
@@ -1,0 +1,3 @@
+<div class="request-attachment">
+  <span class="request-attachment-name">{{name}}</span>: Added on {{uploadDate}}
+</div>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/partials/request-comment.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/partials/request-comment.html
@@ -7,9 +7,7 @@
       </td>
     </tr>
     <tr>
-      <td class="request-comment-body">
-        {{text}}
-      </td>
+      <td class="request-comment-body">{{text}}</td>
     </tr>
   </tbody>
 </table>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/partials/request-comment.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/partials/request-comment.html
@@ -1,0 +1,15 @@
+<table class="request-comment">
+  <tbody>
+    <tr>
+      <td class="request-comment-header">
+        <span class="request-comment-author">{{commenter}}:</span>
+        <span class="request-comment-datetime">{{createdAt}}</span>
+      </td>
+    </tr>
+    <tr>
+      <td class="request-comment-body">
+        {{text}}
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/partials/request-data.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/partials/request-data.html
@@ -1,0 +1,10 @@
+<row class="{{class}}">
+  <columns class="request-data-key" large="{{#if keySize}}{{keySize}}{{else}}3{{/if}}">
+    <{{#if keyTag}}{{keyTag}}{{else}}span{{/if}}>
+      {ts}{{key}}:{/ts}
+    </{{#if keyTag}}{{keyTag}}{{else}}span{{/if}}>
+  </columns>
+  <columns class="request-data-value">
+    <span>{{value}}</span>
+  </columns>
+</row>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/managed_entities/EmailTemplate.mgd.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/managed_entities/EmailTemplate.mgd.php
@@ -208,6 +208,199 @@ return [
       'msg_subject' => 'TOIL Request',
       'msg_text' => 'CiviHR TOIL RequestLeave Request Type{ts}Status:{/ts}{$leaveStatus}{ts}Staff Member:{/ts}{contact.display_name}{if $leaveRequest->from_date eq $leaveRequest->to_date}{ts}Date:{/ts}{$fromDate|truncate:10:\'\'|crmDate}{else}{ts}From Date:{/ts}{$fromDate|truncate:10:\'\'|crmDate}{ts}To Date:{/ts}{$toDate|truncate:10:\'\'|crmDate}{/if}{ts}No. TOIL Days Requested{/ts}{$leaveRequest->toil_to_accrue}{if $leaveRequest->toil_to_accrue > 1}days{else}day{/if}View This Request{if $leaveComments}Request Comments{foreach from=$leaveComments item=value key=label}{$value.commenter}:{$value.created_at|crmDate}{$value.text}{/foreach}{/if}{if $leaveFiles}Other files recorded on this request{foreach from=$leaveFiles item=value key=label}{$value.name}: Added on{$value.upload_date|crmDate}{/foreach}{/if}',
       'msg_html' => '<html><head><title></title></head><body><h3>CiviHR TOIL Request</h3><h4>{$currentDateTime->format("D d F Y")}</h4><p><strong>Leave Request Type</strong></p><table><tbody><tr><td>{ts}Status:{/ts}</td><td>{$leaveStatus}</td></tr><tr><td>{ts}Staff Member:{/ts}</td><td>{contact.display_name}</td></tr>{if $leaveRequest->from_date eq $leaveRequest->to_date}<tr><td>{ts}Date:{/ts}</td><td>{$fromDate|truncate:10:\'\'|crmDate}</td></tr>{else}<tr><td>{ts}From Date:{/ts}</td><td>{$fromDate|truncate:10:\'\'|crmDate}</td></tr><tr><td>{ts}To Date:{/ts}</td><td>{$toDate|truncate:10:\'\'|crmDate}</td></tr>{/if}<tr><td>{ts}No. TOIL Days Requested{/ts}</td><td>{$leaveRequest->toil_to_accrue}{if $leaveRequest->toil_to_accrue > 1}days{else}day{/if}</td></tr></tbody></table><p><a href="{$leaveRequestLink}">View This Request</a></p>{if $leaveComments}<p><strong>Request Comments</strong></p><table border="0" cellpadding="1" cellspacing="1" style="width: 700px;"><tbody>{foreach from=$leaveComments item=value key=label}<tr><td>{$value.commenter}:{$value.created_at|crmDate}</td></tr><tr><td>{$value.text}</td></tr>{/foreach}</tbody></table>{/if}<p></p>{if $leaveFiles}<p><b>Other files recorded on this request</b></p><table border="0" cellpadding="1" cellspacing="1" style="width: 700px";><tbody>{foreach from=$leaveFiles item=value key=label}<tr><td>{$value.name}: Added on{$value.upload_date|crmDate}</td></tr>{/foreach}</tbody></table>{/if}</body></html>',
+      'msg_html' => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+  <head>
+
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>CiviHR TOIL Request</title>
+    <style>{literal}@media only screen {
+  html {
+    min-height: 100%;
+    background: #E8EEF0;
+  }
+}
+
+@media only screen and (max-width: 596px) {
+  .small-text-left {
+    text-align: left !important;
+  }
+}
+
+@media only screen and (max-width: 596px) {
+  table.body img {
+    width: auto;
+    height: auto;
+  }
+
+  table.body center {
+    min-width: 0 !important;
+  }
+
+  table.body .container {
+    width: 95% !important;
+  }
+
+  table.body .columns {
+    height: auto !important;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+
+  table.body .collapse .columns {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  th.small-12 {
+    display: inline-block !important;
+    width: 100% !important;
+  }
+}
+
+@media only screen and (max-width: 596px) {
+  .email-date {
+    line-height: normal !important;
+  }
+}
+
+@media only screen and (max-width: 596px) {
+  .request-data dt {
+    float: none !important;
+    width: auto !important;
+  }
+}{/literal}</style>
+  </head>
+  <body style="-moz-box-sizing: border-box; -ms-text-size-adjust: 100%; -webkit-box-sizing: border-box; -webkit-text-size-adjust: 100%; Margin: 0; box-sizing: border-box; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; min-width: 100%; padding: 0; text-align: left; width: 100% !important;">
+    <span class="preheader" style="color: #E8EEF0; display: none !important; font-size: 1px; line-height: 1px; max-height: 0px; max-width: 0px; mso-hide: all !important; opacity: 0; overflow: hidden; visibility: hidden;"></span>
+    <table class="body" style="Margin: 0; background: #E8EEF0; border-collapse: collapse; border-spacing: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; height: 100%; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+      <tr style="padding: 0; text-align: left; vertical-align: top;">
+        <td class="center" align="center" valign="top" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">
+          <center class="email" data-parsed="" style="Margin: 40px 0; margin: 40px 0; min-width: 580px; width: 100%;">
+            <!-- header -->
+            <table align="center" class="container email-heading float-center" style="Margin: 0 auto; background: transparent; border-collapse: collapse; border-spacing: 0; float: none; margin: 0 auto; padding: 0; text-align: center; vertical-align: top; width: 580px;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">
+              <table class="row collapse" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                <th class="small-12 large-6 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0; padding-right: 0; text-align: left; width: 298px;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                  <h1 class="email-title" style="Margin: 0; Margin-bottom: 0; border-left: 5px solid #42AFCB; color: #4D5663; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 18px; font-weight: 500; line-height: 40px; margin: 0; margin-bottom: 0; padding: 0; padding-left: 15px; text-align: left; word-wrap: normal;">CiviHR TOIL Request</h1>
+                </th></tr></table></th>
+                <th class="small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0; padding-right: 0; text-align: left; width: 298px;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                  <p class="email-date small-text-left text-right" style="Margin: 0; Margin-bottom: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 40px; margin: 0; margin-bottom: 0; padding: 0; text-align: right;">{$currentDateTime->format("D d F Y")}</p>
+                </th></tr></table></th>
+              </tr></tbody></table>
+            </td></tr></tbody></table>
+            <table class="spacer float-center" style="Margin: 0 auto; border-collapse: collapse; border-spacing: 0; float: none; margin: 0 auto; padding: 0; text-align: center; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td height="16px" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; hyphens: auto; line-height: 16px; margin: 0; mso-line-height-rule: exactly; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">&#xA0;</td></tr></tbody></table>
+            <!-- body -->
+            <table align="center" class="container float-center" style="Margin: 0 auto; background: transparent; border-collapse: collapse; border-spacing: 0; float: none; margin: 0 auto; padding: 0; text-align: center; vertical-align: top; width: 580px;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">
+
+              <div class="request">
+                <table class="row collapse" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                  <th class="small-12 large-12 columns first last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0; padding-right: 0; text-align: left; width: 588px;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                    <table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+                      <tr style="padding: 0; text-align: left; vertical-align: top;">
+                        <td class="callout-header" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #F3F6F7; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 15px 20px; text-align: left; vertical-align: top; word-wrap: break-word;">
+                          <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">Leave Request Type</h2>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <table class="callout" style="Margin-bottom: 16px; border-collapse: collapse; border-spacing: 0; margin-bottom: 16px; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner request-data request-data-large" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
+                      <dl style="Margin: 0; margin: 0;">
+                        <dt style="color: #4D5663; float: left; font-weight: 600; width: 200px;">{ts}Status:{/ts}</dt>
+                        <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{$leaveStatus}</dd>
+                        <dt style="color: #4D5663; float: left; font-weight: 600; width: 200px;">{ts}Staff Member:{/ts}</dt>
+                        <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{contact.display_name}</dd>
+                        {if $leaveRequest->from_date eq $leaveRequest->to_date}
+                          <dt style="color: #4D5663; float: left; font-weight: 600; width: 200px;">Date:</dt>
+                          <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</dd>
+                        {else}
+                          <dt style="color: #4D5663; float: left; font-weight: 600; width: 200px;">{ts}From Date:{/ts}</dt>
+                          <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</dd>
+                          <dt style="color: #4D5663; float: left; font-weight: 600; width: 200px;">{ts}To Date:{/ts}</dt>
+                          <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</dd>
+                        {/if}
+                        <div class="request-data-toil" style="line-height: 2.5;">
+                          <dt style="color: #4D5663; float: left; font-weight: 600; width: 200px;">{ts}No. TOIL Days Requested:{/ts}</dt>
+                          <dd style="Margin-left: 0; margin-left: 0;"><span style="border: 1px solid #727E8A; display: inline-block; text-align: center; width: 100px;">{$leaveRequest->toil_to_accrue}{if $leaveRequest->toil_to_accrue > 1}days{else}day{/if}</span></dd>
+                        </div>
+                      </dl>
+                    </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
+                    <table class="button expanded alert" style="Margin: 0 0 16px 0; border-collapse: collapse; border-spacing: 0; margin: 0 0 16px 0; padding: 0; text-align: left; vertical-align: top; width: 100% !important;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #E6807F; border: 0px solid #E6807F; border-collapse: collapse !important; color: #FFF; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;"><center data-parsed="" style="min-width: 0; width: 100%;"><a href="{$leaveRequestLink}" align="center" class="float-center" style="Margin: 0; border: 0 solid #E6807F; border-radius: 3px; color: #FFF; display: inline-block; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 8px 16px 8px 16px; padding-left: 0; padding-right: 0; text-align: center; text-decoration: none; width: 100%;">View This Request</a></center></td></tr></table></td>
+<td class="expander" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; vertical-align: top; visibility: hidden; width: 0; word-wrap: break-word;"></td></tr></table>
+                    {if $leaveComments}
+                      <hr style="Margin: 20px auto; border: 0; border-top: 1px solid #D3DEE2; height: 0; margin: 20px auto;">
+                      <table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+                        <tr style="padding: 0; text-align: left; vertical-align: top;">
+                          <td class="callout-header" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #F3F6F7; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 15px 20px; text-align: left; vertical-align: top; word-wrap: break-word;">
+                            <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">Request comments</h2>
+                          </td>
+                        </tr>
+                      </table>
+
+                      <table class="callout" style="Margin-bottom: 16px; border-collapse: collapse; border-spacing: 0; margin-bottom: 16px; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner callout-no-padding" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left; width: 100%;">
+                        <div class="request-comments">
+                          {foreach from=$leaveComments item=value key=label}
+                            <div class="request-comment" style="border-bottom: 1px solid #E8EEF0; padding: 20px;">
+                              <div class="request-comment-header" style="Margin-bottom: 10px; color: #4D5663; font-weight: 600; margin-bottom: 10px;">
+                                <span class="request-comment-author">{$value.commenter}:</span>
+                                <span class="request-comment-datetime">{$value.created_at|crmDate}</span>
+                              </div>
+                              <div class="request-comment-body">
+                                {$value.text}
+                              </div>
+                            </div>
+                          {/foreach}
+                        </div>
+                      </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
+                    {/if}
+                    {if $leaveFiles}
+                      <hr style="Margin: 20px auto; border: 0; border-top: 1px solid #D3DEE2; height: 0; margin: 20px auto;">
+                      <table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+                        <tr style="padding: 0; text-align: left; vertical-align: top;">
+                          <td class="callout-header" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #F3F6F7; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 15px 20px; text-align: left; vertical-align: top; word-wrap: break-word;">
+                            <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">Other files recorded in this request</h2>
+                          </td>
+                        </tr>
+                      </table>
+
+                      <table class="callout" style="Margin-bottom: 16px; border-collapse: collapse; border-spacing: 0; margin-bottom: 16px; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
+                        <div class="request-attachments">
+                          {foreach from=$leaveFiles item=value key=label}
+                            <div class="request-attachment" style="Margin-bottom: 10px; margin-bottom: 10px;">
+                              <span class="request-attachment-name" style="color: #4D5663; font-weight: 600;">{$value.name}</span>: Added on {$value.upload_date|crmDate}
+                            </div>
+                          {/foreach}
+                        </div>
+                      </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
+                    {/if}
+                  </th>
+<th class="expander" style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table></th>
+                </tr></tbody></table>
+                <table class="row collapse" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                  <th class="small-12 large-12 columns first last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0; padding-right: 0; text-align: left; width: 588px;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                    <table class="spacer" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td height="16px" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; hyphens: auto; line-height: 16px; margin: 0; mso-line-height-rule: exactly; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">&#xA0;</td></tr></tbody></table>
+                    <img class="text-center email-logo" src="https://civihr.org/sites/default/files/email-logo.png" style="-ms-interpolation-mode: bicubic; Margin: 0 auto; clear: both; display: block; float: none; margin: 0 auto; max-width: 100%; outline: none; text-align: center; text-decoration: none; width: 100px;">
+                  </th>
+<th class="expander" style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table></th>
+                </tr></tbody></table>
+              </div>
+
+            </td></tr></tbody></table>
+          </center>
+        </td>
+      </tr>
+    </table>
+    <!-- prevent Gmail on iOS font size manipulation -->
+   <div style="display:none; white-space:nowrap; font:15px courier; line-height:0;"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </div>
+  </body>
+</html>
+
+'
       'is_reserved' => 1
     ],
   ],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/managed_entities/EmailTemplate.mgd.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/managed_entities/EmailTemplate.mgd.php
@@ -54,6 +54,11 @@ return [
     padding-right: 16px !important;
   }
 
+  table.body .columns .columns {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
   table.body .collapse .columns {
     padding-left: 0 !important;
     padding-right: 0 !important;
@@ -61,6 +66,11 @@ return [
 
   th.small-12 {
     display: inline-block !important;
+    width: 100% !important;
+  }
+
+  .columns th.small-12 {
+    display: block !important;
     width: 100% !important;
   }
 }
@@ -72,9 +82,14 @@ return [
 }
 
 @media only screen and (max-width: 596px) {
-  .request-data dt {
-    float: none !important;
-    width: auto !important;
+  .request-data-key {
+    padding-bottom: 0 !important;
+  }
+}
+
+@media only screen and (min-width: 597px) {
+  .request-data .row .columns {
+    padding-bottom: 10px !important;
   }
 }{/literal}</style>
   </head>
@@ -110,24 +125,69 @@ return [
                       </tr>
                     </table>
 
-                    <table class="callout" style="Margin-bottom: 16px; border-collapse: collapse; border-spacing: 0; margin-bottom: 16px; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner request-data" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
-                      <dl style="Margin: 0; margin: 0;">
-                        <dt style="color: #4D5663; float: left; font-weight: 600; width: 150px;">{ts}Status:{/ts}</dt>
-                        <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{$leaveStatus}</dd>
-                        <dt style="color: #4D5663; float: left; font-weight: 600; width: 150px;">{ts}Staff Member:{/ts}</dt>
-                        <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{contact.display_name}</dd>
-                        {if $leaveRequest->from_date eq $leaveRequest->to_date}
-                          <dt style="color: #4D5663; float: left; font-weight: 600; width: 150px;">Date:</dt>
-                          <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</dd>
-                        {else}
-                          <dt style="color: #4D5663; float: left; font-weight: 600; width: 150px;">{ts}From Date:{/ts}</dt>
-                          <dd style="Margin-bottom: 10px; Margin-left: 0; margin-bottom: 10px; margin-left: 0;">{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</dd>
-                          <dt style="color: #4D5663; float: left; font-weight: 600; width: 150px;">{ts}To Date:{/ts}</dt>
-                          <dd style="Margin-left: 0; margin-left: 0;">{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</dd>
-                        {/if}
-                      </dl>
+                    <table class="callout" style="Margin-bottom: 0 !important; border-collapse: collapse; border-spacing: 0; margin-bottom: 0 !important; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner request-data" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
+                      <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                        <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <span style="color: #4D5663; font-weight: 600;">
+                            {ts}Status:{/ts}
+                          </span>
+                        </th></tr></table></th>
+                        <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <span>{$leaveStatus}</span>
+                        </th></tr></table></th>
+                      </tr></tbody></table>
+
+                      <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                        <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <span style="color: #4D5663; font-weight: 600;">
+                            {ts}Staff Member:{/ts}
+                          </span>
+                        </th></tr></table></th>
+                        <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <span>{contact.display_name}</span>
+                        </th></tr></table></th>
+                      </tr></tbody></table>
+
+
+                      {if $leaveRequest->from_date eq $leaveRequest->to_date}
+                        <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                          <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span style="color: #4D5663; font-weight: 600;">
+                              {ts}Date:{/ts}
+                            </span>
+                          </th></tr></table></th>
+                          <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span>{$fromDate|truncate:10:\&#x27;\&#x27;|crmDate} {$fromDateType}</span>
+                          </th></tr></table></th>
+                        </tr></tbody></table>
+
+                      {else}
+                        <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                          <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span style="color: #4D5663; font-weight: 600;">
+                              {ts}From Date:{/ts}
+                            </span>
+                          </th></tr></table></th>
+                          <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span>{$fromDate|truncate:10:\&#x27;\&#x27;|crmDate} {$fromDateType}</span>
+                          </th></tr></table></th>
+                        </tr></tbody></table>
+
+                        <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                          <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 0 !important; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span style="color: #4D5663; font-weight: 600;">
+                              {ts}To Date:{/ts}
+                            </span>
+                          </th></tr></table></th>
+                          <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 0 !important; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span>{$toDate|truncate:10:\&#x27;\&#x27;|crmDate} {$toDateType}</span>
+                          </th></tr></table></th>
+                        </tr></tbody></table>
+
+                      {/if}
                     </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
-                    <table class="button expanded alert" style="Margin: 0 0 16px 0; border-collapse: collapse; border-spacing: 0; margin: 0 0 16px 0; padding: 0; text-align: left; vertical-align: top; width: 100% !important;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #E6807F; border: 0px solid #E6807F; border-collapse: collapse !important; color: #FFF; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;"><center data-parsed="" style="min-width: 0; width: 100%;"><a href="{$leaveRequestLink}" align="center" class="float-center" style="Margin: 0; border: 0 solid #E6807F; border-radius: 3px; color: #FFF; display: inline-block; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 8px 16px 8px 16px; padding-left: 0; padding-right: 0; text-align: center; text-decoration: none; width: 100%;">View This Request</a></center></td></tr></table></td>
+                    <table class="spacer" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td height="16px" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; hyphens: auto; line-height: 16px; margin: 0; mso-line-height-rule: exactly; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">&#xA0;</td></tr></tbody></table>
+                    <table class="button expanded alert" style="Margin: 0 0 16px 0; border-collapse: collapse; border-spacing: 0; margin: 0 0 16px 0; padding: 0; text-align: left; vertical-align: top; width: 100% !important;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; width: 100%; word-wrap: break-word;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #E6807F; border: 0px solid #E6807F; border-collapse: collapse !important; color: #FFF; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 8px 16px 8px 16px; text-align: left; vertical-align: top; width: 100%; word-wrap: break-word;"><center data-parsed="" style="min-width: 0; width: 100%;"><a href="{$leaveRequestLink}" align="center" class="float-center" style="Margin: 0; border: 0 solid #E6807F; border-radius: 3px; color: #FFF; display: inline-block; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; padding-left: 0; padding-right: 0; text-align: center; text-decoration: none; width: 100%;">View This Request</a></center></td></tr></table></td>
 <td class="expander" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; vertical-align: top; visibility: hidden; width: 0; word-wrap: break-word;"></td></tr></table>
                     {if $leaveComments}
                       <hr style="Margin: 20px auto; border: 0; border-top: 1px solid #D3DEE2; height: 0; margin: 20px auto;">
@@ -139,18 +199,25 @@ return [
                         </tr>
                       </table>
 
-                      <table class="callout" style="Margin-bottom: 16px; border-collapse: collapse; border-spacing: 0; margin-bottom: 16px; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner callout-no-padding" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left; width: 100%;">
+                      <table class="callout" style="Margin-bottom: 0 !important; border-collapse: collapse; border-spacing: 0; margin-bottom: 0 !important; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner callout-no-padding" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left; width: 100%;">
                         <div class="request-comments">
                           {foreach from=$leaveComments item=value key=label}
-                            <div class="request-comment" style="border-bottom: 1px solid #E8EEF0; padding: 20px;">
-                              <div class="request-comment-header" style="Margin-bottom: 10px; color: #4D5663; font-weight: 600; margin-bottom: 10px;">
-                                <span class="request-comment-author">{$value.commenter}:</span>
-                                <span class="request-comment-datetime">{$value.created_at|crmDate}</span>
-                              </div>
-                              <div class="request-comment-body">
-                                {$value.text}
-                              </div>
-                            </div>
+                            <table class="request-comment" style="border-bottom: 1px solid #E8EEF0; border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+                              <tbody>
+                                <tr style="padding: 0; text-align: left; vertical-align: top;">
+                                  <td class="request-comment-header" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #4D5663; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: 600; hyphens: auto; line-height: 1.53846; margin: 0; padding: 20px; padding-bottom: 10px; text-align: left; vertical-align: top; word-wrap: break-word;">
+                                    <span class="request-comment-author">{$value.commenter}:</span>
+                                    <span class="request-comment-datetime">{$value.created_at|crmDate}</span>
+                                  </td>
+                                </tr>
+                                <tr style="padding: 0; text-align: left; vertical-align: top;">
+                                  <td class="request-comment-body" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 20px; padding-top: 0; text-align: left; vertical-align: top; word-wrap: break-word;">
+                                    {$value.text}
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+
                           {/foreach}
                         </div>
                       </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
@@ -165,18 +232,18 @@ return [
                         </tr>
                       </table>
 
-                      <table class="callout" style="Margin-bottom: 16px; border-collapse: collapse; border-spacing: 0; margin-bottom: 16px; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
+                      <table class="callout" style="Margin-bottom: 0 !important; border-collapse: collapse; border-spacing: 0; margin-bottom: 0 !important; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
                         <div class="request-attachments">
                           {foreach from=$leaveFiles item=value key=label}
                             <div class="request-attachment" style="Margin-bottom: 10px; margin-bottom: 10px;">
-                              <span class="request-attachment-name" style="color: #4D5663; font-weight: 600;">{$value.name}</span>: Added on {$value.upload_date|crmDate}
+                              <span class="request-attachment-name" style="color: #4D5663; font-weight: 600;">{$value.name}</span>: Added on {$value.created_at|crmDate}
                             </div>
+
                           {/foreach}
                         </div>
                       </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
                     {/if}
-                  </th>
-<th class="expander" style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table></th>
+                  </th></tr></table></th>
                 </tr></tbody></table>
                 <table class="row collapse" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                   <th class="small-12 large-12 columns first last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0; padding-right: 0; text-align: left; width: 588px;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
@@ -207,7 +274,272 @@ return [
       'msg_title' => 'CiviHR TOIL Request Notification',
       'msg_subject' => 'TOIL Request',
       'msg_text' => 'CiviHR TOIL RequestLeave Request Type{ts}Status:{/ts}{$leaveStatus}{ts}Staff Member:{/ts}{contact.display_name}{if $leaveRequest->from_date eq $leaveRequest->to_date}{ts}Date:{/ts}{$fromDate|truncate:10:\'\'|crmDate}{else}{ts}From Date:{/ts}{$fromDate|truncate:10:\'\'|crmDate}{ts}To Date:{/ts}{$toDate|truncate:10:\'\'|crmDate}{/if}{ts}No. TOIL Days Requested{/ts}{$leaveRequest->toil_to_accrue}{if $leaveRequest->toil_to_accrue > 1}days{else}day{/if}View This Request{if $leaveComments}Request Comments{foreach from=$leaveComments item=value key=label}{$value.commenter}:{$value.created_at|crmDate}{$value.text}{/foreach}{/if}{if $leaveFiles}Other files recorded on this request{foreach from=$leaveFiles item=value key=label}{$value.name}: Added on{$value.upload_date|crmDate}{/foreach}{/if}',
-      'msg_html' => '<html><head><title></title></head><body><h3>CiviHR TOIL Request</h3><h4>{$currentDateTime->format("D d F Y")}</h4><p><strong>Leave Request Type</strong></p><table><tbody><tr><td>{ts}Status:{/ts}</td><td>{$leaveStatus}</td></tr><tr><td>{ts}Staff Member:{/ts}</td><td>{contact.display_name}</td></tr>{if $leaveRequest->from_date eq $leaveRequest->to_date}<tr><td>{ts}Date:{/ts}</td><td>{$fromDate|truncate:10:\'\'|crmDate}</td></tr>{else}<tr><td>{ts}From Date:{/ts}</td><td>{$fromDate|truncate:10:\'\'|crmDate}</td></tr><tr><td>{ts}To Date:{/ts}</td><td>{$toDate|truncate:10:\'\'|crmDate}</td></tr>{/if}<tr><td>{ts}No. TOIL Days Requested{/ts}</td><td>{$leaveRequest->toil_to_accrue}{if $leaveRequest->toil_to_accrue > 1}days{else}day{/if}</td></tr></tbody></table><p><a href="{$leaveRequestLink}">View This Request</a></p>{if $leaveComments}<p><strong>Request Comments</strong></p><table border="0" cellpadding="1" cellspacing="1" style="width: 700px;"><tbody>{foreach from=$leaveComments item=value key=label}<tr><td>{$value.commenter}:{$value.created_at|crmDate}</td></tr><tr><td>{$value.text}</td></tr>{/foreach}</tbody></table>{/if}<p></p>{if $leaveFiles}<p><b>Other files recorded on this request</b></p><table border="0" cellpadding="1" cellspacing="1" style="width: 700px";><tbody>{foreach from=$leaveFiles item=value key=label}<tr><td>{$value.name}: Added on{$value.upload_date|crmDate}</td></tr>{/foreach}</tbody></table>{/if}</body></html>',
+      'msg_html' => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+  <head>
+
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>CiviHR TOIL Request</title>
+    <style>{literal}@media only screen {
+  html {
+    min-height: 100%;
+    background: #E8EEF0;
+  }
+}
+
+@media only screen and (max-width: 596px) {
+  .small-text-left {
+    text-align: left !important;
+  }
+}
+
+@media only screen and (max-width: 596px) {
+  table.body img {
+    width: auto;
+    height: auto;
+  }
+
+  table.body center {
+    min-width: 0 !important;
+  }
+
+  table.body .container {
+    width: 95% !important;
+  }
+
+  table.body .columns {
+    height: auto !important;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+
+  table.body .columns .columns {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  table.body .collapse .columns {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  th.small-12 {
+    display: inline-block !important;
+    width: 100% !important;
+  }
+
+  .columns th.small-12 {
+    display: block !important;
+    width: 100% !important;
+  }
+}
+
+@media only screen and (max-width: 596px) {
+  .email-date {
+    line-height: normal !important;
+  }
+}
+
+@media only screen and (max-width: 596px) {
+  .request-data-key {
+    padding-bottom: 0 !important;
+  }
+}
+
+@media only screen and (min-width: 597px) {
+  .request-data .row .columns {
+    padding-bottom: 10px !important;
+  }
+}{/literal}</style>
+  </head>
+  <body style="-moz-box-sizing: border-box; -ms-text-size-adjust: 100%; -webkit-box-sizing: border-box; -webkit-text-size-adjust: 100%; Margin: 0; box-sizing: border-box; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; min-width: 100%; padding: 0; text-align: left; width: 100% !important;">
+    <span class="preheader" style="color: #E8EEF0; display: none !important; font-size: 1px; line-height: 1px; max-height: 0px; max-width: 0px; mso-hide: all !important; opacity: 0; overflow: hidden; visibility: hidden;"></span>
+    <table class="body" style="Margin: 0; background: #E8EEF0; border-collapse: collapse; border-spacing: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; height: 100%; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+      <tr style="padding: 0; text-align: left; vertical-align: top;">
+        <td class="center" align="center" valign="top" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">
+          <center class="email" data-parsed="" style="Margin: 40px 0; margin: 40px 0; min-width: 580px; width: 100%;">
+            <!-- header -->
+            <table align="center" class="container email-heading float-center" style="Margin: 0 auto; background: transparent; border-collapse: collapse; border-spacing: 0; float: none; margin: 0 auto; padding: 0; text-align: center; vertical-align: top; width: 580px;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">
+              <table class="row collapse" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                <th class="small-12 large-6 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0; padding-right: 0; text-align: left; width: 298px;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                  <h1 class="email-title" style="Margin: 0; Margin-bottom: 0; border-left: 5px solid #42AFCB; color: #4D5663; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 18px; font-weight: 500; line-height: 40px; margin: 0; margin-bottom: 0; padding: 0; padding-left: 15px; text-align: left; word-wrap: normal;">CiviHR TOIL Request</h1>
+                </th></tr></table></th>
+                <th class="small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0; padding-right: 0; text-align: left; width: 298px;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                  <p class="email-date small-text-left text-right" style="Margin: 0; Margin-bottom: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 40px; margin: 0; margin-bottom: 0; padding: 0; text-align: right;">{$currentDateTime->format("D d F Y")}</p>
+                </th></tr></table></th>
+              </tr></tbody></table>
+            </td></tr></tbody></table>
+            <table class="spacer float-center" style="Margin: 0 auto; border-collapse: collapse; border-spacing: 0; float: none; margin: 0 auto; padding: 0; text-align: center; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td height="16px" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; hyphens: auto; line-height: 16px; margin: 0; mso-line-height-rule: exactly; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">&#xA0;</td></tr></tbody></table>
+            <!-- body -->
+            <table align="center" class="container float-center" style="Margin: 0 auto; background: transparent; border-collapse: collapse; border-spacing: 0; float: none; margin: 0 auto; padding: 0; text-align: center; vertical-align: top; width: 580px;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">
+
+              <div class="request">
+                <table class="row collapse" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                  <th class="small-12 large-12 columns first last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0; padding-right: 0; text-align: left; width: 588px;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                    <table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+                      <tr style="padding: 0; text-align: left; vertical-align: top;">
+                        <td class="callout-header" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #F3F6F7; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 15px 20px; text-align: left; vertical-align: top; word-wrap: break-word;">
+                          <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">Leave Request Type</h2>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <table class="callout" style="Margin-bottom: 0 !important; border-collapse: collapse; border-spacing: 0; margin-bottom: 0 !important; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner request-data" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
+                      <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                        <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <span style="color: #4D5663; font-weight: 600;">
+                            {ts}Status:{/ts}
+                          </span>
+                        </th></tr></table></th>
+                        <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <span>{$leaveStatus}</span>
+                        </th></tr></table></th>
+                      </tr></tbody></table>
+
+                      <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                        <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <span style="color: #4D5663; font-weight: 600;">
+                            {ts}Staff Member:{/ts}
+                          </span>
+                        </th></tr></table></th>
+                        <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <span>{contact.display_name}</span>
+                        </th></tr></table></th>
+                      </tr></tbody></table>
+
+
+                      {if $leaveRequest->from_date eq $leaveRequest->to_date}
+                        <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                          <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span style="color: #4D5663; font-weight: 600;">
+                              {ts}Date:{/ts}
+                            </span>
+                          </th></tr></table></th>
+                          <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span>{$fromDate|truncate:10:\&#x27;\&#x27;|crmDate} {$fromDateType}</span>
+                          </th></tr></table></th>
+                        </tr></tbody></table>
+
+                      {else}
+                        <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                          <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span style="color: #4D5663; font-weight: 600;">
+                              {ts}From Date:{/ts}
+                            </span>
+                          </th></tr></table></th>
+                          <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span>{$fromDate|truncate:10:\&#x27;\&#x27;|crmDate} {$fromDateType}</span>
+                          </th></tr></table></th>
+                        </tr></tbody></table>
+
+                        <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                          <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span style="color: #4D5663; font-weight: 600;">
+                              {ts}To Date:{/ts}
+                            </span>
+                          </th></tr></table></th>
+                          <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                            <span>{$toDate|truncate:10:\&#x27;\&#x27;|crmDate} {$toDateType}</span>
+                          </th></tr></table></th>
+                        </tr></tbody></table>
+
+                      {/if}
+
+                      <table class="row request-data-toil" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                        <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 0 !important; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <div style="border: 1px solid #FFF; color: #4D5663; font-weight: 600; padding: 10px 0;">
+                            {ts}No. TOIL Days Requested:{/ts}
+                          </div>
+                        </th></tr></table></th>
+                        <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 0 !important; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                          <span style="border: 1px solid #FFF; border-color: #727E8A; display: inline-block; padding: 10px 0; text-align: center; width: 100px;">{$leaveRequest-&gt;toil_to_accrue} {if $leaveRequest-&gt;toil_to_accrue &gt; 1}days{else}day{/if}</span>
+                        </th></tr></table></th>
+                      </tr></tbody></table>
+
+                    </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
+                    <table class="spacer" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td height="16px" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; hyphens: auto; line-height: 16px; margin: 0; mso-line-height-rule: exactly; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">&#xA0;</td></tr></tbody></table>
+                    <table class="button expanded alert" style="Margin: 0 0 16px 0; border-collapse: collapse; border-spacing: 0; margin: 0 0 16px 0; padding: 0; text-align: left; vertical-align: top; width: 100% !important;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; width: 100%; word-wrap: break-word;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #E6807F; border: 0px solid #E6807F; border-collapse: collapse !important; color: #FFF; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 8px 16px 8px 16px; text-align: left; vertical-align: top; width: 100%; word-wrap: break-word;"><center data-parsed="" style="min-width: 0; width: 100%;"><a href="{$leaveRequestLink}" align="center" class="float-center" style="Margin: 0; border: 0 solid #E6807F; border-radius: 3px; color: #FFF; display: inline-block; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; padding-left: 0; padding-right: 0; text-align: center; text-decoration: none; width: 100%;">View This Request</a></center></td></tr></table></td>
+<td class="expander" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; vertical-align: top; visibility: hidden; width: 0; word-wrap: break-word;"></td></tr></table>
+                    {if $leaveComments}
+                      <hr style="Margin: 20px auto; border: 0; border-top: 1px solid #D3DEE2; height: 0; margin: 20px auto;">
+                      <table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+                        <tr style="padding: 0; text-align: left; vertical-align: top;">
+                          <td class="callout-header" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #F3F6F7; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 15px 20px; text-align: left; vertical-align: top; word-wrap: break-word;">
+                            <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">Request comments</h2>
+                          </td>
+                        </tr>
+                      </table>
+
+                      <table class="callout" style="Margin-bottom: 0 !important; border-collapse: collapse; border-spacing: 0; margin-bottom: 0 !important; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner callout-no-padding" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left; width: 100%;">
+                        <div class="request-comments">
+                          {foreach from=$leaveComments item=value key=label}
+                            <table class="request-comment" style="border-bottom: 1px solid #E8EEF0; border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+                              <tbody>
+                                <tr style="padding: 0; text-align: left; vertical-align: top;">
+                                  <td class="request-comment-header" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #4D5663; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: 600; hyphens: auto; line-height: 1.53846; margin: 0; padding: 20px; padding-bottom: 10px; text-align: left; vertical-align: top; word-wrap: break-word;">
+                                    <span class="request-comment-author">{$value.commenter}:</span>
+                                    <span class="request-comment-datetime">{$value.created_at|crmDate}</span>
+                                  </td>
+                                </tr>
+                                <tr style="padding: 0; text-align: left; vertical-align: top;">
+                                  <td class="request-comment-body" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 20px; padding-top: 0; text-align: left; vertical-align: top; word-wrap: break-word;">
+                                    {$value.text}
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+
+                          {/foreach}
+                        </div>
+                      </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
+                    {/if}
+                    {if $leaveFiles}
+                      <hr style="Margin: 20px auto; border: 0; border-top: 1px solid #D3DEE2; height: 0; margin: 20px auto;">
+                      <table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+                        <tr style="padding: 0; text-align: left; vertical-align: top;">
+                          <td class="callout-header" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #F3F6F7; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 15px 20px; text-align: left; vertical-align: top; word-wrap: break-word;">
+                            <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">Other files recorded in this request</h2>
+                          </td>
+                        </tr>
+                      </table>
+
+                      <table class="callout" style="Margin-bottom: 0 !important; border-collapse: collapse; border-spacing: 0; margin-bottom: 0 !important; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th class="callout-inner" style="Margin: 0; background: #FFF; border: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 20px; text-align: left; width: 100%;">
+                        <div class="request-attachments">
+                          {foreach from=$leaveFiles item=value key=label}
+                            <div class="request-attachment" style="Margin-bottom: 10px; margin-bottom: 10px;">
+                              <span class="request-attachment-name" style="color: #4D5663; font-weight: 600;">{$value.name}</span>: Added on {$value.created_at|crmDate}
+                            </div>
+
+                          {/foreach}
+                        </div>
+                      </th><th class="expander" style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table>
+                    {/if}
+                  </th></tr></table></th>
+                </tr></tbody></table>
+                <table class="row collapse" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+                  <th class="small-12 large-12 columns first last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0; padding-right: 0; text-align: left; width: 588px;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
+                    <table class="spacer" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td height="16px" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; hyphens: auto; line-height: 16px; margin: 0; mso-line-height-rule: exactly; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">&#xA0;</td></tr></tbody></table>
+                    <img class="text-center email-logo" src="https://civihr.org/sites/default/files/email-logo.png" style="-ms-interpolation-mode: bicubic; Margin: 0 auto; clear: both; display: block; float: none; margin: 0 auto; max-width: 100%; outline: none; text-align: center; text-decoration: none; width: 100px;">
+                  </th>
+<th class="expander" style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table></th>
+                </tr></tbody></table>
+              </div>
+
+            </td></tr></tbody></table>
+          </center>
+        </td>
+      </tr>
+    </table>
+    <!-- prevent Gmail on iOS font size manipulation -->
+   <div style="display:none; white-space:nowrap; font:15px courier; line-height:0;"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </div>
+  </body>
+</html>',
       'msg_html' => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 


### PR DESCRIPTION
## Overview
This PR adds the TOIL Request email template and refactors some of the code shared between the different L&A emails

![toil-template](https://cloud.githubusercontent.com/assets/6400898/25947433/b99c400a-364f-11e7-9314-5d04905a540d.png)

## Technical Details
### Comments as `<table>`s
To avoid rendering issues in different email clients, the `request-comment` component had been turned into a table

**Before**
```html
<div class="request-comment">
  <div class="request-comment-header">
    <span class="request-comment-author">{$value.commenter}:</span>
    <span class="request-comment-datetime">{$value.created_at|crmDate}</span>
  </div>
  <div class="request-comment-body">
    {$value.text}
  </div>
</div>
```

**After**
```html
  <tbody>
    <tr>
      <td class="request-comment-header">
        <span class="request-comment-author">{$value.commenter}:</span>
        <span class="request-comment-datetime">{$value.created_at|crmDate}</span>
      </td>
    </tr>
    <tr>
      <td class="request-comment-body">
        {$value.text}
      </td>
    </tr>
  </tbody>
</table>
```
### Request data as grid
Before, the `.request-data` was a `<dl>` list. This proved to be too complex for some email clients to style correctly, so the component had been converted to better-supported foundation grid
**Before**
```html
<callout class="request-data request-data-large">
  <dl>
    <dt>{ts}Status:{/ts}</dt>
    <dd>{$leaveStatus}</dd>
    <dt>{ts}Staff Member:{/ts}</dt>
    <dd>{contact.display_name}</dd>
    <dt>{ts}From Date:{/ts}</dt>
    <dd>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</dd>
    <dt>{ts}To Date:{/ts}</dt>
    <dd>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</dd>
  </dl>
</callout>
```
**After**
```html
<callout class="request-data">
  <row>
    <columns class="request-data-key" large="3">
      <span>{ts}Status:{/ts}</span>
    </columns>
    <columns class="request-data-value">
      <span>{$leaveStatus}</span>
    </columns>
  </row>
  <row>
    <columns class="request-data-key" large="3">
      <span>{ts}Staff Member:{/ts}</span>
    </columns>
    <columns class="request-data-value">
      <span>{contact.display_name}</span>
    </columns>
  </row>
  <row>
    <columns class="request-data-key" large="3">
      <span>{ts}From Date:{/ts}</span>
    </columns>
    <columns class="request-data-value">
      <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
    </columns>
    <columns class="request-data-key" large="3">
      <span>{ts}To Date:{/ts}</span>
    </columns>
    <columns class="request-data-value">
      <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
    </columns>
  </row>
</callout>
```
### Partials
The request data, comments, and attachments are now separate partials, since they are common structures used by all the L&A emails

#### la footer
A simple footer for every L&A email template
```html
<container>
  {{> la-footer}}
</container>
```

#### data
```html
<callout class="request-data">
  {{> request-data key="Status" value="{$leaveStatus}" keySize="4"}}
  {{> request-data key="Staff Member" value="{contact.display_name}" keySize="4"}}
  {{> request-data key="From Date" value="{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}" keySize="4"}}
  {{> request-data key="To Date" value="{$toDate|truncate:10:\'\'|crmDate} {$toDateType}" keySize="4"}}
  {{> request-data
    key="No. TOIL Days Requested"
    value="{$leaveRequest->toil_to_accrue} {if $leaveRequest->toil_to_accrue > 1}days{else}day{/if}"
    class="request-data-toil"
    keySize="4"
    keyTag="div"
  }}
</callout>
```
the `keySize` property is used to determine the width of the key column, while the `keyTag` property is used to specify a different wrapping tag for the key than the default `<span>`. This is necessary for outlook in order to render  the "No. TOIL Days Requested" data row correctly

#### comment
```html
<div class="request-comments">
  {foreach from=$leaveComments item=value key=label}
    {{> request-comment commenter="{$value.commenter}" createdAt="{$value.created_at|crmDate}" text="{$value.text}"}}
  {/foreach}
</div>
```

#### attachment
```html
<div class="request-attachments">
  {foreach from=$leaveFiles item=value key=label}
    {{> request-attachment name="{$value.name}" uploadDate="{$value.created_at|crmDate}"}}
  {/foreach}
</div>
````