### PR TITLE
PCHR-2340: Set 'Home' as Default Location and Primary Address

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/Pre/PrimaryAddressSetter.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/Pre/PrimaryAddressSetter.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Class to set 'Home' address as primary address always.
+ */
+class CRM_HRCore_Hook_Pre_PrimaryAddressSetter {
+
+  /**
+   * If address being saved has a 'Home' location type, it should be set as
+   * primary, by altering the given $params array.
+   *
+   * @param string $op
+   *   Operation being done
+   * @param string $objectName
+   *   Name of the object on which the operation is being done
+   * @param int $objectId
+   *   ID of the record the object instantiates
+   * @param array $params
+   *   Parameter array being used to call the operation
+   */
+  public function handle($op, $objectName, $objectId, &$params) {
+
+    if (!$this->shouldHandle($op, $objectName)) {
+      return;
+    }
+
+    $homeLocation = civicrm_api3('LocationType', 'getsingle', [
+      'name' => 'Home',
+    ]);
+
+    if ($params['location_type_id'] == $homeLocation['id']) {
+      $params['is_primary'] = 1;
+    }
+  }
+
+  /**
+   * Checks if the hook should be handled.  Only calls to create or edit an
+   * address should be.
+   *
+   * @param string $op
+   *   Operation being done
+   * @param string $objectName
+   *   Name of the object on which the operation is being done
+   *
+   * @return bool
+   *   True if the hook should be handled, false otherwise.
+   */
+  private function shouldHandle($op, $objectName) {
+
+    if ($objectName === 'Address' && ($op === 'edit' || $op === 'create')) {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -9,6 +9,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1001;
   use CRM_HRCore_Upgrader_Steps_1002;
   use CRM_HRCore_Upgrader_Steps_1003;
+  use CRM_HRCore_Upgrader_Steps_1004;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1004.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1004.php
@@ -29,12 +29,12 @@ trait CRM_HRCore_Upgrader_Steps_1004 {
 
   private function up1004_setAllHomeAddressesAsPrimary() {
     $homeLocation = civicrm_api3('LocationType', 'getsingle', [
-      'name' => "Home",
+      'name' => 'Home',
     ]);
 
     $contactsWithNonPrimaryHomeAddress = civicrm_api3('Address', 'get', [
       'sequential' => 1,
-      'return' => array('contact_id'),
+      'return' => ['contact_id'],
       'location_type_id' => $homeLocation['id'],
       'is_primary' => 0,
     ]);

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1004.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1004.php
@@ -1,0 +1,56 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1004 {
+
+  /**
+   * Upgrader to set 'Home' as default location and set all 'Home' addresses as
+   * primary.
+   *
+   * @return bool
+   */
+  public function upgrade_1004() {
+    $this->up1004_setHomeLocationAsDefault();
+    $this->up1004_setAllHomeAddressesAsPrimary();
+
+    return true;
+  }
+
+  private function up1004_setHomeLocationAsDefault() {
+    civicrm_api3('LocationType', 'get', [
+      'sequential' => 1,
+      'name' => 'Home',
+      'api.LocationType.create' => [
+        'id' => '$value.id',
+        'is_default' => 1,
+        'is_reserved' => 1,
+      ],
+    ]);
+  }
+
+  private function up1004_setAllHomeAddressesAsPrimary() {
+    $homeLocation = civicrm_api3('LocationType', 'getsingle', [
+      'name' => "Home",
+    ]);
+
+    $contactsWithNonPrimaryHomeAddress = civicrm_api3('Address', 'get', [
+      'sequential' => 1,
+      'return' => array('contact_id'),
+      'location_type_id' => $homeLocation['id'],
+      'is_primary' => 0,
+    ]);
+
+    $contactIDs = [];
+    foreach ($contactsWithNonPrimaryHomeAddress['values'] as $currentContact) {
+      $contactIDs[] = $currentContact['contact_id'];
+    }
+
+    if (!empty($contactIDs)) {
+      $query = "
+        UPDATE civicrm_address
+        SET is_primary = CASE WHEN location_type_id = {$homeLocation['id']} THEN 1 ELSE 0 END
+        WHERE contact_id IN (" . implode(',', $contactIDs) . ")
+      ";
+      CRM_Core_DAO::executeQuery($query);
+    }
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1004.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1004.php
@@ -28,29 +28,11 @@ trait CRM_HRCore_Upgrader_Steps_1004 {
   }
 
   private function up1004_setAllHomeAddressesAsPrimary() {
-    $homeLocation = civicrm_api3('LocationType', 'getsingle', [
-      'name' => 'Home',
-    ]);
-
-    $contactsWithNonPrimaryHomeAddress = civicrm_api3('Address', 'get', [
+    civicrm_api3('Address', 'get', [
       'sequential' => 1,
-      'return' => ['contact_id'],
-      'location_type_id' => $homeLocation['id'],
+      'location_type_id' => 'Home',
       'is_primary' => 0,
+      'api.Address.create' => ['id' => '$value.id', 'is_primary' => 1],
     ]);
-
-    $contactIDs = [];
-    foreach ($contactsWithNonPrimaryHomeAddress['values'] as $currentContact) {
-      $contactIDs[] = $currentContact['contact_id'];
-    }
-
-    if (!empty($contactIDs)) {
-      $query = "
-        UPDATE civicrm_address
-        SET is_primary = CASE WHEN location_type_id = {$homeLocation['id']} THEN 1 ELSE 0 END
-        WHERE contact_id IN (" . implode(',', $contactIDs) . ")
-      ";
-      CRM_Core_DAO::executeQuery($query);
-    }
   }
 }

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -139,18 +139,20 @@ function hrcore_civicrm_apiWrappers(&$wrappers, $apiRequest) {
  * Implementation of hook_civicrm_pre hook.
  *
  * @param string $op
+ *   Operation being done
  * @param string $objectName
+ *   Name of the object on which the operation is being done
  * @param int $objectId
+ *   ID of the record the object instantiates
  * @param array $params
+ *   Parameter array being used to call the operation
  */
 function hrcore_civicrm_pre($op, $objectName, $objectId, &$params) {
-  if ($objectName === 'Address' && ($op === 'edit' || $op === 'create')) {
-    $homeLocation = civicrm_api3('LocationType', 'getsingle', [
-      'name' => 'Home',
-    ]);
+  $listeners = [
+    new CRM_HRCore_Hook_Pre_PrimaryAddressSetter(),
+  ];
 
-    if ($params['location_type_id'] == $homeLocation['id']) {
-      $params['is_primary'] = 1;
-    }
+  foreach ($listeners as $currentListener) {
+    $currentListener->handle($op, $objectName, $objectId, $params);
   }
 }

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -134,3 +134,23 @@ function hrcore_civicrm_apiWrappers(&$wrappers, $apiRequest) {
     $wrappers[] = new CRM_HRCore_APIWrapper_DefaultLimitRemover();
   }
 }
+
+/**
+ * Implementation of hook_civicrm_pre hook.
+ *
+ * @param string $op
+ * @param string $objectName
+ * @param int $objectId
+ * @param array $params
+ */
+function hrcore_civicrm_pre($op, $objectName, $objectId, &$params) {
+  if ($objectName === 'Address' && ($op === 'edit' || $op === 'create')) {
+    $homeLocation = civicrm_api3('LocationType', 'getsingle', [
+      'name' => 'Home',
+    ]);
+
+    if ($params['location_type_id'] == $homeLocation['id']) {
+      $params['is_primary'] = 1;
+    }
+  }
+}


### PR DESCRIPTION
## Overview
When an administrator creates a new contact, addresses may have one of several different location types. The system will allow him to add several different addresses (one for each location type) and set one of them as primary. This conflicted with the logic implemented in the SSP, where it is required for the 'Home' address to be the primary address for the contact in order to be able to view and edit the contact's personal information.

## Before
The problem was SSP uses 'Home' location type to look for the address to be used on the dashboard and the My Details edit view, making the assumption this 'Home' address is also the contact's primary address. If the contact did not have the 'Home' address set as primary, but some other address, saving the address through the SSP effectively saved the information on the existing 'Home' address record, but no changes were made to the is_primary flag. This caused the information on the dashboard to remain empty, as the view is built by looking for addresses that are both 'Home' location AND primary.

## After
The requirement for the ticket specified to fix this, two things needed to happen:

1. Make sure on all existing installations and all new installations the default location type is 'Home'
2. Make sure that the address record saved from SSP is saved with Primary flag

Added an upgrader trait to hrcore extension that sets 'Home' location type as default and reserved, to prevent accidental modification or elimination of the record. It also updates all 'Home' location type addresses to be primary, for all contacts that have them.

Finally, I implemented _civicrm_pre hook on hrcore extension to check for when an address is being edited or saved. If the address' location type is 'Home', then it'll set the is_primary flag to true.

---

- [x] Tests Pass
