### PR TITLE
PCHR-2391: Fix error thrown in Sickness email template.

### DIFF
--- a/uk.co.compucorp.civicrm.hremails/email-templates/dist/sickness-request.civicrm.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/dist/sickness-request.civicrm.html
@@ -202,7 +202,11 @@
                           {foreach from=$sicknessRequiredDocuments item=value key=id}
                             <div class="request-document" style="Margin-bottom: 10px; margin-bottom: 10px;">
                               <span class="request-document-required" style="Margin-right: 5px; margin-right: 5px; width: 25px;">
-                                <input type="checkbox" disabled {if="" in_array($id,="" $leaverequireddocuments)}checked{="" if}="" style="Margin: 0; margin: 0;">
+                                {if in_array($id, $leaveRequiredDocuments)}
+                                <input type="checkbox" disabled checked style="Margin: 0; margin: 0;">
+                                {else}
+                                <input type="checkbox" disabled style="Margin: 0; margin: 0;">
+                                {/if}
                               </span>
                               <span class="request-document-title" style="color: #4D5663;">{$value}</span>
                             </div>

--- a/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/sickness-request.civicrm.html
+++ b/uk.co.compucorp.civicrm.hremails/email-templates/src/pages/sickness-request.civicrm.html
@@ -26,7 +26,11 @@ request-type: Sickness
             {foreach from=$sicknessRequiredDocuments item=value key=id}
               <div class="request-document">
                 <span class="request-document-required">
-                  <input type="checkbox" disabled {if in_array($id, $leaveRequiredDocuments)}checked{/if}>
+                  {if in_array($id, $leaveRequiredDocuments)}
+                  <input type="checkbox" disabled checked>
+                  {else}
+                  <input type="checkbox" disabled>
+                  {/if}
                 </span>
                 <span class="request-document-title">{$value}</span>
               </div>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/managed_entities/EmailTemplate.mgd.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/managed_entities/EmailTemplate.mgd.php
@@ -752,7 +752,11 @@ return [
                           {foreach from=$sicknessRequiredDocuments item=value key=id}
                             <div class="request-document" style="Margin-bottom: 10px; margin-bottom: 10px;">
                               <span class="request-document-required" style="Margin-right: 5px; margin-right: 5px; width: 25px;">
-                                <input type="checkbox" disabled {if="" in_array($id,="" $leaverequireddocuments)}checked{="" if}="" style="Margin: 0; margin: 0;">
+                                {if in_array($id, $leaveRequiredDocuments)}
+                                <input type="checkbox" disabled checked style="Margin: 0; margin: 0;">
+                                {else}
+                                <input type="checkbox" disabled style="Margin: 0; margin: 0;">
+                                {/if}
                               </span>
                               <span class="request-document-title" style="color: #4D5663;">{$value}</span>
                             </div>


### PR DESCRIPTION
## Overview
When Importing Leave request data of type sickness, Smarty complains of an error on Line 205 of the sickness request email template although the sickness email still gets sent. 

## After
The error is a syntax error resulting from the php condition on that line not being properly formatted.
This PR properly formats the code and error is no more thrown when importing sickness requests.

- [X] Tests Pass
