### PR TITLE
PCHR-2436: Handle error when Contact does not have Entitlement When importing Leave Requests

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -1454,6 +1454,32 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
   /**
    * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
+   * @expectedExceptionMessage Contact does not have period entitlement for the absence type
+   */
+  public function testLeaveRequestCanNotBeCreatedWhenContactHasNoPeriodEntitlementForTheAbsenceType() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    $contactID = 1;
+    $leaveDate = new DateTime('2016-11-15');
+    $dateType = $this->leaveRequestDayTypes['all_day']['value'];
+
+    LeaveRequest::create([
+      'type_id' => $this->absenceType->id,
+      'contact_id' => $contactID,
+      'status_id' => 1,
+      'from_date' => $leaveDate->format('YmdHis'),
+      'from_date_type' => $dateType,
+      'to_date' => $leaveDate->format('YmdHis'),
+      'to_date_type' => $dateType,
+      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
+    ]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
    * @expectedExceptionMessage Leave Request must have at least one working day to be created
    */
   public function testLeaveRequestCanNotBeCreatedWhenLeaveRequestDateIsAPublicHoliday() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -2258,6 +2258,32 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals($expectedResult, $result);
   }
 
+  public function testLeaveRequestIsValidShouldReturnErrorWhenContactHasNoPeriodEntitlementForTheAbsenceType() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    $contactID = 1;
+    $leaveDate = new DateTime('2016-11-15');
+    $dateType = $this->leaveRequestDayTypes['all_day']['value'];
+
+    $result = civicrm_api3('LeaveRequest', 'isvalid', [
+      'type_id' => $this->absenceType->id,
+      'contact_id' => $contactID,
+      'status_id' => 1,
+      'from_date' => $leaveDate->format('YmdHis'),
+      'from_date_type' => $dateType,
+      'to_date' => $leaveDate->format('YmdHis'),
+      'to_date_type' => $dateType,
+      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
+    ]);
+
+    $errorMessage = 'Contact does not have period entitlement for the absence type';
+    $expectedResult = $this->getExpectedArrayForIsValidError('type_id', $errorMessage);
+    $this->assertEquals($expectedResult, $result);
+  }
+
   public function testLeaveRequestIsValidShouldReturnErrorWhenTheDatesAreNotContainedInValidAbsencePeriod() {
     AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),


### PR DESCRIPTION
## Overview
When importing leave requests for a Contact that does not have entitlement for the absence type being imported for, It causes error to be thrown and the screen goes blank. This error does not currently occur when requesting leave because a contact without entitlement is not allowed to request leave on the SSP.

## Before
Validation is not done to ensure that a contact has Entitlements in the Leave Request BAO mainly because the front end already handles this. 

## After
Validation is done to ensure that a contact has Entitlements in the Leave Request BAO since other sources like the L&A importer now exists to create leave requests.

## Technical Details
The reason for the error occurring was that In the Leave Request BAO validation function the expression `$leavePeriodEntitlement->getBalance()`  was returning an error: `PHP Fatal error:  Call to a member function getBalance() on null` because the `$leavePeriodEntitlement` variable was not checked to ensure that it is a valid `LeavePeriodEntitlement` object. This PR changes this to check that the variable contains a  valid `LeavePeriodEntitlement` object before calling the getBalance function on the object

- [X] Tests Pass
