### PR TITLE
PCHR-2238: Add approve and reject shortcuts

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/manager-leave/components/manager-leave-requests.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/manager-leave/components/manager-leave-requests.js
@@ -22,7 +22,7 @@ define([
 
     var vm = Object.create(this);
     var actionMatrix = {};
-    actionMatrix[sharedSettings.statusNames.awaitingApproval] = ['respond', 'cancel'];
+    actionMatrix[sharedSettings.statusNames.awaitingApproval] = ['respond', 'cancel', 'approve', 'reject'];
     actionMatrix[sharedSettings.statusNames.moreInformationRequired] = ['edit', 'cancel'];
     actionMatrix[sharedSettings.statusNames.approved] = ['edit'];
     actionMatrix[sharedSettings.statusNames.cancelled] = ['edit'];
@@ -93,17 +93,43 @@ define([
      * @param {string} action
      */
     vm.action = function (leaveRequest, action) {
-      if (action === 'cancel') {
-        dialog.open({
-          title: 'Confirm Cancellation?',
-          copyCancel: 'Cancel',
-          copyConfirm: 'Confirm',
-          classConfirm: 'btn-danger',
-          msg: 'This cannot be undone',
-          onConfirm: function () {
-            return leaveRequest.cancel();
-          }
-        });
+      switch (action) {
+        case "cancel":
+          dialog.open({
+            title: 'Confirm Cancellation?',
+            copyCancel: 'Cancel',
+            copyConfirm: 'Confirm',
+            classConfirm: 'btn-danger',
+            msg: 'This cannot be undone',
+            onConfirm: function () {
+              return leaveRequest.cancel();
+            }
+          });
+          break;
+        case "approve":
+          dialog.open({
+            title: 'Confirm Approval?',
+            copyCancel: 'Cancel',
+            copyConfirm: 'Approve',
+            classConfirm: 'btn-primary',
+            msg: 'Please confirm approval',
+            onConfirm: function () {
+              return leaveRequest.approve();
+            }
+          });
+          break;
+        case "reject":
+          dialog.open({
+            title: 'Confirm Rejection?',
+            copyCancel: 'Cancel',
+            copyConfirm: 'Reject',
+            classConfirm: 'btn-primary',
+            msg: 'Please confirm rejection',
+            onConfirm: function () {
+              return leaveRequest.reject();
+            }
+          });
+          break;
       }
     };
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/manager-leave/components/manager-leave-requests.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/manager-leave/components/manager-leave-requests.js
@@ -111,7 +111,7 @@ define([
             title: 'Confirm Approval?',
             copyCancel: 'Cancel',
             copyConfirm: 'Approve',
-            classConfirm: 'btn-primary',
+            classConfirm: 'btn-success',
             msg: 'Please confirm approval',
             onConfirm: function () {
               return leaveRequest.approve();
@@ -123,7 +123,7 @@ define([
             title: 'Confirm Rejection?',
             copyCancel: 'Cancel',
             copyConfirm: 'Reject',
-            classConfirm: 'btn-primary',
+            classConfirm: 'btn-warning',
             msg: 'Please confirm rejection',
             onConfirm: function () {
               return leaveRequest.reject();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/manager-leave/components/manager-leave-requests.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/manager-leave/components/manager-leave-requests.js
@@ -93,44 +93,37 @@ define([
      * @param {string} action
      */
     vm.action = function (leaveRequest, action) {
-      switch (action) {
-        case "cancel":
-          dialog.open({
-            title: 'Confirm Cancellation?',
-            copyCancel: 'Cancel',
-            copyConfirm: 'Confirm',
-            classConfirm: 'btn-danger',
-            msg: 'This cannot be undone',
-            onConfirm: function () {
-              return leaveRequest.cancel();
-            }
-          });
-          break;
-        case "approve":
-          dialog.open({
-            title: 'Confirm Approval?',
-            copyCancel: 'Cancel',
-            copyConfirm: 'Approve',
-            classConfirm: 'btn-success',
-            msg: 'Please confirm approval',
-            onConfirm: function () {
-              return leaveRequest.approve();
-            }
-          });
-          break;
-        case "reject":
-          dialog.open({
-            title: 'Confirm Rejection?',
-            copyCancel: 'Cancel',
-            copyConfirm: 'Reject',
-            classConfirm: 'btn-warning',
-            msg: 'Please confirm rejection',
-            onConfirm: function () {
-              return leaveRequest.reject();
-            }
-          });
-          break;
-      }
+      var map = {
+        cancel: {
+          title: 'Cancellation',
+          btnClass: 'danger',
+          btnLabel: 'Confirm',
+          msg: 'This cannot be undone'
+        },
+        approve: {
+          title: 'Approval',
+          btnClass: 'success',
+          btnLabel: 'Approve',
+          msg: 'Please confirm approval'
+        },
+        reject: {
+          title: 'Rejection',
+          btnClass: 'warning',
+          btnLabel: 'Reject',
+          msg: 'Please confirm rejection'
+        }
+      };
+
+      dialog.open({
+        title: 'Confirm ' + map[action].title + '?',
+        copyCancel: 'Cancel',
+        copyConfirm: map[action].btnLabel,
+        classConfirm: 'btn-' + map[action].btnClass,
+        msg: map[action].msg,
+        onConfirm: function () {
+          return leaveRequest[action]();
+        }
+      });
     };
 
     /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/manager-leave/components/manager-leave-requests.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/manager-leave/components/manager-leave-requests.html
@@ -118,24 +118,21 @@
                     <i class="fa fa-ellipsis-v"></i>
                   </a>
                   <ul class="dropdown-menu dropdown-menu-right" uib-dropdown-menu>
-                    <li ng-repeat="action in ctrl.actionsFor(request)" ng-switch on="action">
-                      <a ng-switch-when="cancel" href
-                        ng-click="ctrl.action(request, action)">
-                        {{action}}
-                      </a>
-                      <a ng-switch-when="approve" href
-                        ng-click="ctrl.action(request, action)">
-                        {{action}}
-                      </a>
-                      <a ng-switch-when="reject" href
-                        ng-click="ctrl.action(request, action)">
+                    <li
+                      ng-repeat="action in ctrl.actionsFor(request)"
+                      ng-switch="['cancel', 'approve', 'reject'].indexOf(action)">
+                      <a
+                        ng-switch-when="-1"
+                        href
+                        leave-request-popup leave-request="request"
+                        contact-id="ctrl.contactId"
+                        user-role="{{$root.role}}">
                         {{action}}
                       </a>
                       <a
                         ng-switch-default
                         href
-                        leave-request-popup leave-request="request"
-                        contact-id="ctrl.contactId" user-role="{{$root.role}}">
+                        ng-click="ctrl.action(request, action)">
                         {{action}}
                       </a>
                     </li>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/manager-leave/components/manager-leave-requests.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/manager-leave/components/manager-leave-requests.html
@@ -118,12 +118,22 @@
                     <i class="fa fa-ellipsis-v"></i>
                   </a>
                   <ul class="dropdown-menu dropdown-menu-right" uib-dropdown-menu>
-                    <li ng-repeat="action in ctrl.actionsFor(request)">
-                      <a ng-if="action === 'cancel'" href
+                    <li ng-repeat="action in ctrl.actionsFor(request)" ng-switch on="action">
+                      <a ng-switch-when="cancel" href
                         ng-click="ctrl.action(request, action)">
                         {{action}}
                       </a>
-                      <a ng-if="action !== 'cancel'" href
+                      <a ng-switch-when="approve" href
+                        ng-click="ctrl.action(request, action)">
+                        {{action}}
+                      </a>
+                      <a ng-switch-when="reject" href
+                        ng-click="ctrl.action(request, action)">
+                        {{action}}
+                      </a>
+                      <a
+                        ng-switch-default
+                        href
                         leave-request-popup leave-request="request"
                         contact-id="ctrl.contactId" user-role="{{$root.role}}">
                         {{action}}


### PR DESCRIPTION
## Overview
Added approve and reject shortcuts to actions dropdown

## Before
In order to approve/reject a leave you needed to click "Respond", then select an according status from a dropdown and then Save the status of leave.

## After
Now along with "Respond" you have "Approve" and "Reject" options which are followed by a simple confirmation popup.

## Technical Details
- Utilised leave.reject() and leave.approve() functions. 
- Refactored the code and remove repetition, use maps.
- Changed ng-if to ng-switch in both JS and template files for better code readability.
- Selected appropriate colors for approval/rejection comparing to a red cancellation (cannot be undone) color.
- TODO: once Angular is updated to 1.5.10 ng-switch-when "approve|reject|cancel" syntax should be used in order to reduce the code.

![pchr-2238](https://cloud.githubusercontent.com/assets/3973243/26720371/e1f245e0-477f-11e7-89e0-6eedcd6593ab.gif)
