### PR TITLE
PCHR-2215: Back button on Manage Leave Entitlements page doesn't redirect to the contract

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
@@ -77,11 +77,14 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
       $this->exportCSV();
     }
 
+    $session = CRM_Core_Session::singleton();
+
     $this->addButtons($this->getAvailableButtons());
     $this->assign('period', $this->absencePeriod);
     $this->assign('contactsIDs', $this->getContactsIDsFromRequest());
     $this->assign('calculations', $this->calculations);
     $this->assign('enabledAbsenceTypes', $this->getEnabledAbsenceTypes());
+    $this->assign('returnUrl', $session->get('ManageEntitlementsReturnUrl'));
 
     CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/hrleaveandabsences.css', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
     CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/crm/vendor/inputmask.min.js');

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
@@ -98,7 +98,7 @@
   </tbody>
 </table>
 <div class="crm-submit-buttons">
-  <a href="{$smarty.get.returnUrl}" class="button"><span>{ts}Back{/ts}</span></a>
+  <a href="{$returnUrl}" class="button"><span>{ts}Back{/ts}</span></a>
   {include file="CRM/common/formButtons.tpl" location="bottom"}
 </div>
 <div id="add-comment-dialog" title="{ts}Add/Edit comment{/ts}">

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
@@ -98,7 +98,7 @@
   </tbody>
 </table>
 <div class="crm-submit-buttons">
-  <a href="javascript:history.back()" class="button"><span>{ts}Back{/ts}</span></a>
+  <a href="{$smarty.get.returnUrl}" class="button"><span>{ts}Back{/ts}</span></a>
   {include file="CRM/common/formButtons.tpl" location="bottom"}
 </div>
 <div id="add-comment-dialog" title="{ts}Add/Edit comment{/ts}">


### PR DESCRIPTION
## Overview

Once you create a contract you are redirected to Manage Leave Entitlements page. This page has a back button and it redirected to Contact Summary tab instead of Job Contract tab.

## Before

Back button redirected to Contact Summary tab.

![new](https://user-images.githubusercontent.com/3973243/26889621-ada7ed46-4ba6-11e7-8283-273754f5f4ec.gif)

## After

Back button redirects to Job Contract tab.

![new](https://user-images.githubusercontent.com/3973243/26889822-498d4ddc-4ba7-11e7-8ac2-33d553a55455.gif)

## Technical Details

Back button's href was changed from javascript:history.back() to {$smarty.get.returnUrl}. "returnUrl" is simply a get query param that we already have in the URL on the Manage Leave Entitlements page. We use $smarty instead of $_GET['returnUrl'] because $_GET will simply not work.

## Comments

Since this is a tpl file that was changed, there are no tests to pass.

---

- [ ] Tests Pass
