### PR TITLE
PCHR-2199: Escape single quotes in templates

### DIFF
--- a/uk.co.compucorp.civicrm.hremails/email-templates/dist/leave-request.civicrm.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/dist/leave-request.civicrm.html
@@ -146,7 +146,7 @@
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:''|crmDate} {$fromDateType}</span>
+                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
                         
@@ -158,7 +158,7 @@
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:''|crmDate} {$fromDateType}</span>
+                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
                         
@@ -169,7 +169,7 @@
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 0 !important; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$toDate|truncate:10:''|crmDate} {$toDateType}</span>
+                            <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
                         

--- a/uk.co.compucorp.civicrm.hremails/email-templates/dist/sickness-request.civicrm.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/dist/sickness-request.civicrm.html
@@ -146,7 +146,7 @@
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:''|crmDate} {$fromDateType}</span>
+                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
                         
@@ -158,7 +158,7 @@
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:''|crmDate} {$fromDateType}</span>
+                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
                         
@@ -169,7 +169,7 @@
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$toDate|truncate:10:''|crmDate} {$toDateType}</span>
+                            <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
                         

--- a/uk.co.compucorp.civicrm.hremails/email-templates/dist/toil-request.civicrm.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/dist/toil-request.civicrm.html
@@ -146,7 +146,7 @@
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:''|crmDate} {$fromDateType}</span>
+                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
                         
@@ -158,7 +158,7 @@
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:''|crmDate} {$fromDateType}</span>
+                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
                         
@@ -169,7 +169,7 @@
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$toDate|truncate:10:''|crmDate} {$toDateType}</span>
+                            <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
                         

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/leave-request.civicrm.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/leave-request.civicrm.html
@@ -13,10 +13,10 @@ request-type: Leave
         {{> request-data key="Staff Member" value="{contact.display_name}"}}
 
         {if $leaveRequest->from_date eq $leaveRequest->to_date}
-          {{> request-data key="Date" value="{$fromDate|truncate:10:''|crmDate} {$fromDateType}"}}
+          {{> request-data key="Date" value="{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}"}}
         {else}
-          {{> request-data key="From Date" value="{$fromDate|truncate:10:''|crmDate} {$fromDateType}"}}
-          {{> request-data key="To Date" value="{$toDate|truncate:10:''|crmDate} {$toDateType}"}}
+          {{> request-data key="From Date" value="{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}"}}
+          {{> request-data key="To Date" value="{$toDate|truncate:10:\'\'|crmDate} {$toDateType}"}}
         {/if}
       </callout>
       <spacer></spacer>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/sickness-request.civicrm.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/sickness-request.civicrm.html
@@ -13,10 +13,10 @@ request-type: Sickness
         {{> request-data key="Staff Member" value="{contact.display_name}"}}
 
         {if $leaveRequest->from_date eq $leaveRequest->to_date}
-          {{> request-data key="Date" value="{$fromDate|truncate:10:''|crmDate} {$fromDateType}"}}
+          {{> request-data key="Date" value="{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}"}}
         {else}
-          {{> request-data key="From Date" value="{$fromDate|truncate:10:''|crmDate} {$fromDateType}"}}
-          {{> request-data key="To Date" value="{$toDate|truncate:10:''|crmDate} {$toDateType}"}}
+          {{> request-data key="From Date" value="{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}"}}
+          {{> request-data key="To Date" value="{$toDate|truncate:10:\'\'|crmDate} {$toDateType}"}}
         {/if}
         <hr>
         {{> request-data key="Additional Details" value=""}}

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/toil-request.civicrm.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/toil-request.civicrm.html
@@ -13,10 +13,10 @@ request-type: TOIL
         {{> request-data key="Staff Member" value="{contact.display_name}" keySize="4"}}
 
         {if $leaveRequest->from_date eq $leaveRequest->to_date}
-          {{> request-data key="Date" value="{$fromDate|truncate:10:''|crmDate} {$fromDateType}" keySize="4"}}
+          {{> request-data key="Date" value="{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}" keySize="4"}}
         {else}
-          {{> request-data key="From Date" value="{$fromDate|truncate:10:''|crmDate} {$fromDateType}" keySize="4"}}
-          {{> request-data key="To Date" value="{$toDate|truncate:10:''|crmDate} {$toDateType}" keySize="4"}}
+          {{> request-data key="From Date" value="{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}" keySize="4"}}
+          {{> request-data key="To Date" value="{$toDate|truncate:10:\'\'|crmDate} {$toDateType}" keySize="4"}}
         {/if}
 
         {{> request-data

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/managed_entities/EmailTemplate.mgd.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/managed_entities/EmailTemplate.mgd.php
@@ -157,7 +157,7 @@ return [
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:''|crmDate} {$fromDateType}</span>
+                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
 
@@ -169,7 +169,7 @@ return [
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:''|crmDate} {$fromDateType}</span>
+                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
 
@@ -180,7 +180,7 @@ return [
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 0 !important; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$toDate|truncate:10:''|crmDate} {$toDateType}</span>
+                            <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
 
@@ -421,7 +421,7 @@ return [
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:''|crmDate} {$fromDateType}</span>
+                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
 
@@ -433,7 +433,7 @@ return [
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:''|crmDate} {$fromDateType}</span>
+                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
 
@@ -444,7 +444,7 @@ return [
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$toDate|truncate:10:''|crmDate} {$toDateType}</span>
+                            <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
 
@@ -696,7 +696,7 @@ return [
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:''|crmDate} {$fromDateType}</span>
+                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
 
@@ -708,7 +708,7 @@ return [
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:''|crmDate} {$fromDateType}</span>
+                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
 
@@ -719,7 +719,7 @@ return [
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$toDate|truncate:10:''|crmDate} {$toDateType}</span>
+                            <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
                           </th></tr></table></th>
                         </tr></tbody></table>
 


### PR DESCRIPTION
## Overview
The single quotes passed to the `truncate` filters weren't escaped, causing a PHP syntax error when the templates were read in the EmailTemplate.mgd.php file

## Before
```html
<span>{$fromDate|truncate:10:''|crmDate} {$fromDateType}</span>
```

## After
```html
<span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
```