### PR TITLE
PCHR-2235: Allow Public Holidays/Public Holiday Leave Requests With Past Dates To be Created

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -634,10 +634,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
             ON balance_change.source_id = leave_request_date.id AND balance_change.source_type = %1
         INNER JOIN {$leaveRequestTable} leave_request
             ON leave_request_date.leave_request_id = leave_request.id AND 
-               (leave_request.request_type IN(%2, %3) AND leave_request.is_deleted = 0)
+               (leave_request.request_type IN(%2, %3, %9) AND leave_request.is_deleted = 0)
         WHERE ({$wherePeriodEntitlementDates}) AND 
               (leave_request_date.date BETWEEN %4 AND %5) AND
-              (leave_request.status_id = %6) AND 
+              (leave_request.status_id IN (%6, %10)) AND 
               (leave_request.contact_id = %7) AND 
               (leave_request.type_id = %8)
       ";
@@ -650,7 +650,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
         5 => [$balanceChangeToExpire['expiry_date']->format('Y-m-d'), 'String'],
         6 => [$leaveRequestStatuses['approved'], 'String'],
         7 => [$periodEntitlement->contact_id, 'Integer'],
-        8 => [$periodEntitlement->type_id, 'Integer']
+        8 => [$periodEntitlement->type_id, 'Integer'],
+        9 => [LeaveRequest::REQUEST_TYPE_PUBLIC_HOLIDAY, 'String'],
+        10 => [$leaveRequestStatuses['admin_approved'], 'String']
       ];
 
       $result = CRM_Core_DAO::executeQuery($query, $params);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
@@ -37,7 +37,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest {
   }
 
   /**
-   * Updates all the Leave Requests for Public Holidays in the future between
+   * Updates all the Leave Requests for Public Holidays between
    * the start and end dates of the given contract.
    *
    * @param int $contractID

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
@@ -45,7 +45,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest {
    * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion::deleteAllForContract()
    * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation::createAllForContract()
    */
-  public function updateAllInTheFutureForContract($contractID) {
+  public function updateAllForContract($contractID) {
     $this->deletionLogic->deleteAllForContract($contractID);
     $this->creationLogic->createAllForContract($contractID);
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -82,8 +82,8 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
   }
 
   /**
-   * Creates Public Holiday Leave Requests for all Public Holidays in the
-   * Future overlapping the start and end dates of the given contract
+   * Creates Public Holiday Leave Requests for all Public Holidays
+   * overlapping the start and end dates of the given contract
    *
    * @param int $contractID
    */

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -140,6 +140,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
 
     $leaveRequest = $this->createLeaveRequest($contactID, $absenceType, $publicHoliday);
     $this->createLeaveBalanceChangeRecord($leaveRequest);
+    $this->recalculateExpiredBalanceChange($leaveRequest);
   }
 
   /**
@@ -256,5 +257,21 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
     }
 
     $this->createForAllInTheFuture($contacts);
+  }
+
+  /**
+   * Recalculates expired Balance changes for the contact of a Public Holiday leave request
+   * with past dates and having expired LeaveBalanceChanges that expired on or after
+   * the LeaveRequest past date.
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_LeaveRequest $leaveRequest
+   */
+  private function recalculateExpiredBalanceChange(LeaveRequest $leaveRequest) {
+    $today = new DateTime();
+    $leaveRequestDate = new DateTime($leaveRequest->from_date);
+
+    if($leaveRequestDate < $today) {
+      $this->leaveBalanceChangeService->recalculateExpiredBalanceChangesForLeaveRequestPastDates($leaveRequest);
+    }
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -100,9 +100,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
     );
 
     foreach($publicHolidays as $publicHoliday) {
-      if(strtotime($publicHoliday->date) >= strtotime('today')) {
-        $this->createForContact($contract['contact_id'], $publicHoliday);
-      }
+      $this->createForContact($contract['contact_id'], $publicHoliday);
     }
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
@@ -79,9 +79,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion {
     );
 
     foreach($publicHolidays as $publicHoliday) {
-      if(strtotime($publicHoliday->date) >= strtotime('today')) {
-        $this->deleteForContact($contract['contact_id'], $publicHoliday);
-      }
+      $this->deleteForContact($contract['contact_id'], $publicHoliday);
     }
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -580,7 +580,7 @@ function _hrleaveandabsences_civicrm_post_hrjobdetails($op, $objectId, &$objectR
       ]);
 
       $service = PublicHolidayLeaveRequestServiceFactory::create();
-      $service->updateAllInTheFutureForContract($revision['jobcontract_id']);
+      $service->updateAllForContract($revision['jobcontract_id']);
     } catch(Exception $e) {}
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -2408,6 +2408,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   public function testCalculateAmountForDateForAContactWithWorkPatternHavingMultipleWeeks() {
     $periodStartDate = new DateTime('2016-01-01');
 
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31')
+    ]);
+
     $contract = HRJobContractFabricator::fabricate(
       [ 'contact_id' => 1 ],
       [ 'period_start_date' => $periodStartDate->format('Y-m-d') ]
@@ -2459,6 +2464,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   public function testCalculateAmountForDateForAContactWithWorkPatternHavingOneWeek() {
     $periodStartDate = new DateTime('2016-01-01');
 
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31')
+    ]);
+
     $contract = HRJobContractFabricator::fabricate(
       [ 'contact_id' => 1 ],
       [ 'period_start_date' => $periodStartDate->format('Y-m-d') ]
@@ -2503,6 +2513,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
   public function testCalculateAmountForDateForAContactUsingTheDefaultWorkPattern() {
     $periodStartDate = new DateTime('2016-01-01');
+
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31')
+    ]);
 
     $contract = HRJobContractFabricator::fabricate(
       [ 'contact_id' => 1 ],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -180,6 +180,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testCanFindAPublicHolidayLeaveRequestForAContact() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-01')
+    ]);
+    
     $contactID = 2;
 
     $publicHoliday = new PublicHoliday();
@@ -1009,6 +1014,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testFindOverlappingLeaveRequestsFilteredBySpecificStatusesAndPublicHolidayCondition() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31')
+    ]);
     $contactID = 1;
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = '2016-11-11';

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/PublicHolidayTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/PublicHolidayTest.php
@@ -76,44 +76,6 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
     ]);
   }
 
-  public function testCannotChangeDateToOneInThePast() {
-    $publicHoliday = PublicHolidayFabricator::fabricateWithoutValidation([
-      'date' => CRM_Utils_Date::processDate('+1 day')
-    ]);
-
-    try {
-      PublicHolidayFabricator::fabricate([
-        'id' => $publicHoliday->id,
-        'date' => CRM_Utils_Date::processDate('-1 day')
-      ]);
-    } catch(Exception $e) {
-      $this->assertInstanceOf(InvalidPublicHolidayException::class, $e);
-      $this->assertEquals('The date cannot be in the past', $e->getMessage());
-      return;
-    }
-
-    $this->fail('Expected an exception, but the public holiday was updated with to a date in the past');
-  }
-
-  public function testCannotChangeTheDateOfAPastPublicHoliday() {
-    $publicHoliday = PublicHolidayFabricator::fabricateWithoutValidation([
-      'date' => CRM_Utils_Date::processDate('2016-01-02')
-    ]);
-
-    try {
-      PublicHoliday::create([
-        'id' => $publicHoliday->id,
-        'date' => CRM_Utils_Date::processDate('+1 day')
-      ]);
-    } catch(Exception $e) {
-      $this->assertInstanceOf(InvalidPublicHolidayException::class, $e);
-      $this->assertEquals('You cannot change the date of a past public holiday', $e->getMessage());
-      return;
-    }
-
-    $this->fail('Expected an exception, but the public holiday was updated with to a date in the past');
-  }
-
   public function testCanChangeTheTitleOfAPastPublicHoliday() {
     AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
@@ -129,47 +91,6 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
       'id' => $publicHoliday->id,
       'title' => 'Updated'
     ]);
-  }
-
-  public function testCannotDisableAnEnabledPastPublicHoliday() {
-    $publicHoliday = PublicHolidayFabricator::fabricateWithoutValidation([
-      'title' => 'Holiday',
-      'date' => CRM_Utils_Date::processDate('2016-01-02')
-    ]);
-
-    try {
-      PublicHoliday::create([
-        'id' => $publicHoliday->id,
-        'is_active' => false
-      ]);
-    } catch(Exception $e) {
-      $this->assertInstanceOf(InvalidPublicHolidayException::class, $e);
-      $this->assertEquals('You cannot disable/enable a past public holiday', $e->getMessage());
-      return;
-    }
-
-    $this->fail('Expected an exception, but the public holiday was disabled');
-  }
-
-  public function testCannotEnableADisabledPastPublicHoliday() {
-    $publicHoliday = PublicHolidayFabricator::fabricateWithoutValidation([
-      'title' => 'Holiday',
-      'date' => CRM_Utils_Date::processDate('2016-01-02'),
-      'is_active' => false,
-    ]);
-
-    try {
-      PublicHoliday::create([
-        'id' => $publicHoliday->id,
-        'is_active' => true
-      ]);
-    } catch(Exception $e) {
-      $this->assertInstanceOf(InvalidPublicHolidayException::class, $e);
-      $this->assertEquals('You cannot disable/enable a past public holiday', $e->getMessage());
-      return;
-    }
-
-    $this->fail('Expected an exception, but the public holiday was disabled');
   }
 
   /**
@@ -489,18 +410,6 @@ class CRM_HRLeaveAndAbsences_BAO_PublicHolidayTest extends BaseHeadlessTest {
     $this->assertCount(1, $publicHolidays);
     $this->assertEquals($nextSunday->title, $publicHolidays[0]->title);
     $this->assertEquals($nextSunday->id, $publicHolidays[0]->id);
-  }
-
-  /**
-   * @expectedException RuntimeException
-   * @expectedExceptionMessage Past Public Holidays cannot be deleted
-   */
-  public function testPublicHolidaysInThePastCannotBeDeleted() {
-    $publicHoliday = PublicHolidayFabricator::fabricateWithoutValidation([
-      'date' => CRM_Utils_Date::processDate('yesterday')
-    ]);
-
-    PublicHoliday::del($publicHoliday->id);
   }
 
   public function testItEnqueuesOnlyATaskToCreateLeaveRequestsWhenCreatingANewPublicHoliday() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -181,7 +181,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
   }
 
-  public function testItCreatesLeaveRequestsForAllPublicHolidaysInTheFutureOverlappingTheContractDates() {
+  public function testItCreatesLeaveRequestsForAllPublicHolidaysOverlappingTheContractDates() {
     $contact = ContactFabricator::fabricate(['first_name' => 'Contact 1']);
 
     $contract = HRJobContractFabricator::fabricate([
@@ -218,13 +218,11 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
 
     $this->creationLogic->createAllForContract($contract['id']);
 
-    // The balance should be -2 because only two leave requests were created:
-    // The one for +5 days and the other one for + 47 days.
-    // The holiday for "yesterday" overlaps the contract, but it is in the past,
-    // so nothing will be created. The holiday for "+101 days" is in the future,
-    // but it doesn't overlap the contract dates and no leave request will be
-    // created for it as well
-    $this->assertEquals(-2, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
+    // The balance should be -3 because three leave requests were created:
+    // The one for +5 days, one for + 47 days and the one for yesterday
+    // The holiday for "+101 days" is in the future, but it doesn't overlap the contract dates and
+    // and no leave request will be created for it as well
+    $this->assertEquals(-3, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
   }
 
   public function testItCreatesLeaveRequestsForAllPublicHolidaysInTheFutureOverlappingAContractWithNoEndDate() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -78,6 +78,10 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
   }
 
   public function testItUpdatesTheBalanceChangeForOverlappingLeaveRequestDayToZero() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31')
+    ]);
     $contactID = 2;
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
@@ -184,6 +188,11 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
   }
 
   public function testItCreatesLeaveRequestsForAllPublicHolidaysOverlappingTheContractDates() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('yesterday'),
+      'end_date' => CRM_Utils_Date::processDate('+300 days')
+    ]);
+
     $contact = ContactFabricator::fabricate(['first_name' => 'Contact 1']);
 
     $contract = HRJobContractFabricator::fabricate([

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -574,7 +574,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $this->creationLogic->createForContact($periodEntitlement->contact_id, $publicHoliday2);
     $this->creationLogic->createForContact($periodEntitlement->contact_id, $publicHoliday3);
 
-    $expiredBalanceChange = $this->getBalanceChangeRecord($balanceChange->id);
+    $expiredBalanceChange = LeaveBalanceChange::findById($balanceChange->id);
 
     //The public holiday date (2016-11-03) is before the date the balance change expired so one will be deducted
     //from $balanceChange remaining 4 left after recalculation.
@@ -592,7 +592,6 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();
 
-
     $periodEntitlement1 = LeavePeriodEntitlementFabricator::fabricate([
       'contact_id' => $contact1['id'],
       'period_id' => $absencePeriod->id,
@@ -605,19 +604,15 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'type_id' => $this->absenceType->id,
     ]);
 
-    HRJobContractFabricator::fabricate([
-      'contact_id' => $contact1['id']
-    ],
-    [
-      'period_start_date' => CRM_Utils_Date::processDate('2016-06-01'),
-    ]);
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      ['period_start_date' => CRM_Utils_Date::processDate('2016-06-01')]
+    );
 
-    HRJobContractFabricator::fabricate([
-      'contact_id' => $contact2['id']
-    ],
-    [
-      'period_start_date' => CRM_Utils_Date::processDate('2016-06-01'),
-    ]);
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => CRM_Utils_Date::processDate('2016-06-01')]
+    );
 
     $expiryDate = new DateTime('2016-11-04');
     $balanceChange1 = $this->createExpiredBroughtForwardBalanceChange(
@@ -647,8 +642,8 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $this->creationLogic->createForAllContacts($publicHoliday2);
     $this->creationLogic->createForAllContacts($publicHoliday3);
 
-    $expiredBalanceChange1 = $this->getBalanceChangeRecord($balanceChange1->id);
-    $expiredBalanceChange2 = $this->getBalanceChangeRecord($balanceChange2->id);
+    $expiredBalanceChange1 = LeaveBalanceChange::findById($balanceChange1->id);
+    $expiredBalanceChange2 = LeaveBalanceChange::findById($balanceChange2->id);
 
     //The public holiday date (2016-11-03) is before the date the balance change expired so one will be deducted
     //from $balanceChange1 and also from $balanceChange2
@@ -701,23 +696,11 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
 
     $this->creationLogic->createAllForContract($contract1['id']);
 
-    $expiredBalanceChange1 = $this->getBalanceChangeRecord($balanceChange1->id);
+    $expiredBalanceChange1 = LeaveBalanceChange::findById($balanceChange1->id);
     //The public holiday date (2016-11-03) is before the date the balance change expired so one will be deducted
     //from $balanceChange1
     //Public Holiday2 is in past but the date is not before an already expired balance change
     //Public Holiday3 is in the future, so it does not affect the recalculation
     $this->assertEquals(-2, $expiredBalanceChange1->amount);
-  }
-
-  private function getBalanceChangeRecord($balanceChangeID) {
-    $record = new LeaveBalanceChange();
-    $record->id = $balanceChangeID;
-    $record->find();
-    if($record->N == 1) {
-      $record->fetch();
-      return $record;
-    }
-
-    return null;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
@@ -131,7 +131,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     $this->assertEquals(-1, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
   }
 
-  public function testItDeletesLeaveRequestsForPublicHolidaysInTheFutureOverlappingTheContractDates() {
+  public function testItDeletesLeaveRequestsForPublicHolidaysOverlappingTheContractDates() {
     $contact = ContactFabricator::fabricate(['first_name' => 'Contact 1']);
 
     $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
@@ -169,13 +169,13 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     $deletionLogic = new PublicHolidayLeaveRequestDeletion(new JobContractService());
     $deletionLogic->deleteAllForContract($contract['id']);
 
-    // It's -2 instead of 0 because the public holiday 1 is in the past and its
-    // respective leave request will not be deleted and the public holiday 3 is
-    // after the contract end date and will not be deleted as well
-    $this->assertEquals(-2, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
+    // It's -1 instead of 0 because the public holiday 1 and public holiday 2
+    // will be deleted and the public holiday 3 is after the contract end date
+    // and will not be deleted.
+    $this->assertEquals(-1, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
   }
 
-  public function testItDeletesLeaveRequestsForAllPublicHolidaysInTheFutureOverlappingAContractWithNoEndDate() {
+  public function testItDeletesLeaveRequestsForAllPublicHolidaysOverlappingAContractWithNoEndDate() {
     $contact = ContactFabricator::fabricate(['first_name' => 'Contact 1']);
 
     $contract = HRJobContractFabricator::fabricate([
@@ -212,9 +212,8 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     $deletionLogic = new PublicHolidayLeaveRequestDeletion(new JobContractService());
     $deletionLogic->deleteAllForContract($contract['id']);
 
-    // It's -1 instead of 0 because the public holiday 1 is in the past and its
-    // respective leave request will not be deleted
-    $this->assertEquals(-1, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
+    //all leave requests within the contract dates are deleted.
+    $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
   }
 
   public function testItDoesntDeleteAnythingIfTheContractIDDoesntExist() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
@@ -13,6 +13,7 @@ use CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHoliday as PublicHolidayFabrica
 use CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest as PublicHolidayLeaveRequestFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern as WorkPatternFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_ContactWorkPattern as ContactWorkPatternFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod as AbsencePeriodFabricator;
 
 /**
  * Class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest
@@ -42,6 +43,10 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
   }
 
   public function testCanDeleteAPublicHolidayLeaveRequestForASingleContact() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31')
+    ]);
     $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
       new DateTime('2016-01-01'),
       new DateTime('2016-12-31')
@@ -62,6 +67,11 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
   }
 
   public function testItUpdatesOverlappingLeaveRequestDatesAfterDeletingAPublicHolidayLeaveRequests() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31')
+    ]);
+
     // We need the Work Pattern and the contract in order to be able to
     // recalculate the deduction after deleting the Public Holiday Leave Request
     WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
@@ -91,6 +101,10 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
   }
 
   public function testCanDeleteAllPublicHolidayLeaveRequestsForFuturePublicHolidays() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days')
+    ]);
     $contact = ContactFabricator::fabricate();
 
     $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
@@ -132,6 +146,10 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
   }
 
   public function testItDeletesLeaveRequestsForPublicHolidaysOverlappingTheContractDates() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('yesterday'),
+      'end_date' => CRM_Utils_Date::processDate('+300 days')
+    ]);
     $contact = ContactFabricator::fabricate(['first_name' => 'Contact 1']);
 
     $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
@@ -176,6 +194,10 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
   }
 
   public function testItDeletesLeaveRequestsForAllPublicHolidaysOverlappingAContractWithNoEndDate() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-10 days'),
+      'end_date' => CRM_Utils_Date::processDate('+400 days')
+    ]);
     $contact = ContactFabricator::fabricate(['first_name' => 'Contact 1']);
 
     $contract = HRJobContractFabricator::fabricate([
@@ -217,6 +239,10 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
   }
 
   public function testItDoesntDeleteAnythingIfTheContractIDDoesntExist() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('yesterday'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days')
+    ]);
     $contact = ContactFabricator::fabricate(['first_name' => 'Contact 1']);
 
     $publicHoliday = $this->instantiatePublicHoliday('today');

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
@@ -82,7 +82,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseH
     $service->updateAllInTheFutureForWorkPatternContacts($workPatternID);
   }
 
-  public function testUpdateAllInTheFutureForContract() {
+  public function testUpdateAllForContract() {
     $contactID = 10;
 
     $deletionLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestDeletion::class)
@@ -104,7 +104,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseH
                       ->with($this->identicalTo($contactID));
 
     $service = new PublicHolidayLeaveRequestService($creationLogicMock, $deletionLogicMock);
-    $service->updateAllInTheFutureForContract($contactID);
+    $service->updateAllForContract($contactID);
   }
 
   /**
@@ -117,7 +117,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseH
    * requests before creating the contract and then checking that they were
    * created after the contract gets saved.
    */
-  public function testItUpdateAllInTheFutureWhenTheContractDetailsAreCreated() {
+  public function testItUpdateAllWhenTheContractDetailsAreCreated() {
     WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
     //All the days selected for the public holidays are working days for the 40hr work week
     $datePublicHoliday1 = new DateTime('last monday');


### PR DESCRIPTION
## Overview
Currently creating a Public Holiday with past dates is not allowed as it would involve creating Public Holiday Leave requests for employees for that date (If MTPHL is true) and this will impact on things like Entitlements, Brought Forward, Expired balance Changes and so on, However there are some valid reasons why this may be necessary, one of such is when migrating data from an old system to use the new L&A it may be necessary to create past public holidays for contacts, also when creating a contract for an employee and the contract is created after the dates for some public holidays have passed but those public holidays are supposed to be included in the contract.

## Before
The system does not allow creating Public Holidays in the past and also does not allow creating past public holidays within a contract period when creating a Contract for a contact.

## After
The system was  modified to allow creating Public Holidays in the past and also to allow creating past public holiday leave requests within a contract period when creating a Contract for a contact. After a Public Holiday Leave request with past dates is created, recalculation of Expired Balance Changes is done to keep the calculation in sync.

## Comments
Creating a Public Holiday Leave Requests will require Entitlement Recalculation to be done as this has an impact on Contacts Entitlement, Nothing is done in the PR about this since the Entitlement Calculation is to be done manually by the user who made the change.
- [X] Tests Pass
