### PR TITLE
PCHR-1687: Catch Exception When Creating PK for Hours Location Table

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1275,7 +1275,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
   /**
    * Makes Hour Location id field autonumeric and adds id as a primary key.
    */
-  public function upgrade_2017051901() {
+  public function upgrade_1030() {
     try {
       CRM_Core_DAO::executeQuery('ALTER TABLE `civicrm_hrhours_location` ADD PRIMARY KEY (`id`)');
       CRM_Core_DAO::executeQuery('ALTER TABLE `civicrm_hrhours_location` CHANGE `id` `id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT');
@@ -1289,7 +1289,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
       }
     }
 
-    return false;
+    return true;
   }
 
   /**

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1280,7 +1280,8 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
       CRM_Core_DAO::executeQuery('ALTER TABLE `civicrm_hrhours_location` ADD PRIMARY KEY (`id`)');
       CRM_Core_DAO::executeQuery('ALTER TABLE `civicrm_hrhours_location` CHANGE `id` `id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT');
     } catch (PEAR_Exception $e) {
-      if (stripos($e->getCause()->userinfo, 'nativecode=1068') === false) {
+      $isDuplicatePrimaryKeyException = stripos($e->getCause()->userinfo, 'nativecode=1068');
+      if ($isDuplicatePrimaryKeyException === false) {
         throw new Exception($e->getMessage() . ' - ' . $e->getCause()->userinfo);
       }
     }

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1275,11 +1275,21 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
   /**
    * Makes Hour Location id field autonumeric and adds id as a primary key.
    */
-  public function upgrade_1030() {
-    CRM_Core_DAO::executeQuery('ALTER TABLE `civicrm_hrhours_location` ADD PRIMARY KEY (`id`)');
-    CRM_Core_DAO::executeQuery('ALTER TABLE `civicrm_hrhours_location` CHANGE `id` `id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT');
+  public function upgrade_2017051901() {
+    try {
+      CRM_Core_DAO::executeQuery('ALTER TABLE `civicrm_hrhours_location` ADD PRIMARY KEY (`id`)');
+      CRM_Core_DAO::executeQuery('ALTER TABLE `civicrm_hrhours_location` CHANGE `id` `id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT');
+    } catch (Exception $e) {
+      $tableStructure = CRM_Core_DAO::executeQuery('DESC civicrm_hrhours_location');
 
-    return true;
+      while ($tableStructure->fetch()) {
+        if ($tableStructure->Field == 'id' && ($tableStructure->Key != 'PRI' || stripos($tableStructure->Extra, 'auto_increment') === false)) {
+          throw $e;
+        }
+      }
+    }
+
+    return false;
   }
 
   /**

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1279,13 +1279,9 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     try {
       CRM_Core_DAO::executeQuery('ALTER TABLE `civicrm_hrhours_location` ADD PRIMARY KEY (`id`)');
       CRM_Core_DAO::executeQuery('ALTER TABLE `civicrm_hrhours_location` CHANGE `id` `id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT');
-    } catch (Exception $e) {
-      $tableStructure = CRM_Core_DAO::executeQuery('DESC civicrm_hrhours_location');
-
-      while ($tableStructure->fetch()) {
-        if ($tableStructure->Field == 'id' && ($tableStructure->Key != 'PRI' || stripos($tableStructure->Extra, 'auto_increment') === false)) {
-          throw $e;
-        }
+    } catch (PEAR_Exception $e) {
+      if (stripos($e->getCause()->userinfo, 'nativecode=1068') === false) {
+        throw new Exception($e->getMessage() . ' - ' . $e->getCause()->userinfo);
       }
     }
 


### PR DESCRIPTION
## Overview
An upgrade for hrjobcontract extension was throwing an exception when being ran on some environments, where the particular fix it was trying to apply was already implemented.

## Before
On some installations, civicrm_hrhours_location table was being created without defining the id field as a primary key and not setting it as autonumeric, which made it all but impossible to add new records to it, via the front-end of civihr. To solve this problem, an upgrader was created to add the constraints to the table. However, staging environment, among others, already had the fix, which caused a DB error when the upgrader tried to add the primary key again.

## After
Fixed by catching the exception, and throwing it only if primary key and autonumeric has not been set for the id field in the table.

---

- [x] Tests Pass
