### PR TITLE
PCHR-2260: Optimize Leave Request Validations

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -2796,8 +2796,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     //4(already accrued) + 2(to be accrued)  = 6 and is greater than max leave accrual for Period 1.
     $params['id'] = $toilRequest2Period2->id;
     $params['toil_to_accrue'] = 2;
-    $params['from_date'] = CRM_Utils_Date::processDate('2016-01-06');
-    $params['to_date'] = CRM_Utils_Date::processDate('2016-01-06');
+    $params['from_date'] = CRM_Utils_Date::processDate('2016-01-08');
+    $params['to_date'] = CRM_Utils_Date::processDate('2016-01-08');
     LeaveRequestFabricator::fabricate($params, true);
   }
 }


### PR DESCRIPTION
## Overview
This PR optimizes the validations that a leave request goes through before getting saved in the database. Aside gain in performance, the intention is also that this will help minimize race conditions currently experienced when same leave request is saves simultaneously and inserted more than once in the database as the validations take time to run else the possibility of having more that one leave request get to the database.
Other options are currently being explored to solve the race condition issue. See [Here](https://gist.github.com/tunbola/515a1cbe70961e70907894a098a176d4)

## After
- Some commonly used objects like Absence Type, Absence Period are now fetched once and passed to required validation functions that need them. 
- Instead of using API to communicate with the Job contract extension to validate overlapping contracts the Job Contract BAO is now used directly thereby reducing the overhead that is caused by API call.
- Also validation functions that use the same method are consolidated so that they can share the functions and avoid calling it more than once.

- [X] Tests Pass
