### PR TITLE
PCHR-2345: Update labels of "1/2 AM" and "1/2 PM" option values

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -892,7 +892,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    *     '2 => [
    *       'id' => 2,
    *       'value' => '2',
-   *       'label' => '1/2 AM'
+   *       'label' => 'Half-day AM'
    *     ]
    *   ]
    */

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
@@ -5,6 +5,8 @@
  */
 class CRM_HRLeaveAndAbsences_Upgrader extends CRM_HRLeaveAndAbsences_Upgrader_Base {
 
+  use CRM_HRLeaveAndAbsences_Upgrader_Step_1000;
+
   /**
    * A list of directories to be scanned for XML installation files
    *

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1000.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1000.php
@@ -1,0 +1,46 @@
+<?php
+
+trait CRM_HRLeaveAndAbsences_Upgrader_Step_1000 {
+
+  /**
+   * Updates the labels of the "1/2 AM" and "1/2 PM" option values to "Half-day AM"
+   * and "Half-day PM" respectively
+   *
+   * @return bool
+   */
+  public function upgrade_1000() {
+    $this->up1000_updateHalfDayAmLabel();
+    $this->up1000_updateHalfDayPmLabel();
+
+    return true;
+  }
+
+  /**
+   * Updates the label of the "1/2 AM" option value
+   */
+  private function up1000_updateHalfDayAmLabel() {
+    $this->up1000_updateOptionValueLabel('half_day_am', 'Half-day AM');
+  }
+
+  /**
+   * Updates the label of the "1/2 PM" option value
+   */
+  private function up1000_updateHalfDayPmLabel() {
+    $this->up1000_updateOptionValueLabel('half_day_pm', 'Half-day PM');
+  }
+
+  /**
+   * Updates the option value with the given $name with the given $label
+   *
+   * @param string $name
+   * @param string $label
+   */
+  private function up1000_updateOptionValueLabel($name, $label) {
+    civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => 'hrleaveandabsences_leave_request_day_type',
+      'name' => ['IN' => [$name]],
+      'api.OptionValue.create' => ['id' => '$value.id', 'label' => $label],
+    ]);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/controllers/request-ctrl.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/controllers/request-ctrl.js
@@ -762,7 +762,7 @@ define([
 
       /**
        * This method will be used on the view to return a list of available
-       * leave request day types (All day, 1/2 AM, 1/2 PM, Non working day,
+       * leave request day types (All day, Half-day AM, Half-day PM, Non working day,
        * Weekend, Public holiday) for the given date (which is the date
        * selected by the user via datepicker)
        *
@@ -794,7 +794,7 @@ define([
               inCalendarList = getDayTypesFromDate.call(this, date, listToReturn);
 
               if (!inCalendarList.length) {
-                // 'All day', '1/2 AM', and '1/2 PM' options
+                // 'All day', 'Half-day AM', and 'Half-day PM' options
                 listToReturn = listToReturn.filter(function (dayType) {
                   return dayType.name === 'all_day' || dayType.name === 'half_day_am' || dayType.name === 'half_day_pm';
                 });

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/mocks/data/leave-request-data.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/mocks/data/leave-request-data.js
@@ -354,7 +354,7 @@ define([
           'type': {
             'id': 2,
             'value': 2,
-            'label': '1/2 AM'
+            'label': 'Half-day AM'
           }
         }]
       }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/mocks/data/option-group-mock-data.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/mocks/data/option-group-mock-data.js
@@ -23,7 +23,7 @@ define([
     }, {
       'id': '1114',
       'option_group_id': '142',
-      'label': '1/2 AM',
+      'label': 'Half-day AM',
       'value': '2',
       'name': 'half_day_am',
       'is_default': '0',
@@ -34,7 +34,7 @@ define([
     }, {
       'id': '1115',
       'option_group_id': '142',
-      'label': '1/2 PM',
+      'label': 'Half-day PM',
       'value': '3',
       'name': 'half_day_pm',
       'is_default': '0',

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/option_groups/leave_request_day_type_install.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/option_groups/leave_request_day_type_install.xml
@@ -25,7 +25,7 @@
     </OptionValue>
 
     <OptionValue>
-      <label>1/2 AM</label>
+      <label>Half-day AM</label>
       <value>2</value>
       <name>half_day_am</name>
       <is_default>0</is_default>
@@ -37,7 +37,7 @@
     </OptionValue>
 
     <OptionValue>
-      <label>1/2 PM</label>
+      <label>Half-day PM</label>
       <value>3</value>
       <name>half_day_pm</name>
       <is_default>0</is_default>


### PR DESCRIPTION
## Overview
The labels were updated to:
- "1/2 AM":  "Half-day AM"
- "1/2 PM":  "Half-day PM"

## Before
![captura de tela de 2017-06-26 12-17-38](https://user-images.githubusercontent.com/388373/27546842-59e79c10-5a6a-11e7-9aab-69b75924323a.png)

## After
![captura de tela de 2017-06-26 12-18-41](https://user-images.githubusercontent.com/388373/27546850-60966afa-5a6a-11e7-92ea-668ec5e9cedc.png)

---

- [x] Tests Pass
