### PR TITLE
PCHR-2149: Validate Username and email

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordTaskForm.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordTaskForm.php
@@ -28,7 +28,7 @@ class CRM_HRCore_Form_CreateUserRecordTaskForm extends AbstractDrupalInteraction
     $haveNoAccount = $this->getContactsWithoutAttribute('uf_id');
     $haveAccount = array_diff_key($this->contactDetails, $haveNoAccount);
 
-    $this->assign('contactsWithoutEmail', $this->getContactsWithoutAttribute('email'));
+    $this->assign('invalidEmailContacts', $this->getContactsWithInvalidEmail());
     $this->assign('contactsWithAccount', $haveAccount);
     $this->assign('contactsForCreation', $this->getValidContactsForCreation());
     $this->assign('emailConflictContact', $this->getEmailConflictContacts());
@@ -58,7 +58,7 @@ class CRM_HRCore_Form_CreateUserRecordTaskForm extends AbstractDrupalInteraction
    * @return array
    */
   private function getValidContactsForCreation() {
-    $missingEmail = $this->getContactsWithoutAttribute('email');
+    $missingEmail = $this->getContactsWithInvalidEmail();
     $haveNoAccount = $this->getContactsWithoutAttribute('uf_id');
     $emailConflict = $this->getEmailConflictContacts();
 
@@ -118,6 +118,24 @@ class CRM_HRCore_Form_CreateUserRecordTaskForm extends AbstractDrupalInteraction
     }
 
     return $badContacts;
+  }
+
+  /**
+   * @return array
+   */
+  private function getContactsWithInvalidEmail() {
+    $invalid = [];
+
+    foreach ($this->contactDetails as $contactID => $contact) {
+      $email = $contact['email'];
+      if (!$this->drupalUserService->isValidEmail($email)
+        || !$this->drupalUserService->isValidUsername($email)
+      ) {
+        $invalid[$contactID] = $contact;
+      }
+    }
+
+    return $invalid;
   }
 
 }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/DrupalUserService.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/DrupalUserService.php
@@ -67,7 +67,7 @@ class CRM_HRCore_Service_DrupalUserService {
   }
 
   /**
-   * @param $name
+   * @param string $name
    *
    * @return bool
    */
@@ -76,7 +76,7 @@ class CRM_HRCore_Service_DrupalUserService {
   }
 
   /**
-   * @param $email
+   * @param string $email
    *
    * @return bool
    */

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/DrupalUserService.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/DrupalUserService.php
@@ -67,6 +67,24 @@ class CRM_HRCore_Service_DrupalUserService {
   }
 
   /**
+   * @param $name
+   *
+   * @return bool
+   */
+  public function isValidUsername($name) {
+    return empty(user_validate_name($name));
+  }
+
+  /**
+   * @param $email
+   *
+   * @return bool
+   */
+  public function isValidEmail($email) {
+    return empty(user_validate_mail($email));
+  }
+
+  /**
    * @param int $contactID
    * @param string $type
    */

--- a/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/CreateUserRecordTaskForm.tpl
+++ b/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/CreateUserRecordTaskForm.tpl
@@ -14,14 +14,18 @@
     <br/>
   {/if}
 
-  {if !empty($contactsWithoutEmail) }
+  {if !empty($invalidEmailContacts) }
     <p>
-      {ts}An email is required to create the account.{/ts}
+      {ts}
+        Some contacts have invalid emails. Contacts must have a primary e-mail,
+        and it cannot contain punctuation except for periods, hyphens,
+        apostrophes and underscores.
+      {/ts}
     </p>
     <p>
-      {ts 1=$contactsWithoutEmail|@count}%1 contact(s) do not have an email set:{/ts}
+      {ts 1=$invalidEmailContacts|@count}%1 contact(s) have invalid emails:{/ts}
     </p>
-    {include file="CRM/HRCore/Common/ContactTable.tpl" contacts=$contactsWithoutEmail}
+    {include file="CRM/HRCore/Common/ContactTable.tpl" contacts=$invalidEmailContacts}
     <br/>
   {/if}
 


### PR DESCRIPTION
## Overview
It is possible to create a user record with an valid email that does not match the drupal username validation rules, for example "foo+1@bar.com"

## Before
You can create a user record from the form that doesn't have a valid username. Attempts to update that user later from the Drupal admin area will fail.

## After
The username and email are validated before creation of user records. Validation failures are displayed with an explanatory message.

## Notes 

- The PR was created as a replacement for #1971 as it used the wrong branch name

- [x] Tests Pass (you know it)
