### PR TITLE
PCHR-2207: Fix issues with Admin or Leave Manager not being able to create Leave Request for themselves

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrix.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrix.php
@@ -151,9 +151,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix {
 
     if ($currentUserID == $leaveRequestContactID) {
       $statusMatrix = $this->getStaffStatusMatrix();
-    }
-
-    if ($this->shouldUseManagerMatrixForCurrentUser($leaveRequestContactID)) {
+    } elseif ($this->shouldUseManagerMatrixForCurrentUser($leaveRequestContactID)) {
       $statusMatrix = $this->getManagerStatusMatrix();
     }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrixTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrixTest.php
@@ -73,28 +73,28 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrixTest extends BaseHe
   }
 
   public function testCanTransitionToForAdminForReturnsTrueAllPossibleTransitionStatuses() {
-    $manager = ContactFabricator::fabricate();
-    $leaveContact = ContactFabricator::fabricate();
-    $this->registerCurrentLoggedInContactInSession($manager['id']);
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer leave and absences'];
+    $adminID = 5;
+    $leaveContact = 2;
+    $this->registerCurrentLoggedInContactInSession($adminID);
+    $this->setPermissions(['administer leave and absences']);
 
     $possibleTransitions = $this->allPossibleStatusTransitionForLeaveApprover();
 
     foreach($possibleTransitions as $transition) {
-      $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $leaveContact['id']));
+      $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $leaveContact));
     }
   }
 
   public function testCanTransitionToForAdminReturnsFalseForAllNonPossibleTransitionStatuses() {
-    $manager = ContactFabricator::fabricate();
-    $leaveContact = ContactFabricator::fabricate();
-    $this->registerCurrentLoggedInContactInSession($manager['id']);
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer leave and absences'];
+    $adminID = 5;
+    $leaveContact = 2;
+    $this->registerCurrentLoggedInContactInSession($adminID);
+    $this->setPermissions(['administer leave and absences']);
 
     $nonPossibleTransitions = $this->allNonPossibleStatusTransitionForLeaveApprover();
 
     foreach($nonPossibleTransitions as $transition) {
-      $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $leaveContact['id']));
+      $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $leaveContact));
     }
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrixTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrixTest.php
@@ -130,45 +130,43 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrixTest extends BaseHe
     $this->registerCurrentLoggedInContactInSession($manager['id']);
     $this->setContactAsLeaveApproverOf($manager, $leaveContact);
 
-    $managerExclusivePossibleStatusTransition = $this->getManagerExclusivePossibleStatusTransitions();
+    $managerExclusivePossibleStatusTransition = $this->getManagerExclusivePossibleStatusTransitionsDataProvider();
     foreach($managerExclusivePossibleStatusTransition as $transition) {
       $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $manager['id']));
     }
   }
 
-  public function testCanTransitionToReturnsTrueForAllPossibleStaffTransitionStatusesWhenAdminIsTheLeaveContact() {
+  /**
+   * @dataProvider allPossibleStatusTransitionForStaffDataProvider
+   */
+  public function testCanTransitionToReturnsTrueForAllPossibleStaffTransitionStatusesWhenAdminIsTheLeaveContact($fromStatus, $toStatus) {
     $adminID = 5;
     $this->registerCurrentLoggedInContactInSession($adminID);
     $this->setPermissions(['administer leave and absences']);
 
-    $possibleTransitions = $this->allPossibleStatusTransitionForStaffDataProvider();
-
-    foreach($possibleTransitions as $transition) {
-      $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $adminID));
-    }
+    $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo($fromStatus, $toStatus, $adminID));
   }
 
-  public function testCanTransitionToReturnsFalseForAllNonPossibleStaffTransitionStatusesWhenAdminIsTheLeaveContact() {
+  /**
+   * @dataProvider allNonPossibleStatusTransitionForStaffDataProvider
+   */
+  public function testCanTransitionToReturnsFalseForAllNonPossibleStaffTransitionStatusesWhenAdminIsTheLeaveContact($fromStatus, $toStatus) {
     $adminID = 5;
     $this->registerCurrentLoggedInContactInSession($adminID);
     $this->setPermissions(['administer leave and absences']);
 
-    $nonPossibleTransitions = $this->allNonPossibleStatusTransitionForStaffDataProvider();
-
-    foreach($nonPossibleTransitions as $transition) {
-      $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $adminID));
-    }
+    $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($fromStatus, $toStatus, $adminID));
   }
 
-  public function testCanTransitionToReturnsFalseForPossibleManagerExclusiveStatusTransitionsWhenAdminIsTheLeaveContact() {
+  /**
+   * @dataProvider getManagerExclusivePossibleStatusTransitionsDataProvider
+   */
+  public function testCanTransitionToReturnsFalseForPossibleManagerExclusiveStatusTransitionsWhenAdminIsTheLeaveContact($fromStatus, $toStatus) {
     $adminID = 5;
     $this->registerCurrentLoggedInContactInSession($adminID);
     $this->setPermissions(['administer leave and absences']);
 
-    $managerExclusivePossibleStatusTransition = $this->getManagerExclusivePossibleStatusTransitions();
-    foreach($managerExclusivePossibleStatusTransition as $transition) {
-      $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $adminID));
-    }
+    $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($fromStatus, $toStatus, $adminID));
   }
 
   public function allPossibleStatusTransitionForStaffDataProvider() {
@@ -264,12 +262,13 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrixTest extends BaseHe
    *
    * @return array
    */
-  public function getManagerExclusivePossibleStatusTransitions() {
+  public function getManagerExclusivePossibleStatusTransitionsDataProvider() {
     $possibleStaffTransitions = $this->allPossibleStatusTransitionForStaffDataProvider();
     $possibleManagerTransitions = $this->allPossibleStatusTransitionForLeaveApprover();
 
     $results = array_diff(array_map('serialize', $possibleManagerTransitions), array_map('serialize', $possibleStaffTransitions));
     $managerExclusiveStatusTransition = array_map('unserialize', $results);
+
     return $managerExclusiveStatusTransition;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -2723,7 +2723,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'from_date_type' => $this->leaveRequestDayTypes['All Day']['value'],
       'to_date' => $endDate->format('Y-m-d'),
       'to_date_type' => $this->leaveRequestDayTypes['All Day']['value'],
-      'status_id' => 1,
+      'status_id' => 3,
       'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE,
       'sequential' => 1,
     ]);


### PR DESCRIPTION
## Overview
Currently when an Admin or Leave manager tries to request leave, an error is returned that the leave request cannot be created. This is due to the fact that the Manager Status transition matrix is used when making the request and it does not allow a transition from 'No status' to 'Awaiting Approval' Status(The default status set for a new leave request).  [See Matrix Here](https://compucorp.atlassian.net/browse/PCHR-1825)

## Before
When an Admin or Leave Manager requests leave for themselves or on behalf of a Staff member, the Manager Status Matrix is used.

An Admin or Leave Manager cannot request leave for themselves.

## After
Changes were made such that when an Admin or Leave Manager requests  leave for themselves, the Staff Status transition matrix is used since at this point they are requesting leave as a staff. When they are making modifications to a Leave Request on behalf of a Staff Member, the Manager Status Matrix is used.

An Admin or Leave Manager can now request leave for themselves.

- [X] Tests Pass
