### PR TITLE
PCHR-2299: Allow non active pay scales

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Form/PayScale.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Form/PayScale.php
@@ -1,30 +1,34 @@
 <?php
 
+use CRM_Hrjobcontract_Page_JobContractTab as JobContractTab;
+use CRM_Hrjobcontract_SelectValues as SelectValues;
+use CRM_Core_Session as Session;
+
 /*
-  +--------------------------------------------------------------------+
-  | CiviHR version 1.4                                                 |
-  +--------------------------------------------------------------------+
-  | Copyright CiviCRM LLC (c) 2004-2014                                |
-  +--------------------------------------------------------------------+
-  | This file is a part of CiviCRM.                                    |
-  |                                                                    |
-  | CiviCRM is free software; you can copy, modify, and distribute it  |
-  | under the terms of the GNU Affero General Public License           |
-  | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
-  |                                                                    |
-  | CiviCRM is distributed in the hope that it will be useful, but     |
-  | WITHOUT ANY WARRANTY; without even the implied warranty of         |
-  | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
-  | See the GNU Affero General Public License for more details.        |
-  |                                                                    |
-  | You should have received a copy of the GNU Affero General Public   |
-  | License and the CiviCRM Licensing Exception along                  |
-  | with this program; if not, contact CiviCRM LLC                     |
-  | at info[AT]civicrm[DOT]org. If you have questions about the        |
-  | GNU Affero General Public License or the licensing of CiviCRM,     |
-  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
-  +--------------------------------------------------------------------+
-*/
++--------------------------------------------------------------------+
+| CiviHR version 1.4                                                 |
++--------------------------------------------------------------------+
+| Copyright CiviCRM LLC (c) 2004-2014                                |
++--------------------------------------------------------------------+
+| This file is a part of CiviCRM.                                    |
+|                                                                    |
+| CiviCRM is free software; you can copy, modify, and distribute it  |
+| under the terms of the GNU Affero General Public License           |
+| Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+|                                                                    |
+| CiviCRM is distributed in the hope that it will be useful, but     |
+| WITHOUT ANY WARRANTY; without even the implied warranty of         |
+| MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+| See the GNU Affero General Public License for more details.        |
+|                                                                    |
+| You should have received a copy of the GNU Affero General Public   |
+| License and the CiviCRM Licensing Exception along                  |
+| with this program; if not, contact CiviCRM LLC                     |
+| at info[AT]civicrm[DOT]org. If you have questions about the        |
+| GNU Affero General Public License or the licensing of CiviCRM,     |
+| see the CiviCRM license FAQ at http://civicrm.org/licensing        |
++--------------------------------------------------------------------+
+ */
 
 /**
  *
@@ -40,8 +44,13 @@
  */
 class CRM_Hrjobcontract_Form_PayScale extends CRM_Core_Form {
 
-  function setDefaultValues() {
-    $defaults = array();
+  /**
+   * @var int
+   */
+  protected $_id;
+
+  public function setDefaultValues() {
+    $defaults = [];
 
     if ($this->_id) {
       $defaults = CRM_Hrjobcontract_BAO_PayScale::getDefaultValues($this->_id);
@@ -60,55 +69,65 @@ class CRM_Hrjobcontract_Form_PayScale extends CRM_Core_Form {
    * @access public
    */
   public function buildQuickForm() {
-    $this->addButtons(array(
-        array(
+    $this->addButtons([
+        [
           'type' => 'next',
           'name' => ts('Save'),
           'isDefault' => TRUE,
-        ),
-        array(
+        ],
+        [
           'type' => 'cancel',
           'name' => ts('Cancel'),
-        ),
-      )
+        ],
+      ]
     );
 
     if ($this->_action & CRM_Core_Action::DELETE) {
-      $this->addButtons(array(
-          array(
+      $this->addButtons([
+          [
             'type' => 'next',
             'name' => ts('Delete'),
             'isDefault' => TRUE,
-          ),
-          array(
+          ],
+          [
             'type' => 'cancel',
             'name' => ts('Cancel'),
-          ),
-        )
+          ],
+        ]
       );
     }
 
-
-    $this->_id = CRM_Utils_Request::retrieve('id' , 'Positive', $this);
+    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
     if ($this->_action & CRM_Core_Action::DELETE) {
       return;
     }
 
-    $currencyFormatsKeys = array_keys(CRM_Hrjobcontract_Page_JobContractTab::getCurrencyFormats());
+    $currencyFormatsKeys = array_keys(JobContractTab::getCurrencyFormats());
     $currencies = array_combine($currencyFormatsKeys, $currencyFormatsKeys);
 
-    $this->add('text', 'pay_scale', ts('Label'), CRM_Core_DAO::getAttribute('CRM_Hrjobcontract_DAO_PayScale', 'pay_scale'), TRUE);
-    $this->add('select', 'currency', ts('Currency'), array('' => ts('- select -')) + $currencies, TRUE);
-    $this->add('text', 'amount', ts('Default Amount'), CRM_Core_DAO::getAttribute('CRM_Hrjobcontract_DAO_PayScale', 'amount'), TRUE);
-    $this->add('select', 'pay_frequency', ts('Pay Frequency'), array('' => ts('- select -')) + CRM_Hrjobcontract_SelectValues::commonUnit(), TRUE);
+    $daoClass = CRM_Hrjobcontract_DAO_PayScale::class;
 
-    $this->add('checkbox', 'is_active', ts('Enabled?'), CRM_Core_DAO::getAttribute('CRM_Hrjobcontract_DAO_PayScale', 'is_active'));
+    $payScaleAttr = CRM_Core_DAO::getAttribute($daoClass, 'pay_scale');
+    $currencyOptions = ['' => ts('- select -')] + $currencies;
+    $amountAttr = CRM_Core_DAO::getAttribute($daoClass, 'amount');
+    $frequencyOptions = ['' => ts('- select -')] + SelectValues::commonUnit();
+    $isActiveAttr = CRM_Core_DAO::getAttribute($daoClass, 'is_active');
 
-    $this->addFormRule(array('CRM_Hrjobcontract_Form_PayScale', 'formRule'), $this);
+    $this->add('text', 'pay_scale', ts('Label'), $payScaleAttr, TRUE);
+    $this->add('select', 'currency', ts('Currency'), $currencyOptions, TRUE);
+    $this->add('text', 'amount', ts('Default Amount'), $amountAttr, TRUE);
+    $this->add('select', 'pay_frequency', ts('Pay Frequency'), $frequencyOptions, TRUE);
+    $this->add('checkbox', 'is_active', ts('Enabled?'), $isActiveAttr);
+    $this->addFormRule([self::class, 'formRule']);
   }
 
-  static function formRule($fields, $files, $self) {
-    $errors = array();
+  /**
+   * @param $fields
+   *
+   * @return array
+   */
+  public static function formRule($fields) {
+    $errors = [];
     if (!array_key_exists('pay_scale', $fields)) {
       $errors['pay_scale'] = ts("Please enter Pay Scale value");
     }
@@ -121,6 +140,7 @@ class CRM_Hrjobcontract_Form_PayScale extends CRM_Core_Form {
     if (!array_key_exists('pay_frequency', $fields)) {
       $errors['pay_frequency'] = ts("Please enter a value fro pay frequency");
     }
+
     return $errors;
   }
 
@@ -133,35 +153,62 @@ class CRM_Hrjobcontract_Form_PayScale extends CRM_Core_Form {
   public function postProcess() {
     if ($this->_action & CRM_Core_Action::DELETE) {
       CRM_Hrjobcontract_BAO_PayScale::del($this->_id);
-      CRM_Core_Session::setStatus(ts('Selected pay scale has been deleted.'), 'Success', 'success');
+      $deleteMsg = ts('Selected pay scale has been deleted.');
+      Session::setStatus($deleteMsg, 'Success', 'success');
     }
     else {
-      $params = $ids = array( );
-      // store the submitted values in an array
-      $params = $this->exportValues();
-
-      foreach (array('pay_scale', 'currency', 'amount', 'pay_frequency') as $key => $index) {
-        if (!array_key_exists($index, $params)) {
-          $params[$index] = 0;
-        }
-      }
+      $params = $this->getParams();
 
       if ($this->_action & CRM_Core_Action::UPDATE) {
         $params['id'] = $this->_id;
       }
 
       $payScale = CRM_Hrjobcontract_BAO_PayScale::create($params);
+      $payScaleName = $payScale->pay_scale;
 
       if ($this->_action & CRM_Core_Action::UPDATE) {
-        CRM_Core_Session::setStatus(ts('The Pay Scale for \'%1\' has been updated.', array( 1 => $payScale->pay_scale)), 'Success', 'success');
+        $msg = ts(
+          'The Pay Scale for \'%1\' has been updated.',
+          [1 => $payScaleName]
+        );
+        Session::setStatus($msg, 'Success', 'success');
       }
       else {
-        CRM_Core_Session::setStatus(ts('The Pay Scale for \'%1\' has been added.', array( 1 => $payScale->pay_scale)), 'Success', 'success');
+        $msg = ts(
+          'The Pay Scale for \'%1\' has been added.',
+          [1 => $payScaleName]
+        );
+        Session::setStatus($msg, 'Success', 'success');
       }
 
       $url = CRM_Utils_System::url('civicrm/pay_scale', 'reset=1&action=browse');
-      $session = CRM_Core_Session::singleton();
+      $session = Session::singleton();
       $session->replaceUserContext($url);
     }
   }
+
+  /**
+   * @return array
+   */
+  private function getParams() {
+    $params = $this->exportValues();
+
+    $properties = [
+      'pay_scale',
+      'currency',
+      'amount',
+      'pay_frequency',
+      'is_active'
+    ];
+
+    // set defaults
+    foreach ($properties as $property) {
+      if (!array_key_exists($property, $params)) {
+        $params[$property] = 0;
+      }
+    }
+
+    return $params;
+  }
+
 }

--- a/hrjobcontract/CRM/Hrjobcontract/Form/PayScale.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Form/PayScale.php
@@ -157,7 +157,8 @@ class CRM_Hrjobcontract_Form_PayScale extends CRM_Core_Form {
       Session::setStatus($deleteMsg, 'Success', 'success');
     }
     else {
-      $params = $this->getParams();
+      $params = $this->exportValues();
+      $params['is_active'] = CRM_Utils_Array::value('is_active', $params, 0);
 
       if ($this->_action & CRM_Core_Action::UPDATE) {
         $params['id'] = $this->_id;
@@ -185,30 +186,6 @@ class CRM_Hrjobcontract_Form_PayScale extends CRM_Core_Form {
       $session = Session::singleton();
       $session->replaceUserContext($url);
     }
-  }
-
-  /**
-   * @return array
-   */
-  private function getParams() {
-    $params = $this->exportValues();
-
-    $properties = [
-      'pay_scale',
-      'currency',
-      'amount',
-      'pay_frequency',
-      'is_active'
-    ];
-
-    // set defaults
-    foreach ($properties as $property) {
-      if (!array_key_exists($property, $params)) {
-        $params[$property] = 0;
-      }
-    }
-
-    return $params;
   }
 
 }


### PR DESCRIPTION
## Overview
When saving a pay scale the "is_active" checkbox is ignored if unchecked. This means that you cannot set a payscale to inactive.

## Before
When saving a payscale with "is active" unchecked it is always saved as active.

## After
The checkbox is not ignored and it is possible to save a checkbox as inactive.

## Technical Details
The cause was that checkbox values are not send from the client in the $_POST request unless they are checked. The solution is to set a default value if not included in the request body.

## Comments
Since this is a small file I did some cleanup, replacing the old array syntax and trying to reduce the long lines to under 80 characters.

---

- [x] Tests Pass
