### PR TITLE
PCHR-2170:  Fix issues with TOIL Days Remaining calculation being incorrect

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -803,6 +803,35 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
   }
 
   /**
+   * This method returns the total sum of approved TOIL accrued for an absence type
+   * by a contact over a given absence period
+   *
+   * @param int $contactID
+   * @param int $typeID
+   * @param \CRM_HRLeaveAndAbsences_BAO_AbsencePeriod $period
+   *
+   * @return float
+   */
+  public static function getTotalApprovedToilForPeriod(AbsencePeriod $period, $contactID, $typeID) {
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+
+    $leaveRequestStatusFilter = [
+      $leaveRequestStatuses['approved'],
+      $leaveRequestStatuses['admin_approved']
+    ];
+
+    $totalApprovedTOIL = self::getTotalTOILBalanceChangeForContact(
+      $contactID,
+      $typeID,
+      new DateTime($period->start_date),
+      new DateTime($period->end_date),
+      $leaveRequestStatusFilter
+    );
+
+    return $totalApprovedTOIL;
+  }
+
+  /**
    * This method calculates the sum of the Leave Requests of type toil (with the
    * given status) balance changes for a given contact over a given period of time.
    *

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -319,22 +319,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    * @return float
    */
   private static function getTotalApprovedToilForPeriod(AbsencePeriod $period, $contactID, $typeID) {
-    $leaveRequestStatuses = array_flip(self::buildOptions('status_id', 'validate'));
-
-    $leaveRequestStatusFilter = [
-      $leaveRequestStatuses['approved'],
-      $leaveRequestStatuses['admin_approved']
-    ];
-
-    $totalApprovedTOIL = LeaveBalanceChange::getTotalTOILBalanceChangeForContact(
-      $contactID,
-      $typeID,
-      new DateTime($period->start_date),
-      new DateTime($period->end_date),
-      $leaveRequestStatusFilter
-    );
-
-    return $totalApprovedTOIL;
+    return LeaveBalanceChange::getTotalApprovedToilForPeriod($period, $contactID, $typeID);
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/EntitlementCalculation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/EntitlementCalculation.php
@@ -4,6 +4,7 @@ use CRM_HRLeaveAndAbsences_Service_ContractEntitlementCalculation as ContractEnt
 use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
 use CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement as LeavePeriodEntitlement;
 use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 
 /**
  * This class encapsulates all of the entitlement calculation logic.
@@ -494,5 +495,25 @@ class CRM_HRLeaveAndAbsences_Service_EntitlementCalculation {
     }
 
     return true;
+  }
+
+  /**
+   * Returns the total Approved TOIL for the contact for
+   * the absence type and previous period.
+   *
+   * @return float
+   */
+  public function getAccruedTOILForPreviousPeriod() {
+    $previousPeriod = $this->getPreviousPeriod();
+
+    if($previousPeriod) {
+      return LeaveBalanceChange::getTotalApprovedToilForPeriod(
+        $previousPeriod,
+        $this->contact['id'],
+        $this->absenceType->id
+      );
+    }
+
+    return 0;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
@@ -44,6 +44,7 @@
     <th>{ts}Employee name{/ts}</th>
     <th>{ts}Leave type{/ts}</th>
     <th>{ts}Prev. yr entitlement{/ts}</th>
+    <th>{ts}Prev. yr Accrued TOIL{/ts}</th>
     <th>{ts}Days taken{/ts}</th>
     <th>{ts}Remaining{/ts}</th>
     <th>{ts}Brought Forward from previous period{/ts}</th>
@@ -74,6 +75,7 @@
       <td>{$contact.display_name}</td>
       <td><span class="absence-type" style="background-color: {$absenceType->color};">{$absenceType->title}</span></td>
       <td>{$calculation->getPreviousPeriodProposedEntitlement()}</td>
+      <td>{$calculation->getAccruedTOILForPreviousPeriod()}</td>
       <td>{$calculation->getNumberOfDaysTakenOnThePreviousPeriod()}</td>
       <td>{$calculation->getNumberOfDaysRemainingInThePreviousPeriod()}</td>
       <td>{$calculation->getBroughtForward()}</td>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -2274,7 +2274,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $this->assertEquals(3, $totalBalanceChange);
   }
 
-  public function testGetTotalApprovedToilForPeriod() {
+  public function testGetTotalApprovedToilForPeriodShouldOnlyAccountForApprovedRequests() {
     $contactID = 1;
     $absenceTypeID = 1;
     $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -2274,6 +2274,58 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $this->assertEquals(3, $totalBalanceChange);
   }
 
+  public function testGetTotalApprovedToilForPeriod() {
+    $contactID = 1;
+    $absenceTypeID = 1;
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-06-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-06-30')
+    ]);
+
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contactID,
+      'status_id' => $leaveRequestStatuses['approved'],
+      'from_date' => CRM_Utils_Date::processDate('2016-06-02'),
+      'to_date' => CRM_Utils_Date::processDate('2016-06-03'),
+      'toil_to_accrue' => 1,
+      'toil_duration' => 120,
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
+    ], true);
+
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contactID,
+      'status_id' => $leaveRequestStatuses['admin_approved'],
+      'from_date' => CRM_Utils_Date::processDate('2016-06-04'),
+      'to_date' => CRM_Utils_Date::processDate('2016-06-05'),
+      'toil_to_accrue' => 2,
+      'toil_duration' => 120,
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
+    ], true);
+
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contactID,
+      'status_id' => $leaveRequestStatuses['awaiting_approval'],
+      'from_date' => CRM_Utils_Date::processDate('2016-06-07'),
+      'to_date' => CRM_Utils_Date::processDate('2016-06-08'),
+      'toil_to_accrue' => 3,
+      'toil_duration' => 120,
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
+    ], true);
+
+    //only the first two TOILs have  Approved and Admin Approved status
+    $totalBalanceChange = LeaveBalanceChange::getTotalApprovedToilForPeriod(
+      $period,
+      $contactID,
+      $absenceTypeID
+    );
+    $this->assertEquals(3, $totalBalanceChange);
+  }
+
   public function testRecalculateExpiredBalanceChangesForLeaveRequestPastDates() {
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),


### PR DESCRIPTION
## Overview
Currently on the Manage Entitlement page, we don't display a column that shows the TOIL accrued by the contact for the previous period, This causes some confusion in the remaining days column calculation. 

## Before
For example with the current default sample data in L&A, the contact took 1 leave day for the TOIL absence Type in 2016, If the entitlement for TOIL in 2016 was overridden to be 10, When being redirected to calculate entitlements for 2017 Period.
Remaining Days = Previous Year Entitlement - Days Taken.
Expected Remaining Days: 10 - 1 = 9
What is actually seen is 10 - 1 = 10

![manage leave entitlements for period -2017- - 01-01-2017 to 31-12-2017 - l_and_a 2017-08-01 13-23-37](https://user-images.githubusercontent.com/6951813/28825174-1e011c02-76bd-11e7-8b79-24103d381037.png)


## After
The reason for 10 - 1 = 10 being observed for the Remaining days in the before section is that the contact accrued an additional TOIL of 1 day during the period 2016. So the calculation for the remaining days column is actually correct but the user needs more visibility. A new column Prev Year Accrued TOIL was added to display the information that is already being accounted for in the calculation for Remaining Days column.
So the new formula should be
Remaining Days = (Previous Year Entitlement + Prev. Year Accrued TOIL) - Days Taken.
(10 + 1 ) - 1 = 10

![manage leave entitlements for period -2017- - 01-01-2017 to 31-12-2017 - l_and_a 2017-08-01 13-31-05](https://user-images.githubusercontent.com/6951813/28825352-bf4ae4ee-76bd-11e7-9f4e-892719df589f.png)

- [X] Tests Pass
