### PR TITLE
PCHR 2384: fix expiry date update on toil request modal

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/controllers/sub-controllers/toil-request-ctrl.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/controllers/sub-controllers/toil-request-ctrl.js
@@ -46,8 +46,8 @@ define([
        * @return {Promise}
        */
       vm.calculateToilExpiryDate = function () {
-        // blocks the expiry date from updating if not a manager and
-        // this is an open request.
+        // blocks the expiry date from updating if this is an existing request
+        // and user is not a manager or admin.
         if (!vm.canManage && vm.request.id) {
           return $q.resolve(vm.request.toil_expiry_date);
         }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/controllers/sub-controllers/toil-request-ctrl.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/controllers/sub-controllers/toil-request-ctrl.js
@@ -42,26 +42,29 @@ define([
 
       /**
        * Calculates toil expiry date.
-       * TODO It will be based on from date for both single and multiple days for now.
        *
        * @return {Promise}
        */
       vm.calculateToilExpiryDate = function () {
-        if (!vm.request.from_date) {
-          vm.errors = ['Please select from date to find expiry date'];
-
-          return $q.reject(vm.errors);
-        }
-
-        // stops staff from updating expiry date on open requests
-        if (!this.canManage && this.request.id) {
+        // blocks the expiry date from updating if not a manager and
+        // this is an open request.
+        if (!vm.canManage && vm.request.id) {
           return $q.resolve(vm.request.toil_expiry_date);
         }
 
-        return AbsenceType.calculateToilExpiryDate(vm.request.type_id, vm.request.from_date)
-          .then(function (expiryDate) {
-            vm.request.toil_expiry_date = expiryDate;
-          });
+        return getReferenceDate().catch(function (errors) {
+          if (errors.length) vm.errors = errors;
+          return $q.reject(errors);
+        }).then(function (referenceDate) {
+          return AbsenceType.calculateToilExpiryDate(
+            vm.request.type_id,
+            referenceDate
+          );
+        })
+        .then(function (expiryDate) {
+          vm.request.toil_expiry_date = expiryDate;
+          return expiryDate;
+        });
       };
 
       /**
@@ -72,6 +75,18 @@ define([
       vm.canSubmit = function () {
         return !!vm.request.toil_duration && !!vm.request.toil_to_accrue &&
           !!vm.request.from_date && !!vm.request.to_date;
+      };
+
+      /**
+       * Extends parent method. Fires calculation of expiry date when the
+       * number of days changes and the expiry date can be calculated.
+       */
+      vm.changeInNoOfDays = function () {
+        parentRequestCtrl.changeInNoOfDays.call(this);
+
+        if (canCalculateExpiryDate()) {
+          vm.calculateToilExpiryDate();
+        }
       };
 
       /**
@@ -151,15 +166,58 @@ define([
       })();
 
       /**
-       * Initializes leave request toil amounts
+       * Determines if the expiry date can be calculated based on the
+       * Number Of Days selected and the corresponding date field has value.
+       *
+       * @return {Boolean}
+       */
+      function canCalculateExpiryDate () {
+        return (vm.uiOptions.multipleDays && vm.request.to_date) ||
+          (!vm.uiOptions.multipleDays && vm.request.from_date);
+      }
+
+      /**
+       * Returns a promise with a date that can be used to calculate the expiry
+       * date. This date depends on the Multiple Days or Single Day options.
        *
        * @return {Promise}
        */
-      function loadToilAmounts () {
-        return OptionGroup.valuesOf('hrleaveandabsences_toil_amounts')
-          .then(function (amounts) {
-            vm.toilAmounts = _.indexBy(amounts, 'value');
+      function getReferenceDate () {
+        if (vm.uiOptions.multipleDays) {
+          return getReferenceDateForField({
+            hasErrors: !vm.request.to_date && !vm.request.from_date,
+            label: 'To Date',
+            value: vm.request.to_date
           });
+        } else {
+          return getReferenceDateForField({
+            hasErrors: !vm.request.from_date,
+            label: 'From Date',
+            value: vm.request.from_date
+          });
+        }
+      }
+
+      /**
+       * Returns a reference date using the field object as source.
+       * If the field has errors, it returns an error message.
+       * If the field has no value, it returns an empty message since it still
+       * is in the process of inserting values.
+       * And if everything is ok it returns the field's date value.
+       *
+       * @return {Promise}
+       */
+      function getReferenceDateForField (field) {
+        if (field.hasErrors) {
+          var message = 'Please select ' + field.label + ' to find expiry date';
+          return $q.reject([message]);
+        }
+
+        if (!field.value) {
+          return $q.reject([]);
+        } else {
+          return $q.resolve(field.value);
+        }
       }
 
       /**
@@ -169,6 +227,18 @@ define([
         if (vm.canManage) {
           vm.uiOptions.expiryDate = vm._convertDateFormatFromServer(vm.request.toil_expiry_date);
         }
+      }
+
+      /**
+       * Initializes leave request toil amounts
+       *
+       * @return {Promise}
+       */
+      function loadToilAmounts () {
+        return OptionGroup.valuesOf('hrleaveandabsences_toil_amounts')
+          .then(function (amounts) {
+            vm.toilAmounts = _.indexBy(amounts, 'value');
+          });
       }
 
       return vm;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/controllers/sub-controllers/toil-request-ctrl.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/controllers/sub-controllers/toil-request-ctrl.js
@@ -53,8 +53,8 @@ define([
           return $q.reject(vm.errors);
         }
 
-        // If manager has already altered then it will directly show that date.
-        if (vm.request.toil_expiry_date) {
+        // stops staff from updating expiry date on open requests
+        if (!this.canManage && this.request.id) {
           return $q.resolve(vm.request.toil_expiry_date);
         }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/controllers/sub-controllers/toil-request-ctrl.spec.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/controllers/sub-controllers/toil-request-ctrl.spec.js
@@ -301,18 +301,43 @@
                 expect($ctrl.request.toil_expiry_date).toEqual(newExpiryDate);
               });
 
-              describe('and staff edits', function () {
+              describe('and staff edits new request', function () {
                 beforeEach(function () {
                   var directiveOptions = {
                     contactId: toilRequest.contact_id, // staff's contact id
                     leaveRequest: $ctrl.request
                   };
+                  role = 'staff';
+                  delete $ctrl.request.id;
 
                   initTestController(directiveOptions);
+                  $ctrl.updateExpiryDate();
+                });
+
+                it('has expired date set by staff', function () {
+                  expect($ctrl.request.toil_expiry_date).toEqual(newExpiryDate);
+                });
+
+                it('has toil amount set by staff', function () {
+                  expect($ctrl.request.toil_to_accrue).toEqual(originalToilToAccrue.value);
+                });
+              });
+
+              describe('and staff edits open request', function () {
+                beforeEach(function () {
+                  var directiveOptions = {
+                    contactId: toilRequest.contact_id, // staff's contact id
+                    leaveRequest: $ctrl.request
+                  };
+                  role = 'staff';
+                  $ctrl.request.toil_expiry_date = oldExpiryDate;
+
+                  initTestController(directiveOptions);
+                  $ctrl.updateExpiryDate();
                 });
 
                 it('has expired date set by manager', function () {
-                  expect($ctrl.request.toil_expiry_date).toEqual(newExpiryDate);
+                  expect($ctrl.request.toil_expiry_date).toEqual(oldExpiryDate);
                 });
 
                 it('has toil amount set by manager', function () {


### PR DESCRIPTION
## Overview
This PR fixes the following issues:

* As a staff, when creating a new TOIL request, after selecting a date the expiry date is calculated, but if the date changes the expiry date is not calculated again.
* The expiry date should be calculated from the *To Date* on *Multiple Days* and from *From Date* on *Single Day*. Currently the expiry date is only calculated from the *From Date*.


## Before
![anim](https://user-images.githubusercontent.com/1642119/28169431-4e8c0254-67b0-11e7-8f78-ab4a00cd5e24.gif)


## After
![anim](https://user-images.githubusercontent.com/1642119/28170005-009eb6fc-67b2-11e7-9993-138e0c5eb3c1.gif)


## Technical Details
`toil-request-ctrl.js`'s method `calculateToilExpiryDate` was refactored to allow staff to update the expiry date for new requests, but lock the expiry date on open requests. Managers can still update the expiry date freely using the UI.

`toil-request-ctrl.spec.js` was refactored to test *staff edits new request* and *staff edits open request* scenarios. 


---

- [x] Tests Pass
