### PR TITLE
PCHR-2265: Fix permissions required for the delete action of the LeaveRequest and Comment APIs

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -118,6 +118,7 @@ function hrleaveandabsences_civicrm_alterAPIPermissions($entity, $action, &$para
     'getbalancechangebyabsencetype' => ['leave_request'],
     'calculatebalancechange' => ['leave_request'],
     'create' => ['leave_request', 'comment'],
+    'delete' => ['leave_request', 'comment'],
     'update' => ['leave_request'],
     'getcalendar' => ['work_pattern'],
     'ismanagedby' => ['leave_request'],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ApiPermissionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ApiPermissionTest.php
@@ -43,6 +43,7 @@ class api_v3_ApiPermissionTest extends BaseHeadlessTest {
       ['LeaveRequest', 'deletecomment'],
       ['LeaveRequest', 'getattachments'],
       ['LeaveRequest', 'deleteattachment'],
+      ['LeaveRequest', 'delete'],
       ['WorkPattern', 'getcalendar'],
       ['AbsenceType', 'get'],
       ['AbsencePeriod', 'get'],
@@ -52,6 +53,7 @@ class api_v3_ApiPermissionTest extends BaseHeadlessTest {
       ['PublicHoliday', 'get'],
       ['Comment', 'get'],
       ['Comment', 'create'],
+      ['Comment', 'delete'],
       ['Contact', 'getleavemanagees'],
     ];
   }


### PR DESCRIPTION
## Overview

Trying to delete a LeaveRequest or a Comment using the API and the check_permissions option enabled (which is the case when you use Javascript for API calls), would result in an error saying that the "administer CiviCRM" permission was required

## Before

The L&A extension sets "access AJAX Api" as the only permission required for a list of APIs it uses. LeaveRequest.delete and Comment.delete were missing from this list.

## After

The list was updated to set the proper required permission for LeaveRequest.delete and Comment.delete. 

---

- [x] Tests Pass
