### PR TITLE
PCHR-2300: Fix Merge Conflict

### DIFF
--- a/hrcase/CRM/HRCase/Upgrader.php
+++ b/hrcase/CRM/HRCase/Upgrader.php
@@ -341,16 +341,11 @@ class CRM_HRCase_Upgrader extends CRM_HRCase_Upgrader_Base {
   private function up1402_removedUnusedManagedEntities($caseTypes, $activityTypes) {
     $entitiesToRemove['civicase:act:Background Check'] = 'OptionValue';
 
-    $allActivityTypes = [];
-    foreach ($activityTypes as $componentActivities) {
-      $allActivityTypes = array_merge($allActivityTypes, $componentActivities);
-    }
-
     foreach (array_merge($caseTypes, ['Appraisal', 'Probation']) as $caseType) {
       $entitiesToRemove[$caseType] = 'CaseType';
     }
 
-    foreach ($allActivityTypes as $extension) {
+    foreach ($activityTypes as $extension) {
       foreach ($extension as $activityType) {
         $entitiesToRemove['civitask:act:' . $activityType] = 'OptionValue';
       }


### PR DESCRIPTION
## Overview
A merge conflict caused an upgrader in the hrcase extension to produce warnings when being run.

## Before
The hrcase upgrader caused "Invalid argument supplied for foreach()" warnings. The upgrader was likely not functioning as expected.

## After
The upgrader runs as expected and without warnings.

---

- [ ] Tests Pass
hrcase only has a broken selinium test :cry: 