### PR TITLE
PCHR-2388: display expiry date for TOIL requests on My Leave

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/staff-leave-report.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/staff-leave-report.html
@@ -200,6 +200,9 @@
                           <tr ng-repeat="request in report.sections.approved.data track by $index">
                             <td class="chr_leave-report__label">
                               {{report.absenceTypes[request.type_id].title}}
+                              <span ng-if="request.toil_expiry_date">
+                                (expires {{request.toil_expiry_date | date:report.dateFormat}})
+                              </span>
                             </td>
                             <td>
                               {{request.from_date | date:report.dateFormat}} - {{request.to_date | date:report.dateFormat}}
@@ -372,6 +375,9 @@
                         <tr ng-repeat="request in report.sections.pending.data">
                           <td class="chr_leave-report__label">
                             {{report.absenceTypes[request.type_id].title}}
+                            <span ng-if="request.toil_expiry_date">
+                              (expires {{request.toil_expiry_date | date:report.dateFormat}})
+                            </span>
                           </td>
                           <td>
                             {{request.from_date | date:report.dateFormat}} - {{request.to_date | date:report.dateFormat}}
@@ -470,6 +476,9 @@
                         <tr ng-repeat="request in report.sections.other.data track by $index">
                           <td class="chr_leave-report__label">
                             {{report.absenceTypes[request.type_id].title}}
+                            <span ng-if="request.toil_expiry_date">
+                              (expires {{request.toil_expiry_date | date:report.dateFormat}})
+                            </span>
                           </td>
                           <td>
                             {{request.from_date | date:report.dateFormat}} - {{request.to_date | date:report.dateFormat}}


### PR DESCRIPTION
## Overview
As a Staff, on the My Leave report section the TOIL requests are missing their expiry date label according to Invision mock:
https://projects.invisionapp.com/share/WX71LBMPJ#/screens/157876104

This PR fixes that issue.

## Before
![anim](https://user-images.githubusercontent.com/1642119/28024252-24204132-655e-11e7-811e-71650ed51f0c.gif)


## After
![anim](https://user-images.githubusercontent.com/1642119/28024472-cd69e824-655e-11e7-8a96-f79d1b813d31.gif)



## Technical Details
The `toil_expiry_date` was used to display the expiry date and the format comes from the `report.dateFormat` setting.

---

- [x] Tests Pass
