### PR TITLE
PCHR-2406: Add missing SCSS file

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/scss/base/helpers/_disabled.scss
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/scss/base/helpers/_disabled.scss
@@ -1,0 +1,5 @@
+// disable the element and prevent any user interaction
+.chr_disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Overview

As per https://github.com/civicrm/civihr/pull/2002 the styling source file were forgotten to be added. This PR adds this SCSS file.

## Technical Details

The built CSS file was included, but the source SCSS file was forgotten to be added.

## Comments

No tests needed to be run for this PR.