### PR TITLE
PCHR-2432: Fix date types not loading when editing a leave request

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/controllers/request-ctrl.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/controllers/request-ctrl.js
@@ -139,7 +139,6 @@ define([
           return $q.resolve();
         }
 
-        self.errors = [];
         self.loading.showBalanceChange = true;
         return LeaveRequest.calculateBalanceChange(getParamsForBalanceChange.call(self))
           .then(function (balanceChange) {
@@ -420,6 +419,10 @@ define([
             this._setMinMaxDate();
 
             return filterLeaveRequestDayTypes.call(this, date, dayType);
+          }.bind(this))
+          .catch(handleError.bind(this))
+          .finally(function () {
+            this.loading[dayType + 'DayTypes'] = false;
           }.bind(this));
       };
 
@@ -437,13 +440,9 @@ define([
         .then(function () {
           return this.updateBalance();
         }.bind(this))
-        .catch(function (error) {
-          this.errors = [error];
-
+        .catch(function (errors) {
+          handleError.call(this, errors);
           this._setDateAndTypes();
-        }.bind(this))
-        .finally(function () {
-          this.loading[dayType + 'DayTypes'] = false;
         }.bind(this));
       };
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/controllers/request-ctrl.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/controllers/request-ctrl.js
@@ -420,8 +420,11 @@ define([
 
             return filterLeaveRequestDayTypes.call(this, date, dayType);
           }.bind(this))
-          .catch(handleError.bind(this))
           .finally(function () {
+            /**
+             * after the request is completed fromDayTypes or toDayTypes are
+             * set to false and the corresponding field is shown on the ui.
+             */
             this.loading[dayType + 'DayTypes'] = false;
           }.bind(this));
       };

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/controllers/sub-controllers/leave-request-ctrls.spec.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/controllers/sub-controllers/leave-request-ctrls.spec.js
@@ -1177,6 +1177,16 @@
           it('does not load contacts', function () {
             expect($ctrl.managedContacts.length).toEqual(0);
           });
+
+          describe('loading', function () {
+            it('is not loading fromDayTypes', function () {
+              expect($ctrl.loading.fromDayTypes).toBe(false);
+            });
+
+            it('is not loading toDayTypes', function () {
+              expect($ctrl.loading.toDayTypes).toBe(false);
+            });
+          });
         });
       });
 


### PR DESCRIPTION
## Overview
This PR fixes an issue when opening an existing leave request the date types fields stay in a loading state that never completes.

## Before
![anim](https://user-images.githubusercontent.com/1642119/28534039-45a34e0c-706d-11e7-9037-59d9a96c90ce.gif)

## After
![anim](https://user-images.githubusercontent.com/1642119/28534409-9828ce30-706e-11e7-941b-ac676c2818be.gif)

## Technical Details

The error was introduced after moving code on the `request-ctrl.js`'s `updateAbsencePeriodDatesTypes` method into `loadAbsencePeriodDatesTypes` to separate initializing vs updating values. The specific issue was failing to set the loading `fromDayTypes` and `toDayTypes` variables to false after the initialization phase was completed.

Tests were added to the initialization phase to make sure the loading variables are set to false after requests are completed.

The error handling on `updateAbsencePeriodDatesTypes` was refactored in order to take advantage of the already defined `handleError` function.

---

- [x] Tests Pass
