### PR TITLE
PCHR-2303: Improve semistandard hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,6 +5,7 @@
 ESC_SEQ="\x1b["
 COL_RESET=$ESC_SEQ"39;49;00m"
 COL_RED=$ESC_SEQ"31;01m"
+COL_GREEN=$ESC_SEQ"32;01m"
 COL_YELLOW=$ESC_SEQ"33;01m"
 
 ## Checks if a given command exists in the local environment
@@ -22,11 +23,14 @@ if [ -n "$files" ]; then
   command_exists semistandard "https://www.npmjs.com/package/semistandard"
   command_exists snazzy "https://www.npmjs.com/package/snazzy"
 
+  echo "$COL_GREEN Running semistandard linter... $COL_RESET";
   semistandard $files --verbose | snazzy
 
   if [ $? -ne 0 ]; then
     echo "$COL_YELLOW Some of the JS files you have committed are not following the \"JavaScript Semi-Standard Style\", please fix them! $COL_RESET";
     echo "$COL_YELLOW Run the following to check the state of your file as you work on it: semistandard %{path_to_file} --verbose | snazzy $COL_RESET \n";
     echo "$COL_RED For the time being the files had been committed and can be pushed, but in the future the commit will be rejected until all the issues are fixed! $COL_RESET";
+  else
+    echo "$COL_GREEN ...all good! $COL_RESET";
   fi
 fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -22,7 +22,7 @@ if [ -n "$files" ]; then
   command_exists semistandard "https://www.npmjs.com/package/semistandard"
   command_exists snazzy "https://www.npmjs.com/package/snazzy"
 
-  semistandard --global inject --global CRM --verbose "$files" | snazzy
+  semistandard $files --verbose | snazzy
 
   if [ $? -ne 0 ]; then
     echo "$COL_YELLOW Some of the JS files you have committed are not following the \"JavaScript Semi-Standard Style\", please fix them! $COL_RESET";

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "semistandard": {
+    "globals": [ "CRM", "inject" ]
+  }
+}


### PR DESCRIPTION
## Problem
For reasons I wasn't able to identify, using `semistandard "$files" --verbose` randomly fails, not catching style errors of files that are about to be committed

Also common globals should not be declared inline in the hook, otherwise manual `semistandard` invocations might end up giving a different output than the hook

## Solution
1. Using `semistandard $files --verbose | snazzy` (so `$files` instead of `"$files"`) seems to solve the problem with random linter failures when committing files with style errors
2. Created a `package.json` file with the global declarations
3. As a bonus, added messages informing when the linter starts and if the linter didn't find any error
<img width="392" alt="example" src="https://user-images.githubusercontent.com/6400898/26918312-bfbd3c62-4c31-11e7-9160-19cba38a6e5c.png">
