### PR TITLE
PCHR-2246: Changes to a Work Pattern does not reflect on Public Holiday Leave Request

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
@@ -522,7 +522,7 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
    *  A date string in a format supported by strtotime
    * @param null|string $endDate
    *  A date string in a format supported by strtotime
-   * @param null|int $contactID
+   * @param null|int|array $contactID
    *
    * @return array
    */
@@ -541,9 +541,12 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
     }
 
     $whereContactID = '';
-    if($contactID) {
-      $contactID = (int)$contactID;
-      $whereContactID = " AND c.contact_id = {$contactID}";
+    if(!empty($contactID)) {
+      if(!is_array($contactID)) {
+        $contactID = [$contactID];
+      }
+      array_walk($contactID, 'intval');
+      $whereContactID = ' AND c.contact_id IN('. implode(', ', $contactID) .')';
     }
 
     $query = "

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
@@ -513,8 +513,9 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
    *   dates
    * - The contract is not deleted
    *
-   * This method also accepts a Contact ID as a parameter. In that case, it will
-   * only return contracts for that given Contact.
+   * This method also accepts a Contact ID as a parameter which could be a single contact
+   * or an array of Contact(s). In that case, it will only return contracts for the given Contact(s).
+   *
    *
    * The contracts are returned ordered by their start date in ascending order.
    *

--- a/hrjobcontract/api/v3/HRJobContract.php
+++ b/hrjobcontract/api/v3/HRJobContract.php
@@ -93,9 +93,9 @@ function civicrm_api3_h_r_job_contract_deletecontract($params) {
 
 /**
  * HRJobContract.getlengthofservice
- * 
+ *
  * Return a number of Length of Service in days for specific 'contact_id'.
- * 
+ *
  * @param array $params
  * @return array API result descriptor
  * @throws API_Exception
@@ -110,11 +110,11 @@ function civicrm_api3_h_r_job_contract_getlengthofservice($params) {
 
 /**
  * HRJobContract.getlengthofserviceymd
- * 
+ *
  * Return an object containing years, months and days of Length of Service
  * for specific 'contact_id'.
  * Useful for front-end part of Contact Summary block.
- * 
+ *
  * @param array $params
  * @return array API result descriptor
  * @throws API_Exception
@@ -129,10 +129,10 @@ function civicrm_api3_h_r_job_contract_getlengthofserviceymd($params) {
 
 /**
  * HRJobContract.updatelengthofservice
- * 
+ *
  * Update Length of Service values for specific 'contact_id' or for every Contact
  * if $params['contact_id'] is not specified.
- * 
+ *
  * @param array $params
  * @return array API result descriptor
  * @throws API_Exception
@@ -185,7 +185,7 @@ function _civicrm_api3_h_r_job_contract_getcontractswithdetailsinperiod_spec(&$s
 function civicrm_api3_h_r_job_contract_getcontractswithdetailsinperiod($params) {
   $startDate = null;
   $endDate = null;
-  $contractID = null;
+  $contactID = null;
 
   if(!empty($params['start_date'])) {
     if(is_array($params['start_date'])) {
@@ -202,11 +202,34 @@ function civicrm_api3_h_r_job_contract_getcontractswithdetailsinperiod($params) 
   }
 
   if(!empty($params['contact_id'])) {
-    $contractID = (int)$params['contact_id'];
+    $contactID = _civicrm_api3_h_r_job_contract_get_contacts_from_params($params);
   }
 
-  $result = CRM_Hrjobcontract_BAO_HRJobContract::getContractsWithDetailsInPeriod($startDate, $endDate, $contractID);
+  $result = CRM_Hrjobcontract_BAO_HRJobContract::getContractsWithDetailsInPeriod($startDate, $endDate, $contactID);
   return civicrm_api3_create_success($result, $params);
+}
+
+/**
+ * Extracts the list of contactID's from the $params array
+ *
+ * @param array $params
+ *
+ * @return array
+ */
+function _civicrm_api3_h_r_job_contract_get_contacts_from_params($params) {
+  if(empty($params['contact_id'])) {
+    return [];
+  }
+
+  if(!is_array($params['contact_id'])) {
+    return [$params['contact_id']];
+  }
+
+  if(!array_key_exists('IN', $params['contact_id'])) {
+    throw new InvalidArgumentException('The contact_id parameter only supports the IN operator');
+  }
+
+  return $params['contact_id']['IN'];
 }
 
 /**

--- a/hrjobcontract/tests/phpunit/CRM/Hrjobcontract/BAO/HRJobContractTest.php
+++ b/hrjobcontract/tests/phpunit/CRM/Hrjobcontract/BAO/HRJobContractTest.php
@@ -123,7 +123,7 @@ class CRM_Hrjobcontract_BAO_HRJobContractTest extends PHPUnit_Framework_TestCase
     $this->assertCount(2, $contracts);
   }
 
-  public function testGetContractsWithDetailsInPeriodCanReturnOnlyContractsOfASpecificContact() {
+  public function testGetContractsWithDetailsInPeriodCanReturnContractsOfASpecificContact() {
     $this->createContacts(2);
 
     $startDateContract1 = '2016-01-01';
@@ -170,6 +170,38 @@ class CRM_Hrjobcontract_BAO_HRJobContractTest extends PHPUnit_Framework_TestCase
     $this->assertEquals($contract3->id, $contact2Contracts[0]['id']);
     $this->assertEquals($startDateContract3, $contact2Contracts[0]['period_start_date']);
     $this->assertNull($contact2Contracts[0]['period_end_date']);
+  }
+
+  public function testGetContractsWithDetailsInPeriodCanReturnContractsOfMultipleContacts() {
+    $this->createContacts(2);
+
+    $startDateContract1 = '2016-01-01';
+    $endDateContract1 = '2016-03-10';
+
+    $contract1 = $this->createJobContract(
+      $this->contacts[0]['id'],
+      $startDateContract1,
+      $endDateContract1
+    );
+
+    $startDateContract2 = '2016-03-03';
+
+    $contract2 = $this->createJobContract(
+      $this->contacts[1]['id'],
+      $startDateContract2
+    );
+
+    $allContracts = CRM_Hrjobcontract_BAO_HRJobContract::getContractsWithDetailsInPeriod(
+      '2016-01-01', '2016-12-31', [$this->contacts[0]['id'], $this->contacts[1]['id']]
+    );
+
+    $this->assertCount(2, $allContracts);
+    $this->assertEquals($contract1->id, $allContracts[0]['id']);
+    $this->assertEquals($startDateContract1, $allContracts[0]['period_start_date']);
+    $this->assertEquals($endDateContract1, $allContracts[0]['period_end_date']);
+    $this->assertEquals($contract2->id, $allContracts[1]['id']);
+    $this->assertEquals($startDateContract2, $allContracts[1]['period_start_date']);
+    $this->assertNull($allContracts[1]['period_end_date']);
   }
 
   public function testGetContractsWithDetailsInPeriodShouldReturnTheDetailsFromTheLatestDetailsRevision() {

--- a/hrjobcontract/tests/phpunit/api/v3/HRJobContractTest.php
+++ b/hrjobcontract/tests/phpunit/api/v3/HRJobContractTest.php
@@ -68,7 +68,7 @@ class api_v3_HRJobContractTest extends PHPUnit_Framework_TestCase implements
    *
    * @dataProvider invalidGetContractsWithDetailsInPeriodContactIDOperator
    */
-  public function testOnGetContractsWithDetailsInPeriodTheContactIDOnlyAcceptsINOperator($operator) {
+  public function testGetContractsWithDetailsInPeriodTheContactIDOnlyAcceptsINOperator($operator) {
     civicrm_api3('HRJobContract', 'getcontractswithdetailsinperiod', ['contact_id' => [$operator => '1']]);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/ContactWorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/ContactWorkPattern.php
@@ -223,41 +223,25 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern extends CRM_HRLeaveAndAbsenc
   }
 
   /**
-   * Gets the contacts that have work patterns overlapping the start and end date period.
+   * Gets the contacts that have work patterns with effective_end_date
+   * greater than or equal to the date parameter.
    *
-   * @param \DateTime $start
-   * @param \DateTime $end
-   * @param null|int $workPatternID
-   * @param bool $ignoreEffectiveDate
-   *   If true will return contacts who has Contact work patterns with effective_end date greater than
-   *   or equal to the start date parameter irrespective of what the effective/start date of the
-   *   Contact Work Pattern is.
+   * @param \DateTime $date
+   * @param int $workPatternID
    *
    * @return array
    *   Array of contact ID's
    */
-  public static function getContactsForPeriod(DateTime $start, DateTime $end, $workPatternID = null, $ignoreEffectiveDate = false) {
+  public static function getContactsUsingWorkPatternFromDate(DateTime $date, $workPatternID) {
     $tableName = self::getTableName();
-    $where = '';
+    $query = "SELECT DISTINCT contact_id FROM {$tableName} WHERE pattern_id = %1 AND
+              (effective_end_date >= %2 OR effective_end_date IS NULL)";
 
     $params = [
-      1 => [$end->format('Y-m-d'), 'String'],
-      2 => [$start->format('Y-m-d'), 'String']
+      1 => [$workPatternID, 'Integer'],
+      2 => [$date->format('Y-m-d'), 'String']
     ];
-
-    if($workPatternID) {
-      $where .= "pattern_id = %3 AND ";
-      $params[3] = [$workPatternID, 'Integer'];
-    }
-
-    if(!$ignoreEffectiveDate) {
-      $where .= "effective_date <= %1 AND ";
-    }
-
-    $where .= "(effective_end_date >= %2 OR effective_end_date IS NULL)";
-    $query = "SELECT DISTINCT contact_id FROM {$tableName} WHERE  ". $where;
-
-    $result = CRM_Core_DAO::executeQuery($query, $params, true, self::class);
+    $result = CRM_Core_DAO::executeQuery($query, $params);
 
     $contacts = [];
     while($result->fetch()) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/Task/UpdateAllFuturePublicHolidayLeaveRequestsForWorkPatternContacts.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/Task/UpdateAllFuturePublicHolidayLeaveRequestsForWorkPatternContacts.php
@@ -1,0 +1,22 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Factory_PublicHolidayLeaveRequestService as PublicHolidayLeaveRequestServiceFactory;
+
+/**
+ * This is the Queue Task which will be executed by the whenever the
+ * PublicHolidayLeaveRequestUpdates queue is processed.
+ *
+ * Basically, it uses the PublicHolidayLeaveRequest service to update all leave
+ * requests for public holidays in the future for contacts using the Work Pattern
+ */
+class CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequestsForWorkPatternContacts {
+
+  /**
+   * @param \CRM_Queue_TaskContext $ctx
+   * @param int $workPatternID
+   */
+  public static function run(CRM_Queue_TaskContext $ctx, $workPatternID) {
+    $service = PublicHolidayLeaveRequestServiceFactory::create();
+    $service->updateAllInTheFutureForWorkPatternContacts($workPatternID);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/JobContract.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/JobContract.php
@@ -63,13 +63,15 @@ class CRM_HRLeaveAndAbsences_Service_JobContract {
    *
    * @param \DateTime $startDate
    * @param \DateTime|NULL $endDate
+   * @param array $contactID
    *
    * @return mixed
    */
-  public function getContractsForPeriod(DateTime $startDate, DateTime $endDate) {
+  public function getContractsForPeriod(DateTime $startDate, DateTime $endDate, array $contactID = []) {
     $result = $this->callHRJobContractAPI('getcontractswithdetailsinperiod', [
       'start_date' => $startDate->format('Y-m-d'),
       'end_date' => $endDate->format('Y-m-d'),
+      'contact_id' => !empty($contactID) ? ['IN' => $contactID] : []
     ]);
 
     return $result['values'];

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
@@ -70,4 +70,19 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest {
     $this->deletionLogic->deleteForAllContacts($publicHoliday);
   }
 
+  /**
+   * Updates all the Leave Requests for Public Holidays in the future for the
+   * contacts using given WorkPattern. If it is the default Work Pattern, It updates for all
+   * contacts.
+   *
+   * @param int $workPatternID
+   *
+   * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion::deleteAllInTheFutureForWorkPatternContacts()
+   * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation::createAllInFutureForWorkPatternContacts()
+   */
+  public function updateAllInTheFutureForWorkPatternContacts($workPatternID) {
+    $this->deletionLogic->deleteAllInTheFutureForWorkPatternContacts($workPatternID);
+    $this->creationLogic->createAllInFutureForWorkPatternContacts($workPatternID);
+  }
+
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -251,12 +251,9 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
     $contacts = [];
 
     if (!$workPattern->is_default) {
-      $ignoreEffectiveDate = true;
-      $contacts = ContactWorkPattern::getContactsForPeriod(
+      $contacts = ContactWorkPattern::getContactsUsingWorkPatternFromDate(
         new DateTime(),
-        new DateTime(),
-        $workPatternID,
-        $ignoreEffectiveDate
+        $workPatternID
       );
     }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -7,6 +7,8 @@ use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
 use CRM_HRLeaveAndAbsences_Service_JobContract as JobContractService;
 use CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange as LeaveBalanceChangeService;
+use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
+use CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern as ContactWorkPattern;
 
 class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
 
@@ -50,8 +52,11 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
    *
    * For each contract overlapping one Public Holiday, a Leave Request will be
    * created for the contract's contact and the public holiday date.
+   *
+   * @param array $contactID
+   *  If not empty, Public Holiday Leave Requests are created for only these contacts
    */
-  public function createForAllInTheFuture() {
+  public function createForAllInTheFuture(array $contactID = []) {
     $absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
 
     if(!$absenceType) {
@@ -63,7 +68,8 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
 
     $contracts = $this->jobContractService->getContractsForPeriod(
       new DateTime(),
-      new DateTime($lastPublicHoliday->date)
+      new DateTime($lastPublicHoliday->date),
+      $contactID
     );
 
     foreach($contracts as $contract) {
@@ -233,4 +239,27 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
     return $startDate <= $publicHolidayDate && (!$endDate || $endDate >= $publicHolidayDate);
   }
 
+  /**
+   * Creates Public Holiday Leave Requests for all Public Holidays in the
+   * Future for the contacts using the given workPatternID, If it is the default Work Pattern
+   * the Leave Requests are created for all contacts.
+   *
+   * @param int $workPatternID
+   */
+  public function createAllInFutureForWorkPatternContacts($workPatternID) {
+    $workPattern = WorkPattern::findById($workPatternID);
+    $contacts = [];
+
+    if (!$workPattern->is_default) {
+      $ignoreEffectiveDate = true;
+      $contacts = ContactWorkPattern::getContactsForPeriod(
+        new DateTime(),
+        new DateTime(),
+        $workPatternID,
+        $ignoreEffectiveDate
+      );
+    }
+
+    $this->createForAllInTheFuture($contacts);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -241,7 +241,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
 
   /**
    * Creates Public Holiday Leave Requests for all Public Holidays in the
-   * Future for the contacts using the given workPatternID, If it is the default Work Pattern
+   * Future for the contacts using the given workPatternID. If it is the default Work Pattern
    * the Leave Requests are created for all contacts.
    *
    * @param int $workPatternID

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
@@ -137,7 +137,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion {
 
   /**
    * Deletes all the Public Holiday Leave Requests for Public Holidays in the
-   * future for the contacts using the given workPatternID, If it is the default Work Pattern
+   * future for the contacts using the given workPatternID. If it is the default Work Pattern
    * the Leave Requests are deleted for all contacts.
    *
    * @param int $workPatternID

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
@@ -147,12 +147,9 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion {
     $contacts = [];
 
     if (!$workPattern->is_default) {
-      $ignoreEffectiveDate = true;
-      $contacts = ContactWorkPattern::getContactsForPeriod(
+      $contacts = ContactWorkPattern::getContactsUsingWorkPatternFromDate(
         new DateTime(),
-        new DateTime(),
-        $workPatternID,
-        $ignoreEffectiveDate
+        $workPatternID
       );
     }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/ContactWorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/ContactWorkPatternTest.php
@@ -424,93 +424,7 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest extends BaseHeadlessTest
     ));
   }
 
-  public function getAllForPeriodReturnsOnlyTheContactWorkPatternsOverlappingTheGivenPeriod() {
-    $contact = ContactFabricator::fabricate();
-    $workPattern = WorkPatternFabricator::fabricate();
-
-    ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $contact['id'],
-      'pattern_id' => $workPattern->id,
-      'effective_date' => CRM_Utils_Date::processDate('2015-01-10'),
-    ]);
-
-    $contactWorkPattern2 = ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $contact['id'],
-      'pattern_id' => $workPattern->id,
-      'effective_date' => CRM_Utils_Date::processDate('2015-01-15'),
-    ]);
-
-    $contactWorkPattern3 = ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $contact['id'],
-      'pattern_id' => $workPattern->id,
-      'effective_date' => CRM_Utils_Date::processDate('2015-01-20'),
-    ]);
-
-    ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $contact['id'],
-      'pattern_id' => $workPattern->id,
-      'effective_date' => CRM_Utils_Date::processDate('2015-01-30'),
-    ]);
-
-    $contactWorkPatterns = ContactWorkPattern::getAllForPeriod(
-      $contact['id'],
-      new DateTime('2015-01-16'),
-      new DateTime('2015-01-29')
-    );
-
-    // Only 2 (number 2 and 3) contact work patterns are within the given
-    // period
-    $this->assertCount(2, $contactWorkPatterns);
-    $this->assertInstanceOf(ContactWorkPattern::class, $contactWorkPatterns[0]);
-    $this->assertEquals($contactWorkPattern2->id, $contactWorkPatterns[0]);
-
-    $this->assertInstanceOf(ContactWorkPattern::class, $contactWorkPatterns[1]);
-    $this->assertEquals($contactWorkPattern3->id, $contactWorkPatterns[1]);
-  }
-
-  public function testGetContactsForPeriodReturnsOnlyTheContactsWithWorkPatternsOverlappingTheGivenPeriod() {
-    $contactID1 = 1;
-    $contactID2 = 2;
-    $contactID3 = 3;
-    $workPatternID = 1;
-
-    $contactWorkPattern1 = ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $contactID1,
-      'pattern_id' => $workPatternID,
-      'effective_date' => CRM_Utils_Date::processDate('2015-01-10'),
-    ]);
-
-    $contactWorkPattern2 = ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $contactID2,
-      'pattern_id' => $workPatternID,
-      'effective_date' => CRM_Utils_Date::processDate('2015-01-15'),
-    ]);
-
-    $contactWorkPattern3 = ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $contactID1,
-      'pattern_id' => $workPatternID,
-      'effective_date' => CRM_Utils_Date::processDate('2015-01-20'),
-    ]);
-
-    ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $contactID3,
-      'pattern_id' => $workPatternID,
-      'effective_date' => CRM_Utils_Date::processDate('2015-01-30'),
-    ]);
-
-    $contacts = ContactWorkPattern::getContactsForPeriod(
-      new DateTime('2015-01-14'),
-      new DateTime('2015-01-29')
-    );
-
-    // ContactWork Patterns 1,2 and 3  overlapps the given date range
-    // Unique Contacts attached to these Contact work patterns will be returned
-    $this->assertCount(2, $contacts);
-    sort($contacts);
-    $this->assertEquals($contacts, [$contactID1, $contactID2]);
-  }
-
-  public function testGetContactsForPeriodReturnsCorrectlyWhenWorkPatternsOverlappsTheGivenPeriodAndForAGivenWorkPatternID() {
+  public function testGetContactsUsingWorkPatternFromDate() {
     $contactID1 = 1;
     $contactID2 = 2;
     $contactID3 = 3;
@@ -541,67 +455,16 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest extends BaseHeadlessTest
       'effective_date' => CRM_Utils_Date::processDate('2015-01-30'),
     ]);
 
-    $contacts = ContactWorkPattern::getContactsForPeriod(
+    $contacts = ContactWorkPattern::getContactsUsingWorkPatternFromDate(
       new DateTime('2015-01-14'),
-      new DateTime('2015-01-29'),
       $workPattern1
     );
 
-    // ContactWork Patterns 1,2 and 3 overlapps the given date range
+    // ContactWork Patterns 1,2 and 3 has effective_end date greater than the '2015-01-14'
     // period but ContactWorkPattern3 is attached to workPattern2,
     // so only unique contacts attached to Contact Work Patterns 1 and 2 will be returned.
     $this->assertCount(2, $contacts);
     sort($contacts);
     $this->assertEquals($contacts, [$contactID1, $contactID2]);
-  }
-
-  public function testGetContactsForPeriodReturnsCorrectlyWhenContactWorkPatternEffectiveDateIsIgnored() {
-    $contactID1 = 1;
-    $contactID2 = 2;
-    $contactID3 = 3;
-    $contactID4 = 4;
-    $workPattern1 = 1;
-    $workPattern2 = 2;
-
-    $contactWorkPattern1 = ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $contactID1,
-      'pattern_id' => $workPattern1,
-      'effective_date' => CRM_Utils_Date::processDate('2015-01-10'),
-    ]);
-
-    $contactWorkPattern2 = ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $contactID2,
-      'pattern_id' => $workPattern1,
-      'effective_date' => CRM_Utils_Date::processDate('2015-01-15'),
-    ]);
-
-    $contactWorkPattern3 = ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $contactID3,
-      'pattern_id' => $workPattern1,
-      'effective_date' => CRM_Utils_Date::processDate('2015-01-30'),
-    ]);
-
-    $contactWorkPattern4 = ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $contactID4,
-      'pattern_id' => $workPattern2,
-      'effective_date' => CRM_Utils_Date::processDate('2015-01-30'),
-    ]);
-
-    $ignoreEffectiveDate = true;
-    $contacts = ContactWorkPattern::getContactsForPeriod(
-      new DateTime('2015-01-16'),
-      new DateTime('2015-01-29'),
-      $workPattern1,
-      $ignoreEffectiveDate
-    );
-
-    //ContactWork Patterns 1 and 2 overlapps the given date range period
-    // but ContactWorkPattern 3 will also be included since its
-    // effective_end_date is greater than the start date of the period
-    // and effective/start date of contact work patterns arw ignored
-    // The unique contacts for these Contact Work Patterns will be returned.
-    $this->assertCount(3, $contacts);
-    sort($contacts);
-    $this->assertEquals($contacts, [$contactID1, $contactID2, $contactID3]);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/JobContractTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/JobContractTest.php
@@ -95,4 +95,40 @@ class CRM_HRLeaveAndAbsences_Service_JobContractTest extends BaseHeadlessTest {
     $this->assertEquals($contract2['id'], $contracts[0]['id']);
     $this->assertEquals($contract3['id'], $contracts[1]['id']);
   }
+
+  public function testGetContractsForPeriodWithContactIDs() {
+    $contact2 = ContactFabricator::fabricate();
+    $contract1 = HRJobContractFabricator::fabricate([
+      'contact_id' => $this->contact['id']
+    ],
+    [
+      'period_start_date' => '2016-01-01',
+      'period_end_date' => '2016-03-15',
+    ]);
+
+    $contract2 = HRJobContractFabricator::fabricate([
+      'contact_id' => $this->contact['id']
+    ],
+    [
+      'period_start_date' => '2016-04-02',
+      'period_end_date' => '2016-11-30',
+    ]);
+
+    $contract3 = HRJobContractFabricator::fabricate([
+      'contact_id' => $contact2['id']
+    ],
+    [
+      'period_start_date' => '2016-12-01'
+    ]);
+
+    $contracts = $this->jobContractService->getContractsForPeriod(
+      new DateTime('2016-07-01'),
+      new DateTime('2016-12-21'),
+      [$this->contact['id'], $contact2['id']]
+    );
+
+    $this->assertCount(2, $contracts);
+    $this->assertEquals($contract2['id'], $contracts[0]['id']);
+    $this->assertEquals($contract3['id'], $contracts[1]['id']);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
@@ -58,6 +58,30 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseH
     $service->updateAllInTheFuture();
   }
 
+  public function testUpdateAllLeaveRequestsInTheFutureForWorkPatternContacts() {
+    $workPatternID = 5;
+    $deletionLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestDeletion::class)
+                              ->disableOriginalConstructor()
+                              ->setMethods(['deleteAllInTheFutureForWorkPatternContacts'])
+                              ->getMock();
+
+    $deletionLogicMock->expects($this->once())
+                      ->method('deleteAllInTheFutureForWorkPatternContacts')
+                      ->with($this->identicalTo($workPatternID));
+
+    $creationLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestCreation::class)
+                              ->disableOriginalConstructor()
+                              ->setMethods(['createAllInFutureForWorkPatternContacts'])
+                              ->getMock();
+
+    $creationLogicMock->expects($this->once())
+                      ->method('createAllInFutureForWorkPatternContacts')
+                      ->with($this->identicalTo($workPatternID));
+
+    $service = new PublicHolidayLeaveRequestService($creationLogicMock, $deletionLogicMock);
+    $service->updateAllInTheFutureForWorkPatternContacts($workPatternID);
+  }
+
   public function testUpdateAllInTheFutureForContract() {
     $contactID = 10;
 


### PR DESCRIPTION
## Overview
The amount deducted for a Public Holiday Leave request is gotten from the leave day amount on the Work Pattern that a contact is using. It is therefore necessary to update Public Holiday Leave requests in the future when a Work Pattern changes so that the amount deducted for these requests can be kept in sync with appropriate amount to be deducted based on the leave day amount. 

## Before
When a Work Pattern is updated, Public Holiday Leave requests in the future are not updated.

## After
When a Work Pattern is updated, Public Holiday Leave requests in the future are updated.

## Technical Details
Rather than update Public Holiday Leave Requests for all contacts when a Work Pattern is updated, for WorkPatterns that is not the default and is used or will be used by some contacts in the future , Public Holiday Leave Requests are updated only for these contacts. 
However when the default WorkPattern is updated, Public Holiday Leave requests are updated for all the contacts. The reasons for these are:

- The default Work Pattern would likely not change often. 
- Getting an accurate number of contacts using the default Work Pattern or who will use it in the future is tricky coupled with the fact that a contact may use a custom work pattern for some part of a period and use the default Work Pattern at some latter part of the period.

- [X] Tests Pass
