### PR TITLE
PCHR-2275: Modify Leave And Absence Alerts To Conform to What is in WireFrame

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -412,7 +412,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
       'end_date' => $toDate->format('Y-m-d'),
     ]);
 
-    if ($contract['count'] > 1) {
+    $contractForEndDate = civicrm_api3('HRJobContract', 'getcontractswithdetailsinperiod', [
+      'contact_id' => $params['contact_id'],
+      'start_date' => $toDate->format('Y-m-d'),
+      'end_date' => $toDate->format('Y-m-d'),
+    ]);
+
+    if ($contract['count'] > 1 || $contractForEndDate['count'] != 1) {
       throw new InvalidLeaveRequestException(
         'This leave request is after your contract end date. Please modify dates of this request',
         'leave_request_overlapping_multiple_contracts',

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -251,7 +251,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
 
     if ($leaveDatesHasPastDates && !$absenceType->allow_accrue_in_the_past) {
       throw new InvalidLeaveRequestException(
-        'You may only request TOIL for Overtime to be worked in the future. Please modify the date of this request',
+        'You may only request TOIL for overtime to be worked in the future. Please modify the date of this request',
         'leave_request_toil_cannot_be_requested_for_past_days',
         'from_date'
       );
@@ -406,19 +406,19 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     $fromDate = new DateTime($params['from_date']);
     $toDate = new DateTime($params['to_date']);
 
-    $contract = civicrm_api3('HRJobContract', 'getcontractswithdetailsinperiod', [
+    $contractsContainingToOrFromDates = civicrm_api3('HRJobContract', 'getcontractswithdetailsinperiod', [
       'contact_id' => $params['contact_id'],
       'start_date' => $fromDate->format('Y-m-d'),
       'end_date' => $toDate->format('Y-m-d'),
     ]);
 
-    $contractForEndDate = civicrm_api3('HRJobContract', 'getcontractswithdetailsinperiod', [
+    $contractsContainingEndDate = civicrm_api3('HRJobContract', 'getcontractswithdetailsinperiod', [
       'contact_id' => $params['contact_id'],
       'start_date' => $toDate->format('Y-m-d'),
       'end_date' => $toDate->format('Y-m-d'),
     ]);
 
-    if ($contract['count'] > 1 || $contractForEndDate['count'] != 1) {
+    if ($contractsContainingToOrFromDates['count'] > 1 || $contractsContainingEndDate['count'] != 1) {
       throw new InvalidLeaveRequestException(
         'This leave request is after your contract end date. Please modify dates of this request',
         'leave_request_overlapping_multiple_contracts',
@@ -597,7 +597,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     $intervalInDays = $interval->format("%a");
     $maxConsecutiveLeaveDays = $absenceType->max_consecutive_leave_days;
 
-    if (!empty($maxConsecutiveLeaveDays) && $intervalInDays > $absenceType->max_consecutive_leave_days) {
+    if (!empty($maxConsecutiveLeaveDays) && $intervalInDays > $maxConsecutiveLeaveDays) {
       throw new InvalidLeaveRequestException(
         'Only a maximum '. $maxConsecutiveLeaveDays .' days leave can be taken in one request. Please modify days of this request',
         'leave_request_days_greater_than_max_consecutive_days',

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -251,7 +251,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
 
     if ($leaveDatesHasPastDates && !$absenceType->allow_accrue_in_the_past) {
       throw new InvalidLeaveRequestException(
-        'You cannot request TOIL for past days',
+        'You may only request TOIL for Overtime to be worked in the future. Please modify the date of this request',
         'leave_request_toil_cannot_be_requested_for_past_days',
         'from_date'
       );
@@ -296,9 +296,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
       }
     }
 
-    if ($totalProjectedToilForPeriod > $absenceType->max_leave_accrual && !$unlimitedAccrual) {
+    $maxLeaveAccrual = $absenceType->max_leave_accrual;
+    if ($totalProjectedToilForPeriod > $maxLeaveAccrual && !$unlimitedAccrual) {
       throw new InvalidLeaveRequestException(
-        'The TOIL amount plus all approved TOIL for current period is greater than the maximum for this Absence Type',
+        'The maximum amount of leave that you can accrue is '. $maxLeaveAccrual .' days. Please modify the dates of this request',
         'leave_request_toil_amount_more_than_maximum_for_absence_type',
         'toil_to_accrue'
       );
@@ -413,7 +414,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
 
     if ($contract['count'] > 1) {
       throw new InvalidLeaveRequestException(
-        'The Leave request dates must not have dates in more than one contract period',
+        'This leave request is after your contract end date. Please modify dates of this request',
         'leave_request_overlapping_multiple_contracts',
         'from_date'
       );
@@ -447,7 +448,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
 
     if(!$absenceType->allow_overuse && $leaveRequestBalance > $currentBalance) {
       throw new InvalidLeaveRequestException(
-        'Balance change for the leave request cannot be greater than the remaining balance of the period',
+        'There are only '. $currentBalance .' days leave available. This request cannot be made or approved',
         'leave_request_balance_change_greater_than_remaining_balance',
         'type_id'
       );
@@ -542,7 +543,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
 
     if ($overlappingLeaveRequests) {
       throw new InvalidLeaveRequestException(
-        'This Leave request has dates that overlaps with an existing leave request',
+        'This leave request overlaps with another request. Please modify dates of this request',
         'leave_request_overlaps_another_leave_request',
         'from_date'
       );
@@ -588,10 +589,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
 
     $interval = $toDate->diff($fromDate);
     $intervalInDays = $interval->format("%a");
+    $maxConsecutiveLeaveDays = $absenceType->max_consecutive_leave_days;
 
-    if (!empty($absenceType->max_consecutive_leave_days) && $intervalInDays > $absenceType->max_consecutive_leave_days) {
+    if (!empty($maxConsecutiveLeaveDays) && $intervalInDays > $absenceType->max_consecutive_leave_days) {
       throw new InvalidLeaveRequestException(
-        'Leave Request days cannot be greater than maximum consecutive days for absence type',
+        'Only a maximum '. $maxConsecutiveLeaveDays .' days leave can be taken in one request. Please modify days of this request',
         'leave_request_days_greater_than_max_consecutive_days',
         'type_id'
       );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -395,7 +395,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
   }
 
   /**
-   * This method validates that the leave request does not overlapp
+   * This method validates that the leave request does not overlap
    * contracts with lapses in between any of the contract periods.
    *
    * @param array $params
@@ -421,7 +421,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
           new DateTime($nextContract['period_start_date'])
         );
 
-        $contractToCompare =  $nextContract;
+        $contractToCompare = $nextContract;
 
         if($intervalInDays > 1) {
           throw new InvalidLeaveRequestException(

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -403,7 +403,7 @@ function civicrm_api3_leave_request_isvalid($params) {
     CRM_HRLeaveAndAbsences_BAO_LeaveRequest::validateParams($params);
   }
   catch (CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException $e) {
-    $result[$e->getField()] = [$e->getExceptionCode()];
+    $result[$e->getField()] = [ts($e->getMessage())];
   }
 
   $results =  civicrm_api3_create_success($result);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -139,6 +139,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
     ]);
 
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => 1],
+      ['period_start_date' => '2016-01-01']
+    );
+
     $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
       'type_id' => $this->absenceType->id,
       'contact_id' => 1,
@@ -1156,6 +1161,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
     ]);
 
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contactID],
+      ['period_start_date' => '2016-01-01']
+    );
+
     $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
       'type_id' => $this->absenceType->id,
       'contact_id' => $contactID,
@@ -1199,6 +1209,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
     ]);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contactID],
+      ['period_start_date' => '2016-01-01']
+    );
 
     $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
       'type_id' => $this->absenceType->id,
@@ -2410,6 +2425,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'end_date' => CRM_Utils_Date::processDate('+15 days'),
     ]);
 
+    $contactID = 1;
+    $periodStartDate = new DateTime('-2 days');
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contactID],
+      ['period_start_date' => $periodStartDate->format('Y-m-d')]
+    );
+
     $absenceType = AbsenceTypeFabricator::fabricate([
       'title' => 'Type 1',
       'allow_accruals_request' => true,
@@ -2424,7 +2446,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     $params = [
       'type_id' => $absenceType->id,
-      'contact_id' => 1,
+      'contact_id' => $contactID,
       'toil_to_accrue'=> 2,
       'from_date' => CRM_Utils_Date::processDate('monday'),
       'to_date' => CRM_Utils_Date::processDate('monday'),
@@ -2455,6 +2477,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testToilCanBeAccruedWhenUpdatingApprovedToilWithAToilAmountLesserThanWhatWasInitiallyApprovedAndTotalToilToBeAccruedIsNotGreaterThanMaximumForTheAbsenceType() {
+    $contactID = 1;
     $period = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-1 day'),
       'end_date' => CRM_Utils_Date::processDate('+15 days'),
@@ -2466,9 +2489,15 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'max_leave_accrual' => 5
     ]);
 
+    $periodStartDate = new DateTime('-2 days');
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contactID],
+      ['period_start_date' => $periodStartDate->format('Y-m-d')]
+    );
+
     $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
       'type_id' => $absenceType->id,
-      'contact_id' => 1,
+      'contact_id' => $contactID,
       'period_id' => $period->id
     ]);
 
@@ -2505,6 +2534,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testToilCanBeAccruedWhenUpdatingApprovedToilWithAToilAmountSameAsWhatWasInitiallyApprovedAndTotalToilToBeAccruedIsNotGreaterThanMaximumForTheAbsenceType() {
+    $contactID = 1;
     $period = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-1 day'),
       'end_date' => CRM_Utils_Date::processDate('+15 days'),
@@ -2516,9 +2546,15 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'max_leave_accrual' => 5
     ]);
 
+    $periodStartDate = new DateTime('-5 days');
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contactID],
+      ['period_start_date' => $periodStartDate->format('Y-m-d')]
+    );
+
     $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
       'type_id' => $absenceType->id,
-      'contact_id' => 1,
+      'contact_id' => $contactID,
       'period_id' => $period->id
     ]);
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -1906,7 +1906,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
   /**
    * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
-   * @expectedExceptionMessage You may only request TOIL for Overtime to be worked in the future. Please modify the date of this request
+   * @expectedExceptionMessage You may only request TOIL for overtime to be worked in the future. Please modify the date of this request
    */
   public function testLeaveRequestCanNotBeCreatedWhenRequestTypeIsToilAndDatesAreInThePastAndAbsenceTypeDoesNotAllow() {
     AbsencePeriodFabricator::fabricate([

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -1687,11 +1687,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     ]);
 
     $this->createLeaveBalanceChange($periodEntitlement->id, 30);
-    $periodStartDate1 = date('2016-01-01');
-    $periodEndDate1 = date('2016-06-30');
+    $periodStartDate1 = '2016-01-01';
+    $periodEndDate1 = '2016-06-30';
 
-    $periodStartDate2 = date('2016-07-02');
-    $periodEndDate2 = date('2016-07-31');
+    $periodStartDate2 = '2016-07-02';
+    $periodEndDate2 = '2016-07-31';
 
     HRJobContractFabricator::fabricate(
       ['contact_id' => $periodEntitlement->contact_id],
@@ -1746,13 +1746,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     ]);
 
     $this->createLeaveBalanceChange($periodEntitlement->id, 30);
-    $periodStartDate1 = date('2016-06-01');
-    $periodEndDate1 = date('2016-06-08');
+    $periodStartDate1 = '2016-06-01';
+    $periodEndDate1 = '2016-06-08';
 
-    $periodStartDate2 = date('2016-06-09');
-    $periodEndDate2 = date('2016-06-12');
+    $periodStartDate2 = '2016-06-09';
+    $periodEndDate2 = '2016-06-12';
 
-    $periodStartDate3 = date('2016-06-14');
+    $periodStartDate3 = '2016-06-14';
 
     HRJobContractFabricator::fabricate(
       ['contact_id' => $periodEntitlement->contact_id],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -1925,7 +1925,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $params = $this->mergeWithDefaultLeaveRequestParams(['from_date' => '']);
     $result = civicrm_api3('LeaveRequest', 'isvalid', $params);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('from_date', 'leave_request_empty_from_date');
+    $errorMessage = 'The from_date field should not be empty';
+    $expectedResult = $this->getExpectedArrayForIsValidError('from_date', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -1933,7 +1934,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $params = $this->mergeWithDefaultLeaveRequestParams(['contact_id' => '']);
     $result = civicrm_api3('LeaveRequest', 'isvalid', $params);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('contact_id', 'leave_request_empty_contact_id');
+    $errorMessage = 'The contact_id field should not be empty';
+    $expectedResult = $this->getExpectedArrayForIsValidError('contact_id', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -1941,7 +1943,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $params = $this->mergeWithDefaultLeaveRequestParams(['type_id' => '']);
     $result = civicrm_api3('LeaveRequest', 'isvalid', $params);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('type_id', 'leave_request_empty_type_id');
+    $errorMessage = 'The type_id field should not be empty';
+    $expectedResult = $this->getExpectedArrayForIsValidError('type_id', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -1949,7 +1952,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $params = $this->mergeWithDefaultLeaveRequestParams(['status_id' => '']);
     $result = civicrm_api3('LeaveRequest', 'isvalid', $params);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('status_id', 'leave_request_empty_status_id');
+    $errorMessage = 'The status_id field should not be empty';
+    $expectedResult = $this->getExpectedArrayForIsValidError('status_id', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -1957,7 +1961,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $params = $this->mergeWithDefaultLeaveRequestParams(['to_date_type' => '']);
     $result = civicrm_api3('LeaveRequest', 'isvalid', $params);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('to_date_type', 'leave_request_empty_to_date_type');
+    $errorMessage = 'The to_date_type field should not be empty';
+    $expectedResult = $this->getExpectedArrayForIsValidError('to_date_type', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -1965,7 +1970,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $params = $this->mergeWithDefaultLeaveRequestParams(['request_type' => '']);
     $result = civicrm_api3('LeaveRequest', 'isvalid', $params);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('request_type', 'leave_request_empty_request_type');
+    $errorMessage = 'The request_type field should not be empty';
+    $expectedResult = $this->getExpectedArrayForIsValidError('request_type', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -1973,7 +1979,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $params = $this->mergeWithDefaultLeaveRequestParams(['request_type' => 'fdasfdasfdsafdsafdsafsda' . microtime()]);
     $result = civicrm_api3('LeaveRequest', 'isvalid', $params);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('request_type', 'leave_request_invalid_request_type');
+    $errorMessage = 'The request_type is invalid';
+    $expectedResult = $this->getExpectedArrayForIsValidError('request_type', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -1981,7 +1988,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $params = $this->mergeWithDefaultTOILRequestParams(['toil_duration' => '', 'toil_to_accrue' => 1]);
     $result = civicrm_api3('LeaveRequest', 'isvalid', $params);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('toil_duration', 'leave_request_empty_toil_duration');
+    $errorMessage = 'The toil_duration can not be empty when request_type is toil';
+    $expectedResult = $this->getExpectedArrayForIsValidError('toil_duration', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -1989,7 +1997,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $params = $this->mergeWithDefaultTOILRequestParams(['toil_to_accrue' => '']);
     $result = civicrm_api3('LeaveRequest', 'isvalid', $params);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('toil_to_accrue', 'leave_request_empty_toil_to_accrue');
+    $errorMessage = 'The toil_to_accrue can not be empty when request_type is toil';
+    $expectedResult = $this->getExpectedArrayForIsValidError('toil_to_accrue', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -1997,7 +2006,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $params = $this->mergeWithDefaultLeaveRequestParams(['toil_duration' => '1']);
     $result = civicrm_api3('LeaveRequest', 'isvalid', $params);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('toil_duration', 'leave_request_non_empty_toil_duration');
+    $errorMessage = 'The toil_duration should be empty when request_type is not toil';
+    $expectedResult = $this->getExpectedArrayForIsValidError('toil_duration', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -2005,7 +2015,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $params = $this->mergeWithDefaultLeaveRequestParams(['toil_to_accrue' => '1']);
     $result = civicrm_api3('LeaveRequest', 'isvalid', $params);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('toil_to_accrue', 'leave_request_non_empty_toil_to_accrue');
+    $errorMessage = 'The toil_to_accrue should be empty when request_type is not toil';
+    $expectedResult = $this->getExpectedArrayForIsValidError('toil_to_accrue', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -2013,7 +2024,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $params = $this->mergeWithDefaultLeaveRequestParams(['toil_expiry_date' => '2016-01-01']);
     $result = civicrm_api3('LeaveRequest', 'isvalid', $params);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('toil_expiry_date', 'leave_request_non_empty_toil_expiry_date');
+    $errorMessage = 'The toil_expiry_date should be empty when request_type is not toil';
+    $expectedResult = $this->getExpectedArrayForIsValidError('toil_expiry_date', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -2021,7 +2033,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $params = $this->mergeWithDefaultSicknessRequestParams(['sickness_reason' => '']);
     $result = civicrm_api3('LeaveRequest', 'isvalid', $params);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('sickness_reason', 'leave_request_empty_sickness_reason');
+    $errorMessage = 'The sickness_reason can not be empty when request_type is sickness';
+    $expectedResult = $this->getExpectedArrayForIsValidError('sickness_reason', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -2029,7 +2042,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $params = $this->mergeWithDefaultLeaveRequestParams(['sickness_reason' => '1']);
     $result = civicrm_api3('LeaveRequest', 'isvalid', $params);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('sickness_reason', 'leave_request_non_empty_sickness_reason');
+    $errorMessage = 'The sickness_reason should be empty when request_type is not sickness';
+    $expectedResult = $this->getExpectedArrayForIsValidError('sickness_reason', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -2037,9 +2051,10 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $params = $this->mergeWithDefaultLeaveRequestParams(['sickness_required_documents' => '1']);
     $result = civicrm_api3('LeaveRequest', 'isvalid', $params);
 
+    $errorMessage = 'The sickness_required_documents should be empty when request_type is not sickness';
     $expectedResult = $this->getExpectedArrayForIsValidError(
       'sickness_required_documents',
-      'leave_request_non_empty_sickness_required_documents'
+      $errorMessage
     );
     $this->assertEquals($expectedResult, $result);
   }
@@ -2052,7 +2067,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ]);
     $result = civicrm_api3('LeaveRequest', 'isvalid', $params);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('from_date', 'leave_request_from_date_greater_than_end_date');
+    $errorMessage = 'Leave Request start date cannot be greater than the end date';
+    $expectedResult = $this->getExpectedArrayForIsValidError('from_date', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -2063,7 +2079,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ]);
     $result = civicrm_api3('LeaveRequest', 'isvalid', $params);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('is_deleted', 'leave_request_cannot_be_soft_deleted');
+    $errorMessage = 'Leave Request can not be soft deleted during an update, use the delete method instead!';
+    $expectedResult = $this->getExpectedArrayForIsValidError('is_deleted', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -2103,7 +2120,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ]);
     $result = civicrm_api3('LeaveRequest', 'isvalid', $params);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('from_date', 'leave_request_overlaps_another_leave_request');
+    $errorMessage = 'This leave request overlaps with another request. Please modify dates of this request';
+    $expectedResult = $this->getExpectedArrayForIsValidError('from_date', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -2124,7 +2142,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'period_id' => $period->id
     ]);
 
-    $this->createLeaveBalanceChange($periodEntitlement->id, 3);
+    $entitlementBalanceChange = 3;
+    $this->createLeaveBalanceChange($periodEntitlement->id, $entitlementBalanceChange);
     $periodStartDate = date('2016-01-01');
 
     HRJobContractFabricator::fabricate(
@@ -2154,7 +2173,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
     ]);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('type_id', 'leave_request_balance_change_greater_than_remaining_balance');
+    $errorMessage =  'There are only '. $entitlementBalanceChange .' days leave available. This request cannot be made or approved';
+    $expectedResult = $this->getExpectedArrayForIsValidError('type_id', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -2203,7 +2223,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
     ]);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('from_date', 'leave_request_doesnt_have_working_day');
+    $errorMessage = 'Leave Request must have at least one working day to be created';
+    $expectedResult = $this->getExpectedArrayForIsValidError('from_date', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -2230,7 +2251,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
     ]);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('from_date', 'leave_request_not_within_absence_period');
+    $errorMessage = 'The Leave request dates are not contained within a valid absence period';
+    $expectedResult = $this->getExpectedArrayForIsValidError('from_date', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -2292,7 +2314,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
     ]);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('from_date', 'leave_request_overlapping_multiple_contracts');
+    $errorMessage = 'This leave request is after your contract end date. Please modify dates of this request';
+    $expectedResult = $this->getExpectedArrayForIsValidError('from_date', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -2315,7 +2338,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
     ]);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('type_id', 'leave_request_absence_type_not_active');
+    $errorMessage = 'Absence Type is not active';
+    $expectedResult = $this->getExpectedArrayForIsValidError('type_id', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -2339,7 +2363,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
     ]);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('type_id', 'leave_request_invalid_toil_absence_type');
+    $errorMessage = 'This absence type does not allow TOIL requests';
+    $expectedResult = $this->getExpectedArrayForIsValidError('type_id', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -2362,13 +2387,15 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_SICKNESS
     ]);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('type_id', 'leave_request_invalid_sickness_absence_type');
+    $errorMessage = 'This absence type does not allow sickness requests';
+    $expectedResult = $this->getExpectedArrayForIsValidError('type_id', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
   public function testLeaveRequestIsValidShouldReturnErrorWhenLeaveDaysIsGreaterThanAbsenceTypeMaxConsecutiveLeaveDays() {
+    $maxConsecutiveLeaveDays = 2;
     $absenceType = AbsenceTypeFabricator::fabricate([
-      'max_consecutive_leave_days' => 2
+      'max_consecutive_leave_days' => $maxConsecutiveLeaveDays
     ]);
 
     $fromDate = new DateTime();
@@ -2384,7 +2411,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
     ]);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('type_id', 'leave_request_days_greater_than_max_consecutive_days');
+    $errorMessage = 'Only a maximum '. $maxConsecutiveLeaveDays .' days leave can be taken in one request. Please modify days of this request';
+    $expectedResult = $this->getExpectedArrayForIsValidError('type_id', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -2423,7 +2451,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
     ]);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('type_id', 'leave_request_absence_type_disallows_cancellation');
+    $errorMessage = 'Absence Type does not allow leave request cancellation';
+    $expectedResult = $this->getExpectedArrayForIsValidError('type_id', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -2462,7 +2491,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
     ]);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('type_id', 'leave_request_past_days_cannot_be_cancelled');
+    $errorMessage = 'Leave Request with past days cannot be cancelled';
+    $expectedResult = $this->getExpectedArrayForIsValidError('type_id', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -2486,7 +2516,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
     ]);
 
-    $expectedResult = $this->getExpectedArrayForIsValidError('toil_to_accrue', 'leave_request_toil_to_accrue_is_invalid');
+    $errorMessage = 'The TOIL to accrue amount is not valid';
+    $expectedResult = $this->getExpectedArrayForIsValidError('toil_to_accrue', $errorMessage);
     $this->assertEquals($expectedResult, $result);
   }
 
@@ -2513,9 +2544,10 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
     ]);
 
+    $errorMessage = 'You may only request TOIL for Overtime to be worked in the future. Please modify the date of this request';
     $expectedResult = $this->getExpectedArrayForIsValidError(
       'from_date',
-      'leave_request_toil_cannot_be_requested_for_past_days'
+      $errorMessage
     );
     $this->assertEquals($expectedResult, $result);
   }
@@ -2526,9 +2558,10 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'end_date'   => CRM_Utils_Date::processDate('+100 days'),
     ]);
 
+    $maxLeaveAccrual = 1;
     $absenceType = AbsenceTypeFabricator::fabricate([
       'allow_accruals_request' => true,
-      'max_leave_accrual' => 1,
+      'max_leave_accrual' => $maxLeaveAccrual,
     ]);
 
     $result = civicrm_api3('LeaveRequest', 'isValid', [
@@ -2544,9 +2577,10 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
     ]);
 
+    $errorMessage = 'The maximum amount of leave that you can accrue is '. $maxLeaveAccrual .' days. Please modify the dates of this request';
     $expectedResult = $this->getExpectedArrayForIsValidError(
       'toil_to_accrue',
-      'leave_request_toil_amount_more_than_maximum_for_absence_type'
+      $errorMessage
     );
     $this->assertEquals($expectedResult, $result);
   }
@@ -2557,9 +2591,10 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'end_date'   => CRM_Utils_Date::processDate('+10 days'),
     ]);
 
+    $maxLeaveAccrual = 4;
     $absenceType = AbsenceTypeFabricator::fabricate([
       'allow_accruals_request' => true,
-      'max_leave_accrual' => 4,
+      'max_leave_accrual' => $maxLeaveAccrual,
     ]);
 
     $contactID  = 1;
@@ -2592,9 +2627,10 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
     ]);
 
+    $errorMessage = 'The maximum amount of leave that you can accrue is '. $maxLeaveAccrual .' days. Please modify the dates of this request';
     $expectedResult = $this->getExpectedArrayForIsValidError(
       'toil_to_accrue',
-      'leave_request_toil_amount_more_than_maximum_for_absence_type'
+      $errorMessage
     );
     $this->assertEquals($expectedResult, $result);
   }
@@ -2626,6 +2662,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $toilRequest = LeaveRequestFabricator::fabricateWithoutValidation($params, true);
 
+    $maxLeaveAccrual = 1;
     // decrease the max leave accrual
     AbsenceType::create([
       'id' => $absenceType->id,
@@ -2639,9 +2676,11 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $params['status_id'] = 1;
     $result = civicrm_api3('LeaveRequest', 'isValid', $params);
 
+    $errorMessage = 'The maximum amount of leave that you can accrue is '. $maxLeaveAccrual .' days. Please modify the dates of this request';
+
     $expectedResult = $this->getExpectedArrayForIsValidError(
       'toil_to_accrue',
-      'leave_request_toil_amount_more_than_maximum_for_absence_type'
+      $errorMessage
     );
     $this->assertEquals($expectedResult, $result);
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -2544,7 +2544,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
     ]);
 
-    $errorMessage = 'You may only request TOIL for Overtime to be worked in the future. Please modify the date of this request';
+    $errorMessage = 'You may only request TOIL for overtime to be worked in the future. Please modify the date of this request';
     $expectedResult = $this->getExpectedArrayForIsValidError(
       'from_date',
       $errorMessage

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -2693,6 +2693,11 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
     ]);
 
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contactID],
+      ['period_start_date' => '2016-01-01']
+    );
+
     $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
       'type_id' => $this->absenceType->id,
       'contact_id' => $contactID,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -2256,7 +2256,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals($expectedResult, $result);
   }
 
-  public function testLeaveRequestIsValidShouldReturnErrorWhenTheDatesOverlapMoreThanOneContract() {
+  public function testLeaveRequestCanNotBeCreatedWhenTheDatesOverlapTwoContractsWithALapseBetweenTheContracts() {
     $period = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
@@ -2272,7 +2272,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $periodStartDate1 = date('2016-01-01');
     $periodEndDate1 = date('2016-06-30');
 
-    $periodStartDate2 = date('2016-07-01');
+    $periodStartDate2 = date('2016-07-02');
     $periodEndDate2 = date('2016-12-31');
 
     HRJobContractFabricator::fabricate(


### PR DESCRIPTION
## Overview
When a  Leave request is to be created/updated and It fails validation, the error message is displayed in a red bar, at the bottom of the Leave Request modal. This PR modifies the error message sent from the back end for these validations to conform to that described in the L&A Wireframe document. 
Also currently the error code for the leave request validation exception that is thrown when a validation fails is sent to the Frontend. This PR changes this to send the Error message because it is user friendly and more readable.

## Before
The L&A leave request validation alerts does not conform to that described in the L&A Wireframe document.
The Back end sends error code for the validation exception to the Frontend.

## After
The L&A leave request validation alerts conforms to that described in the L&A Wireframe document.
Instead of the error code being sent to the Frontend, the Back end now sends the Error message, also the error message is sent after passing it through the translate function.


## Comments
There is no validation for one of the alerts described in the ticket:  _If the user requests the leave with end date >= contract end date please display the alert "This leave request is after your contract end date. Please modify dates of this request."_ 
This validation is no longer valid as [Things that affect my balance](https://compucorp.atlassian.net/wiki/display/PCHR/Things+that+affect+my+balance) says that a leave request can be created outside contract dates. Instead the previous validation on contracts was modified to throw an exception if a leave request overlapps multiple contracts with lapses in between any of the contract periods.


---

- [X] Tests Pass
