### PR TITLE
PCHR-2241: Fix issues with WorkPattern.getCalendar API returning inconsistent results

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/WorkPatternCalendar.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/WorkPatternCalendar.php
@@ -173,7 +173,8 @@ class CRM_HRLeaveAndAbsences_Service_WorkPatternCalendar {
   private function getContractsWithAdjustedDatesForPeriod() {
     $contracts = $this->jobContractService->getContractsForPeriod(
       new DateTime($this->absencePeriod->start_date),
-      new DateTime($this->absencePeriod->end_date)
+      new DateTime($this->absencePeriod->end_date),
+      [$this->contactID]
     );
 
     foreach($contracts as $i => $contract) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
@@ -695,6 +695,7 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends BaseHeadlessTest {
   private function assertPublicHolidayQueueTask($numberOfItems, $class = null, $expectedArgument = null) {
     $queue = PublicHolidayLeaveRequestUpdatesQueue::getQueue();
     $this->assertEquals($numberOfItems, $queue->numberOfItems());
+    $item = '';
 
     if($class || $expectedArgument) {
       $item = $queue->claimItem();
@@ -708,7 +709,7 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends BaseHeadlessTest {
       $this->assertEquals($expectedArgument, $item->data->arguments[0]);
     }
 
-    if($class || $expectedArgument) {
+    if($item) {
       $queue->deleteItem($item);
     }
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
@@ -695,7 +695,10 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends BaseHeadlessTest {
   private function assertPublicHolidayQueueTask($numberOfItems, $class = null, $expectedArgument = null) {
     $queue = PublicHolidayLeaveRequestUpdatesQueue::getQueue();
     $this->assertEquals($numberOfItems, $queue->numberOfItems());
-    $item = $queue->claimItem();
+
+    if($class || $expectedArgument) {
+      $item = $queue->claimItem();
+    }
 
     if($class) {
       $this->assertEquals($class, $item->data->callback[0]);
@@ -704,6 +707,9 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends BaseHeadlessTest {
     if($expectedArgument) {
       $this->assertEquals($expectedArgument, $item->data->arguments[0]);
     }
-    $queue->deleteItem($item);
+
+    if($class || $expectedArgument) {
+      $queue->deleteItem($item);
+    }
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/WorkPatternCalendarTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/WorkPatternCalendarTest.php
@@ -434,7 +434,7 @@ class CRM_HRLeaveAndAbsences_Service_WorkPatternCalendarTest extends BaseHeadles
     ]);
 
     WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => true]);
-    $contact2 =ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
 
     HRJobContractFabricator::fabricate(
       ['contact_id' => $this->contact['id']],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/WorkPatternCalendarTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/WorkPatternCalendarTest.php
@@ -426,4 +426,34 @@ class CRM_HRLeaveAndAbsences_Service_WorkPatternCalendarTest extends BaseHeadles
     // second week and a friday is a non working day on it
     $this->assertEquals($workDayTypes['non_working_day'], $calendarDates[11]['type']);
   }
+
+  public function testItGeneratesAccurateNumberOfCalendarDatesUsingOnlyTheContractOfTheContact() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => true]);
+    $contact2 =ContactFabricator::fabricate();
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $this->contact['id']],
+      [
+        'period_start_date' => '2016-01-01'
+      ]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      [
+        'period_start_date' => '2016-05-01'
+      ]
+    );
+
+    $calendar = new WorkPatternCalendarService($this->contact['id'], $absencePeriod, $this->jobContractService);
+    $calendarDates = $calendar->get();
+
+    //Year 2016 is a leap year, so there are 366 days.
+    $this->assertCount(366, $calendarDates);
+  }
 }


### PR DESCRIPTION
## Overview
WorkPattern.getCalendar API returns the calendar dates for a contact for a given period. The dates returned are dates for which the contact has an active contract.
For a contact that has an active contract for a given period that spans over a year, 365 calendar dates are supposed to be returned but the API returns inconsistent results for this on different environments like staging, test sites, local.

## Before
The WorkPattern.getCalendar API returns inconsistent results.
The reason for this is that the API fetches all the existing contracts for all contacts in the system for the period and uses that to calculate calendar dates for a contact instead of fetching just the contracts for the contact.

## After
Results returned by the The WorkPattern.getCalendar API is now consistent.
The API was changed to fetch only the contracts of the given contact and use that to generate the calendar dates.

- [X] Tests Pass
