### PR TITLE
PCHR-2167:  Allow Leave Manager to Edit Sickness Request dates For all Statuses

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
@@ -51,15 +51,17 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
    */
   public function canChangeDatesFor($contactID, $statusID, $requestType) {
     $leaveRequestStatuses = self::getLeaveRequestStatuses();
-    $currentUserCanChangeDates = $requestType === LeaveRequest::REQUEST_TYPE_SICKNESS ||
-                                 $this->currentUserIsLeaveContact($contactID);
-
     $openStatuses = [
       $leaveRequestStatuses['awaiting_approval'],
       $leaveRequestStatuses['more_information_required']
     ];
+    $isSicknessRequest = $requestType === LeaveRequest::REQUEST_TYPE_SICKNESS;
+    $isOpenLeaveRequest = in_array($statusID, $openStatuses);
 
-    return $currentUserCanChangeDates && in_array($statusID, $openStatuses);
+    $currentUserCanChangeDates = ($isSicknessRequest && $this->currentUserIsManagerOrAdmin($contactID)) ||
+                                 ($this->currentUserIsLeaveContact($contactID) && $isOpenLeaveRequest);
+
+    return $currentUserCanChangeDates;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -137,9 +137,9 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
   }
 
   /**
-   * @dataProvider openLeaveRequestStatusesDataProvider
+   * @dataProvider leaveRequestStatusesDataProvider
    */
-  public function testCanChangeDatesForReturnsTrueForSicknessRequestTypeWhenCurrentUserIsLeaveManagerOrAdminAndTheLeaveRequestIsOpen($status) {
+  public function testCanChangeDatesForReturnsTrueForSicknessRequestTypeWhenCurrentUserIsLeaveManagerOrAdminForAllStatuses($status) {
     $contactID = 2;
     $managerRightsService = $this->getLeaveRequestRightsForLeaveManagerAsCurrentUser();
     $adminRightsService = $this->getLeaveRequestRightsForAdminAsCurrentUser();
@@ -149,23 +149,6 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     );
 
     $this->assertTrue(
-      $adminRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_SICKNESS)
-    );
-  }
-
-  /**
-   * @dataProvider closedLeaveRequestStatusesDataProvider
-   */
-  public function testCanChangeDatesForReturnsFalseForSicknessRequestTypeWhenCurrentUserIsLeaveManagerOrAdminAndTheLeaveRequestIsClosed($status) {
-    $contactID = 2;
-    $managerRightsService = $this->getLeaveRequestRightsForLeaveManagerAsCurrentUser();
-    $adminRightsService = $this->getLeaveRequestRightsForAdminAsCurrentUser();
-
-    $this->assertFalse(
-      $managerRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_SICKNESS)
-    );
-
-    $this->assertFalse(
       $adminRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_SICKNESS)
     );
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -246,9 +246,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
    * @expectedException RuntimeException
    * @expectedExceptionMessage You are not allowed to change the request dates
    */
-  public function testCreateThrowsAnExceptionWhenLeaveManagerUpdatesDatesForAClosedSicknessRequest($status) {
+  public function testCreateThrowsAnExceptionWhenLeaveContactUpdatesDatesForAClosedSicknessRequest($status) {
     $params = $this->getDefaultParams([
-      'contact_id' => 5,
       'status_id' => $status,
       'request_type' => LeaveRequest::REQUEST_TYPE_SICKNESS
     ]);
@@ -259,29 +258,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     $params['to_date'] = $toDate->modify('+10 days')->format('YmdHis');
     $params['id'] = $leaveRequest->id;
 
-    $this->getLeaveRequestServiceWhenCurrentUserIsLeaveManager()->create($params, false);
-  }
-
-  /**
-   * @dataProvider closedLeaveRequestStatusesDataProvider
-   *
-   * @expectedException RuntimeException
-   * @expectedExceptionMessage You are not allowed to change the request dates
-   */
-  public function testCreateThrowsAnExceptionWhenAdminUpdatesDatesForAClosedSicknessRequest($status) {
-    $params = $this->getDefaultParams([
-      'contact_id' => 5,
-      'status_id' => $status,
-      'request_type' => LeaveRequest::REQUEST_TYPE_SICKNESS
-    ]);
-
-    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
-
-    $toDate = new DateTime($params['to_date']);
-    $params['to_date'] = $toDate->modify('+10 days')->format('YmdHis');
-    $params['id'] = $leaveRequest->id;
-
-    $this->getLeaveRequestServiceWhenCurrentUserIsAdmin()->create($params, false);
+    $this->getLeaveRequestService()->create($params, false);
   }
 
   /**


### PR DESCRIPTION
## Overview
Currently A Leave manager  can only edit the dates of a Sickness Request when it is in an Open status (Awaiting Approval or More Information Required). This PR removes that restriction.

## Before
A Leave manager can only edit the dates of a Sickness Request when it is in an Open status.

## After
A Leave manager can edit the dates of a Sickness Request in any status provided all other validation rules pass.

- [X] Tests Pass
