### PR TITLE
PCHR-2352: Better error handling duplicated ContactWorkPattern

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/ContactWorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/ContactWorkPattern.php
@@ -52,7 +52,31 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern extends CRM_HRLeaveAndAbsenc
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidContactWorkPatternException
    */
   private static function validateParams($params) {
+    self::validateMandatory($params);
     self::validateUniquePerContactAndEffectiveDate($params);
+  }
+
+  /**
+   * A method for validating the mandatory fields in the params
+   * passed to the ContactWorkPattern create method
+   *
+   * @param array $params
+   *   The params array received by the create method
+   *
+   * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidContactWorkPatternException
+   */
+  private static function validateMandatory($params) {
+    $mandatoryFields = [
+      'contact_id',
+      'effective_date',
+      'pattern_id',
+    ];
+
+    foreach($mandatoryFields as $field) {
+      if (empty($params[$field])) {
+        throw new InvalidContactWorkPatternException("The {$field} field should not be empty");
+      }
+    }
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/ContactWorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/ContactWorkPattern.php
@@ -2,6 +2,7 @@
 
 use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
 use CRM_HRLeaveAndAbsences_BAO_WorkDay as WorkDay;
+use CRM_HRLeaveAndAbsences_Exception_InvalidContactWorkPatternException as InvalidContactWorkPatternException;
 
 class CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern extends CRM_HRLeaveAndAbsences_DAO_ContactWorkPattern {
 
@@ -23,13 +24,15 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern extends CRM_HRLeaveAndAbsenc
     $instance = new self();
     $instance->copyValues($params);
 
+    self::validateParams($params);
+
     $transaction = new CRM_Core_Transaction();
     try {
       self::endEmployeePreviousWorkPattern($params);
       $instance->save();
       $transaction->commit();
 
-    } catch(Exception $e) {
+    } catch (Exception $e) {
       $transaction->rollback();
       // re-throw the error how it can be handled somewhere else
       throw $e;
@@ -38,6 +41,50 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern extends CRM_HRLeaveAndAbsenc
     CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
 
     return $instance;
+  }
+
+  /**
+   * A method for validating the params passed to the ContactWorkPattern create method
+   *
+   * @param array $params
+   *   The params array received by the create method
+   *
+   * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidContactWorkPatternException
+   */
+  private static function validateParams($params) {
+    self::validateUniquePerContactAndEffectiveDate($params);
+  }
+
+  /**
+   * Gets the contact_id and effective_date from the params and validates that
+   * the contact doesn't have another work pattern with the same effective date.
+   *
+   * In case of an update, this method also considers the ID, to make sure the
+   * other work pattern with the same effective date is not itself.
+   *
+   * @param array $params
+   *
+   * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidContactWorkPatternException
+   */
+  private static function validateUniquePerContactAndEffectiveDate($params) {
+    $tableName = self::getTableName();
+    $query = "SELECT id FROM {$tableName} WHERE contact_id = %1 AND effective_date = %2";
+
+    $queryParams = [
+      1 => [$params['contact_id'], 'Integer'],
+      2 => [date('Y-m-d', strtotime($params['effective_date'])), 'String']
+    ];
+
+    if (!empty($params['id'])) {
+      $query .= ' AND id <> %3';
+      $queryParams[3] = [$params['id'], 'Integer'];
+    }
+
+    $result = CRM_Core_DAO::executeQuery($query, $queryParams);
+
+    if ($result->N) {
+      throw new InvalidContactWorkPatternException('This contact already have a Work Pattern with this effective date');
+    }
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Exception/InvalidContactWorkPatternException.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Exception/InvalidContactWorkPatternException.php
@@ -1,0 +1,2 @@
+<?php
+class CRM_HRLeaveAndAbsences_Exception_InvalidContactWorkPatternException extends Exception {}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/ContactWorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/ContactWorkPatternTest.php
@@ -19,6 +19,39 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest extends BaseHeadlessTest
     CRM_Core_DAO::executeQuery('SET foreign_key_checks = 0;');
   }
 
+  /**
+   * @expectedException \CRM_HRLeaveAndAbsences_Exception_InvalidContactWorkPatternException
+   * @expectedExceptionMessage The contact_id field should not be empty
+   */
+  public function testItCannotBeCreatedWithoutAContactID() {
+    ContactWorkPattern::create([
+      'pattern_id' => 1,
+      'effective_date' => CRM_Utils_Date::processDate('2016-01-01'),
+    ]);
+  }
+
+  /**
+   * @expectedException \CRM_HRLeaveAndAbsences_Exception_InvalidContactWorkPatternException
+   * @expectedExceptionMessage The pattern_id field should not be empty
+   */
+  public function testItCannotBeCreatedWithoutAPatternID() {
+    ContactWorkPattern::create([
+      'contact_id' => 1,
+      'effective_date' => CRM_Utils_Date::processDate('2016-01-01'),
+    ]);
+  }
+
+  /**
+   * @expectedException \CRM_HRLeaveAndAbsences_Exception_InvalidContactWorkPatternException
+   * @expectedExceptionMessage The effective_date field should not be empty
+   */
+  public function testItCannotBeCreatedWithoutAnEffectiveDate() {
+    ContactWorkPattern::create([
+      'contact_id' => 1,
+      'pattern_id' => 1,
+    ]);
+  }
+
   public function testThereCannotBeTwoWorkPatternsForTheSameEmployeeWithTheSameEffectiveDate() {
     $workPattern1 = WorkPatternFabricator::fabricate();
     $workPattern2 = WorkPatternFabricator::fabricate();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/ContactWorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/ContactWorkPatternTest.php
@@ -53,21 +53,18 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest extends BaseHeadlessTest
   }
 
   public function testThereCannotBeTwoWorkPatternsForTheSameEmployeeWithTheSameEffectiveDate() {
-    $workPattern1 = WorkPatternFabricator::fabricate();
-    $workPattern2 = WorkPatternFabricator::fabricate();
-
     $effectiveDate = CRM_Utils_Date::processDate('2016-01-01');
 
     ContactWorkPattern::create([
       'contact_id' => 2,
-      'pattern_id' => $workPattern1->id,
+      'pattern_id' => 1,
       'effective_date' => $effectiveDate,
     ]);
 
     try {
       ContactWorkPattern::create([
         'contact_id' => 2,
-        'pattern_id' => $workPattern2->id,
+        'pattern_id' => 2,
         'effective_date' => $effectiveDate,
       ]);
     } catch(InvalidContactWorkPatternException $e) {
@@ -103,11 +100,9 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest extends BaseHeadlessTest
   }
 
   public function testTheEffectiveEndDateShouldBeAutomaticallyUpdatedWhenANewWorkPatternIsLinkedToAnEmployee() {
-    $workPattern1 = WorkPatternFabricator::fabricate();
-
     $contactWorkPattern1 = ContactWorkPattern::create([
       'contact_id' => 2,
-      'pattern_id' => $workPattern1->id,
+      'pattern_id' => 1,
       'effective_date' => CRM_Utils_Date::processDate('2016-01-01'),
     ]);
 
@@ -116,7 +111,7 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest extends BaseHeadlessTest
 
     $contactWorkPattern2 = ContactWorkPattern::create([
       'contact_id' => 2,
-      'pattern_id' => $workPattern1->id,
+      'pattern_id' => 1,
       'effective_date' => CRM_Utils_Date::processDate('2016-04-02'),
     ]);
 


### PR DESCRIPTION
## Overview
The DB schema of the ContactWorkPattern has a unique key that prevents the creation of two records with the same contact_id and effective_date. If you use the API and try to create such a duplicate record, it will respond with a cryptic "DB Error: already exists message" and also the faulty SQL query, in case debug was enabled.

## Before
The response of the ContactWorkPattern.create API that would create a duplicate record would look like this:

```json
{
    "error_code": "already exists",
    "sql": "INSERT INTO civicrm_hrleaveandabsences_contact_work_pattern (contact_id , pattern_id , effective_date ) VALUES ( 204 ,  1 ,  20160607000000 )  [nativecode=1062 ** Duplicate entry '204-2016-06-07' for key 'unique_pattern_per_effective_date']",
    "tip": "add debug=1 to your API call to have more info about the error",
    "is_error": 1,
    "error_message": "DB Error: already exists",
    "debug_information": "INSERT INTO civicrm_hrleaveandabsences_contact_work_pattern (contact_id , pattern_id , effective_date ) VALUES ( 204 ,  1 ,  20160607000000 )  [nativecode=1062 ** Duplicate entry '204-2016-06-07' for key 'unique_pattern_per_effective_date']"
}
```

## After
The response for the same API call will look like:

```json
{
    "is_error": 1,
    "error_message": "This contact already have a Work Pattern with this effective date"
}
```

## Technical Details
In order to be able to return a meaningful message to the API, we need to catch the original error and throw a new one. This was done by adding a `validateParams()` method to the ContactWorkPattern BAO, which works exactly the same way as the other `validateParams()` method in BAOs like the AbsenceType or LeaveRequest. In the event of an error, it throws an `InvalidContactWorkPatternException`.

Besides the unique validation, I also added validation for mandatory fields. We also have schema level validation for them, but I added the `validateMandatory()` method to keep consistency and have higher level validations for this too.

---

- [x] Tests Pass
