### PR TITLE
PCHR-2278: Fix crash when running Public Holiday Job when no Absence Type with MTPHL exists

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -36,6 +36,10 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
   public function createForAllContacts(PublicHoliday $publicHoliday) {
     $absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
 
+    if(!$absenceType) {
+      return;
+    }
+
     $contracts = $this->jobContractService->getContractsForPeriod(
       new DateTime($publicHoliday->date),
       new DateTime($publicHoliday->date)


### PR DESCRIPTION
## Overview
When running the Public Holidays batch job after setting Must Take Public Holiday Leave Requests set to No for an absence type right after creating a Public Holiday, the job is unable to run and an error is displayed. This is because the function responsible for creating Public Holiday leave requests for all contacts does not return early if it does not find an Absence type with MTPHL set to Yes.

## Before
The function responsible for creating Public Holiday leave requests for all contacts does not return early if it does not find an Absence type with MTPHL set to Yes.

## After
The function responsible for creating Public Holiday leave requests for all contacts returns if it does not find an Absence type with MTPHL set to Yes.


- [X] Tests Pass
