### PR TITLE
PCHR-2423: Disabled Work Pattern Is Still Applied to Leave Request Amount Calculations and Contact Calendar

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/ContactWorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/ContactWorkPattern.php
@@ -140,7 +140,7 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern extends CRM_HRLeaveAndAbsenc
 
   /**
    * Returns the ContactWorkPattern instance for the given contact and $date
-   * The function will only return the ContactWorkPattern instance that is
+   * This function will only return the ContactWorkPattern instance that is
    * linked to an active WorkPattern.
    *
    * @param int $contactID
@@ -152,7 +152,7 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern extends CRM_HRLeaveAndAbsenc
     $contactWorkPatternTable = self::getTableName();
     $workPatternTable = WorkPattern::getTableName();
 
-    $query = "SELECT * FROM {$contactWorkPatternTable} cwp
+    $query = "SELECT cwp.* FROM {$contactWorkPatternTable} cwp
               INNER JOIN {$workPatternTable} wp 
                 ON cwp.pattern_id = wp.id
               WHERE cwp.contact_id = %1 AND 
@@ -268,6 +268,8 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern extends CRM_HRLeaveAndAbsenc
   /**
    * Returns a list of ContactWorkPattern instances for the given $contactID,
    * which overlap the period enclosed by the given $start and $end dates
+   * Only ContactWorkPattern instances linked to an active work pattern are
+   * returned.
    *
    * @param int $contactID
    * @param \DateTime $start
@@ -276,12 +278,16 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern extends CRM_HRLeaveAndAbsenc
    * @return \CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern[]
    */
   public static function getAllForPeriod($contactID, DateTime $start, DateTime $end) {
-    $tableName = self::getTableName();
+    $contactWorkPatternTable = self::getTableName();
+    $workPatternTable = WorkPattern::getTableName();
 
-    $query = "SELECT * FROM {$tableName}
-              WHERE contact_id = %1 AND 
-                    effective_date <= %2 AND 
-                    (effective_end_date >= %3 OR effective_end_date IS NULL)";
+    $query = "SELECT cwp.* FROM {$contactWorkPatternTable} cwp
+              INNER JOIN {$workPatternTable} wp 
+                ON cwp.pattern_id = wp.id
+              WHERE cwp.contact_id = %1 AND 
+              cwp.effective_date <= %2 AND 
+              (cwp.effective_end_date >= %3 OR cwp.effective_end_date IS NULL) AND
+              wp.is_active = 1";
 
     $params = [
       1 => [$contactID, 'Integer'],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/ContactWorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/ContactWorkPattern.php
@@ -149,29 +149,13 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern extends CRM_HRLeaveAndAbsenc
    * @return \CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern|null
    */
   public static function getForDate($contactID, DateTime $date) {
-    $contactWorkPatternTable = self::getTableName();
-    $workPatternTable = WorkPattern::getTableName();
+    $contactWorkPattern = self::getAllForPeriod($contactID, $date, $date);
 
-    $query = "SELECT cwp.* FROM {$contactWorkPatternTable} cwp
-              INNER JOIN {$workPatternTable} wp 
-                ON cwp.pattern_id = wp.id
-              WHERE cwp.contact_id = %1 AND 
-              cwp.effective_date <= %2 AND 
-              (cwp.effective_end_date >= %2 OR cwp.effective_end_date IS NULL) AND
-              wp.is_active = 1";
-
-    $params = [
-      1 => [$contactID, 'Integer'],
-      2 => [$date->format('Y-m-d'), 'String']
-    ];
-
-    $result = CRM_Core_DAO::executeQuery($query, $params, true, self::class);
-    if($result->N == 1) {
-      $result->fetch();
-      return $result;
+    if(!$contactWorkPattern) {
+      return null;
     }
 
-    return null;
+    return $contactWorkPattern[0];
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/ContactWorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/ContactWorkPattern.php
@@ -140,6 +140,8 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern extends CRM_HRLeaveAndAbsenc
 
   /**
    * Returns the ContactWorkPattern instance for the given contact and $date
+   * The function will only return the ContactWorkPattern instance that is
+   * linked to an active WorkPattern.
    *
    * @param int $contactID
    * @param \DateTime $date
@@ -147,12 +149,16 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern extends CRM_HRLeaveAndAbsenc
    * @return \CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern|null
    */
   public static function getForDate($contactID, DateTime $date) {
-    $tableName = self::getTableName();
+    $contactWorkPatternTable = self::getTableName();
+    $workPatternTable = WorkPattern::getTableName();
 
-    $query = "SELECT * FROM {$tableName}
-              WHERE contact_id = %1 AND 
-                    effective_date <= %2 AND 
-                    (effective_end_date >= %2 OR effective_end_date IS NULL)";
+    $query = "SELECT * FROM {$contactWorkPatternTable} cwp
+              INNER JOIN {$workPatternTable} wp 
+                ON cwp.pattern_id = wp.id
+              WHERE cwp.contact_id = %1 AND 
+              cwp.effective_date <= %2 AND 
+              (cwp.effective_end_date >= %2 OR cwp.effective_end_date IS NULL) AND
+              wp.is_active = 1";
 
     $params = [
       1 => [$contactID, 'Integer'],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/ContactWorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/ContactWorkPatternTest.php
@@ -490,6 +490,43 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest extends BaseHeadlessTest
     ));
   }
 
+  public function testGetAllForPeriodOnlyReturnsContactWorkPatternsLinkedToAnActiveWorkPatternForTheGivenPeriod() {
+    $workPattern1 = WorkPatternFabricator::fabricate();
+    $workPattern2 = WorkPatternFabricator::fabricate(['is_active' => 0]);
+    $workPattern3 = WorkPatternFabricator::fabricate();
+    $contactID = 2;
+
+    $contactWorkPattern1 = ContactWorkPattern::create([
+      'contact_id' => $contactID,
+      'pattern_id' => $workPattern1->id,
+      'effective_date' => CRM_Utils_Date::processDate('2016-01-01'),
+    ]);
+
+    $contactWorkPattern2 = ContactWorkPattern::create([
+      'contact_id' => $contactID,
+      'pattern_id' => $workPattern2->id,
+      'effective_date' => CRM_Utils_Date::processDate('2016-02-23'),
+    ]);
+
+    $contactWorkPattern3 = ContactWorkPattern::create([
+      'contact_id' => $contactID,
+      'pattern_id' => $workPattern3->id,
+      'effective_date' => CRM_Utils_Date::processDate('2016-03-01'),
+    ]);
+
+    $contactWorkPatterns = ContactWorkPattern::getAllForPeriod(
+      $contactID,
+      new DateTime('2016-01-01'),
+      new DateTime('2016-03-30')
+    );
+
+    //ContactWorkPattern3 is not linked to an active WorkPattern therefore it wil not
+    //be returned.
+    $this->assertCount(2, $contactWorkPatterns);
+    $this->assertEquals($contactWorkPattern1->id, $contactWorkPatterns[0]->id);
+    $this->assertEquals($contactWorkPattern3->id, $contactWorkPatterns[1]->id);
+  }
+
   public function testGetContactsUsingWorkPatternFromDate() {
     $contactID1 = 1;
     $contactID2 = 2;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/ContactWorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/ContactWorkPatternTest.php
@@ -157,6 +157,20 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest extends BaseHeadlessTest
     $this->assertEquals($workPattern3->id, $contactWorkPattern->pattern_id);
   }
 
+  public function testGetForDateReturnsNullForADisabledWorkPatternEvenThoughTheContactWorkPatternIsStillEffective() {
+    $workPattern1 = WorkPatternFabricator::fabricate(['is_active' => 0]);
+    $contactID = 2;
+
+    ContactWorkPattern::create([
+      'contact_id' => $contactID,
+      'pattern_id' => $workPattern1->id,
+      'effective_date' => CRM_Utils_Date::processDate('2016-01-01'),
+    ]);
+
+    $contactWorkPattern = ContactWorkPattern::getForDate($contactID, new DateTime('2016-03-25'));
+    $this->assertNull($contactWorkPattern);
+  }
+
   public function testGetForDateReturnsNullIfTheEmployeeHasNoWorkPatterns() {
     $contactWorkPattern = ContactWorkPattern::getForDate(2, new DateTime('2016-03-25'));
     $this->assertNull($contactWorkPattern);


### PR DESCRIPTION
## Overview
When a Work Pattern is assigned to a Contact and the Work Pattern gets disabled, The disabled Work pattern is still applied to leave request deduction amount calculations and and is also used for the Contact's calendar  for the period when the Contact Work pattern is effective even though the Work pattern has been disabled.

## After
A disabled Work Pattern that is assigned to a Contact is no longer applied to Leave Request deduction amount calculations and not used for the Contact's calendar even though the Contact Work pattern is still effective, rather, the calculation is done based on the default Work pattern and also the calendar is displayed based on the default Work Pattern.

## Technical Details
The `ContactWorkPattern::getForDate` method was modified to return Contact Work patterns that is linked to an active Work Pattern.

- [X] Tests Pass
