### PR TITLE
PCHR-2196: Add permissions for accessing my leave and leave manager page on SSP

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -104,6 +104,8 @@ function hrleaveandabsences_civicrm_permission(&$permissions) {
   $prefix = ts('CiviHRLeaveAndAbsences') . ': '; // name of extension or module
   $permissions['access leave and absences'] = $prefix . ts('Access Leave and Absences');
   $permissions['administer leave and absences'] = $prefix . ts('Administer Leave and Absences');
+  $permissions['access leave and absences in ssp'] = $prefix . ts('Access Leave and Absences in SSP');
+  $permissions['manage leave and absences in ssp'] = $prefix . ts('Manage Leave and Absences in SSP');
 }
 
 /**


### PR DESCRIPTION
## Overview
When the Leave and Absence civiHR extension is disabled/uninstalled, the Leave manager can still see Manager Leave and My Leave page on the SSP. The reason is that it is the Employee portal module that creates the permissions that is needed to see this pages. This PR allows the L&A extension to create these permissions itself.

## Before
The L&A extension does not create the permissions for accessing Manager Leave and My Leave page on the SSP.

## After
The L&A extension creates the permissions for accessing Manager Leave and My Leave page on the SSP.

- [X] Tests Pass
