### PR TITLE
PCHR-2217: Fix Issues with "Manage Entitlements" action on the Absence Period list

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.php
@@ -48,6 +48,7 @@ class CRM_HRLeaveAndAbsences_Page_AbsencePeriod extends CRM_Core_Page_Basic {
 
     CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/crm/hrleaveandabsences.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
     CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/crm/hrleaveandabsences.list.absenceperiod.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
+    CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'js/jquery/jquery.crmEditable.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
 
     $this->assign('rows', $rows);
   }


### PR DESCRIPTION
## Overview
When the 'Manage Entitlement' action for an absence period is clicked Instead of leading to the Entitlement Calculation page, It does not respond and some errors appear in the console. 

## Before
The Absence Period listing page requires a core JS file 'jquery.crmEditable.js' which used to be loaded by default in Civicrm version 4.7.9 but now is no longer loaded by default in Civicrm version 4.7.18.
![absenceperiodbefore2](https://cloud.githubusercontent.com/assets/6951813/25950907/fb2f25b0-3653-11e7-9fa1-94749b021be4.gif)




## After
The 'jquery.crmEditable.js' file is loaded for the Absence Period listing page.
![absenceperiodafter](https://cloud.githubusercontent.com/assets/6951813/25950930/0eccb074-3654-11e7-9a9c-9410a5d86494.gif)

- [X] Tests Pass
