### PR TITLE
PCHR-2396: Fix an upgrader error during the extension installation

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1000.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1000.php
@@ -36,11 +36,20 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1000 {
    * @param string $label
    */
   private function up1000_updateOptionValueLabel($name, $label) {
-    civicrm_api3('OptionValue', 'get', [
-      'sequential' => 1,
-      'option_group_id' => 'hrleaveandabsences_leave_request_day_type',
-      'name' => ['IN' => [$name]],
-      'api.OptionValue.create' => ['id' => '$value.id', 'label' => $label],
-    ]);
+    try {
+      civicrm_api3('OptionValue', 'get', [
+        'sequential' => 1,
+        'option_group_id' => 'hrleaveandabsences_leave_request_day_type',
+        'name' => ['IN' => [$name]],
+        'api.OptionValue.create' => ['id' => '$value.id', 'label' => $label],
+      ]);
+    } catch(Exception $e) {
+      // We run all the upgraders during the extension installation, but, during
+      // this process, the hrleaveandabsences_leave_request_day_type option group
+      // is still not available and the API call will fail and throw an exception.
+      // So, to avoid the installation process to stop, we simply catch the exception
+      // and don't do anything. The option group and values will be create just
+      // fine, based on the values set on xml/option_groups/leave_request_day_type_install.xml
+    }
   }
 }


### PR DESCRIPTION
## Overview
Installing the extension on a new site will result in an error saying that `hrleaveandabsences_leave_request_day_type' is not a valid option for field option_group_id`. The error started after one of the changes introduced by https://github.com/civicrm/civihr/pull/1983, where we now run all the upgraders during the installation. One of them, tries to access the option group mentioned on the error, but it does this at a moment of the process where it's not available yet.

## Before
The installation process cannot be finished because of the mentioned error. Since the option group doesn't exists, the API call used to updated one of its option values fail and throw an Exception.

## After
The installation process completes without any problems. We now catch the thrown exception to avoid the error.

---

- [x] Tests Pass
