### PR TITLE
PCHR-2213: Add user guide link in civicrm pages

### DIFF
--- a/hrui/templates/CRM/common/footer.tpl
+++ b/hrui/templates/CRM/common/footer.tpl
@@ -41,6 +41,7 @@
     {/if}
     CiviHR is openly available under the <a href="http://www.gnu.org/licenses/agpl-3.0.html "> GNU AGPL License</a>.
     <br />
+    <a target="_blank" href="http://civihr-documentation.readthedocs.io/en/latest/">User Guide</a>&nbsp;
     <a target="_blank" href="https://github.com/civicrm/civihr">{ts}Download CiviHR{/ts}</a>&nbsp;
     <a target="_blank" href="https://civihr.atlassian.net/wiki/display/CIV/Welcome ">View Wiki page</a>&nbsp;
     <a target="_blank" href="https://civihr.org">Project website</a>
@@ -52,5 +53,3 @@
   </div>
   {include file="CRM/common/notifications.tpl"}
 {/if}
-
-


### PR DESCRIPTION
## Overview
Add "User guide" link to civicrm pages which links to "http://civihr-documentation.readthedocs.io/en/latest/"

## Before
<img width="1100" alt="screen shot 2017-05-29 at 6 58 39 pm" src="https://cloud.githubusercontent.com/assets/6307362/26551174/e4c8ac00-44a0-11e7-96b5-ff31620ef77c.png">

## After
<img width="1144" alt="screen shot 2017-05-29 at 6 57 27 pm" src="https://cloud.githubusercontent.com/assets/6307362/26551120/b1055184-44a0-11e7-8d28-84f5b4ff081c.png">

