### PR TITLE
PCHR-1877 : Changing foreign keys join columns from ID to jobcontract_revision_id for HRJobContractRevision entity

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobContractRevision.php
+++ b/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobContractRevision.php
@@ -230,6 +230,7 @@ class CRM_Hrjobcontract_DAO_HRJobContractRevision extends CRM_Core_DAO
           'export' => true,
           'import' => true,
           'FKClassName' => 'CRM_Hrjobcontract_DAO_HRJobDetails',
+          'FKKeyColumn' => 'jobcontract_revision_id',
           'headerPattern' => '/^details\s?revision\s?id/i',
         ) ,
         'health_revision_id' => array(
@@ -240,6 +241,7 @@ class CRM_Hrjobcontract_DAO_HRJobContractRevision extends CRM_Core_DAO
           'export' => true,
           'import' => true,
           'FKClassName' => 'CRM_Hrjobcontract_DAO_HRJobHealth',
+          'FKKeyColumn' => 'jobcontract_revision_id',
           'headerPattern' => '/^health\s?revision\s?id/i',
         ) ,
         'hour_revision_id' => array(
@@ -250,6 +252,7 @@ class CRM_Hrjobcontract_DAO_HRJobContractRevision extends CRM_Core_DAO
           'export' => true,
           'import' => true,
           'FKClassName' => 'CRM_Hrjobcontract_DAO_HRJobHour',
+          'FKKeyColumn' => 'jobcontract_revision_id',
           'headerPattern' => '/^hour\s?revision\s?id/i',
         ) ,
         'leave_revision_id' => array(
@@ -260,6 +263,7 @@ class CRM_Hrjobcontract_DAO_HRJobContractRevision extends CRM_Core_DAO
           'export' => true,
           'import' => true,
           'FKClassName' => 'CRM_Hrjobcontract_DAO_HRJobLeave',
+          'FKKeyColumn' => 'jobcontract_revision_id',
           'headerPattern' => '/^leave\s?revision\s?id/i',
         ) ,
         'pay_revision_id' => array(
@@ -270,6 +274,7 @@ class CRM_Hrjobcontract_DAO_HRJobContractRevision extends CRM_Core_DAO
           'export' => true,
           'import' => true,
           'FKClassName' => 'CRM_Hrjobcontract_DAO_HRJobPay',
+          'FKKeyColumn' => 'jobcontract_revision_id',
           'headerPattern' => '/^pay\s?revision\s?id/i',
         ) ,
         'pension_revision_id' => array(
@@ -280,6 +285,7 @@ class CRM_Hrjobcontract_DAO_HRJobContractRevision extends CRM_Core_DAO
           'export' => true,
           'import' => true,
           'FKClassName' => 'CRM_Hrjobcontract_DAO_HRJobPension',
+          'FKKeyColumn' => 'jobcontract_revision_id',
           'headerPattern' => '/^pension\s?revision\s?id/i',
         ) ,
         'role_revision_id' => array(
@@ -290,6 +296,7 @@ class CRM_Hrjobcontract_DAO_HRJobContractRevision extends CRM_Core_DAO
           'export' => true,
           'import' => true,
           'FKClassName' => 'CRM_Hrjobcontract_DAO_HRJobRole',
+          'FKKeyColumn' => 'jobcontract_revision_id',
           'headerPattern' => '/^role\s?revision\s?id/i',
         ) ,
         'deleted' => array(


### PR DESCRIPTION
## Overview
Job contract history table does not show Pay scale, Total salary and Hours type data. Depending on the contact, it is possible that it shows contract details for another unrelated contact.

## Before
1- Create a new contact
2- Add a contract with pay and hour details
3- Update terms and create a new revision but just change the position title
4- Update terms again but only update pay
5- Refresh the page. The latest revision in "Full History" will not show pay details

<img width="782" alt="2017-06-08 13_46_18-" src="https://user-images.githubusercontent.com/6275540/26925381-83523fe2-4c41-11e7-8c98-b1b1e11eb1dd.png">


## After

1- Create a new contact
2- Add a contract with pay and hour details
3- Update terms and create a new revision but just change the position title
4- Update terms again but only update pay
5- Refresh the page. The latest revision in "Full History" will still show all the current details.

<img width="795" alt="2017-06-08 13_51_41-" src="https://user-images.githubusercontent.com/6275540/26925398-933bd1d4-4c41-11e7-94d5-544a030a3786.png">



## Technical Details

When getting a given job contract entity data (such details , leaves , pension , health .. etc) for a specific 
revision via the API Join on feature and while using **HRJobContractRevision** as main entity , e.g : 

```php
civicrm_api3('HRJobContractRevision', 'get', array(
  'return' => array("pay_revision_id.pay_scale"),
  'id' => 1,
));
```

then the API call will result in wrong data, because API joins use the ID field of the referenced table but for job contract
entities case we should use **jobcontract_revision_id** instead , so  for example instead of  : 

```php
LEFT JOIN  civicrm_hrjobcontract_pay ON
civicrm_hrjobcontract_revision.pay_revision_id = civicrm_hrjobcontract_pay.id
```

it should be : 

```php
LEFT JOIN  civicrm_hrjobcontract_pay ON
civicrm_hrjobcontract_revision.pay_revision_id = civicrm_hrjobcontract_pay.jobcontract_revision_id
```

and to achieve that I used **FKClassName** key inside the **HRJobContractRevision** DAO class for all job contract entities revision IDs columns to point for **jobcontract_revision_id** instead of the default value which is the **ID** field, so now all the Joined API calls for these entities should return the correct result.

---

- [x] Tests Pass
