### PR TITLE
PCHR-2298: Fix Issue with Calendar Not Showing Up for a Contact Without A Contract

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/WorkPatternCalendar.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/WorkPatternCalendar.php
@@ -30,6 +30,12 @@ class CRM_HRLeaveAndAbsences_Service_WorkPatternCalendar {
    */
   private $workPatternCache;
 
+  /**
+   * @var \CRM_HRLeaveAndAbsences_BAO_WorkPattern
+   *   The default WorkPattern
+   */
+  private $defaultWorkPattern;
+
   public function __construct($contactID, AbsencePeriod $absencePeriod, JobContractService $jobContractService) {
     $this->contactID = $contactID;
     $this->absencePeriod = $absencePeriod;
@@ -383,7 +389,7 @@ class CRM_HRLeaveAndAbsences_Service_WorkPatternCalendar {
    * @return array
    */
   private function fabricateDefaultWorkPatternPeriod(DateTime $startDate, DateTime $endDate, DateTime $effectiveDate = null) {
-    $workPattern = WorkPattern::getDefault();
+    $workPattern = $this->getDefaultWorkPattern();
     $workPatternPeriod = [
       'pattern_id' => (int)$workPattern->id,
       'effective_date' => $effectiveDate ? $effectiveDate : $startDate,
@@ -440,5 +446,18 @@ class CRM_HRLeaveAndAbsences_Service_WorkPatternCalendar {
    */
   private function fillContractsLapses($contracts) {
     return $this->fabricateForLapses($contracts, 'fabricateContractPeriod');
+  }
+
+  /**
+   * Returns the default WorkPattern
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_WorkPattern
+   */
+  private function getDefaultWorkPattern() {
+    if(!$this->defaultWorkPattern) {
+      $this->defaultWorkPattern = WorkPattern::getDefault();
+    }
+
+    return $this->defaultWorkPattern;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -1842,7 +1842,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'status_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-06-29'),
       'from_date_type' => $this->leaveRequestDayTypes['all_day']['value'],
-      'to_date' => CRKM_Utils_Date::processDate('2016-07-03'),
+      'to_date' => CRM_Utils_Date::processDate('2016-07-03'),
       'to_date_type' => $this->leaveRequestDayTypes['all_day']['value'],
       'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
     ]);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/WorkPatternCalendarTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/WorkPatternCalendarTest.php
@@ -396,4 +396,170 @@ class CRM_HRLeaveAndAbsences_Service_WorkPatternCalendarTest extends BaseHeadles
     //Year 2016 is a leap year, so there are 366 days.
     $this->assertCount(366, $calendarDates);
   }
+
+  public function testGetReturnsResultsForContactWithoutAContractAndFillsTheContactWorkPatternPeriodLapsesWithTheDefaultWorkPattern() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-03-03'),
+      'end_date' => CRM_Utils_Date::processDate('2016-03-09'),
+    ]);
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => true]);
+    $workPattern1 = WorkPatternFabricator::fabricateWithTwoWeeksAnd31AndHalfHours();
+
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $this->contact['id'],
+      'pattern_id' => $workPattern1->id,
+      'effective_date' => CRM_Utils_Date::processDate('2016-03-07'),
+    ]);
+
+    //A contract is fabricated for the contract with start date as 2016-03-03 and end date as 2016-03-09
+    $calendar = new WorkPatternCalendarService($this->contact['id'], $absencePeriod, $this->jobContractService);
+    $calendarDates = $calendar->get();
+
+    $workDayTypes = $this->getWorkDayTypeOptionsArray();
+
+    $this->assertCount(7, $calendarDates);
+
+    //Since the work pattern for the contact becomes effective on 2016-03-07, default work pattern
+    //will be used to determine the day type before then.
+    $this->assertEquals('2016-03-03', $calendarDates[0]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[0]['type']);
+    $this->assertEquals('2016-03-04', $calendarDates[1]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[1]['type']);
+    $this->assertEquals('2016-03-05', $calendarDates[2]['date']);
+    $this->assertEquals($workDayTypes['weekend'], $calendarDates[2]['type']);
+    $this->assertEquals('2016-03-06', $calendarDates[3]['date']);
+    $this->assertEquals($workDayTypes['weekend'], $calendarDates[3]['type']);
+
+    //The contact work pattern starts being effective on 2016-03-07, a monday
+    $this->assertEquals('2016-03-07', $calendarDates[4]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[4]['type']);
+    $this->assertEquals('2016-03-08', $calendarDates[5]['date']);
+    $this->assertEquals($workDayTypes['non_working_day'], $calendarDates[5]['type']);
+    $this->assertEquals('2016-03-09', $calendarDates[6]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[6]['type']);
+  }
+
+  public function testGetReturnsResultsForContactWithoutAContractAndUsingTheDefaultWorkPatternOnly() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-03-03'),
+      'end_date' => CRM_Utils_Date::processDate('2016-03-06'),
+    ]);
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => true]);
+
+    //A contract is fabricated for the contract with start date as 2016-03-03 and end date as 2016-03-06
+    $calendar = new WorkPatternCalendarService($this->contact['id'], $absencePeriod, $this->jobContractService);
+    $calendarDates = $calendar->get();
+
+    $workDayTypes = $this->getWorkDayTypeOptionsArray();
+
+    $this->assertCount(4, $calendarDates);
+
+    //Default work pattern is used to determine the day type
+    $this->assertEquals('2016-03-03', $calendarDates[0]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[0]['type']);
+    $this->assertEquals('2016-03-04', $calendarDates[1]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[1]['type']);
+    $this->assertEquals('2016-03-05', $calendarDates[2]['date']);
+    $this->assertEquals($workDayTypes['weekend'], $calendarDates[2]['type']);
+    $this->assertEquals('2016-03-06', $calendarDates[3]['date']);
+    $this->assertEquals($workDayTypes['weekend'], $calendarDates[3]['type']);
+  }
+
+  public function testGetReturnsResultsForContactWithContractsAndFillsThePeriodLapsesUsingTheDefaultWorkPattern() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-01-31'),
+    ]);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $this->contact['id']],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => '2016-01-10'
+      ]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $this->contact['id']],
+      [
+        'period_start_date' => '2016-01-18',
+        'period_end_date' => '2016-01-31'
+      ]
+    );
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => true]);
+    $workPattern1 = WorkPatternFabricator::fabricateWithTwoWeeksAnd31AndHalfHours();
+
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $this->contact['id'],
+      'pattern_id' => $workPattern1->id,
+      'effective_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'effective_end_date' => CRM_Utils_Date::processDate('2016-01-10'),
+    ]);
+
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $this->contact['id'],
+      'pattern_id' => $workPattern1->id,
+      'effective_date' => CRM_Utils_Date::processDate('2016-01-18'),
+      'effective_end_date' => CRM_Utils_Date::processDate('2016-01-24'),
+    ]);
+
+    $calendar = new WorkPatternCalendarService($this->contact['id'], $absencePeriod, $this->jobContractService);
+    $calendarDates = $calendar->get();
+    $workDayTypes = $this->getWorkDayTypeOptionsArray();
+    $this->assertCount(31, $calendarDates);
+
+    // There is no Work Pattern between the period 2016-01-01 to 2016-01-03 although a contract exists
+    //The default work pattern will be used for these dates
+    $this->assertEquals('2016-01-01', $calendarDates[0]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[0]['type']);
+    $this->assertEquals('2016-01-02', $calendarDates[1]['date']);
+    $this->assertEquals($workDayTypes['weekend'], $calendarDates[1]['type']);
+    $this->assertEquals('2016-01-03', $calendarDates[2]['date']);
+    $this->assertEquals($workDayTypes['weekend'], $calendarDates[2]['type']);
+
+    // The period 2016-01-04 to 2016-01-10 will use the contact work pattern, also a valid contract exist
+    // within this period.
+    $this->assertEquals('2016-01-04', $calendarDates[3]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[0]['type']);
+    $this->assertEquals('2016-01-05', $calendarDates[4]['date']);
+    $this->assertEquals($workDayTypes['non_working_day'], $calendarDates[4]['type']);
+    $this->assertEquals('2016-01-10', $calendarDates[9]['date']);
+    $this->assertEquals($workDayTypes['weekend'], $calendarDates[9]['type']);
+
+    // The period 2016-01-11 to 2016-01-17 will use the default work pattern, a contract does not exist
+    // within this period.
+    $this->assertEquals('2016-01-11', $calendarDates[10]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[10]['type']);
+    $this->assertEquals('2016-01-12', $calendarDates[11]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[11]['type']);
+    $this->assertEquals('2016-01-13', $calendarDates[12]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[12]['type']);
+    $this->assertEquals('2016-01-17', $calendarDates[16]['date']);
+    $this->assertEquals($workDayTypes['weekend'], $calendarDates[16]['type']);
+
+    // The period 2016-01-18 to 2016-01-24 will use the contact work pattern, also a valid contract exist
+    // within this period.
+    $this->assertEquals('2016-01-18', $calendarDates[17]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[17]['type']);
+    $this->assertEquals('2016-01-19', $calendarDates[18]['date']);
+    $this->assertEquals($workDayTypes['non_working_day'], $calendarDates[18]['type']);
+    $this->assertEquals('2016-01-20', $calendarDates[19]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[19]['type']);
+    $this->assertEquals('2016-01-21', $calendarDates[20]['date']);
+    $this->assertEquals($workDayTypes['non_working_day'], $calendarDates[20]['type']);
+
+    // The period 2016-01-25 to 2016-01-31 will use the default work pattern, a contract does not exist
+    // within this period.
+    $this->assertEquals('2016-01-25', $calendarDates[24]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[24]['type']);
+    $this->assertEquals('2016-01-26', $calendarDates[25]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[25]['type']);
+    $this->assertEquals('2016-01-27', $calendarDates[26]['date']);
+    $this->assertEquals($workDayTypes['working_day'], $calendarDates[26]['type']);
+    $this->assertEquals('2016-01-31', $calendarDates[30]['date']);
+    $this->assertEquals($workDayTypes['weekend'], $calendarDates[30]['type']);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/WorkPatternCalendarTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/WorkPatternCalendarTest.php
@@ -412,7 +412,7 @@ class CRM_HRLeaveAndAbsences_Service_WorkPatternCalendarTest extends BaseHeadles
       'effective_date' => CRM_Utils_Date::processDate('2016-03-07'),
     ]);
 
-    //A contract is fabricated for the contract with start date as 2016-03-03 and end date as 2016-03-09
+    //A contract is fabricated for the period between 2016-03-03 and 2016-03-09
     $calendar = new WorkPatternCalendarService($this->contact['id'], $absencePeriod, $this->jobContractService);
     $calendarDates = $calendar->get();
 
@@ -448,7 +448,7 @@ class CRM_HRLeaveAndAbsences_Service_WorkPatternCalendarTest extends BaseHeadles
 
     WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => true]);
 
-    //A contract is fabricated for the contract with start date as 2016-03-03 and end date as 2016-03-06
+    //A contract is fabricated period between 2016-03-03 and 2016-03-06
     $calendar = new WorkPatternCalendarService($this->contact['id'], $absencePeriod, $this->jobContractService);
     $calendarDates = $calendar->get();
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/WorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/WorkPatternTest.php
@@ -60,16 +60,6 @@ class api_v3_WorkPatternTest extends BaseHeadlessTest {
     ]);
   }
 
-  public function testGetCalendarShouldReturnEmptyIfTheGivenContactDoesntExists() {
-    $absencePeriod = AbsencePeriodFabricator::fabricate([
-      'start_date' => CRM_Utils_Date::processDate('2015-01-05'),
-      'end_date'   => CRM_Utils_Date::processDate('2015-01-19'),
-    ]);
-
-    $result = civicrm_api3('WorkPattern', 'getCalendar', ['contact_id' => 321, 'period_id' => $absencePeriod->id]);
-    $this->assertEmpty($result['values'][0]['calendar']);
-  }
-
   /**
    * Just an small test to make sure it can call the service and return the dates
    */
@@ -80,7 +70,7 @@ class api_v3_WorkPatternTest extends BaseHeadlessTest {
     // 15 days absence period
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2015-01-05'),
-      'end_date'   => CRM_Utils_Date::processDate('2015-01-19'),
+      'end_date'   => CRM_Utils_Date::processDate('2015-01-08'),
     ]);
 
     WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => true]);


### PR DESCRIPTION
## Overview
Currently when viewing the calendar view as a manager, the calendar does not show up for contacts without a contract. This is because the logic for returning the calendar for a contact depends on the contact having an active contract.
## Before
Contacts without contracts does not have calendar dates returned for the period selected

## After
The main reason why the contract is needed is for contacts using work pattern with multiple weeks, we need the contract dates to determine the effective date for the work pattern.

Contacts without contracts now have calendar dates returned for the period selected. The calendar dates are based off the contacts work pattern and for dates where the contact's work pattern is not active, the default work pattern is used.

## Technical Details
Initially, the route to fix this problem was to fabricate lapses between the work pattern periods, but discovered that since it is possible for a contact to have a work pattern without having an active contract, those work patterns will not be returned without fabricating a contract to cover the period where those work patterns are active.
For contacts without a contract:

- A default contract is fabricated with start date as the Absence period start date and end date as the Absence Period end date.

For contacts with contracts but with lapses between the contracts for the absence period:

- These lapses are filled with fabricated contract dates and also lapses between the Absence period start date and the first contract start date and lapses between the last contract end date and absence period end date.

After filling the lapses for the contracts, I discovered that dates within the Work pattern periods where a work pattern does not exist are not returned. For These:

- The lapses are filled with fabricated Work Pattern periods using the default work pattern, and also if there are lapses between the first Work pattern period start date and the Absence period start date and also between the Absence period end date and the last Work pattern period end date, these lapses are filled as well.

## Comment
Note that the effective date of the default Work Pattern periods used in filling the lapses may not be 100% accurate for the case where the default work pattern has multiple weeks(not likely) and the contact actually has a contract active within the period the lapse was filled. I thought of filling with the effective date of the contract before the lapse but this is also not fail proof as the work pattern might actually be active in the contract for the work pattern after the lapse. These complexities made me keep it simple for now.

- [X] Tests Pass
