### PR TITLE
PCHR-2292: Fix Issues being unable to delete a Public Holiday

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/PublicHoliday.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/PublicHoliday.php
@@ -36,6 +36,7 @@ class CRM_HRLeaveAndAbsences_Page_PublicHoliday extends CRM_Core_Page_Basic {
     CRM_Utils_Weight::addOrder($rows, 'CRM_HRLeaveAndAbsences_DAO_PublicHoliday', 'id', $returnURL);
 
     CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/crm/hrleaveandabsences.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
+    CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'js/jquery/jquery.crmEditable.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
 
     $this->assign('rows', $rows);
   }


### PR DESCRIPTION
## Overview
When the 'Delete' action for a Public Holiday on the Public Holidays listing page is clicked Instead of the Public Holiday being deleted, It does not respond and some errors appear in the console.

## Before
The Public Holidays listing page requires a core JS file 'jquery.crmEditable.js' which used to be loaded by default in Civicrm version 4.7.9 but now is no longer loaded by default in Civicrm version 4.7.18.
![publicholidaysbefore](https://cloud.githubusercontent.com/assets/6951813/26727015/0c8e1dac-479d-11e7-9878-9af70a157197.gif)


## After
The 'jquery.crmEditable.js' file is loaded for the Public Holidays listing page.
![publicholidaysafter](https://cloud.githubusercontent.com/assets/6951813/26727023/141ee164-479d-11e7-87f0-0cbd3ef0d640.gif)

- [X] Tests Pass
