### PR TITLE
PCHR-2154: Fix FTE Calculation on Import of Full Time Hours Type

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Import/Parser/Api.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Parser/Api.php
@@ -847,6 +847,10 @@ class CRM_Hrjobcontract_Import_Parser_Api extends CRM_Hrjobcontract_Import_Parse
       if (!empty($hourLocation))  {
         $this->_params['HRJobHour-hours_unit'] = $hourLocation['periodicity'];
 
+        if ($hourType['name'] == 'Full_Time') {
+          $this->_params['HRJobHour-hours_amount'] = $params['HRJobHour-hours_amount'] = $hourLocation['standard_hours'];
+        }
+
         // calculate FTE Numerator/Denominator Equivalence
         if (isset($params['HRJobHour-hours_amount']) 
           && $params['HRJobHour-hours_amount'] != '' 
@@ -854,9 +858,11 @@ class CRM_Hrjobcontract_Import_Parser_Api extends CRM_Hrjobcontract_Import_Parse
         ) {
           $inputHourAmount = round(floatval($params['HRJobHour-hours_amount']), 2);
           $actualHourAmount = round(floatval($hourLocation['standard_hours']), 2);
-          $fteNoRound = $inputHourAmount/$actualHourAmount;
+
           $fte = round($inputHourAmount/$actualHourAmount, 2);
+          $fteNoRound = $inputHourAmount/$actualHourAmount;
           list ($num, $denom) = $this->float2rat($fteNoRound);
+
           $this->_params['HRJobHour-fte_num'] = $num;
           $this->_params['HRJobHour-fte_denom'] = $denom;
           $this->_params['HRJobHour-hours_fte'] = $fte;


### PR DESCRIPTION
## Overview
Importing contracts with 'Full Time' hours type was rendering blank FTE's, that were able to be fixed by editing the contract and saving with no modifications.

## Before
When importing contracts with Full Time Hours Type, Actual Hours amount is not and should not be given, as it should be calculated from the selected hours location instead.  However, when importing, hours amount was being left blank, causing FTE to be blank also.

## After
Added a check for hours type when calculating automatic values, so that when 'Full Time' hours type is selected for the contract being imported, the value of the number of hours is copied from the standard hours configured in the hours/location.

## Technical Details
Added a test that asserts when 'Full Time' hours type is used, the value of hours_amount is equal to the value of standard_hours.

---

- [x] Tests Pass
