### PR TITLE
PCHR-2236: Dont display decimals for contracts entitlements

### DIFF
--- a/hrjobcontract/views/modalForm.html
+++ b/hrjobcontract/views/modalForm.html
@@ -588,6 +588,7 @@
                                name="leave-{{leaveEntry.leave_type}}"
                                class="form-control"
                                hrjc-number="2"
+                               hrjc-number-float="true"
                                ng-model="leaveEntry.leave_amount" ng-disabled="isDisabled">
                       </div>
                       <div class="col-sm-3">


### PR DESCRIPTION
## Problem
While creating new contract, in the Leave tab, if the input boxes for Entitlement are clicked and then deselected, numbers are shown as floating point even though the number is an integer. Floating points should not be shown until the number is a float.
![claudio_adams_jr____hr16-4](https://user-images.githubusercontent.com/5058867/26887223-0d273538-4bc5-11e7-858a-1cefca5d8aff.png)

## Solution
Added `hrjc-number-float="true"` in the HTML which takes care of this scenario.

![2236](https://user-images.githubusercontent.com/5058867/26887176-f154814e-4bc4-11e7-9f09-69974d51541a.gif)