### PR TITLE
PCHR-2150: Bulk Sending of Invitation Mails

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/AbstractDrupalInteractionTaskForm.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/AbstractDrupalInteractionTaskForm.php
@@ -92,7 +92,7 @@ abstract class CRM_HRCore_Form_AbstractDrupalInteractionTaskForm extends CRM_Con
    *
    * @return array
    */
-  protected function getContactsWithout($property) {
+  protected function getContactsWithoutAttribute($property) {
     $checker = function ($contactDetail) use ($property) {
       return empty($contactDetail[$property]);
     };

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/AbstractDrupalInteractionTaskForm.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/AbstractDrupalInteractionTaskForm.php
@@ -1,0 +1,103 @@
+<?php
+
+use CRM_HRCore_Service_DrupalUserService as DrupalUserService;
+use CRM_Utils_Array as ArrayHelper;
+
+abstract class CRM_HRCore_Form_AbstractDrupalInteractionTaskForm extends CRM_Contact_Form_Task {
+  /**
+   * @var array
+   */
+  protected $contactDetails = [];
+
+  /**
+   * @var DrupalUserService
+   */
+  protected $drupalUserService;
+
+  /**
+   * @param null $state
+   * @param mixed $action
+   * @param string $method
+   * @param null $name
+   */
+  public function __construct(
+    $state = NULL,
+    $action = CRM_Core_Action::NONE,
+    $method = 'post',
+    $name = NULL
+  ) {
+    $this->drupalUserService = Civi::container()->get('drupal_user_service');
+    parent::__construct($state, $action, $method, $name);
+  }
+
+  public function preProcess() {
+    $this->initContactDetails();
+    parent::preProcess();
+  }
+
+  /**
+   * Creates an array to store contact details
+   */
+  private function initContactDetails() {
+    $emailParams = [
+      'contact_id' => '$value.id',
+      'return' => ['email'],
+      'is_primary' => 1,
+    ];
+    $ufMatchParams = [
+      'contact_id' => '$value.id',
+      'return' => ['uf_id']
+    ];
+    $params = [
+      'return' => ['display_name'],
+      'id' => ['IN' => $this->_contactIds],
+      'options' => ['limit' => 0],
+      'api.Email.getsingle' => $emailParams,
+      'api.UFMatch.getsingle' => $ufMatchParams,
+    ];
+    $contactDetails = civicrm_api3('Contact', 'get', $params);
+    $contactDetails = ArrayHelper::value('values', $contactDetails);
+
+    foreach ($contactDetails as $detail) {
+      $contactID = (int) ArrayHelper::value('contact_id', $detail);
+      $displayName = ArrayHelper::value('display_name', $detail);
+      $ufMatch = ArrayHelper::value('api.UFMatch.getsingle', $detail, []);
+      $ufId = (int) ArrayHelper::value('uf_id', $ufMatch);
+      $emailDetails = ArrayHelper::value('api.Email.getsingle', $detail, []);
+      $email = ArrayHelper::value('email', $emailDetails);
+
+      $this->setContactDetail($contactID, 'display_name', $displayName);
+      $this->setContactDetail($contactID, 'uf_id', $ufId);
+      $this->setContactDetail($contactID, 'email', $email);
+      $this->setContactDetail($contactID, 'id', $contactID);
+    }
+  }
+
+  /**
+   * Helper method to prevent overwriting of contact details
+   *
+   * @param int $contactId
+   * @param string $type
+   * @param mixed $value
+   */
+  private function setContactDetail($contactId, $type, $value) {
+    if (!isset($this->contactDetails[$contactId][$type])) {
+      $this->contactDetails[$contactId][$type] = $value;
+    }
+  }
+
+  /**
+   * @param $property
+   *  The property to check if empty
+   *
+   * @return array
+   */
+  protected function getContactsWithout($property) {
+    $checker = function ($contactDetail) use ($property) {
+      return empty($contactDetail[$property]);
+    };
+
+    return array_filter($this->contactDetails, $checker);
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/AbstractDrupalInteractionTaskForm.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/AbstractDrupalInteractionTaskForm.php
@@ -42,7 +42,7 @@ abstract class CRM_HRCore_Form_AbstractDrupalInteractionTaskForm extends CRM_Con
     $emailParams = [
       'contact_id' => '$value.id',
       'return' => ['email'],
-      'is_primary' => 1,
+      'is_primary' => 1
     ];
     $ufMatchParams = [
       'contact_id' => '$value.id',
@@ -51,9 +51,8 @@ abstract class CRM_HRCore_Form_AbstractDrupalInteractionTaskForm extends CRM_Con
     $params = [
       'return' => ['display_name'],
       'id' => ['IN' => $this->_contactIds],
-      'options' => ['limit' => 0],
       'api.Email.getsingle' => $emailParams,
-      'api.UFMatch.getsingle' => $ufMatchParams,
+      'api.UFMatch.getsingle' => $ufMatchParams
     ];
     $contactDetails = civicrm_api3('Contact', 'get', $params);
     $contactDetails = ArrayHelper::value('values', $contactDetails);
@@ -93,11 +92,11 @@ abstract class CRM_HRCore_Form_AbstractDrupalInteractionTaskForm extends CRM_Con
    * @return array
    */
   protected function getContactsWithoutAttribute($property) {
-    $checker = function ($contactDetail) use ($property) {
+    $attributesFilter = function ($contactDetail) use ($property) {
       return empty($contactDetail[$property]);
     };
 
-    return array_filter($this->contactDetails, $checker);
+    return array_filter($this->contactDetails, $attributesFilter);
   }
 
 }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/AbstractDrupalInteractionTaskForm.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/AbstractDrupalInteractionTaskForm.php
@@ -31,8 +31,8 @@ abstract class CRM_HRCore_Form_AbstractDrupalInteractionTaskForm extends CRM_Con
   }
 
   public function preProcess() {
-    $this->initContactDetails();
     parent::preProcess();
+    $this->initContactDetails();
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordTaskForm.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordTaskForm.php
@@ -24,8 +24,10 @@ class CRM_HRCore_Form_CreateUserRecordTaskForm extends AbstractDrupalInteraction
    */
   public function preProcess() {
     parent::preProcess();
+
     $haveNoAccount = $this->getContactsWithoutAttribute('uf_id');
     $haveAccount = array_diff_key($this->contactDetails, $haveNoAccount);
+
     $this->assign('contactsWithoutEmail', $this->getContactsWithoutAttribute('email'));
     $this->assign('contactsWithAccount', $haveAccount);
     $this->assign('contactsForCreation', $this->getValidContactsForCreation());

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordTaskForm.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordTaskForm.php
@@ -105,7 +105,7 @@ class CRM_HRCore_Form_CreateUserRecordTaskForm extends CRM_Contact_Form_Task {
     $user = $this->drupalUserService->createNew($id, $email, TRUE, $roles);
 
     if ($this->sendEmail) {
-      $this->drupalUserService->sendActivationMail($id, $user);
+      $this->drupalUserService->sendActivationMail($id, $email);
     }
 
     return $user;

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/SendInvitationEmailTaskForm.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/SendInvitationEmailTaskForm.php
@@ -1,0 +1,63 @@
+<?php
+
+use CRM_HRCore_Form_AbstractDrupalInteractionTaskForm as AbstractDrupalInteractionTaskForm;
+
+class CRM_HRCore_Form_SendInvitationEmailTaskForm extends AbstractDrupalInteractionTaskForm {
+
+  /**
+   * @var bool
+   */
+  protected $resend = FALSE;
+
+  /**
+   * Build the form object.
+   */
+  public function buildQuickForm() {
+    CRM_Utils_System::setTitle(ts('Send Invitation Email'));
+    $this->addDefaultButtons(ts('Create Records'));
+    $this->add('advcheckbox', 'resendEmail', ts('Resend?'));
+  }
+
+  /**
+   * Fetch contact details and set some template variables
+   */
+  public function preProcess() {
+    parent::preProcess();
+    $this->assign('contactsForSending', $this->getContactsToSendMailTo());
+    $this->assign('contactsWithoutEmail', $this->getContactsWithout('email'));
+    $this->assign('contactsWithoutAccount', $this->getContactsWithout('uf_id'));
+  }
+
+  /**
+   * Process the form after the input has been submitted and validated.
+   */
+  public function postProcess() {
+    $this->resend = (bool) $this->getElementValue('resendEmail');
+    // todo select contactToSendMailTo depending on onboarding status
+    $toBeSent = $this->getContactsToSendMailTo();
+    foreach ($toBeSent as $contact) {
+      $id = $contact['id'];
+      $email = $contact['email'];
+      $this->drupalUserService->sendActivationMail($id, $email);
+    }
+
+    CRM_Core_Session::setStatus(
+      ts('%1 invitation emails were sent', [1 => count($toBeSent)]),
+      ts('Emails Sent'),
+      'success'
+    );
+  }
+
+  /**
+   * Gets contacts the have an email set
+   *
+   * @return array
+   */
+  private function getContactsToSendMailTo() {
+    $haveNoEmail = $this->getContactsWithout('email');
+    $haveNoAccount = $this->getContactsWithout('uf_id');
+
+    return array_diff_key($this->contactDetails, $haveNoEmail, $haveNoAccount);
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/SendInvitationEmailTaskForm.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/SendInvitationEmailTaskForm.php
@@ -5,17 +5,11 @@ use CRM_HRCore_Form_AbstractDrupalInteractionTaskForm as AbstractDrupalInteracti
 class CRM_HRCore_Form_SendInvitationEmailTaskForm extends AbstractDrupalInteractionTaskForm {
 
   /**
-   * @var bool
-   */
-  protected $resend = FALSE;
-
-  /**
    * Build the form object.
    */
   public function buildQuickForm() {
     CRM_Utils_System::setTitle(ts('Send Invitation Email'));
     $this->addDefaultButtons(ts('Create Records'));
-    $this->add('advcheckbox', 'resendEmail', ts('Resend?'));
   }
 
   /**
@@ -32,9 +26,8 @@ class CRM_HRCore_Form_SendInvitationEmailTaskForm extends AbstractDrupalInteract
    * Process the form after the input has been submitted and validated.
    */
   public function postProcess() {
-    $this->resend = (bool) $this->getElementValue('resendEmail');
-    // todo select contactToSendMailTo depending on onboarding status
     $toBeSent = $this->getContactsToSendMailTo();
+
     foreach ($toBeSent as $contact) {
       $id = $contact['id'];
       $email = $contact['email'];

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/SendInvitationEmailTaskForm.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/SendInvitationEmailTaskForm.php
@@ -24,8 +24,8 @@ class CRM_HRCore_Form_SendInvitationEmailTaskForm extends AbstractDrupalInteract
   public function preProcess() {
     parent::preProcess();
     $this->assign('contactsForSending', $this->getContactsToSendMailTo());
-    $this->assign('contactsWithoutEmail', $this->getContactsWithout('email'));
-    $this->assign('contactsWithoutAccount', $this->getContactsWithout('uf_id'));
+    $this->assign('contactsWithoutEmail', $this->getContactsWithoutAttribute('email'));
+    $this->assign('contactsWithoutAccount', $this->getContactsWithoutAttribute('uf_id'));
   }
 
   /**
@@ -54,8 +54,8 @@ class CRM_HRCore_Form_SendInvitationEmailTaskForm extends AbstractDrupalInteract
    * @return array
    */
   private function getContactsToSendMailTo() {
-    $haveNoEmail = $this->getContactsWithout('email');
-    $haveNoAccount = $this->getContactsWithout('uf_id');
+    $haveNoEmail = $this->getContactsWithoutAttribute('email');
+    $haveNoAccount = $this->getContactsWithoutAttribute('uf_id');
 
     return array_diff_key($this->contactDetails, $haveNoEmail, $haveNoAccount);
   }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/DrupalUserService.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/DrupalUserService.php
@@ -54,9 +54,14 @@ class CRM_HRCore_Service_DrupalUserService {
 
   /**
    * @param int $contactID
-   * @param object $user
+   * @param string $email
    */
-  public function sendActivationMail($contactID, $user) {
+  public function sendActivationMail($contactID, $email) {
+    $user = user_load_by_mail($email);
+    if (!$user) {
+      return;
+    }
+
     _user_mail_notify('status_activated', $user);
     $this->createActivity($contactID, 'Send Onboarding Email');
   }

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -34,6 +34,10 @@ function hrcore_civicrm_searchTasks($objectName, &$tasks) {
     'title'  => ts('Create User Record'),
     'class'  => CRM_HRCore_Form_CreateUserRecordTaskForm::class,
   ];
+  $tasks[] = [
+    'title'  => ts('Send Invitation Email'),
+    'class'  => CRM_HRCore_Form_SendInvitationEmailTaskForm::class,
+  ];
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/SendInvitationEmailTaskForm.tpl
+++ b/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/SendInvitationEmailTaskForm.tpl
@@ -1,0 +1,58 @@
+<div class = 'crm-container'>
+
+  <h3>
+    {ts 1=$totalSelectedContacts 2=$contactsForSending|@count}
+      From your selection of %1 contacts, %2 users can receive mails.
+    {/ts}
+  </h3>
+
+  <br/>
+
+  {if !empty($contactsWithoutEmail) }
+    <p>
+      {ts}An email is required to send the invitation.{/ts}
+    </p>
+    <p>
+      {ts 1=$contactsWithoutEmail|@count}%1 contacts do not have an email set:{/ts}
+    </p>
+    {include file="CRM/HRCore/Common/ContactTable.tpl" contacts=$contactsWithoutEmail}
+    <br/>
+  {/if}
+
+  {if !empty($contactsWithoutAccount) }
+    <p>
+      {ts}
+        An account is required before you can send the invitation mail.
+        You can create an account using the "Create User Record" action.
+      {/ts}
+    </p>
+    <p>
+      {ts 1=$contactsWithoutAccount|@count}%1 contacts do not have an account yet:{/ts}
+    </p>
+    {include file="CRM/HRCore/Common/ContactTable.tpl" contacts=$contactsWithoutAccount}
+    <br/>
+  {/if}
+
+  <div class="crm-block crm-form-block" style="padding: 20px 10px">
+    <div class="checkbox">
+      {$form.resendEmail.html}
+      {$form.resendEmail.label}
+      <br/>
+      <h4 class = "description">
+          {ts}
+            Invitation emails will be resent to users who have already
+            received one if this is checked.
+          {/ts}
+        </h4>
+    </div>
+  </div>
+
+  <div class="spacer"></div>
+
+  <div class="crm-block crm-form-block">
+    <div class="crm-inline-button crm-submit-buttons">
+      {include file="CRM/common/formButtons.tpl"}
+    </div>
+  </div>
+
+</div>

--- a/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/SendInvitationEmailTaskForm.tpl
+++ b/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/SendInvitationEmailTaskForm.tpl
@@ -33,20 +33,6 @@
     <br/>
   {/if}
 
-  <div class="crm-block crm-form-block" style="padding: 20px 10px">
-    <div class="checkbox">
-      {$form.resendEmail.html}
-      {$form.resendEmail.label}
-      <br/>
-      <h4 class = "description">
-          {ts}
-            Invitation emails will be resent to users who have already
-            received one if this is checked.
-          {/ts}
-        </h4>
-    </div>
-  </div>
-
   <div class="spacer"></div>
 
   <div class="crm-block crm-form-block">


### PR DESCRIPTION
## Overview
After user accounts are created in bulk without an invitation email being sent, there should be a way to send out invitation email in bulk.

## Before
There wasn't a way to send invitation e-mails to contacts created by importing a file.

## After
Added an action on the Advanced Search form to send invitation e-mail to selected contacts.

---

- [x] Tests Pass
