### PR TITLE
PCHR-2382: Fix bug causing Contacts with future Contract Dates not being displayed in Manage Entitlement page

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
@@ -217,8 +217,8 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
   private function getContactsWithContractsInPeriod(AbsencePeriod $absencePeriod, $filter = []) {
     try {
       $contacts = civicrm_api3('HRJobContract', 'getcontactswithcontractsinperiod' , [
-        $absencePeriod->start_date,
-        $absencePeriod->end_date
+        'start_date' => $absencePeriod->start_date,
+        'end_date' => $absencePeriod->end_date
       ])['values'];
 
       if(!empty($filter)) {


### PR DESCRIPTION
## Overview
When a contract with future date is added for a contact and after saving the contract and upon redirection to the Manage entitlement page, the entitlement page is blank for the period that the future contract is active in.

## Before
Entitlement cannot be updated for Contacts having contracts with future dates.

## After
The reason for the Management entitlement page being empty is because the start and end dates of the absence period was not properly passed to the `HrJobContract.getcontactswithcontractsinperiod` and the API was using the value of the current present date as the start and end date (see [Here](https://github.com/civicrm/civihr/blob/a3a8ec3d4aedc9d749b9d32fda05b3432707ab97/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php#L649-L649)) to find contacts with contracts so for Contacts whose contracts begin after the present date, entitlements can not be added for them or Contacts whose contract has ended before the present date will not show up on the entitlements page.

This PR fixes the issue by passing in the start and end dates to the `HrJobContract.getcontactswithcontractsinperiod` API properly.
Contacts with future contracts now show up on manage entitlement page for the period containing the contract.

---

- [X] Tests Pass
