### PR TITLE
PCHR-2428: Fix Issue with being able to disable the default Work Pattern.

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/WorkPattern.php
@@ -174,6 +174,7 @@ class CRM_HRLeaveAndAbsences_Page_WorkPattern extends CRM_Core_Page_Basic {
 
     if($workPattern->is_default) {
       $mask -= CRM_Core_Action::BASIC;
+      $mask -= CRM_Core_Action::DISABLE;
     }
 
     if($this->canNotDelete($workPattern->id)) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
@@ -194,25 +194,6 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends BaseHeadlessTest {
     $this->assertEmpty($values);
   }
 
-  /**
-   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkPatternException
-   * @expectedExceptionMessage You cannot disable a Work Pattern if it's the last one
-   */
-  public function testCannotDisablePatternIfItIsTheLastWorkPatternEnabled() {
-    $workPattern = WorkPatternFabricator::fabricate(['is_active' => 1]);
-    $this->updateBasicWorkPattern($workPattern->id, ['is_active' => 0]);
-  }
-
-  public function testCanDisablePatternIfItIsNotTheLastWorkPatternEnabled() {
-    $workPattern1 = WorkPatternFabricator::fabricate(['is_active' => 1]);
-    WorkPatternFabricator::fabricate(['is_active' => 1]);
-
-    $this->updateBasicWorkPattern($workPattern1->id, ['is_active' => 0]);
-
-    $workPattern1 = WorkPattern::findById($workPattern1->id);
-    $this->assertEquals(0, $workPattern1->is_active);
-  }
-
   public function testGetLeaveDaysForDateShouldReturnZeroIfDateIsNotGreaterThanOrEqualTheStartDate() {
     $pattern = new WorkPattern();
 
@@ -712,5 +693,24 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends BaseHeadlessTest {
     if($item) {
       $queue->deleteItem($item);
     }
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkPatternException
+   * @expectedExceptionMessage You cannot create a new Work Pattern as default and set disabled
+   */
+  public function testCannotCreateANewDefaultWorkPatternThatIsInactive() {
+    WorkPatternFabricator::fabricate(['is_default' => 1, 'is_active' => 0]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidWorkPatternException
+   * @expectedExceptionMessage You cannot disable the default Work Pattern
+   */
+  public function testCannotDisableTheDefaultWorkPattern() {
+    $workPattern = WorkPatternFabricator::fabricate(['is_default' => 1]);
+    $params = ['id' => $workPattern->id, 'is_active' => 0];
+
+    WorkPattern::create($params);
   }
 }


### PR DESCRIPTION
## Overview
The default Work pattern is the work pattern used by contacts without an effective Contact Work pattern, therefore it must be enabled always and should not be disabled.

## Before
The default Work Pattern can be disabled from the Work Pattern listing page. Also a new Work Pattern can be created as default and inactive.

## After
The default Work Pattern cannot be disabled from the Work Pattern listing page and also a new Work Pattern cannot be created as default and inactive.

## Technical Details
A `validateParams` method was created in the Work Pattern BAO patterned after the one in LeaveRequest BAO and some other BAO's in L&A. A new `validateDefaultWorkPattern` method was created to handle the validations for this task.

## Comments
A validation method that ensures that there is at least one active Work Pattern available was removed as it was no longer necessary because with the new changes introduced, the default Work Pattern will always be active.


- [X] Tests Pass
