### PR TITLE
PCHR-2381: Only consider requests overlapping contracts for balance calculation

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
@@ -329,6 +329,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
       new DateTime('+8 days')
     );
 
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $periodEntitlement->contact_id],
+      ['period_start_date' => CRM_Utils_Date::processDate('today')]
+    );
+
     // None of these will be included in the Leave Request balance
     $this->createLeaveBalanceChange($periodEntitlement->id, 6);
     $this->createBroughtForwardBalanceChange($periodEntitlement->id, 3);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -2549,6 +2549,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'period_id' => $period->id
     ]);
 
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $periodEntitlement->contact_id],
+      ['period_start_date' => $period->start_date]
+    );
+
     $params = [
       'type_id' => $absenceType->id,
       'contact_id' => 1,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -47,7 +47,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
   }
 
   public function testCanCreateAPublicHolidayLeaveRequestForASingleContact() {
-    AbsencePeriodFabricator::fabricate([
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('first day of this year'),
       'end_date' => CRM_Utils_Date::processDate('last day of this year')
     ]);
@@ -55,6 +55,11 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests();
     $periodEntitlement->contact_id = 2;
     $periodEntitlement->type_id = $this->absenceType->id;
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $periodEntitlement->contact_id],
+      ['period_start_date' => $absencePeriod->start_date]
+    );
 
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = CRM_Utils_Date::processDate('first monday of this year');

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -350,6 +350,11 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'type_id' => $this->absenceType->id,
     ]);
 
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $entitlement->contact_id],
+      ['period_start_date' => $period->start_date]
+    );
+
     $this->createLeaveRequestBalanceChange(
       $this->absenceType->id,
       $entitlement->contact_id,
@@ -416,6 +421,11 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'period_id' => $period->id,
       'type_id' => $this->absenceType->id,
     ]);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $entitlement->contact_id],
+      ['period_start_date' => $period->start_date]
+    );
 
     $this->createExpiredTOILRequestBalanceChange(
       $entitlement->type_id,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -118,6 +118,11 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'type_id' => $absenceType2->id
     ]);
 
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $periodEntitlement1->contact_id],
+      ['period_start_date' => $absencePeriod->start_date]
+    );
+
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $periodEntitlement1->contact_id,
       'type_id' => $periodEntitlement1->type_id,
@@ -189,6 +194,11 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'type_id' => 1
     ]);
 
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $periodEntitlement->contact_id],
+      ['period_start_date' => $absencePeriod->start_date]
+    );
+
     $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
 
     LeaveRequestFabricator::fabricateWithoutValidation([
@@ -246,6 +256,11 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'type_id' => $absenceType->id,
     ]);
 
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $periodEntitlement->contact_id],
+      ['period_start_date' => $absencePeriod->start_date]
+    );
+
     $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
 
     LeaveRequestFabricator::fabricateWithoutValidation([
@@ -295,6 +310,11 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'period_id' => $period->id,
       'type_id' => $this->absenceType->id,
     ]);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $entitlement->contact_id],
+      ['period_start_date' => $period->start_date]
+    );
 
     $this->createLeaveRequestBalanceChange(
       $this->absenceType->id,


### PR DESCRIPTION
## Overview
After deleting a contract, the Leave Requests and Public Holidays within its period are not displayed on the Absence Report anymore, but their balance changes are still counted in the balance calculation, resulting on an invalid value.

## Before
The Absence Report uses the `LeaveRequest.get` and` LeaveRequest.getFull` APIs to load the requests to be displayed. These APIs only return requests that overlap the contracts of a user. The balance information, however, is loaded using the `LeaveRequest.getBalanceChangeByAbsenceType` API, which has a slightly different logic that doesn't consider contracts for the balance calculation. If an admin deletes a contract, a call to `LeaveRequest.get` (or `getFull`) will return no requests for that contract period, but `LeaveRequest.getBalanceChangeByAbsenceType` will still return the number days deducted by leave requests during its period:

![1987 - 2](https://user-images.githubusercontent.com/388373/28282196-0355d064-6b00-11e7-853c-ac6a807b9341.png)

## After
The `LeaveRequest.getBalanceChangeByAbsenceType` API was updated so that it works the same way as `LeaveRequest.get` and `LeaveRequest.getFull` APIs and only count for requests overlapping contracts.

## Technical Details
Internally, `LeaveRequest.getBalanceChangeByAbsenceType` uses the `LeaveBalanceChange::getBalanceForEntitlement` and `LeaveBalanceChange::getLeaveRequestBalanceFor` methods. Both were updated to have their queries joining with the contract tables and filtering out requests not overlapping contracts. Due to this change, multiple tests had to be updated as now a contract is required in order to be able to get the balance information.


## Comments
In order to simplify the deletion logic, when a contract is deleted the respective leave requests ARE NOT deleted. We just keep them in the database and make sure that the APIs won't return them. That is why the `.get` and `.getFull` APIs work this way.

---

- [x] Tests Pass
