### PR TITLE
PCHR-2316: Fix Social Account Type Dropdown

### DIFF
--- a/hrui/CRM/HRUI/Upgrader.php
+++ b/hrui/CRM/HRUI/Upgrader.php
@@ -35,6 +35,7 @@ class CRM_HRUI_Upgrader extends CRM_HRUI_Upgrader_Base {
   use CRM_HRUI_Upgrader_Steps_4702;
   use CRM_HRUI_Upgrader_Steps_4703;
   use CRM_HRUI_Upgrader_Steps_4704;
+  use CRM_HRUI_Upgrader_Steps_4705;
 
   public function install() {
     $this->runAllUpgraders();

--- a/hrui/CRM/HRUI/Upgrader/Steps/4705.php
+++ b/hrui/CRM/HRUI/Upgrader/Steps/4705.php
@@ -1,0 +1,22 @@
+<?php
+
+trait CRM_HRUI_Upgrader_Steps_4705 {
+
+  /**
+   * Upgrader to fix Social Account Type (formerly Website Type) option group,
+   * which got deactivated on upgrade 4702.
+   *
+   * @return bool
+   */
+  public function upgrade_4705() {
+    civicrm_api3('OptionGroup', 'get', [
+      'name' => 'website_type',
+      'api.OptionGroup.create' => [
+        'id' => '$value.id',
+        'is_active' => 1,
+      ],
+    ]);
+
+    return TRUE;
+  }
+}


### PR DESCRIPTION
## Overview
Dropdown select Social Account Type on contact edit view was showing no values,
![image](https://user-images.githubusercontent.com/21999940/27481625-1ed0432c-57e3-11e7-9221-481aa26b10b6.png)


## Before
Option group for Social Account Type (name: website_type) was inadvertently disabled by a previous upgrade (4702 of HRUI extension) when making a chained create call to change the option group title from "Website Type" to "Social Account Type".

## After
Fixed by adding an upgrader to activate the website_type option group.
![image](https://user-images.githubusercontent.com/21999940/27481686-78749bbc-57e3-11e7-8578-7ccb3c84145f.png)

---

- [x] Tests Pass
