### PR TITLE
PCHR-2134: Allow a LeaveRequest with half day to use all the remaining balance

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -482,17 +482,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    * @return float
    */
   private static function calculateBalanceChangeFromCreateParams($params) {
-    $leaveRequestOptionsValue = self::getLeaveRequestDayTypeOptionsGroupByValue();
-
-    $fromDateType = $leaveRequestOptionsValue[$params['from_date_type']];
-    $toDateType = $leaveRequestOptionsValue[$params['to_date_type']];
-
     $leaveRequestBalance = self::calculateBalanceChange(
       $params['contact_id'],
       new DateTime($params['from_date']),
-      $fromDateType,
+      $params['from_date_type'],
       new DateTime($params['to_date']),
-      $toDateType
+      $params['to_date_type']
     );
 
     return abs($leaveRequestBalance['amount']);
@@ -928,38 +923,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = $date->format('Y-m-d');
     return self::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
-  }
-
-  /**
-   * Returns LeaveRequest Day Type Options in a nested array format
-   * with the day_type_id key as the array key and details about the day_type_id as the value
-   *
-   * @return array
-   *   [
-   *     '1' => [
-   *     'id' => 1,
-   *     'value' => '1',
-   *     'name' => 'all_day'
-   *     ],
-   *     '2 => [
-   *     'id' => 2,
-   *     'value' => '2',
-   *     'name' => 'half_day_am',
-   *     ]
-   *   ]
-   */
-  private static function getLeaveRequestDayTypeOptionsGroupByValue() {
-    $leaveRequestDayTypeOptionsGroup = [];
-    $leaveRequestDayTypeOptions = self::buildOptions('from_date_type');
-    foreach($leaveRequestDayTypeOptions  as $key => $label) {
-      $name = CRM_Core_Pseudoconstant::getName(self::class, 'from_date_type', $key);
-      $leaveRequestDayTypeOptionsGroup[$key] = [
-        'id' => $key,
-        'value' => $key,
-        'name' => $name
-      ];
-    }
-    return $leaveRequestDayTypeOptionsGroup;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -1312,6 +1312,48 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     ]);
   }
 
+  public function testLeaveRequestWithHalfDaysCanBeCreatedWhenBalanceChangeIsEqualToTheRemainingBalanceWhenAbsenceTypeDoesntAllowOveruse() {
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $this->absenceType->id,
+      'contact_id' => 1,
+      'period_id' => $period->id
+    ]);
+
+    $this->createLeaveBalanceChange($periodEntitlement->id, 1.5);
+    $periodStartDate = date('2016-01-01');
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $periodEntitlement->contact_id],
+      ['period_start_date' => $periodStartDate]
+    );
+
+    $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $periodEntitlement->contact_id,
+      'pattern_id' => $workPattern->id
+    ]);
+
+    //two working days, but the second day is half, so the balance change
+    //will be 1.5, exactly the same as the remaining balance (which, since we
+    //don't have any other deductions, it's the same as the entitlement)
+    $leaveRequest = LeaveRequest::create([
+      'type_id' => $this->absenceType->id,
+      'contact_id' => $periodEntitlement->contact_id,
+      'status_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-11-14'),
+      'from_date_type' => $this->leaveRequestDayTypes['all_day']['value'],
+      'to_date' => CRM_Utils_Date::processDate('2016-11-15'),
+      'to_date_type' => $this->leaveRequestDayTypes['half_day_am']['value'],
+      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
+    ]);
+    $this->assertNotNull($leaveRequest->id);
+  }
+
   public function testLeaveRequestCanBeCreatedWhenBalanceChangeGreaterThanPeriodBalanceChangeAndAbsenceTypeAllowOveruseTrue() {
     $period = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),


### PR DESCRIPTION
### Overview
In a scenario where you cannot use more than your remaining balance, and it also has half days (say 1.5), if you request a Leave Request with the same amount, the validation would fail, saying you cannot use more than the remaining balance

### Before

During the Leave Request validation, we pass the `$params` array to the `calculateBalanceChangeFromParams` method, which would then convert the `from_date_type` and `to_date_type` values to option values arrays (containing labels, values and names). These arrays would be passed to the `calculateBalanceChange` method, where the calculation actually happens. This method expects the date types as values though, not as arrays. Whenever it get the values in an unexpected format, it would consider it to be a full day. So, when `calculateBalanceChangeFromParams` passed a half day to it, it would be considered as a full day, resulting in the wrong balance change.

## After
Now `calculateBalanceChangeFromParams` doesn't convert the date types to arrays anymore, making `calculateBalanceChange` receive the data in the expected format and calculate the amount properly

## Technical Details
The tests never caught this before because this is a very specific scenario and most of them always use full days. A new test was added to cover this scenario.

---

- [x] Tests Pass
