### PR TITLE
PCHR-1687: Fix Failing Tests

### DIFF
--- a/hrcase/CRM/HRCase/Upgrader.php
+++ b/hrcase/CRM/HRCase/Upgrader.php
@@ -345,8 +345,10 @@ class CRM_HRCase_Upgrader extends CRM_HRCase_Upgrader_Base {
       $entitiesToRemove[$caseType] = 'CaseType';
     }
 
-    foreach ($activityTypes as $activityType) {
-      $entitiesToRemove['civitask:act:' . $activityType] = 'OptionValue';
+    foreach ($activityTypes as $extension) {
+      foreach ($extension as $activityType) {
+        $entitiesToRemove['civitask:act:' . $activityType] = 'OptionValue';
+      }
     }
 
     foreach ($entitiesToRemove as $name => $entity) {

--- a/hrjobcontract/CRM/Hrjobcontract/Test/Fabricator/HRHoursLocation.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Test/Fabricator/HRHoursLocation.php
@@ -4,7 +4,7 @@ class CRM_Hrjobcontract_Test_Fabricator_HRHoursLocation {
 
   private static $defaultParams = [
     'location' => 'test location',
-    'standard_hours' => 40,
+    'standard_hours' => '40.00',
     'periodicity' => "Week",
     'sequential'   => 1
   ];

--- a/hrjobcontract/CRM/Hrjobcontract/Test/Fabricator/HRPayScale.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Test/Fabricator/HRPayScale.php
@@ -6,7 +6,7 @@ class CRM_Hrjobcontract_Test_Fabricator_HRPayScale {
     'pay_scale' => 'test scale',
     'pay_grade' => 'test grade',
     'currency' => "USD",
-    'amount' => "35000",
+    'amount' => "35000.00",
     'periodicity' => "Year",
     'sequential'   => 1
   ];

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -157,19 +157,18 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
 
     CRM_Core_DAO::executeQuery("DROP TABLE IF EXISTS civicrm_hrhours_location");
     CRM_Core_DAO::executeQuery("
-        CREATE TABLE IF NOT EXISTS `civicrm_hrhours_location` (
-          `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-          `location` varchar(63) DEFAULT NULL,
-          `standard_hours` int(4) DEFAULT NULL,
-          `periodicity` varchar(63) DEFAULT NULL,
-          `is_active` tinyint(4) DEFAULT '1',
-          PRIMARY KEY(id)
-        ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 AUTO_INCREMENT=1
-      ");
-      CRM_Core_DAO::executeQuery("
-        INSERT INTO `civicrm_hrhours_location` (`id`, `location`, `standard_hours`, `periodicity`, `is_active`) 
-        VALUES (1, 'Head office', 40, 'Week', 1)
-      ");
+      CREATE TABLE IF NOT EXISTS `civicrm_hrhours_location` (
+        `id` int(10) unsigned NOT NULL,
+        `location` varchar(63) DEFAULT NULL,
+        `standard_hours` int(4) DEFAULT NULL,
+        `periodicity` varchar(63) DEFAULT NULL,
+        `is_active` tinyint(4) DEFAULT '1'
+      ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 AUTO_INCREMENT=1
+    ");
+    CRM_Core_DAO::executeQuery("
+      INSERT INTO `civicrm_hrhours_location` (`id`, `location`, `standard_hours`, `periodicity`, `is_active`) 
+      VALUES (1, 'Head office', 40, 'Week', 1)
+    ");
 
     $optionGroupID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'hrjc_revision_change_reason', 'id', 'name');
     if (!$optionGroupID) {
@@ -511,6 +510,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     $this->upgrade_1027();
     $this->upgrade_1028();
     $this->upgrade_1029();
+    $this->upgrade_1030();
   }
 
   function upgrade_1001() {
@@ -1268,6 +1268,16 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     }
 
     $this->up1029_sortContractTypes();
+
+    return true;
+  }
+
+  /**
+   * Makes Hour Location id field autonumeric and adds id as a primary key.
+   */
+  public function upgrade_1030() {
+    CRM_Core_DAO::executeQuery('ALTER TABLE `civicrm_hrhours_location` ADD PRIMARY KEY (`id`)');
+    CRM_Core_DAO::executeQuery('ALTER TABLE `civicrm_hrhours_location` CHANGE `id` `id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT');
 
     return true;
   }

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -158,11 +158,12 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     CRM_Core_DAO::executeQuery("DROP TABLE IF EXISTS civicrm_hrhours_location");
     CRM_Core_DAO::executeQuery("
         CREATE TABLE IF NOT EXISTS `civicrm_hrhours_location` (
-        `id` int(10) unsigned NOT NULL,
+          `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
           `location` varchar(63) DEFAULT NULL,
           `standard_hours` int(4) DEFAULT NULL,
           `periodicity` varchar(63) DEFAULT NULL,
-          `is_active` tinyint(4) DEFAULT '1'
+          `is_active` tinyint(4) DEFAULT '1',
+          PRIMARY KEY(id)
         ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 AUTO_INCREMENT=1
       ");
       CRM_Core_DAO::executeQuery("

--- a/hrui/CRM/HRUI/Upgrader/Steps/4701.php
+++ b/hrui/CRM/HRUI/Upgrader/Steps/4701.php
@@ -63,7 +63,9 @@ trait CRM_HRUI_Upgrader_Steps_4701 {
       'name' => 'Identify'
     ]);
 
-    return $customGroupResult['values'][0]['table_name'];
+    if ($customGroupResult['count'] > 0) {
+      return $customGroupResult['values'][0]['table_name'];
+    }
   }
 
   private function up4701_getIdentFieldName() {
@@ -72,7 +74,9 @@ trait CRM_HRUI_Upgrader_Steps_4701 {
       'name' => 'Number'
     ]);
 
-    return $customFieldResult['values'][0]['column_name'];
+    if ($customFieldResult['count'] > 0) {
+      return $customFieldResult['values'][0]['column_name'];
+    }
   }
 
 }

--- a/hrui/tests/phpunit/CRM/HRUI/HelperTest.php
+++ b/hrui/tests/phpunit/CRM/HRUI/HelperTest.php
@@ -15,6 +15,9 @@ class CRM_HRUI_HelperTest extends \PHPUnit_Framework_TestCase implements Headles
   public function setUpHeadless() {
     // hrcase create ( Line Manager is ) relationship type which is need for the tests
     return \Civi\Test::headless()
+      ->install('uk.co.compucorp.civicrm.hrcore')
+      ->install('org.civicrm.hrident')
+      ->install('uk.co.compucorp.civicrm.tasksassignments')
       ->installMe(__DIR__)
       ->install('org.civicrm.hrcase')
       ->apply();

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1000.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1000.php
@@ -38,7 +38,7 @@ trait CRM_HRCore_Upgrader_Steps_1000 {
       mkdir($downloadPath, 0755, true);
     }
 
-    file_put_contents($downloadPath, fopen($localizationURL, 'r'));
+    file_put_contents($downloadPath . 'civicrm.mo', fopen($localizationURL, 'r'));
 
     return TRUE;
   }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1001.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1001.php
@@ -93,7 +93,9 @@ trait CRM_HRCore_Upgrader_Steps_1001 {
       'options' => ['limit' => 1]
     ]);
 
-    return $ethnicityGroup['values'][0]['option_group_id'];
+    if ($ethnicityGroup['count'] > 0) {
+      return $ethnicityGroup['values'][0]['option_group_id'];
+    }
   }
 
   /**


### PR DESCRIPTION
## Overview
Some tests of hrjobcontract and hrui extension were failing due to the changes introduced in PCHR-1687.

## Before
Tests for hrjobcontract and hrui extensions were failing, since they relied on values that were removed in upgrades created for PCHR-1687.  Also, some warnings were being thrown by upgrades, when trying to access non-existing array keys.  Upgrade 1000 of hrcore extension was also failing on tests.

## After
 Fixed by using constructors to create missing values for tests, implementing checks prior to access array values and updating tests setup to install required extensions.  Fixed upgrade 1000 of hrcore installation by including the name of the file being downloaded.

---

- [x] Tests Pass
