### PR TITLE
PCHR-2219: Remove the default API limit

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/APIWrapper/DefaultLimitRemover.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/APIWrapper/DefaultLimitRemover.php
@@ -8,7 +8,7 @@ class CRM_HRCore_APIWrapper_DefaultLimitRemover implements API_Wrapper {
   const NO_LIMIT_ON_RESULTS = 0;
 
   /**
-   * the wrapper contains a method that allows you to alter the parameters of the api request (including the action and the entity)
+   * {@inheritDoc}
    */
   public function fromApiInput($apiRequest) {
     $this->removeDefaultLimit($apiRequest);
@@ -17,7 +17,7 @@ class CRM_HRCore_APIWrapper_DefaultLimitRemover implements API_Wrapper {
   }
 
   /**
-   * alter the result before returning it to the caller.
+   * {@inheritDoc}
    */
   public function toApiOutput($apiRequest, $result) {
     return $result;

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/APIWrapper/DefaultLimitRemover.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/APIWrapper/DefaultLimitRemover.php
@@ -5,7 +5,11 @@ class CRM_HRCore_APIWrapper_DefaultLimitRemover implements API_Wrapper {
   /**
    * In civicrm API, 0 means there is no limit on the retrieved results
    */
-  const NO_LIMIT_ON_RESULTS = 0;
+  static private $DEFAULT_NO_LIMIT_VALUE = 0;
+
+  public function getDefaultNoLimitValue() {
+    return self::$DEFAULT_NO_LIMIT_VALUE;
+  }
 
   /**
    * {@inheritDoc}
@@ -30,7 +34,7 @@ class CRM_HRCore_APIWrapper_DefaultLimitRemover implements API_Wrapper {
    */
   private function removeDefaultLimit(&$apiRequest) {
     if (empty($apiRequest['params']['options']['limit'])) {
-      $apiRequest['params']['options']['limit'] = self::NO_LIMIT_ON_RESULTS;
+      $apiRequest['params']['options']['limit'] = $this->getDefaultNoLimitValue();
     }
   }
 }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/APIWrapper/DefaultLimitRemover.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/APIWrapper/DefaultLimitRemover.php
@@ -1,0 +1,36 @@
+<?php
+
+class CRM_HRCore_APIWrapper_DefaultLimitRemover implements API_Wrapper {
+
+  /**
+   * In civicrm API, 0 means there is no limit on the retrieved results
+   */
+  const NO_LIMIT_ON_RESULTS = 0;
+
+  /**
+   * the wrapper contains a method that allows you to alter the parameters of the api request (including the action and the entity)
+   */
+  public function fromApiInput($apiRequest) {
+    $this->removeDefaultLimit($apiRequest);
+
+    return $apiRequest;
+  }
+
+  /**
+   * alter the result before returning it to the caller.
+   */
+  public function toApiOutput($apiRequest, $result) {
+    return $result;
+  }
+
+  /**
+   * Removes the default API limit if it's not set
+   *
+   * @param $apiRequest
+   */
+  private function removeDefaultLimit(&$apiRequest) {
+    if (empty($apiRequest['params']['options']['limit'])) {
+      $apiRequest['params']['options']['limit'] = self::NO_LIMIT_ON_RESULTS;
+    }
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -125,3 +125,12 @@ function hrcore_civicrm_angularModules(&$angularModules) {
 function hrcore_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   _hrcore_civix_civicrm_alterSettingsFolders($metaDataFolders);
 }
+
+/**
+ * Implements hook_civicrm_apiWrappers
+ */
+function hrcore_civicrm_apiWrappers(&$wrappers, $apiRequest) {
+  if ($apiRequest['action'] === 'get') {
+    $wrappers[] = new CRM_HRCore_APIWrapper_DefaultLimitRemover();
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/phpunit.xml.dist
+++ b/uk.co.compucorp.civicrm.hrcore/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/phpunit/bootstrap.php">
+  <testsuites>
+    <testsuite name="My Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/APIWrapper/DefaultLimitRemoverTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/APIWrapper/DefaultLimitRemoverTest.php
@@ -3,6 +3,8 @@
 use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
 
+use CRM_HRCore_APIWrapper_DefaultLimitRemover as DefaultLimitRemover;
+
 /**
  * Class CRM_HRCore_APIWrapper_DefaultLimitRemoverTest
  *
@@ -10,9 +12,10 @@ use Civi\Test\TransactionalInterface;
  */
 class CRM_HRCore_APIWrapper_DefaultLimitRemoverTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface, TransactionalInterface {
 
-  private $defaultLimitRemoverObj;
-
-  private $testParameters = [];
+  /**
+   * @var DefaultLimitRemover
+   */
+  private $defaultLimitRemover;
 
   public function setUpHeadless() {
     return \Civi\Test::headless()
@@ -21,46 +24,37 @@ class CRM_HRCore_APIWrapper_DefaultLimitRemoverTest extends \PHPUnit_Framework_T
   }
 
   public function setUp() {
-    $this->defaultLimitRemoverObj = new CRM_HRCore_APIWrapper_DefaultLimitRemover();
-
-    $this->testParameters['params'] = [
-      'action' => 'get',
-      'entity' => 'contact',
-      'id' => 1,
-    ];
+    $this->defaultLimitRemover = new DefaultLimitRemover();
   }
 
-  public function testFromApiInputWithLimitSetInParameters() {
-    $this->testParameters['params']['options']['limit'] = 10;
+  public function testTheDefaultLimitShouldNotBeAppliedIfASpecificLimitHasBeenSet() {
+    $testParameters['params']['options']['limit'] = 10;
 
-    $actualValue =  $this->defaultLimitRemoverObj->fromApiInput($this->testParameters);
+    $actualValue =  $this->defaultLimitRemover->fromApiInput($testParameters);
 
     $this->assertEquals(
-      $this->testParameters['params']['options']['limit'],
+      $testParameters['params']['options']['limit'],
       $actualValue['params']['options']['limit']
     );
   }
 
-  public function testFromApiInputWithLimitNotSetInParameters() {
-    $actualValue =  $this->defaultLimitRemoverObj->fromApiInput($this->testParameters);
+  public function testTheDefaultLimitValueShouldBeAppliedIfNoLimitHasBeenSet() {
+    $actualValue =  $this->defaultLimitRemover->fromApiInput([]);
 
     $this->assertEquals(
-      $this->defaultLimitRemoverObj->getDefaultNoLimitValue(),
+      $this->defaultLimitRemover->getDefaultNoLimitValue(),
       $actualValue['params']['options']['limit']
     );
   }
 
-  public function testToApiInputDoesNotChangeResults() {
+  public function testTheResultOfAPIResponseShouldNotBeAffectedOrChanged() {
     $testResult = [
       'is_error' => 0,
       'version' => 3,
       'count' =>  5
     ];
 
-    $actualValue =  $this->defaultLimitRemoverObj->toApiOutput(
-      $this->testParameters,
-      $testResult
-    );
+    $actualValue =  $this->defaultLimitRemover->toApiOutput([], $testResult);
 
     $this->assertEquals($testResult, $actualValue);
   }

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/APIWrapper/DefaultLimitRemoverTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/APIWrapper/DefaultLimitRemoverTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Class CRM_HRCore_APIWrapper_DefaultLimitRemoverTest
+ *
+ * @group headless
+ */
+class CRM_HRCore_APIWrapper_DefaultLimitRemoverTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface, TransactionalInterface {
+
+  private $defaultLimitRemoverObj;
+
+  private $testParameters = [];
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp() {
+    $this->defaultLimitRemoverObj = new CRM_HRCore_APIWrapper_DefaultLimitRemover();
+
+    $this->testParameters['params'] = [
+      'action' => 'get',
+      'entity' => 'contact',
+      'id' => 1,
+    ];
+  }
+
+  public function testFromApiInputWithLimitSetInParameters() {
+    $this->testParameters['params']['options']['limit'] = 10;
+
+    $actualValue =  $this->defaultLimitRemoverObj->fromApiInput($this->testParameters);
+
+    $this->assertEquals(
+      $this->testParameters['params']['options']['limit'],
+      $actualValue['params']['options']['limit']
+    );
+  }
+
+  public function testFromApiInputWithLimitNotSetInParameters() {
+    $actualValue =  $this->defaultLimitRemoverObj->fromApiInput($this->testParameters);
+
+    $this->assertEquals(
+      $this->defaultLimitRemoverObj->getDefaultNoLimitValue(),
+      $actualValue['params']['options']['limit']
+    );
+  }
+
+  public function testToApiInputDoesNotChangeResults() {
+    $testResult = [
+      'is_error' => 0,
+      'version' => 3,
+      'count' =>  5
+    ];
+
+    $actualValue =  $this->defaultLimitRemoverObj->toApiOutput(
+      $this->testParameters,
+      $testResult
+    );
+
+    $this->assertEquals($testResult, $actualValue);
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/bootstrap.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/bootstrap.php
@@ -1,0 +1,49 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+eval(cv('php:boot --level=classloader', 'phpcode'));
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}


### PR DESCRIPTION
## Overview
CiviCRM API has by a default a limit of 25 results when doing a "get" action and when there is no limit specified. This could cause problems specially when some developers forget this fact so its better to remove the limit and whenever the developer need any limit on the results then he can just add the limit as a parameter to the API.

## Before
If no limit specified , all "get" API calls return only the first 25 results.

<img width="768" alt="2017-06-02 19_30_26-civihr api _ hr16_3" src="https://cloud.githubusercontent.com/assets/6275540/26735350/834de1e0-47b9-11e7-90ab-a73a5e6e0d9a.png">

<img width="750" alt="2017-06-02 19_31_50-civihr api _ hr16_3" src="https://cloud.githubusercontent.com/assets/6275540/26735355/881d099e-47b9-11e7-9da2-91459d249a96.png">


## After
If not limit specified , all the results appear and not just the first 25 :
 
<img width="609" alt="2017-06-02 19_34_36-civihr api _ hr16_3" src="https://cloud.githubusercontent.com/assets/6275540/26735415/cc34768a-47b9-11e7-9160-28fcdc6885fc.png">

also if the limit specified  , it should still works fine as before : 

<img width="750" alt="2017-06-02 19_31_50-civihr api _ hr16_3" src="https://cloud.githubusercontent.com/assets/6275540/26735430/d932954c-47b9-11e7-96f6-5a4521073283.png">


## Technical Details

I've implemented [hook_civicrm_apiWrappers ](https://docs.civicrm.org/dev/en/master/hooks/hook_civicrm_apiWrappers/) hook inside hrcore extension and defined a wrapper class called CRM_HRCore_APIWrapper_DefaultLimitRemover  that take care of setting the limit to 0 if its not set.

---

- [x] Tests Pass

Some tests Are already broken on staging so they are broken on this branch too but the rest are passing without problem , Here are the failed tests on staging  : 

**Job roles Extension**

Tests: 20, Assertions: 41, Failures: 2.


**contactsummary Extension**

Fatal error: require_once(): Failed opening required 'CiviTest/CiviUnitTestCase.php' (include_path='.:/usr/share/php:/usr/share/pear') in /vagrant/hr16_6/sites/all/modules/civicrm/tools/extensions/civihr/contactsummary/tests/phpunit/CRM/Contactsummary/Utils/AbsencesTest.php on line 3


**hrui Extension**

PHP Fatal error:  Uncaught CiviCRM_API3_Exception: [2001: 'task_status' is not a valid option for field option_group_id

  thrown in /vagrant/hr16_6/sites/all/modules/civicrm/api/api.php on line 45

Fatal error: Uncaught CiviCRM_API3_Exception: [2001: 'task_status' is not a valid option for field option_group_id

  thrown in /vagrant/hr16_6/sites/all/modules/civicrm/api/api.php on line 45

vagrant@vagrant-ubuntu-trusty-64:/vagrant/hr16_6/sites/all/modules/civicrm/tools/extensions/civihr/hrui$ phpunit4 tests
/phpunit/CRM/
PHPUnit 4.8.21 by Sebastian Bergmann and contributors.

Installing hr166civi_bf66o schema
PHP Fatal error:  Uncaught CiviCRM_API3_Exception: [2001: 'task_status' is not a valid option for field option_group_id

  thrown in /vagrant/hr16_6/sites/all/modules/civicrm/api/api.php on line 45

Fatal error: Uncaught CiviCRM_API3_Exception: [2001: 'task_status' is not a valid option for field option_group_id

  thrown in /vagrant/hr16_6/sites/all/modules/civicrm/api/api.php on line 45
  
  
  
**Appraisals Extension**
  
FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
  
  
**Sample data Extension**

  FAILURES!
Tests: 29, Assertions: 90, Errors: 5.


So I will assume the tests on this branch are passed too since it is not the cause for these issues , but these test issues need to be addressed and fixed later.