### PR TITLE
PCHR-2142: Fix Leave Request Link. Add some more parameters to Email Templates

### DIFF
--- a/uk.co.compucorp.civicrm.hremails/email-templates/dist/leave-request.civicrm.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/dist/leave-request.civicrm.html
@@ -109,7 +109,7 @@
                     <table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
                       <tr style="padding: 0; text-align: left; vertical-align: top;">
                         <td class="callout-header" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #F3F6F7; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 15px 20px; text-align: left; vertical-align: top; word-wrap: break-word;">
-                          <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">Leave Request Type</h2>
+                          <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">{$absenceTypeName}</h2>
                         </td>
                       </tr>
                     </table>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/dist/sickness-request.civicrm.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/dist/sickness-request.civicrm.html
@@ -109,7 +109,7 @@
                     <table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
                       <tr style="padding: 0; text-align: left; vertical-align: top;">
                         <td class="callout-header" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #F3F6F7; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 15px 20px; text-align: left; vertical-align: top; word-wrap: break-word;">
-                          <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">Leave Request Type</h2>
+                          <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">{$absenceTypeName}</h2>
                         </td>
                       </tr>
                     </table>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/dist/toil-request.civicrm.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/dist/toil-request.civicrm.html
@@ -109,7 +109,7 @@
                     <table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
                       <tr style="padding: 0; text-align: left; vertical-align: top;">
                         <td class="callout-header" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #F3F6F7; border-collapse: collapse !important; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 15px 20px; text-align: left; vertical-align: top; word-wrap: break-word;">
-                          <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">Leave Request Type</h2>
+                          <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">{$absenceTypeName}</h2>
                         </td>
                       </tr>
                     </table>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/leave-request.civicrm.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/leave-request.civicrm.html
@@ -7,7 +7,7 @@ request-type: Leave
 <div class="request">
   <row class="collapse">
     <columns>
-      {{> callout-header title="Leave Request Type"}}
+      {{> callout-header title="{$absenceTypeName}"}}
       <callout class="request-data">
         {{> request-data key="Status" value="{$leaveStatus}"}}
         {{> request-data key="Staff Member" value="{contact.display_name}"}}

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/sickness-request.civicrm.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/sickness-request.civicrm.html
@@ -7,7 +7,7 @@ request-type: Sickness
 <div class="request request-sickness">
   <row class="collapse">
     <columns>
-      {{> callout-header title="Leave Request Type"}}
+      {{> callout-header title="{$absenceTypeName}"}}
       <callout class="request-data">
         {{> request-data key="Status" value="{$leaveStatus}"}}
         {{> request-data key="Staff Member" value="{contact.display_name}"}}

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/toil-request.civicrm.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/toil-request.civicrm.html
@@ -7,7 +7,7 @@ request-type: TOIL
 <div class="request">
   <row class="collapse">
     <columns>
-      {{> callout-header title="Leave Request Type"}}
+      {{> callout-header title="{$absenceTypeName}"}}
       <callout class="request-data">
         {{> request-data key="Status" value="{$leaveStatus}" keySize="4"}}
         {{> request-data key="Staff Member" value="{contact.display_name}" keySize="4"}}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Message.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Message.php
@@ -10,6 +10,11 @@ class CRM_HRLeaveAndAbsences_Mail_Message {
   use CRM_HRLeaveAndAbsences_Service_SettingsManagerTrait;
 
   /**
+   * @var array
+   */
+  private $templateParameters;
+
+  /**
    * @var \CRM_HRLeaveAndAbsences_BAO_LeaveRequest
    */
   private $leaveRequest;
@@ -84,15 +89,24 @@ class CRM_HRLeaveAndAbsences_Mail_Message {
 
   /**
    * Gets the template parameters for the Leave Request template
+   * for the recipient.
+   *
+   * @param int $recipientID
    *
    * @return array|null
    */
-  public function getTemplateParameters() {
+  public function getTemplateParameters($recipientID) {
     if (!$this->isValidTemplate()) {
       return null;
     }
 
-    return $this->getTemplate()->getTemplateParameters($this->leaveRequest);
+    if (is_null($this->templateParameters)) {
+      $this->templateParameters = $this->getTemplate()->getTemplateParameters($this->leaveRequest);
+    }
+
+    $leaveRequestLink = ['leaveRequestLink' => $this->getLeaveRequestURL($recipientID)];
+
+    return array_merge($this->templateParameters, $leaveRequestLink);
   }
 
   /**
@@ -115,6 +129,24 @@ class CRM_HRLeaveAndAbsences_Mail_Message {
    */
   public function getLeaveContactID() {
     return $this->leaveRequest->contact_id;
+  }
+
+  /**
+   * Gets appropriate leave Request URL Link for the Contact
+   *
+   * @param int $contactID
+   *  The contact to get the Leave Request URL for
+   *
+   * @return string
+   */
+  private function getLeaveRequestURL($contactID) {
+    $leaveUrl = CRM_Utils_System::url('my-leave', [], true);
+
+    if ($this->leaveRequest->contact_id != $contactID) {
+      $leaveUrl = CRM_Utils_System::url('manager-leave', [], true);
+    }
+
+    return $leaveUrl;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Template/BaseRequestNotification.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Template/BaseRequestNotification.php
@@ -54,7 +54,6 @@ abstract class CRM_HRLeaveAndAbsences_Mail_Template_BaseRequestNotification {
       'fromDateType' => $this->getLeaveRequestDayTypeLabel($leaveRequest->from_date_type),
       'toDateType' => $this->getLeaveRequestDayTypeLabel($leaveRequest->to_date_type),
       'leaveStatus' => $this->getLeaveRequestStatusLabel($leaveRequest->status_id),
-      'leaveRequestLink' => $this->getLeaveRequestURL(),
       'leaveRequest' => $leaveRequest,
       'currentDateTime' => new DateTime()
     ];
@@ -125,16 +124,5 @@ abstract class CRM_HRLeaveAndAbsences_Mail_Template_BaseRequestNotification {
     ]);
 
     return $result['values'];
-  }
-
-  /**
-   * Return URL for the leave request on SSP
-   *
-   * @TODO This should return the actual url for the leave request in future.
-   *
-   * @return string
-   */
-  private function getLeaveRequestURL() {
-    return CRM_Utils_System::url('my-leave', [], true);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Template/BaseRequestNotification.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Template/BaseRequestNotification.php
@@ -55,6 +55,7 @@ abstract class CRM_HRLeaveAndAbsences_Mail_Template_BaseRequestNotification {
       'toDateType' => $this->getLeaveRequestDayTypeLabel($leaveRequest->to_date_type),
       'leaveStatus' => $this->getLeaveRequestStatusLabel($leaveRequest->status_id),
       'leaveRequest' => $leaveRequest,
+      'absenceTypeName' => $this->getAbsenceTypeName($leaveRequest),
       'currentDateTime' => new DateTime()
     ];
 
@@ -124,5 +125,20 @@ abstract class CRM_HRLeaveAndAbsences_Mail_Template_BaseRequestNotification {
     ]);
 
     return $result['values'];
+  }
+
+  /**
+   * Gets the Name of the Absence Type for this LeaveRequest
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_LeaveRequest $leaveRequest
+   *
+   * @return string
+   */
+  private function getAbsenceTypeName(LeaveRequest $leaveRequest) {
+    $absenceType = new CRM_HRLeaveAndAbsences_BAO_AbsenceType();
+    $absenceType->id = $leaveRequest->type_id;
+    $absenceType->find(true);
+
+    return $absenceType->title;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Template/SicknessRequestNotification.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Template/SicknessRequestNotification.php
@@ -34,7 +34,7 @@ class CRM_HRLeaveAndAbsences_Mail_Template_SicknessRequestNotification extends
    */
   public function getTemplateParameters(LeaveRequest $leaveRequest) {
     $templateParameters = [];
-    $templateParameters['sicknessReasons'] = $this->getSicknessReasons();
+    $templateParameters['sicknessReason'] = $this->getSicknessReasonLabel($leaveRequest->sickness_reason);
     if ($leaveRequest->sickness_required_documents) {
       $templateParameters['sicknessRequiredDocuments'] = $this->getSicknessRequiredDocuments();
       $templateParameters['leaveRequiredDocuments'] = explode(',', $leaveRequest->sickness_required_documents);
@@ -42,19 +42,6 @@ class CRM_HRLeaveAndAbsences_Mail_Template_SicknessRequestNotification extends
     $templateParameters = array_merge(parent::getTemplateParameters($leaveRequest), $templateParameters);
 
     return $templateParameters;
-  }
-
-  /**
-   * Returns the array of the option values for the LeaveRequest sickness_reason field.
-   *
-   * @return array
-   */
-  private function getSicknessReasons() {
-    if (is_null($this->sicknessReasons)) {
-      $this->sicknessReasons = LeaveRequest::buildOptions('sickness_reason');
-    }
-
-    return $this->sicknessReasons;
   }
 
   /**
@@ -77,5 +64,20 @@ class CRM_HRLeaveAndAbsences_Mail_Template_SicknessRequestNotification extends
     }
 
     return $this->sicknessRequiredDocuments;
+  }
+
+  /**
+   * Returns the label for the LeaveRequest sickness_reason option value.
+   *
+   * @param int $sicknessReason
+   *
+   * @return string
+   */
+  private function getSicknessReasonLabel($sicknessReason) {
+    if (is_null($this->sicknessReasons)) {
+      $this->sicknessReasons = LeaveRequest::buildOptions('sickness_reason');
+    }
+
+    return $this->sicknessReasons[$sicknessReason];
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestMailNotificationSender.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestMailNotificationSender.php
@@ -18,17 +18,18 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestMailNotificationSender {
 
     $recipientEmails = $message->getRecipientEmails();
     $templateID = $message->getTemplateID();
-    $templateParameters = $message->getTemplateParameters();
     $contactID = $message->getLeaveContactID();
     $fromEmail = $message->getFromEmail();
     $status = [];
 
     foreach($recipientEmails as $recipient) {
+      $recipientID = $recipient['api.Contact.get']['values'][0]['id'];
+
       $mailSent =
         MessageTemplate::sendTemplate([
           'messageTemplateID' => $templateID,
           'contactId' => $contactID,
-          'tplParams' => $templateParameters,
+          'tplParams' => $message->getTemplateParameters($recipientID),
           'from' => $fromEmail,
           'toName' => $recipient['api.Contact.get']['values'][0]['display_name'],
           'toEmail' => $recipient['email'],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/managed_entities/EmailTemplate.mgd.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/managed_entities/EmailTemplate.mgd.php
@@ -120,7 +120,7 @@ return [
                     <table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
                       <tr style="padding: 0; text-align: left; vertical-align: top;">
                         <td class="callout-header" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #F3F6F7; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 15px 20px; text-align: left; vertical-align: top; word-wrap: break-word;">
-                          <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">Leave Request Type</h2>
+                          <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">{$absenceTypeName}</h2>
                         </td>
                       </tr>
                     </table>
@@ -384,7 +384,7 @@ return [
                     <table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
                       <tr style="padding: 0; text-align: left; vertical-align: top;">
                         <td class="callout-header" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #F3F6F7; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 15px 20px; text-align: left; vertical-align: top; word-wrap: break-word;">
-                          <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">Leave Request Type</h2>
+                          <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">{$absenceTypeName}</h2>
                         </td>
                       </tr>
                     </table>
@@ -659,7 +659,7 @@ return [
                     <table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
                       <tr style="padding: 0; text-align: left; vertical-align: top;">
                         <td class="callout-header" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #F3F6F7; border-collapse: collapse !important; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; hyphens: auto; line-height: 1.53846; margin: 0; padding: 15px 20px; text-align: left; vertical-align: top; word-wrap: break-word;">
-                          <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">Leave Request Type</h2>
+                          <h2 class="callout-title" style="Margin: 0; Margin-bottom: 0; color: #4D5663; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 500; line-height: 1.53846; margin: 0; margin-bottom: 0; padding: 0; text-align: left; word-wrap: normal;">{$absenceTypeName}</h2>
                         </td>
                       </tr>
                     </table>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
@@ -138,17 +138,37 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
     $this->assertEquals($leaveRequest->contact_id, $message->getLeaveContactID());
   }
 
-  public function testGetTemplateParameters() {
-    $expectedParameters = [
+  public function testGetTemplateParametersForLeaveContact() {
+    $templateParameters = [
       'status' => 'Mock Status',
       'date' => 'Test Date'
     ];
-    $leaveTemplate = $this->createLeaveTemplateMock($expectedParameters);
+    $expectedUrl = ['leaveRequestLink' => CRM_Utils_System::url('my-leave', [], true)];
+    $expectedParameters = array_merge($templateParameters, $expectedUrl);
+    $leaveTemplate = $this->createLeaveTemplateMock($templateParameters);
     $notificationTemplateFactory = $this->createRequestNotificationTemplateFactoryMock($leaveTemplate);
 
     $leaveRequest = new LeaveRequest();
+    $leaveRequest->contact_id = 1;
     $message = new Message($leaveRequest, $notificationTemplateFactory);
-    $this->assertEquals($expectedParameters, $message->getTemplateParameters());
+    $this->assertEquals($expectedParameters, $message->getTemplateParameters($leaveRequest->contact_id));
+  }
+
+  public function testGetTemplateParametersForManager() {
+    $templateParameters = [
+      'status' => 'Mock Status',
+      'date' => 'Test Date'
+    ];
+    $expectedUrl = ['leaveRequestLink' => CRM_Utils_System::url('manager-leave', [], true)];
+    $expectedParameters = array_merge($templateParameters, $expectedUrl);
+    $leaveTemplate = $this->createLeaveTemplateMock($templateParameters);
+    $notificationTemplateFactory = $this->createRequestNotificationTemplateFactoryMock($leaveTemplate);
+
+    $leaveRequest = new LeaveRequest();
+    $leaveRequest->contact_id = 1;
+    $managerID = 2;
+    $message = new Message($leaveRequest, $notificationTemplateFactory);
+    $this->assertEquals($expectedParameters, $message->getTemplateParameters($managerID));
   }
 
   public function testGetTemplateID() {
@@ -181,7 +201,7 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
     ], false);
 
     $message = new Message($leaveRequest, $this->leaveRequestTemplateFactory);
-    $this->assertNull($message->getTemplateParameters());
+    $this->assertNull($message->getTemplateParameters($leaveRequest->contact_id));
   }
 
   public function testGetTemplateIDReturnsNullWhenThereIsNoTemplateForARequestType() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/LeaveRequestNotificationTemplateTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/LeaveRequestNotificationTemplateTest.php
@@ -76,7 +76,6 @@ class CRM_HRLeaveAndAbsences_Mail_Template_LeaveRequestNotificationTemplateTest 
     $this->assertEquals($tplParams['fromDateType'], $leaveRequestDayTypes[$leaveRequest->from_date_type]);
     $this->assertEquals($tplParams['toDateType'], $leaveRequestDayTypes[$leaveRequest->to_date_type]);
     $this->assertEquals($tplParams['leaveStatus'], $leaveRequestStatuses[$leaveRequest->status_id]);
-    $this->assertEquals($tplParams['leaveRequestLink'], CRM_Utils_System::url('my-leave', [], true));
     $this->assertEquals($tplParams['currentDateTime'], $dateTimeNow, '', 10);
 
     //There are two attachments for the leave request

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/LeaveRequestNotificationTemplateTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/LeaveRequestNotificationTemplateTest.php
@@ -4,6 +4,7 @@ use CRM_HRLeaveAndAbsences_Mail_Template_LeaveRequestNotification as LeaveReques
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestComment as LeaveRequestCommentService;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
 
 /**
  * Class CRM_HRLeaveAndAbsences_Mail_LeaveRequestNotificationTemplateTest
@@ -34,8 +35,9 @@ class CRM_HRLeaveAndAbsences_Mail_Template_LeaveRequestNotificationTemplateTest 
   }
 
   public function testGetTemplateParametersReturnsTheExpectedParametersForTheTemplate() {
+    $absenceType = AbsenceTypeFabricator::fabricate(['title' => 'Vacation/Holiday']);
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
-      'type_id' => 1,
+      'type_id' => $absenceType->id,
       'contact_id' =>2,
       'from_date' => CRM_Utils_Date::processDate('tomorrow'),
       'to_date' => CRM_Utils_Date::processDate('tomorrow'),
@@ -77,6 +79,7 @@ class CRM_HRLeaveAndAbsences_Mail_Template_LeaveRequestNotificationTemplateTest 
     $this->assertEquals($tplParams['toDateType'], $leaveRequestDayTypes[$leaveRequest->to_date_type]);
     $this->assertEquals($tplParams['leaveStatus'], $leaveRequestStatuses[$leaveRequest->status_id]);
     $this->assertEquals($tplParams['currentDateTime'], $dateTimeNow, '', 10);
+    $this->assertEquals($tplParams['absenceTypeName'], $absenceType->title);
 
     //There are two attachments for the leave request
     $this->assertCount(2, $tplParams['leaveFiles']);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/SicknessRequestNotificationTemplateTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/SicknessRequestNotificationTemplateTest.php
@@ -97,7 +97,7 @@ class CRM_HRLeaveAndAbsences_Mail_Template_SicknessRequestNotificationTemplateTe
 
     $this->assertEquals($leaveCommentText, ['Random Commenter', 'Sample text']);
 
-    $this->assertEquals($tplParams['sicknessReasons'], $sicknessReasons);
+    $this->assertEquals($tplParams['sicknessReason'], $sicknessReasons[$leaveRequest->sickness_reason]);
     $this->assertEquals($tplParams['sicknessRequiredDocuments'], $this->getSicknessRequiredDocuments());
     $this->assertEquals($tplParams['leaveRequiredDocuments'], explode(',', $leaveRequest->sickness_required_documents));
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/SicknessRequestNotificationTemplateTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/SicknessRequestNotificationTemplateTest.php
@@ -4,6 +4,7 @@ use CRM_HRLeaveAndAbsences_Mail_Template_SicknessRequestNotification as Sickness
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestComment as LeaveRequestCommentService;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
 
 /**
  * Class RM_HRLeaveAndAbsences_Mail_SicknessRequestNotificationTemplateTest
@@ -34,8 +35,9 @@ class CRM_HRLeaveAndAbsences_Mail_Template_SicknessRequestNotificationTemplateTe
   }
 
   public function testGetTemplateParametersReturnsTheExpectedParametersForTheTemplate() {
+    $absenceType = AbsenceTypeFabricator::fabricate(['title' => 'Vacation/Holiday']);
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
-      'type_id' => 1,
+      'type_id' => $absenceType->id,
       'contact_id' =>2,
       'from_date' => CRM_Utils_Date::processDate('tomorrow'),
       'to_date' => CRM_Utils_Date::processDate('tomorrow'),
@@ -81,6 +83,7 @@ class CRM_HRLeaveAndAbsences_Mail_Template_SicknessRequestNotificationTemplateTe
     $this->assertEquals($tplParams['toDateType'], $leaveRequestDayTypes[$leaveRequest->to_date_type]);
     $this->assertEquals($tplParams['leaveStatus'], $leaveRequestStatuses[$leaveRequest->status_id]);
     $this->assertEquals($tplParams['currentDateTime'], $dateTimeNow, '', 10);
+    $this->assertEquals($tplParams['absenceTypeName'], $absenceType->title);
 
     //There are two attachments for the Sickness request
     $this->assertCount(2, $tplParams['leaveFiles']);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/SicknessRequestNotificationTemplateTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/SicknessRequestNotificationTemplateTest.php
@@ -80,7 +80,6 @@ class CRM_HRLeaveAndAbsences_Mail_Template_SicknessRequestNotificationTemplateTe
     $this->assertEquals($tplParams['fromDateType'], $leaveRequestDayTypes[$leaveRequest->from_date_type]);
     $this->assertEquals($tplParams['toDateType'], $leaveRequestDayTypes[$leaveRequest->to_date_type]);
     $this->assertEquals($tplParams['leaveStatus'], $leaveRequestStatuses[$leaveRequest->status_id]);
-    $this->assertEquals($tplParams['leaveRequestLink'], CRM_Utils_System::url('my-leave', [], true));
     $this->assertEquals($tplParams['currentDateTime'], $dateTimeNow, '', 10);
 
     //There are two attachments for the Sickness request

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/TOILRequestNotificationTemplateTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/TOILRequestNotificationTemplateTest.php
@@ -4,6 +4,7 @@ use CRM_HRLeaveAndAbsences_Mail_Template_TOILRequestNotification as TOILRequestN
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestComment as LeaveRequestCommentService;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
 
 /**
  * Class CRM_HRLeaveAndAbsences_Mail_TOILRequestNotificationTemplateTest
@@ -34,8 +35,9 @@ class CRM_HRLeaveAndAbsences_Mail_Template_TOILRequestNotificationTemplateTest e
   }
 
   public function testGetTemplateParametersReturnsTheExpectedParametersForTheTemplate() {
+    $absenceType = AbsenceTypeFabricator::fabricate(['title' => 'Vacation/Holiday']);
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
-      'type_id' => 1,
+      'type_id' => $absenceType->id,
       'contact_id' =>2,
       'from_date' => CRM_Utils_Date::processDate('tomorrow'),
       'to_date' => CRM_Utils_Date::processDate('tomorrow'),
@@ -79,6 +81,7 @@ class CRM_HRLeaveAndAbsences_Mail_Template_TOILRequestNotificationTemplateTest e
     $this->assertEquals($tplParams['toDateType'], $leaveRequestDayTypes[$leaveRequest->to_date_type]);
     $this->assertEquals($tplParams['leaveStatus'], $leaveRequestStatuses[$leaveRequest->status_id]);
     $this->assertEquals($tplParams['currentDateTime'], $dateTimeNow, '', 10);
+    $this->assertEquals($tplParams['absenceTypeName'], $absenceType->title);
 
     //There are two attachments for the TOIL request
     $this->assertCount(2, $tplParams['leaveFiles']);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/TOILRequestNotificationTemplateTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/TOILRequestNotificationTemplateTest.php
@@ -78,7 +78,6 @@ class CRM_HRLeaveAndAbsences_Mail_Template_TOILRequestNotificationTemplateTest e
     $this->assertEquals($tplParams['fromDateType'], $leaveRequestDayTypes[$leaveRequest->from_date_type]);
     $this->assertEquals($tplParams['toDateType'], $leaveRequestDayTypes[$leaveRequest->to_date_type]);
     $this->assertEquals($tplParams['leaveStatus'], $leaveRequestStatuses[$leaveRequest->status_id]);
-    $this->assertEquals($tplParams['leaveRequestLink'], CRM_Utils_System::url('my-leave', [], true));
     $this->assertEquals($tplParams['currentDateTime'], $dateTimeNow, '', 10);
 
     //There are two attachments for the TOIL request


### PR DESCRIPTION
## Overview
When an Email Notification is sent for a Leave Request, The leave request link in the email is the same regardless of whether the recipient is the Staff or Leave Manager. The link is supposed to lead to `my-leave` page for a Staff member and `manager-leave` page for the Leave manager.
This PR also adds the Absence Type Name parameter to the Email templates and also the Sickness reason parameter is now passed directly to Sickness Email template.

## Before
The Leave request link is the same for a staff and a leave manager.
The Absence type name is a static value in the email templates.
The Sickness reason parameter was not passed directly to the template.

## After
The leave request link in the email templates is now determined by who the recipient is i.e whether a Staff or Leave manager.
The Absence Type name is no longer static in the templates. 
The Sickness reason is now passed directly to the template.


- [X] Tests Pass
