### PR TITLE
PCHR-2262: Add pre-commit hook to check for JS style

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -20,9 +20,13 @@ command_exists () {
 command_exists semistandard "https://www.npmjs.com/package/semistandard"
 command_exists snazzy "https://www.npmjs.com/package/snazzy"
 
-git diff --name-only --cached -- '*.js' ':(exclude)**/dist/**' ':(exclude)*min.js' | xargs semistandard --verbose | snazzy
-if [ $? -ne 0 ]; then
-  echo "$COL_YELLOW Some of the JS files you have committed are not following the \"JavaScript Semi-Standard Style\", please fix them! $COL_RESET";
-  echo "$COL_YELLOW Run the following to check the state of your file as you work on it: semistandard %{path_to_file} --verbose | snazzy $COL_RESET \n";
-  echo "$COL_RED For the time being the files had been committed and can be pushed, but in the future the commit will be rejected until all the issues are fixed! $COL_RESET";
+files=`git diff --name-only --cached -- '*.js' ':(exclude)**/dist/**' ':(exclude)*min.js'`
+if [ -n "$files" ]; then
+  semistandard "$files" --verbose | snazzy
+
+  if [ $? -ne 0 ]; then
+    echo "$COL_YELLOW Some of the JS files you have committed are not following the \"JavaScript Semi-Standard Style\", please fix them! $COL_RESET";
+    echo "$COL_YELLOW Run the following to check the state of your file as you work on it: semistandard %{path_to_file} --verbose | snazzy $COL_RESET \n";
+    echo "$COL_RED For the time being the files had been committed and can be pushed, but in the future the commit will be rejected until all the issues are fixed! $COL_RESET";
+  fi
 fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -17,11 +17,11 @@ command_exists () {
 
 
 # Compliance to "JavaScript Semi-Standard Style" (https://github.com/Flet/semistandard)
-command_exists semistandard "https://www.npmjs.com/package/semistandard"
-command_exists snazzy "https://www.npmjs.com/package/snazzy"
-
 files=`git diff --name-only --cached -- '*.js' ':(exclude)**/dist/**' ':(exclude)*min.js'`
 if [ -n "$files" ]; then
+  command_exists semistandard "https://www.npmjs.com/package/semistandard"
+  command_exists snazzy "https://www.npmjs.com/package/snazzy"
+
   semistandard "$files" --verbose | snazzy
 
   if [ $? -ne 0 ]; then

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Colors
+# (http://wiki.bash-hackers.org/snipplets/add_color_to_your_scripts)
+ESC_SEQ="\x1b["
+COL_RESET=$ESC_SEQ"39;49;00m"
+COL_RED=$ESC_SEQ"31;01m"
+COL_YELLOW=$ESC_SEQ"33;01m"
+
+## Checks if a given command exists in the local environment
+command_exists () {
+  if ! hash "$1" >/dev/null 2>&1; then
+    echo >&2 "$COL_RED $1 ($2) is required globally but it's not installed. Aborting commit. $COL_RESET";
+    exit 1;
+  fi;
+}
+
+
+# Compliance to "JavaScript Semi-Standard Style" (https://github.com/Flet/semistandard)
+command_exists semistandard "https://www.npmjs.com/package/semistandard"
+command_exists snazzy "https://www.npmjs.com/package/snazzy"
+
+git diff --name-only --cached -- '*.js' ':(exclude)**/dist/**' ':(exclude)*min.js' | xargs semistandard --verbose | snazzy
+if [ $? -ne 0 ]; then
+  echo "$COL_YELLOW Some of the JS files you have committed are not following the \"JavaScript Semi-Standard Style\", please fix them! $COL_RESET";
+  echo "$COL_YELLOW Run the following to check the state of your file as you work on it: semistandard %{path_to_file} --verbose | snazzy $COL_RESET \n";
+  echo "$COL_RED For the time being the files had been committed and can be pushed, but in the future the commit will be rejected until all the issues are fixed! $COL_RESET";
+fi


### PR DESCRIPTION
## Overview
This PR adds a sharable pre-commit hook that will run the "[JavaScript Semi-Standard Style](https://github.com/Flet/semistandard)" linter on any non-minified javascript file that is about to get committed.

For the time being if the linter throws an error the dev simply gets a warning, but the idea is that in a month time (just to make sure that there is no flaw in the process) the hook will reject the commit altogether.

The reason for using https://github.com/Flet/semistandard instead of https://github.com/feross/standard is simply that the former doesn't have the insane "no semicolons" rule

Below is an annotated example of the hook in action
```shell
# Checking the branch status
$ git s
On branch PCHR-2262-precommit-js-styleguide
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)
	modified:   contactaccessrights/js/src/access-rights/controllers/access-rights-modal-ctrl.js

# Committing the file
$ git commit -m 'f'

# semistandard is automatically run and reports errors
semistandard: Semicolons For All! (https://github.com/Flet/semistandard)
semistandard: Run `semistandard --fix` to automatically fix some problems.

civihr/contactaccessrights/js/src/access-rights/controllers/access-rights-modal-ctrl.js
  50:18  error  Expected error to be handled                    handle-callback-err
  64:29  error  Missing space before function parentheses       space-before-function-paren
  94:20  error  Missing space before function parentheses       space-before-function-paren
  96:13  error  Expected indentation of 10 spaces but found 12  indent
  97:13  error  Expected indentation of 10 spaces but found 12  indent
  98:11  error  Expected indentation of 8 spaces but found 10   indent

✖ 6 problems

# pre-commit hook message
 Some of the JS files you have committed are not following the "JavaScript Semi-Standard Style", please fix them! 
 Run the following to check the state of your file as you work on it: semistandard %{path_to_file} --verbose | snazzy  

  For the time being the files had been committed and can be pushed, but in the future the commit will be rejected until all the issues are fixed!


# Commit is still created
[PCHR-2262-precommit-js-styleguide cb0b8f9] f
 1 file changed, 1 insertion(+)
```

## Technical Details
* The hook is stored in a _.githooks/_ folder, so it can be easily distributed to any dev working on the project
* Initially I thought of creating a _.githooks/_ folder in all the 4 repos of CiviHR, but then that would lead to too much unnecessary duplication. So you can simply take the hook from the main repo (this one) and copy it in all the other repos
* The hook checks for the presence of https://www.npmjs.com/package/semistandard and https://www.npmjs.com/package/snazzy. If the check fails, the whole commit is aborted