### PR TITLE
PCHR-2249: Remove chained API calls while getting count

### DIFF
--- a/org.civicrm.reqangular/dist/reqangular.min.js
+++ b/org.civicrm.reqangular/dist/reqangular.min.js
@@ -25488,9 +25488,8 @@ define('common/services/api',[
           }.bind(this))(),
           (function () {
             var params = _.assign({}, filters, { 'return': 'id' });
-            params = _.omit(params, function (value, key) {
-              return key.startsWith('api.');
-            });
+            // Removing chained calls, they are not necessary for getting the count
+            params = _.omit(params, function (__, key) { return _.startsWith(key, 'api.'); });
 
             return this.sendGET(entity, action, params, cache);
           }.bind(this))()
@@ -28055,15 +28054,13 @@ define('common/models/contact',[
        * @return {object}
        */
       function injectContactIdsInFilters (filters, contactIds) {
-        filters = _(filters)
+        return _(filters)
           .omit(groupFiltersKeys)
           .omit(jobRoleFiltersKeys)
           .assign({
             id: {in: _.intersection.apply(null, contactIds)}
           })
           .value();
-
-        return filters;
       }
 
       /**

--- a/org.civicrm.reqangular/dist/reqangular.min.js
+++ b/org.civicrm.reqangular/dist/reqangular.min.js
@@ -25401,6 +25401,7 @@ define('common/modules/apis',[
     return angular.module('common.apis', []);
 });
 
+/* eslint-env amd */
 define('common/services/api',[
   'common/angular',
   'common/lodash',
@@ -25419,7 +25420,7 @@ define('common/services/api',[
      * @param {object} response - response from backend
      * @return {Promise/Any}
      */
-    function responseHandler(response) {
+    function responseHandler (response) {
       if (!!response.data.is_error) {
         $log.error(response.data);
 
@@ -25429,9 +25430,9 @@ define('common/services/api',[
       return response.data;
     }
 
-    function prepareParams(params) {
+    function prepareParams (params) {
       var defaults = {
-        options: {limit: 0}
+        options: { limit: 0 }
       };
 
       return JSON.stringify(_.merge(defaults, params || {}));
@@ -25473,7 +25474,7 @@ define('common/services/api',[
         return $q.all([
           (function () {
             var params = _.assign({}, filters, (additionalParams || {}), {
-              options: {sort: sort || 'id DESC'}
+              options: { sort: sort || 'id DESC' }
             });
 
             if (pagination) {
@@ -25486,7 +25487,10 @@ define('common/services/api',[
             });
           }.bind(this))(),
           (function () {
-            var params = _.assign({}, filters, {'return': 'id'});
+            var params = _.assign({}, filters, { 'return': 'id' });
+            params = _.omit(params, function (value, key) {
+              return key.startsWith('api.');
+            });
 
             return this.sendGET(entity, action, params, cache);
           }.bind(this))()
@@ -27992,151 +27996,154 @@ define('common/models/instances/contact-instance',[
     }]);
 });
 
+/* eslint-env amd */
 define('common/models/contact',[
-    'common/lodash',
-    'common/modules/models',
-    'common/models/model',
-    'common/models/group',
-    'common/models/job-role',
-    'common/models/instances/contact-instance',
-    'common/mocks/services/api/contact-mock' // Temporary, necessary to use the mocked API data
+  'common/lodash',
+  'common/modules/models',
+  'common/models/model',
+  'common/models/group',
+  'common/models/job-role',
+  'common/models/instances/contact-instance',
+  'common/mocks/services/api/contact-mock' // Temporary, necessary to use the mocked API data
 ], function (_, models) {
-    'use strict';
+  'use strict';
 
-    models.factory('Contact', [
-        '$q', 'Model', 'api.contact.mock', 'Group', 'JobRole', 'ContactInstance',
-        function ($q, Model, contactAPI, Group, JobRole, instance) {
-            var groupFiltersKeys = ['group_id'];
-            var jobRoleFiltersKeys = ['region', 'department', 'level_type', 'location'];
+  models.factory('Contact', [
+    '$q', 'Model', 'api.contact.mock', 'Group', 'JobRole', 'ContactInstance',
+    function ($q, Model, contactAPI, Group, JobRole, instance) {
+      var groupFiltersKeys = ['group_id'];
+      var jobRoleFiltersKeys = ['region', 'department', 'level_type', 'location'];
 
-            /**
-             * Checks if the given filters object contains filters
-             * related to the foreign models
-             *
-             * @param {object} filters
-             * @param {Array} foreignKeys - The keys that are for foreign models
-             * @return {boolean}
-             */
-            function containsForeignFilters(filters, foreignKeys) {
-                return !_.isEmpty(_.intersection(_.keys(filters), foreignKeys));
-            }
+      /**
+       * Checks if the given filters object contains filters
+       * related to the foreign models
+       *
+       * @param {object} filters
+       * @param {Array} foreignKeys - The keys that are for foreign models
+       * @return {boolean}
+       */
+      function containsForeignFilters (filters, foreignKeys) {
+        return !_.isEmpty(_.intersection(_.keys(filters), foreignKeys));
+      }
 
-            /**
-             * Returns the contact ids of the job roles that match the given filters
-             *
-             * @param {object} filters
-             * @return {Promise} resolve to an array of contact ids
-             */
-            function jobRoleContactids(filters) {
-                return JobRole.all(filters)
-                    .then(function (jobRoles) {
-                        return jobRoles.list.map(function (jobRole) {
-                            return jobRole.contact_id;
-                        })
-                    });
-            }
-
-            /**
-             * Adds the contact ids list to the filters, removing also all foreign
-             * filters belonging to other models
-             *
-             * The final contact ids list is the intersection (that is, an `AND`)
-             * of all the contact ids returned by the foreign models
-             *
-             * @param {object} filters
-             * @param {Array} contactIds
-             *   Coming from different promises (different models), this is
-             *   an array of arrays
-             * @return {object}
-             */
-            function injectContactIdsInFilters(filters, contactIds) {
-                return filters = _(filters)
-                    .omit(groupFiltersKeys)
-                    .omit(jobRoleFiltersKeys)
-                    .assign({
-                        id: { in: _.intersection.apply(null, contactIds) }
-                    })
-                    .value();
-            }
-
-            /**
-             * Processes the filters
-             *
-             * It extracts any given foreign model specific filters, gets the
-             * ids of the contacts linked to models that match those filters,
-             * and then use those ids as an additional filter
-             *
-             * @param {object} filters
-             * @return {Promise} resolves to the processed filters
-             */
-            function processContactFilters(filters) {
-                var deferred = $q.defer();
-                var promises = [];
-
-                filters = this.compactFilters(filters);
-
-                if (containsForeignFilters(filters, jobRoleFiltersKeys)) {
-                    promises.push(jobRoleContactids(_.pick(filters, jobRoleFiltersKeys)));
-                }
-
-                if (containsForeignFilters(filters, groupFiltersKeys)) {
-                    promises.push(Group.contactIdsOf(filters.group_id));
-                }
-
-                if (!_.isEmpty(promises)) {
-                    $q.all(promises)
-                        .then(function (results) {
-                            filters = injectContactIdsInFilters(filters, results);
-
-                            deferred.resolve(this.processFilters(filters));
-                        }.bind(this));
-                } else {
-                    deferred.resolve(this.processFilters(filters));
-                }
-
-                return deferred.promise;
-            }
-
-            return Model.extend({
-
-                /**
-                 * Returns a list of contacts, each converted to a model instance
-                 *
-                 * @param {object} filters - Values the full list should be filtered by
-                 * @param {object} pagination
-                 *   `page` for the current page, `size` for number of items per page
-                 * @return {Promise}
-                 */
-                all: function (filters, pagination) {
-                    return processContactFilters.call(this, filters)
-                        .then(function (filters) {
-                            return contactAPI.all(filters, pagination);
-                        })
-                        .then(function (response) {
-                            response.list = response.list.map(function (contact) {
-                                return instance.init(contact, true);
-                            });
-
-                            return response;
-                        });
-                },
-
-                /**
-                 * Finds a contact by id
-                 *
-                 * @param {string} id
-                 * @return {Promise} - Resolves with found contact
-                 */
-                find: function (id) {
-                    return contactAPI.find(id).then(function (contact) {
-                        return instance.init(contact, true);
-                    });
-                },
+      /**
+       * Returns the contact ids of the job roles that match the given filters
+       *
+       * @param {object} filters
+       * @return {Promise} resolve to an array of contact ids
+       */
+      function jobRoleContactids (filters) {
+        return JobRole.all(filters)
+          .then(function (jobRoles) {
+            return jobRoles.list.map(function (jobRole) {
+              return jobRole.contact_id;
             });
+          });
+      }
+
+      /**
+       * Adds the contact ids list to the filters, removing also all foreign
+       * filters belonging to other models
+       *
+       * The final contact ids list is the intersection (that is, an `AND`)
+       * of all the contact ids returned by the foreign models
+       *
+       * @param {object} filters
+       * @param {Array} contactIds
+       *   Coming from different promises (different models), this is
+       *   an array of arrays
+       * @return {object}
+       */
+      function injectContactIdsInFilters (filters, contactIds) {
+        filters = _(filters)
+          .omit(groupFiltersKeys)
+          .omit(jobRoleFiltersKeys)
+          .assign({
+            id: {in: _.intersection.apply(null, contactIds)}
+          })
+          .value();
+
+        return filters;
+      }
+
+      /**
+       * Processes the filters
+       *
+       * It extracts any given foreign model specific filters, gets the
+       * ids of the contacts linked to models that match those filters,
+       * and then use those ids as an additional filter
+       *
+       * @param {object} filters
+       * @return {Promise} resolves to the processed filters
+       */
+      function processContactFilters (filters) {
+        var deferred = $q.defer();
+        var promises = [];
+
+        filters = this.compactFilters(filters);
+
+        if (containsForeignFilters(filters, jobRoleFiltersKeys)) {
+          promises.push(jobRoleContactids(_.pick(filters, jobRoleFiltersKeys)));
         }
-    ]);
-})
-;
+
+        if (containsForeignFilters(filters, groupFiltersKeys)) {
+          promises.push(Group.contactIdsOf(filters.group_id));
+        }
+
+        if (!_.isEmpty(promises)) {
+          $q.all(promises)
+            .then(function (results) {
+              filters = injectContactIdsInFilters(filters, results);
+
+              deferred.resolve(this.processFilters(filters));
+            }.bind(this));
+        } else {
+          deferred.resolve(this.processFilters(filters));
+        }
+
+        return deferred.promise;
+      }
+
+      return Model.extend({
+
+        /**
+         * Returns a list of contacts, each converted to a model instance
+         *
+         * @param {object} filters - Values the full list should be filtered by
+         * @param {object} pagination
+         *   `page` for the current page, `size` for number of items per page
+         * @return {Promise}
+         */
+        all: function (filters, pagination) {
+          return processContactFilters.call(this, filters)
+            .then(function (filters) {
+              return contactAPI.all(filters, pagination);
+            })
+            .then(function (response) {
+              response.list = response.list.map(function (contact) {
+                return instance.init(contact, true);
+              });
+
+              return response;
+            });
+        },
+
+        /**
+         * Finds a contact by id
+         *
+         * @param {string} id
+         * @return {Promise} - Resolves with found contact
+         */
+        find: function (id) {
+          return contactAPI.find(id).then(function (contact) {
+            return instance.init(contact, true);
+          });
+        }
+      });
+    }
+  ]);
+});
+
 define('common/models/option-group',[
     'common/modules/models',
     'common/models/model',

--- a/org.civicrm.reqangular/src/common/models/contact.js
+++ b/org.civicrm.reqangular/src/common/models/contact.js
@@ -1,144 +1,147 @@
+/* eslint-env amd */
 define([
-    'common/lodash',
-    'common/modules/models',
-    'common/models/model',
-    'common/models/group',
-    'common/models/job-role',
-    'common/models/instances/contact-instance',
-    'common/mocks/services/api/contact-mock' // Temporary, necessary to use the mocked API data
+  'common/lodash',
+  'common/modules/models',
+  'common/models/model',
+  'common/models/group',
+  'common/models/job-role',
+  'common/models/instances/contact-instance',
+  'common/mocks/services/api/contact-mock' // Temporary, necessary to use the mocked API data
 ], function (_, models) {
-    'use strict';
+  'use strict';
 
-    models.factory('Contact', [
-        '$q', 'Model', 'api.contact.mock', 'Group', 'JobRole', 'ContactInstance',
-        function ($q, Model, contactAPI, Group, JobRole, instance) {
-            var groupFiltersKeys = ['group_id'];
-            var jobRoleFiltersKeys = ['region', 'department', 'level_type', 'location'];
+  models.factory('Contact', [
+    '$q', 'Model', 'api.contact.mock', 'Group', 'JobRole', 'ContactInstance',
+    function ($q, Model, contactAPI, Group, JobRole, instance) {
+      var groupFiltersKeys = ['group_id'];
+      var jobRoleFiltersKeys = ['region', 'department', 'level_type', 'location'];
 
-            /**
-             * Checks if the given filters object contains filters
-             * related to the foreign models
-             *
-             * @param {object} filters
-             * @param {Array} foreignKeys - The keys that are for foreign models
-             * @return {boolean}
-             */
-            function containsForeignFilters(filters, foreignKeys) {
-                return !_.isEmpty(_.intersection(_.keys(filters), foreignKeys));
-            }
+      /**
+       * Checks if the given filters object contains filters
+       * related to the foreign models
+       *
+       * @param {object} filters
+       * @param {Array} foreignKeys - The keys that are for foreign models
+       * @return {boolean}
+       */
+      function containsForeignFilters (filters, foreignKeys) {
+        return !_.isEmpty(_.intersection(_.keys(filters), foreignKeys));
+      }
 
-            /**
-             * Returns the contact ids of the job roles that match the given filters
-             *
-             * @param {object} filters
-             * @return {Promise} resolve to an array of contact ids
-             */
-            function jobRoleContactids(filters) {
-                return JobRole.all(filters)
-                    .then(function (jobRoles) {
-                        return jobRoles.list.map(function (jobRole) {
-                            return jobRole.contact_id;
-                        })
-                    });
-            }
-
-            /**
-             * Adds the contact ids list to the filters, removing also all foreign
-             * filters belonging to other models
-             *
-             * The final contact ids list is the intersection (that is, an `AND`)
-             * of all the contact ids returned by the foreign models
-             *
-             * @param {object} filters
-             * @param {Array} contactIds
-             *   Coming from different promises (different models), this is
-             *   an array of arrays
-             * @return {object}
-             */
-            function injectContactIdsInFilters(filters, contactIds) {
-                return filters = _(filters)
-                    .omit(groupFiltersKeys)
-                    .omit(jobRoleFiltersKeys)
-                    .assign({
-                        id: { in: _.intersection.apply(null, contactIds) }
-                    })
-                    .value();
-            }
-
-            /**
-             * Processes the filters
-             *
-             * It extracts any given foreign model specific filters, gets the
-             * ids of the contacts linked to models that match those filters,
-             * and then use those ids as an additional filter
-             *
-             * @param {object} filters
-             * @return {Promise} resolves to the processed filters
-             */
-            function processContactFilters(filters) {
-                var deferred = $q.defer();
-                var promises = [];
-
-                filters = this.compactFilters(filters);
-
-                if (containsForeignFilters(filters, jobRoleFiltersKeys)) {
-                    promises.push(jobRoleContactids(_.pick(filters, jobRoleFiltersKeys)));
-                }
-
-                if (containsForeignFilters(filters, groupFiltersKeys)) {
-                    promises.push(Group.contactIdsOf(filters.group_id));
-                }
-
-                if (!_.isEmpty(promises)) {
-                    $q.all(promises)
-                        .then(function (results) {
-                            filters = injectContactIdsInFilters(filters, results);
-
-                            deferred.resolve(this.processFilters(filters));
-                        }.bind(this));
-                } else {
-                    deferred.resolve(this.processFilters(filters));
-                }
-
-                return deferred.promise;
-            }
-
-            return Model.extend({
-
-                /**
-                 * Returns a list of contacts, each converted to a model instance
-                 *
-                 * @param {object} filters - Values the full list should be filtered by
-                 * @param {object} pagination
-                 *   `page` for the current page, `size` for number of items per page
-                 * @return {Promise}
-                 */
-                all: function (filters, pagination) {
-                    return processContactFilters.call(this, filters)
-                        .then(function (filters) {
-                            return contactAPI.all(filters, pagination);
-                        })
-                        .then(function (response) {
-                            response.list = response.list.map(function (contact) {
-                                return instance.init(contact, true);
-                            });
-
-                            return response;
-                        });
-                },
-
-                /**
-                 * Finds a contact by id
-                 *
-                 * @param {string} id
-                 * @return {Promise} - Resolves with found contact
-                 */
-                find: function (id) {
-                    return contactAPI.find(id).then(function (contact) {
-                        return instance.init(contact, true);
-                    });
-                },
+      /**
+       * Returns the contact ids of the job roles that match the given filters
+       *
+       * @param {object} filters
+       * @return {Promise} resolve to an array of contact ids
+       */
+      function jobRoleContactids (filters) {
+        return JobRole.all(filters)
+          .then(function (jobRoles) {
+            return jobRoles.list.map(function (jobRole) {
+              return jobRole.contact_id;
             });
+          });
+      }
+
+      /**
+       * Adds the contact ids list to the filters, removing also all foreign
+       * filters belonging to other models
+       *
+       * The final contact ids list is the intersection (that is, an `AND`)
+       * of all the contact ids returned by the foreign models
+       *
+       * @param {object} filters
+       * @param {Array} contactIds
+       *   Coming from different promises (different models), this is
+       *   an array of arrays
+       * @return {object}
+       */
+      function injectContactIdsInFilters (filters, contactIds) {
+        filters = _(filters)
+          .omit(groupFiltersKeys)
+          .omit(jobRoleFiltersKeys)
+          .assign({
+            id: {in: _.intersection.apply(null, contactIds)}
+          })
+          .value();
+
+        return filters;
+      }
+
+      /**
+       * Processes the filters
+       *
+       * It extracts any given foreign model specific filters, gets the
+       * ids of the contacts linked to models that match those filters,
+       * and then use those ids as an additional filter
+       *
+       * @param {object} filters
+       * @return {Promise} resolves to the processed filters
+       */
+      function processContactFilters (filters) {
+        var deferred = $q.defer();
+        var promises = [];
+
+        filters = this.compactFilters(filters);
+
+        if (containsForeignFilters(filters, jobRoleFiltersKeys)) {
+          promises.push(jobRoleContactids(_.pick(filters, jobRoleFiltersKeys)));
         }
-    ]);
-})
+
+        if (containsForeignFilters(filters, groupFiltersKeys)) {
+          promises.push(Group.contactIdsOf(filters.group_id));
+        }
+
+        if (!_.isEmpty(promises)) {
+          $q.all(promises)
+            .then(function (results) {
+              filters = injectContactIdsInFilters(filters, results);
+
+              deferred.resolve(this.processFilters(filters));
+            }.bind(this));
+        } else {
+          deferred.resolve(this.processFilters(filters));
+        }
+
+        return deferred.promise;
+      }
+
+      return Model.extend({
+
+        /**
+         * Returns a list of contacts, each converted to a model instance
+         *
+         * @param {object} filters - Values the full list should be filtered by
+         * @param {object} pagination
+         *   `page` for the current page, `size` for number of items per page
+         * @return {Promise}
+         */
+        all: function (filters, pagination) {
+          return processContactFilters.call(this, filters)
+            .then(function (filters) {
+              return contactAPI.all(filters, pagination);
+            })
+            .then(function (response) {
+              response.list = response.list.map(function (contact) {
+                return instance.init(contact, true);
+              });
+
+              return response;
+            });
+        },
+
+        /**
+         * Finds a contact by id
+         *
+         * @param {string} id
+         * @return {Promise} - Resolves with found contact
+         */
+        find: function (id) {
+          return contactAPI.find(id).then(function (contact) {
+            return instance.init(contact, true);
+          });
+        }
+      });
+    }
+  ]);
+});

--- a/org.civicrm.reqangular/src/common/models/contact.js
+++ b/org.civicrm.reqangular/src/common/models/contact.js
@@ -57,15 +57,13 @@ define([
        * @return {object}
        */
       function injectContactIdsInFilters (filters, contactIds) {
-        filters = _(filters)
+        return _(filters)
           .omit(groupFiltersKeys)
           .omit(jobRoleFiltersKeys)
           .assign({
             id: {in: _.intersection.apply(null, contactIds)}
           })
           .value();
-
-        return filters;
       }
 
       /**

--- a/org.civicrm.reqangular/src/common/services/api.js
+++ b/org.civicrm.reqangular/src/common/services/api.js
@@ -85,9 +85,8 @@ define([
           }.bind(this))(),
           (function () {
             var params = _.assign({}, filters, { 'return': 'id' });
-            params = _.omit(params, function (value, key) {
-              return key.startsWith('api.');
-            });
+            // Removing chained calls, they are not necessary for getting the count
+            params = _.omit(params, function (__, key) { return _.startsWith(key, 'api.'); });
 
             return this.sendGET(entity, action, params, cache);
           }.bind(this))()

--- a/org.civicrm.reqangular/src/common/services/api.js
+++ b/org.civicrm.reqangular/src/common/services/api.js
@@ -1,3 +1,4 @@
+/* eslint-env amd */
 define([
   'common/angular',
   'common/lodash',
@@ -16,7 +17,7 @@ define([
      * @param {object} response - response from backend
      * @return {Promise/Any}
      */
-    function responseHandler(response) {
+    function responseHandler (response) {
       if (!!response.data.is_error) {
         $log.error(response.data);
 
@@ -26,7 +27,7 @@ define([
       return response.data;
     }
 
-    function prepareParams(params) {
+    function prepareParams (params) {
       var defaults = {
         options: { limit: 0 }
       };
@@ -84,6 +85,9 @@ define([
           }.bind(this))(),
           (function () {
             var params = _.assign({}, filters, { 'return': 'id' });
+            params = _.omit(params, function (value, key) {
+              return key.startsWith('api.');
+            });
 
             return this.sendGET(entity, action, params, cache);
           }.bind(this))()


### PR DESCRIPTION
## Overview
Remove chained API calls from base `API`while getting count of total number of records.

## Technical Details
1. In Base API's `getAll()` the same API call is made twice, 1st call is made only to get specific no of records according to pagination setup, and the 2nd call is made to get all the data to determine no of pages for `pagination`. The 2nd call does not need to have the chained API calls as it only cares about total no of records and not the actual data. So removing the chained API calls will improve performance.
```javascript
_.omit(params, function (__, key) { return _.startsWith(key, 'api.'); });
```
---

- [x] Tests Pass
