### PR TITLE
PCHR-2180: Fix issue with Manager being able to view own leave requests

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -714,3 +714,25 @@ function _hrleaveandabsences_set_has_leave_approved_by_as_default_relationship_t
     );
   }
 }
+
+/**
+ * Implementation of the hook_civicrm_validateForm.
+ *
+ * @param string $formName
+ * @param array $fields
+ * @param array $files
+ * @param object $form
+ * @param array $errors
+ */
+function hrleaveandabsences_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
+  if ($formName == 'CRM_Contact_Form_Relationship') {
+    //True If the contact is being assigned a relationship with itself
+    if($fields['related_contact_id'] == $form->_contactId) {
+      $leaveApproverRelationships = Civi::service('hrleaveandabsences.settings_manager')
+                                    ->get('relationship_types_allowed_to_approve_leave');
+      if(in_array($form->_relationshipTypeId, $leaveApproverRelationships)) {
+        $errors['relationship_type_id'] = ts('You cannot assign a contact as its own leave approver');
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview
Currently when adding a relationship for a contact, it is possible to add a Leave Approver relationship with between a contact and itself. For the case of a Leave manager, this would allow the manager view his/her own leave requests in the manage leave page. 

## Before
A contact can be assigned a Leave Approver relationship with itself.

## After
A contact cannot be assigned a Leave Approver relationship with itself.

![relationship](https://cloud.githubusercontent.com/assets/6951813/26558127/4ef0804c-449e-11e7-9bd4-2382a74b57e8.gif)
---

- [X] Tests Pass
