### PR TITLE
PCHR-1344: Add env and global options for semistandard

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -22,7 +22,7 @@ if [ -n "$files" ]; then
   command_exists semistandard "https://www.npmjs.com/package/semistandard"
   command_exists snazzy "https://www.npmjs.com/package/snazzy"
 
-  semistandard --env jasmine --env amd --global inject --global CRM --verbose "$files" | snazzy
+  semistandard --global inject --global CRM --verbose "$files" | snazzy
 
   if [ $? -ne 0 ]; then
     echo "$COL_YELLOW Some of the JS files you have committed are not following the \"JavaScript Semi-Standard Style\", please fix them! $COL_RESET";

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -22,7 +22,7 @@ if [ -n "$files" ]; then
   command_exists semistandard "https://www.npmjs.com/package/semistandard"
   command_exists snazzy "https://www.npmjs.com/package/snazzy"
 
-  semistandard "$files" --verbose | snazzy
+  semistandard --env jasmine --env amd --global inject --global CRM --verbose "$files" | snazzy
 
   if [ $? -ne 0 ]; then
     echo "$COL_YELLOW Some of the JS files you have committed are not following the \"JavaScript Semi-Standard Style\", please fix them! $COL_RESET";


### PR DESCRIPTION
## Overview
Updated pre commit hook from 
`semistandard  "$files" --verbose | snazzy`
to
`semistandard --global inject --global CRM --verbose "$files" | snazzy`

This will avoid declaring inject/CRM globals manually or in files.