### PR TITLE
PCHR 2310:  Add 'Other- Please add Comment' Sickness Reason Option value

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Import/Parser/Base.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Import/Parser/Base.php
@@ -58,6 +58,12 @@ class CRM_HRLeaveAndAbsences_Import_Parser_Base extends CRM_HRLeaveAndAbsences_I
   private $sicknessAbsenceTypes;
 
   /**
+   * @var array
+   *   Stores the sickness_reason Leave request Option values.
+   */
+  private $sicknessReasons;
+
+  /**
    * Class constructor.
    *
    * @param array $mapperKeys
@@ -401,6 +407,19 @@ class CRM_HRLeaveAndAbsences_Import_Parser_Base extends CRM_HRLeaveAndAbsences_I
   }
 
   /**
+   * Returns the sickness_reason Leave request Option values.
+   *
+   * @return array
+   */
+  private function getSicknessReasons() {
+    if (empty($this->sicknessReasons)) {
+      $this->sicknessReasons = array_flip(LeaveRequest::buildOptions('sickness_reason', 'validate'));
+    }
+
+    return $this->sicknessReasons;
+  }
+
+  /**
    * Returns the date_type Leave request Option values.
    *
    * @return LeaveRequestCommentService
@@ -462,8 +481,9 @@ class CRM_HRLeaveAndAbsences_Import_Parser_Base extends CRM_HRLeaveAndAbsences_I
     }
 
     if (!empty($this->getSicknessAbsenceTypes()[$params['absence_type']])) {
+      $sicknessReasons = $this->getSicknessReasons();
       $payload['request_type'] = LeaveRequest::REQUEST_TYPE_SICKNESS;
-      $payload['sickness_reason'] = 1;
+      $payload['sickness_reason'] = $sicknessReasons['other'];
     }
 
     return LeaveRequest::create($payload);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
@@ -7,6 +7,7 @@ class CRM_HRLeaveAndAbsences_Upgrader extends CRM_HRLeaveAndAbsences_Upgrader_Ba
 
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1000;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1001;
+  use CRM_HRLeaveAndAbsences_Upgrader_Step_1002;
 
   /**
    * A list of directories to be scanned for XML installation files

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
@@ -37,6 +37,10 @@ class CRM_HRLeaveAndAbsences_Upgrader extends CRM_HRLeaveAndAbsences_Upgrader_Ba
         }
       }
     }
+    // Flush the cache so that all pseudoconstants can be re-read from db
+    // This is to avoid issues when running upgraders during installation
+    // whereby some pseudoconstants were not available.
+    CRM_Core_PseudoConstant::flush();
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1000.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1000.php
@@ -36,20 +36,11 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1000 {
    * @param string $label
    */
   private function up1000_updateOptionValueLabel($name, $label) {
-    try {
-      civicrm_api3('OptionValue', 'get', [
-        'sequential' => 1,
-        'option_group_id' => 'hrleaveandabsences_leave_request_day_type',
-        'name' => ['IN' => [$name]],
-        'api.OptionValue.create' => ['id' => '$value.id', 'label' => $label],
-      ]);
-    } catch(Exception $e) {
-      // We run all the upgraders during the extension installation, but, during
-      // this process, the hrleaveandabsences_leave_request_day_type option group
-      // is still not available and the API call will fail and throw an exception.
-      // So, to avoid the installation process to stop, we simply catch the exception
-      // and don't do anything. The option group and values will be create just
-      // fine, based on the values set on xml/option_groups/leave_request_day_type_install.xml
-    }
+    civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => 'hrleaveandabsences_leave_request_day_type',
+      'name' => ['IN' => [$name]],
+      'api.OptionValue.create' => ['id' => '$value.id', 'label' => $label],
+    ]);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1002.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1002.php
@@ -1,0 +1,41 @@
+<?php
+
+trait CRM_HRLeaveAndAbsences_Upgrader_Step_1002 {
+
+  /**
+   * Creates the 'other' sickness reason option value.
+   *
+   * @return bool
+   */
+  public function upgrade_1002() {
+    try {
+      $result = civicrm_api3('OptionValue', 'get', [
+        'sequential' => 1,
+        'option_group_id' => 'hrleaveandabsences_sickness_reason',
+        'name' => 'other',
+      ]);
+
+      if ($result['count'] == 0) {
+        civicrm_api3('OptionValue', 'create', [
+          'option_group_id' => 'hrleaveandabsences_sickness_reason',
+          'name' => 'other',
+          'label' => 'Other - Please leave a comment',
+          'value' => 12,
+          'weight' => 11,
+          'is_reserved' => 1,
+          'is_default' => 0,
+          'is_active' => 1
+        ]);
+      }
+    } catch(Exception $e) {
+      // We run all the upgraders during the extension installation, but, during
+      // this process, the hrleaveandabsences_sickness_reason option group
+      // is still not available and the get API call will fail and throw an exception.
+      // So, to avoid the installation process to stop, we simply catch the exception
+      // and don't do anything. The option group and values will be created just
+      // fine, based on the values set on xml/option_groups/sickness_reason_install.xml
+    }
+
+    return true;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1002.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1002.php
@@ -8,31 +8,22 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1002 {
    * @return bool
    */
   public function upgrade_1002() {
-    try {
-      $result = civicrm_api3('OptionValue', 'getcount', [
+    $result = civicrm_api3('OptionValue', 'getcount', [
+      'option_group_id' => 'hrleaveandabsences_sickness_reason',
+      'name' => 'other',
+    ]);
+
+    if ($result['result'] == 0) {
+      civicrm_api3('OptionValue', 'create', [
         'option_group_id' => 'hrleaveandabsences_sickness_reason',
         'name' => 'other',
+        'label' => 'Other - Please leave a comment',
+        'value' => 12,
+        'weight' => 11,
+        'is_reserved' => 1,
+        'is_default' => 0,
+        'is_active' => 1
       ]);
-
-      if ($result['result'] == 0) {
-        civicrm_api3('OptionValue', 'create', [
-          'option_group_id' => 'hrleaveandabsences_sickness_reason',
-          'name' => 'other',
-          'label' => 'Other - Please leave a comment',
-          'value' => 12,
-          'weight' => 11,
-          'is_reserved' => 1,
-          'is_default' => 0,
-          'is_active' => 1
-        ]);
-      }
-    } catch(Exception $e) {
-      // We run all the upgraders during the extension installation, but, during
-      // this process, the hrleaveandabsences_sickness_reason option group
-      // is still not available and the get API call will fail and throw an exception.
-      // So, to avoid the installation process to stop, we simply catch the exception
-      // and don't do anything. The option group and values will be created just
-      // fine, based on the values set on xml/option_groups/sickness_reason_install.xml
     }
 
     return true;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1002.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1002.php
@@ -9,13 +9,12 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1002 {
    */
   public function upgrade_1002() {
     try {
-      $result = civicrm_api3('OptionValue', 'get', [
-        'sequential' => 1,
+      $result = civicrm_api3('OptionValue', 'getcount', [
         'option_group_id' => 'hrleaveandabsences_sickness_reason',
         'name' => 'other',
       ]);
 
-      if ($result['count'] == 0) {
+      if ($result['result'] == 0) {
         civicrm_api3('OptionValue', 'create', [
           'option_group_id' => 'hrleaveandabsences_sickness_reason',
           'name' => 'other',

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/option_groups/sickness_reason_install.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/option_groups/sickness_reason_install.xml
@@ -144,5 +144,17 @@
       <option_group_name>hrleaveandabsences_sickness_reason</option_group_name>
     </OptionValue>
 
+    <OptionValue>
+      <label>Other - Please leave a comment</label>
+      <value>12</value>
+      <name>other</name>
+      <is_default>0</is_default>
+      <weight>11</weight>
+      <is_optgroup>0</is_optgroup>
+      <is_reserved>1</is_reserved>
+      <is_active>1</is_active>
+      <option_group_name>hrleaveandabsences_sickness_reason</option_group_name>
+    </OptionValue>
+
   </OptionValues>
 </CustomData>


### PR DESCRIPTION
## Overview
This PR adds the _Other- Please add Comment_ Sickness reason option value.

Also an issue whereby an error is thrown during installation on a fresh site where L&A has not been previously installed was fixed. See [PR](https://github.com/civicrm/civihr/pull/1996).

Also previously, the value of `1` was set as default sickness reason when importing sickness requests via the L&A Importer. This PR replaces that value with the `Other` sickness option value just created.

## After
the _Other- Please add Comment_ Sickness reason option value is now part of the sickness reason option group.

The PseudoConstant cache was flushed so that the values can be fetched from the db rather than returning the cached values. The error reported on [PR](https://github.com/civicrm/civihr/pull/1996) was due to the fact that the the call to fetch the L&A option groups was throwing errors because It was trying to look for them in the cache rather than fetching from db.

![sickness reasons options - l_and_a 2017-07-13 12-13-55](https://user-images.githubusercontent.com/6951813/28163891-d0faee1c-67c4-11e7-814f-f543d992fe3f.png)


---

- [X] Tests Pass
