### PR TITLE
PCHR-2227: TOIL not showing up in Record New Absence Popup

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/controllers/sub-controllers/leave-request-ctrl.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/controllers/sub-controllers/leave-request-ctrl.js
@@ -1,22 +1,22 @@
+/* eslint-env amd */
 define([
   'leave-absences/shared/modules/controllers',
   'leave-absences/shared/controllers/request-ctrl',
-  'leave-absences/shared/models/instances/leave-request-instance',
+  'leave-absences/shared/models/instances/leave-request-instance'
 ], function (controllers) {
   controllers.controller('LeaveRequestCtrl', [
     '$controller', '$log', '$uibModalInstance', 'directiveOptions', 'LeaveRequestInstance',
     function ($controller, $log, $modalInstance, directiveOptions, LeaveRequestInstance) {
       $log.debug('LeaveRequestCtrl');
 
-      var parentRequestCtrl = $controller('RequestCtrl'),
-        vm = Object.create(parentRequestCtrl);
-        
+      var parentRequestCtrl = $controller('RequestCtrl');
+      var vm = Object.create(parentRequestCtrl);
+
       vm.directiveOptions = directiveOptions;
       vm.$modalInstance = $modalInstance;
       vm.initParams = {
         absenceType: {
-          is_sick: false,
-          allow_accruals_request: false
+          is_sick: false
         }
       };
 
@@ -32,7 +32,7 @@ define([
       /**
        * Initializes the controller on loading the dialog
        */
-      (function initController() {
+      (function initController () {
         vm.loading.absenceTypes = true;
 
         vm._init()

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/controllers/sub-controllers/leave-request-ctrl_test.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/controllers/sub-controllers/leave-request-ctrl_test.js
@@ -191,8 +191,7 @@
 
             it('gets absence types with false sick param', function () {
               expect(AbsenceTypeAPI.all).toHaveBeenCalledWith({
-                is_sick: false,
-                allow_accruals_request: false
+                is_sick: false
               });
             });
 


### PR DESCRIPTION
## Problem
The absence types which does allow to have Accrual Requests(TOIL) , are not visible in the Record New Absence popup's Dropdown.
![my_leave___hr16-4](https://user-images.githubusercontent.com/5058867/26878814-60887084-4bac-11e7-9a27-2377a761ae75.png)


## Solution
1. in `leave-request-ctrl.js` `allow_accruals_request` was set to false, which means the popup will not display such absence types in the dropdown. It was wrong so removed it.

2. Code has been refactored, 

- `self` replaced by `bind`
- `initAbsenceType()` renamed to more meaningful `setInitialAbsenceTypes()`
- `canViewOrEdit()` removed as it is not required, and in most cases `!this.isMode('create')` is used instead of `canViewOrEdit()`, as both means same.

**Screenshot**
![my_leave___hr16-4](https://user-images.githubusercontent.com/5058867/26875835-41fa7302-4ba1-11e7-854f-0b292fea5ffd.png)


## Comments
Still there is a issue when we first select TOIL and then click on Single Day, the dropdown values is being reset to Holiday. This is because `changeInNoOfDays()` function internally calls `setInitialAbsenceTypes()` which resets the absence type to the first value of the `absenceType` array. Now this wrong, because when `changeInNoOfDays()` is called only the balance calculation should be done, nothing else. As @igorpavlov 's PR (https://github.com/civicrm/civihr/pull/1923) also touched the same thing and same fix is required there too, I left the comment to fix this in his PR.

---

- [x] Tests Pass
