### PR TITLE
PCHR-2145: Update backstopjs tests to reflect new changes in document modal

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/documents/document/pick-due-date.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/documents/document/pick-due-date.js
@@ -4,6 +4,6 @@ var page = require('../../../page-objects/documents');
 
 module.exports = function (casper) {
   page.init(casper).addDocument().then(function (modal) {
-    modal.pickDueDate();
+    modal.showTab("Assignments").pickDueDate();
   });
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/documents/document/select-assignee.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/documents/document/select-assignee.js
@@ -4,6 +4,6 @@ var page = require('../../../page-objects/documents');
 
 module.exports = function (casper) {
   page.init(casper).addDocument().then(function (modal) {
-    modal.showField('Assignee').selectAssignee();
+    modal.showTab('Assignments').showField('Assignee').selectAssignee();
   });
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/documents/document/show-all-fields.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/documents/document/show-all-fields.js
@@ -6,7 +6,6 @@ module.exports = function (casper) {
   page.init(casper).addDocument().then(function (modal) {
     modal
       .showField('Assignee')
-      .showField('Assignment')
-      .showMore();
+      .showField('Assignment');
   });
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/document.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/document.js
@@ -44,7 +44,7 @@ module.exports = (function () {
       var casper = this.casper;
 
       casper.then(function () {
-        casper.click(this.modalRoot + ' [ng-model="document.assignee_contact_id[0]"] .ui-select-match');
+        casper.click(this.modalRoot + ' [ng-model="document.assignee_contact"] .ui-select-match');
         casper.waitUntilVisible('.select2-with-searchbox');
       }.bind(this));
 

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/document.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/document.js
@@ -68,15 +68,15 @@ module.exports = (function () {
     },
 
     /**
-     * Expands fully the modal
+     * Opens the given tab
      *
      * @return {object}
      */
-    showMore: function () {
+    showTab: function (tabName) {
       var casper = this.casper;
 
       casper.then(function () {
-        casper.click(this.modalRoot + ' [ng-click*="expanded"]');
+        casper.click(this.modalRoot + ' [heading="' + tabName + '"] a');
         casper.wait(200);
       }.bind(this));
 


### PR DESCRIPTION
## Overview
Since, the layout of the the New Document Modal in Task and Assignment is modified as per the new requirement, previous test cases need to be updated work with new changes.
(Previous and after screenshot of modal can be seen in backstopjs tests screenshot below)

## Technical Details
1. `/casper_scripts/documents/document/pick-due-date.js` and `/casper_scripts/documents/document/select-assignee.js` files are modified to open respective tab before selecting the fields.

2. `/casper_scripts/documents/document/show-all-fields.js` `showMore()` function is removed as now there is no section for show more fields.

3. Updated the selector in `/page-objects/modals/document.js` while selecting assignee. And added `showTab(tabName)` function to show respective tab based on `tabName`

4. Backstopjs Tests:
Following failed test are due to the added changes as per new requirements, so they are fine.
![screencapture-file-users-bmn-buildkit-build-hr16-new-sites-all-modules-civicrm-tools-extensions-civihr-uk-co-compucorp-civicrm-hrcore-backstop_data-html_report-index-html-1495035404108](https://cloud.githubusercontent.com/assets/6307362/26164279/ebb939ca-3b4b-11e7-902a-eddf89c56f59.png)

- [x] Tests Pass
