### PR TITLE
PCHR-2198: emails framework amendments

### DIFF
--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/app.scss
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/app.scss
@@ -1,11 +1,13 @@
 @import "SCSSROOT/org.civicrm.shoreditch/scss/bootstrap/overrides/variables";
 @import "SCSSROOT/org.civicrm.shoreditch/base/scss/vendor/bootstrap/variables";
 
+@import "mixins/buttons";
 @import "mixins/margin";
 
 @import 'settings';
 @import 'base';
 @import 'foundation-emails';
 
+@import 'components/buttons';
 @import 'components/callout';
 @import 'components/email';

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/components/_buttons.scss
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/components/_buttons.scss
@@ -1,0 +1,23 @@
+table.button {
+  // https://github.com/zurb/foundation-emails/issues/415
+  @include button-padding(default);
+
+  &.large {
+    @include button-padding(large);
+  }
+
+  &.small {
+    @include button-padding(small);
+  }
+
+  &.tiny {
+    @include button-padding(tiny);
+  }
+
+  // https://github.com/zurb/foundation-emails/issues/415
+  &.expanded {
+    td:not(.expander) {
+      width: 100%;
+    }
+  }
+}

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/components/_buttons.scss
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/components/_buttons.scss
@@ -1,5 +1,5 @@
 table.button {
-  // https://github.com/zurb/foundation-emails/issues/415
+  // https://github.com/zurb/foundation-emails/issues/416
   @include button-padding(default);
 
   &.large {

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/components/_callout.scss
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/components/_callout.scss
@@ -1,3 +1,7 @@
+.callout {
+  @include margin(0, bottom, true);
+}
+
 .callout-header {
   background: $panel-default-heading-bg;
   padding: $panel-heading-padding;

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/mixins/_buttons.scss
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/mixins/_buttons.scss
@@ -1,0 +1,15 @@
+// https://github.com/zurb/foundation-emails/issues/416
+@mixin button-padding($type: default) {
+  table {
+
+    td {
+      padding: map-get($button-padding, $type);
+
+      @if ($type == default) {
+        a {
+          padding: 0;
+        }
+      }
+    }
+  }
+}

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/mixins/_margin.scss
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/assets/scss/mixins/_margin.scss
@@ -1,8 +1,9 @@
 // Automatically adds a capitalized version of the `margin` property
 // to ensure outlook compatibility
-@mixin margin($value, $type: '') {
-  $suffix: if($type != '', -#{$type}, '');
+@mixin margin($value, $type: '', $important: false) {
+  $suffix   : if($type != '', -#{$type}, '');
+  $important: if($important, !important, null);
 
-  margin#{$suffix}: $value;
-  Margin#{$suffix}: $value;
+  margin#{$suffix}: $value $important;
+  Margin#{$suffix}: $value $important;
 }


### PR DESCRIPTION
## Overview
This PR contains fixes for the Outlook desktop and web client, so that it can render the email templates as expected

## Technical Details
### Buttons padding
https://github.com/zurb/foundation-emails/issues/416

Solution described in [this comment](https://github.com/zurb/foundation-emails/issues/416#issuecomment-249432270) had been implemented

### Expanded buttons
https://github.com/zurb/foundation-emails/issues/415

Solution described in [this comment](https://github.com/zurb/foundation-emails/issues/415) had been implemented

### Margin bottom for callouts
https://litmus.com/help/email-clients/outlookcom-margins/

So apparently Outlook decides to strip margins for block elements (or at least for `<table>`s). So from now on if we need to put a bottom margin after a `<callout>`, we need to use `<spacer>`. The margin had been removed from the callout to avoid inconsistency with the other email clients
