### PR TITLE
PCHR-2397: Allow admin edit toil request dates

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
@@ -58,7 +58,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
     $isSicknessRequest = $requestType === LeaveRequest::REQUEST_TYPE_SICKNESS;
     $isOpenLeaveRequest = in_array($statusID, $openStatuses);
 
-    $currentUserCanChangeDates = ($isSicknessRequest && $this->currentUserIsManager($contactID)) ||
+    $currentUserCanChangeDates = ($isSicknessRequest && $this->currentUserIsLeaveManagerOf($contactID)) ||
                                  ($this->currentUserIsLeaveContact($contactID) && $isOpenLeaveRequest) ||
                                   $this->currentUserIsAdmin();
 
@@ -103,14 +103,14 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
   }
 
   /**
-   * Checks if the current user is a leave manager
+   * Checks if the current user is a leave manager of the contact ID passed in
    *
    * @param int $contactID
    *   The contactID of the leave request
    *
    * @return bool
    */
-  private function currentUserIsManager($contactID) {
+  private function currentUserIsLeaveManagerOf($contactID) {
     return $this->leaveManagerService->currentUserIsLeaveManagerOf($contactID);
   }
 
@@ -123,7 +123,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
    * @return bool
    */
   private function currentUserIsManagerOrAdmin($contactID) {
-    return $this->currentUserIsManager($contactID) ||
+    return $this->currentUserIsLeaveManagerOf($contactID) ||
            $this->currentUserIsAdmin();
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
@@ -58,8 +58,9 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
     $isSicknessRequest = $requestType === LeaveRequest::REQUEST_TYPE_SICKNESS;
     $isOpenLeaveRequest = in_array($statusID, $openStatuses);
 
-    $currentUserCanChangeDates = ($isSicknessRequest && $this->currentUserIsManagerOrAdmin($contactID)) ||
-                                 ($this->currentUserIsLeaveContact($contactID) && $isOpenLeaveRequest);
+    $currentUserCanChangeDates = ($isSicknessRequest && $this->currentUserIsManager($contactID)) ||
+                                 ($this->currentUserIsLeaveContact($contactID) && $isOpenLeaveRequest) ||
+                                  $this->currentUserIsAdmin();
 
     return $currentUserCanChangeDates;
   }
@@ -89,7 +90,28 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
    * @return bool
    */
   public function canDeleteFor($contactID) {
+    return $this->currentUserIsAdmin();
+  }
+
+  /**
+   * Checks if the current user is an Admin
+   *
+   * @return bool
+   */
+  private function currentUserIsAdmin() {
     return $this->leaveManagerService->currentUserIsAdmin();
+  }
+
+  /**
+   * Checks if the current user is a leave manager
+   *
+   * @param int $contactID
+   *   The contactID of the leave request
+   *
+   * @return bool
+   */
+  private function currentUserIsManager($contactID) {
+    return $this->leaveManagerService->currentUserIsLeaveManagerOf($contactID);
   }
 
   /**
@@ -101,8 +123,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
    * @return bool
    */
   private function currentUserIsManagerOrAdmin($contactID) {
-    return $this->leaveManagerService->currentUserIsLeaveManagerOf($contactID) ||
-           $this->leaveManagerService->currentUserIsAdmin();
+    return $this->currentUserIsManager($contactID) ||
+           $this->currentUserIsAdmin();
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -105,34 +105,68 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
   /**
    * @dataProvider leaveRequestStatusesDataProvider
    */
-  public function testCanChangeDatesForReturnsFalseForTOILAndLeaveRequestTypesWhenCurrentUserNotLeaveContactIrrespectiveOfStatusPassed($status) {
+  public function testCanChangeDatesForReturnsFalseForAnyRequestTypeWhenCurrentUserIsStaffAndNotLeaveContactIrrespectiveOfStatusPassed($status) {
     $contactID = 2;
-    $managerRightsService = $this->getLeaveRequestRightsForLeaveManagerAsCurrentUser();
-    $adminRightsService = $this->getLeaveRequestRightsForAdminAsCurrentUser();
     $staffRightsService = $this->getLeaveRightsService();
-
-    $this->assertFalse(
-      $managerRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_LEAVE)
-    );
-
-    $this->assertTrue(
-      $adminRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_LEAVE)
-    );
 
     $this->assertFalse(
       $staffRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_LEAVE)
     );
 
     $this->assertFalse(
-      $managerRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_TOIL)
-    );
-
-    $this->assertTrue(
-      $adminRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_TOIL)
+      $staffRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_SICKNESS)
     );
 
     $this->assertFalse(
       $staffRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_TOIL)
+    );
+  }
+
+  /**
+   * @dataProvider leaveRequestStatusesDataProvider
+   */
+  public function testCanChangeDatesForReturnsFalseForTOILAndLeaveRequestTypesWhenCurrentUserIsLeaveManagerIrrespectiveOfStatusPassed($status) {
+    $contactID = 2;
+    $managerRightsService = $this->getLeaveRequestRightsForLeaveManagerAsCurrentUser();
+
+    $this->assertFalse(
+      $managerRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_LEAVE)
+    );
+
+    $this->assertFalse(
+      $managerRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_TOIL)
+    );
+  }
+
+  /**
+   * @dataProvider leaveRequestStatusesDataProvider
+   */
+  public function testCanChangeDatesForReturnsTrueForSicknessRequestTypeWhenCurrentUserIsLeaveManagerIrrespectiveOfStatusPassed($status) {
+    $contactID = 2;
+    $managerRightsService = $this->getLeaveRequestRightsForLeaveManagerAsCurrentUser();
+
+    $this->assertTrue(
+      $managerRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_SICKNESS)
+    );
+  }
+
+  /**
+   * @dataProvider leaveRequestStatusesDataProvider
+   */
+  public function testCanChangeDatesForReturnsTrueForAnyRequestTypeWhenCurrentUserIsAdminIrrespectiveOfStatusPassed($status) {
+    $contactID = 2;
+    $adminRightsService = $this->getLeaveRequestRightsForAdminAsCurrentUser();
+
+    $this->assertTrue(
+      $adminRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_LEAVE)
+    );
+
+    $this->assertTrue(
+      $adminRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_SICKNESS)
+    );
+
+    $this->assertTrue(
+      $adminRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_TOIL)
     );
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -170,23 +170,6 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     );
   }
 
-  /**
-   * @dataProvider leaveRequestStatusesDataProvider
-   */
-  public function testCanChangeDatesForReturnsTrueForSicknessRequestTypeWhenCurrentUserIsLeaveManagerOrAdminForAllStatuses($status) {
-    $contactID = 2;
-    $managerRightsService = $this->getLeaveRequestRightsForLeaveManagerAsCurrentUser();
-    $adminRightsService = $this->getLeaveRequestRightsForAdminAsCurrentUser();
-
-    $this->assertTrue(
-      $managerRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_SICKNESS)
-    );
-
-    $this->assertTrue(
-      $adminRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_SICKNESS)
-    );
-  }
-
   public function testCanChangeAbsenceTypeForReturnsTrueWhenCurrentUserIsLeaveContactAndStatusPassedIsInAllowedStatuses() {
     //When user is leave request contact and status is 'More information Required'
     $this->assertTrue(

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -115,7 +115,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
       $managerRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_LEAVE)
     );
 
-    $this->assertFalse(
+    $this->assertTrue(
       $adminRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_LEAVE)
     );
 
@@ -127,7 +127,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
       $managerRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_TOIL)
     );
 
-    $this->assertFalse(
+    $this->assertTrue(
       $adminRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_TOIL)
     );
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -187,16 +187,17 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   /**
-   * @expectedException RuntimeException
-   * @expectedExceptionMessage You are not allowed to change the request dates
+   * @dataProvider openLeaveRequestStatusesDataProvider
    */
-  public function testCreateThrowsAnExceptionWhenAdminUpdatesDatesForLeaveRequest() {
-    $contactID = 5;
-    $params = $this->getDefaultParams(['contact_id' => $contactID]);
+  public function testCreateDoesNotThrowAnExceptionWhenAdminUpdatesDatesForAnyOpenRequest($status) {
+    $params = $this->getDefaultParams([
+      'status_id' => $status
+    ]);
+
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
 
-    $params['from_date'] = CRM_Utils_Date::processDate('2016-01-10');
-    $params['to_date'] = CRM_Utils_Date::processDate('2016-01-15');
+    $toDate = new DateTime($params['to_date']);
+    $params['to_date'] = $toDate->modify('+10 days')->format('YmdHis');
     $params['id'] = $leaveRequest->id;
 
     $this->getLeaveRequestServiceWhenCurrentUserIsAdmin()->create($params, false);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -186,13 +186,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     $this->getLeaveRequestServiceWhenCurrentUserIsLeaveManager()->create($params, false);
   }
 
-  /**
-   * @dataProvider openLeaveRequestStatusesDataProvider
-   */
-  public function testCreateDoesNotThrowAnExceptionWhenAdminUpdatesDatesForAnyOpenRequest($status) {
-    $params = $this->getDefaultParams([
-      'status_id' => $status
-    ]);
+  public function testCreateDoesNotThrowAnExceptionWhenAdminUpdatesDatesForLeaveRequest() {
+    $params = $this->getDefaultParams(['status_id' => 2]);
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
 
@@ -201,6 +196,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     $params['id'] = $leaveRequest->id;
 
     $this->getLeaveRequestServiceWhenCurrentUserIsAdmin()->create($params, false);
+    $this->assertNotNull($leaveRequest->id);
   }
 
   /**


### PR DESCRIPTION
## Overview

When an admin tries to edit a Leave/TOIL request dates, the Leave Request popup never completes the save action and doesn't save updated dates. This PR fixes this issue.

## Before

An admin could not successfully edit the dates of a TOIL or leave request.

![new](https://user-images.githubusercontent.com/3973243/28128549-fba7399c-6727-11e7-8b6b-a374b660205f.gif)

## After

An admin can edit successfully the dates of a TOIL/Leave request.

![new](https://user-images.githubusercontent.com/3973243/28128671-64fb177e-6728-11e7-9ffc-4478b111d205.gif)

## Technical Details

This PR fixes access rights for admin actions while editing TOIL request.

The condition logic in the `CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php` was amended to grant Admins all rights on the date change, yet preserving the current condition logic for Managers.

## Comments

1. The code is slightly refactored in order to remove duplicating pieces.
2. Unit tests contained assumptions that Admin **cannot** change dates. Since the requirements have been changed, the tests had been amended accordingly.

---

- [x] Tests Pass
