### PR TITLE
PCHR-2482: Import Contract Entitlements for L&A

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/ExportImportValuesConverter.php
+++ b/hrjobcontract/CRM/Hrjobcontract/ExportImportValuesConverter.php
@@ -105,9 +105,9 @@ class CRM_Hrjobcontract_ExportImportValuesConverter
         // leave types options:
         $absenceTypes = AbsenceType::getEnabledAbsenceTypes();
         foreach($absenceTypes as $absenceType) {
-          $absenceTypeArray = (array)$absenceType;
-          $this->_leaveTypes[$absenceType->id] = $absenceTypeArray;
-          $this->_leaveTypesFlipped[$absenceTypeArray['title']] = $absenceType->id;
+            $absenceTypeArray = (array)$absenceType;
+            $this->_leaveTypes[$absenceType->id] = $absenceTypeArray;
+            $this->_leaveTypesFlipped[$absenceTypeArray['title']] = $absenceType->id;
         }
 
         // location options:
@@ -575,5 +575,14 @@ class CRM_Hrjobcontract_ExportImportValuesConverter
         }
 
         return $contactId;
+    }
+
+    /**
+     * Returns Leave/Absence Types
+     *
+     * @return array
+     */
+    public function getLeaveTypes() {
+        return $this->_leaveTypes;
     }
 }

--- a/hrjobcontract/CRM/Hrjobcontract/ExportImportValuesConverter.php
+++ b/hrjobcontract/CRM/Hrjobcontract/ExportImportValuesConverter.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+
 class CRM_Hrjobcontract_ExportImportValuesConverter
 {
     static private $_singleton = NULL;
@@ -101,12 +103,11 @@ class CRM_Hrjobcontract_ExportImportValuesConverter
         }
 
         // leave types options:
-        $absenceType = new CRM_HRAbsence_BAO_HRAbsenceType();
-        $absenceType->find();
-        while ($absenceType->fetch()) {
-            $absenceTypeArray = (array)$absenceType;
-            $this->_leaveTypes[$absenceType->id] = $absenceTypeArray;
-            $this->_leaveTypesFlipped[$absenceTypeArray['title']] = $absenceType->id;
+        $absenceTypes = AbsenceType::getEnabledAbsenceTypes();
+        foreach($absenceTypes as $absenceType) {
+          $absenceTypeArray = (array)$absenceType;
+          $this->_leaveTypes[$absenceType->id] = $absenceTypeArray;
+          $this->_leaveTypesFlipped[$absenceTypeArray['title']] = $absenceType->id;
         }
 
         // location options:

--- a/hrjobcontract/CRM/Hrjobcontract/Import/EntityHandler/HRJobLeave.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/EntityHandler/HRJobLeave.php
@@ -9,22 +9,9 @@ class CRM_Hrjobcontract_Import_EntityHandler_HRJobLeave extends CRM_Hrjobcontrac
   }
 
   public function handle(array $params, CRM_Hrjobcontract_DAO_HRJobContractRevision $contractRevision, array &$previousRevision) {
-    $importExportUtility = ImportExportUtility::singleton();
-    $leaveTypes = $importExportUtility->getLeaveTypes();
-    $leaveData = [];
-
-    foreach($leaveTypes as $leaveType) {
-      $key = filter_var($leaveType['title'], FILTER_SANITIZE_STRING);
-      if(!empty($params[$key])){
-        $leaveData[] = [
-          'leave_type' => $leaveType['id'],
-          'leave_amount' => "{$params[$leaveType['title']]}",
-          'add_public_holidays' => $leaveType['add_public_holiday_to_entitlement'],
-          "jobcontract_revision_id" => $contractRevision->id,
-          "jobcontract_id" => $contractRevision->jobcontract_id,
-        ];
-      }
-    }
+    $leaveData = $this->prepareLeaveData(
+      $params, $contractRevision->jobcontract_id, $contractRevision->id
+    );
 
     return civicrm_api3('HRJobLeave', 'replace', [
       'sequential' => 1,
@@ -33,4 +20,35 @@ class CRM_Hrjobcontract_Import_EntityHandler_HRJobLeave extends CRM_Hrjobcontrac
       'jobcontract_revision_id' => $contractRevision->id,
     ])['values'][0];
   }
+
+  /**
+   * Prepares Job Leave entity data to a valid API format.
+   *
+   * @param array $params
+   * @param int $contractID
+   * @param int $revisionID
+   *
+   * @return array
+   */
+  private function prepareLeaveData($params, $contractID, $revisionID) {
+    $leaveRows = [];
+    $importExportUtility = ImportExportUtility::singleton();
+    $leaveTypes = $importExportUtility->getLeaveTypes();
+
+    foreach ($leaveTypes as $leaveType) {
+      $key = filter_var($leaveType['title'], FILTER_SANITIZE_STRING);
+      $leaveAmount = !empty($params[$key]) ? $params[$key] : 0;
+      $leaveRows[] = [
+        'leave_type' => $leaveType['id'],
+        'leave_amount' => $leaveAmount,
+        'add_public_holidays' => $leaveType['add_public_holiday_to_entitlement'],
+        'jobcontract_revision_id' => $revisionID,
+        'jobcontract_id' => $contractID,
+      ];
+
+      return $leaveRows;
+    }
+  }
 }
+
+

--- a/hrjobcontract/CRM/Hrjobcontract/Import/EntityHandler/HRJobLeave.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/EntityHandler/HRJobLeave.php
@@ -1,5 +1,6 @@
 <?php
 
+use CRM_Hrjobcontract_DAO_HRJobContractRevision as HRJobContractRevision;
 use CRM_Hrjobcontract_ExportImportValuesConverter as ImportExportUtility;
 
 class CRM_Hrjobcontract_Import_EntityHandler_HRJobLeave extends CRM_Hrjobcontract_Import_EntityHandler {
@@ -8,7 +9,7 @@ class CRM_Hrjobcontract_Import_EntityHandler_HRJobLeave extends CRM_Hrjobcontrac
     parent::__construct('HRJobLeave');
   }
 
-  public function handle(array $params, CRM_Hrjobcontract_DAO_HRJobContractRevision $contractRevision, array &$previousRevision) {
+  public function handle(array $params, HRJobContractRevision $contractRevision, array &$previousRevision) {
     $leaveData = $this->prepareLeaveData(
       $params, $contractRevision->jobcontract_id, $contractRevision->id
     );

--- a/hrjobcontract/CRM/Hrjobcontract/Import/EntityHandler/HRJobLeave.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/EntityHandler/HRJobLeave.php
@@ -1,19 +1,30 @@
 <?php
 
+use CRM_Hrjobcontract_ExportImportValuesConverter as ImportExportUtility;
+
 class CRM_Hrjobcontract_Import_EntityHandler_HRJobLeave extends CRM_Hrjobcontract_Import_EntityHandler {
+
   public function __construct() {
     parent::__construct('HRJobLeave');
   }
 
   public function handle(array $params, CRM_Hrjobcontract_DAO_HRJobContractRevision $contractRevision, array &$previousRevision) {
-    $leaveAmounts = [];
-    if (!empty($params['HRJobLeave-leave_amount'])) {
-      $leaveAmounts = $params['HRJobLeave-leave_amount'];
-    }
+    $importExportUtility = ImportExportUtility::singleton();
+    $leaveTypes = $importExportUtility->getLeaveTypes();
+    $leaveData = [];
 
-    $leaveData = $this->prepareLeaveData(
-      $leaveAmounts, $contractRevision->jobcontract_id, $contractRevision->id
-    );
+    foreach($leaveTypes as $leaveType) {
+      $key = filter_var($leaveType['title'], FILTER_SANITIZE_STRING);
+      if(!empty($params[$key])){
+        $leaveData[] = [
+          'leave_type' => $leaveType['id'],
+          'leave_amount' => "{$params[$leaveType['title']]}",
+          'add_public_holidays' => $leaveType['add_public_holiday_to_entitlement'],
+          "jobcontract_revision_id" => $contractRevision->id,
+          "jobcontract_id" => $contractRevision->jobcontract_id,
+        ];
+      }
+    }
 
     return civicrm_api3('HRJobLeave', 'replace', [
       'sequential' => 1,
@@ -21,34 +32,5 @@ class CRM_Hrjobcontract_Import_EntityHandler_HRJobLeave extends CRM_Hrjobcontrac
       'jobcontract_id' => $contractRevision->jobcontract_id,
       'jobcontract_revision_id' => $contractRevision->id,
     ])['values'][0];
-  }
-
-  /**
-   * Prepares Job Leave entity data to a valid API format.
-   *
-   * @param array $leaveEntitlements
-   *   Job leave entity data.
-   * @param int $contractID
-   * @param int $revisionID
-   *
-   * @return array
-   */
-  private function prepareLeaveData($leaveEntitlements, $contractID, $revisionID) {
-    $leaveRows = [];
-    $leaveTypes = CRM_Hrjobcontract_SelectValues::buildLeaveTypes();
-
-    foreach($leaveTypes as $leaveType) {
-      $leaveAmount = isset($leaveEntitlements[$leaveType['id']]) ?  $leaveEntitlements[$leaveType['id']] : 0;
-
-      $leaveRows[] = [
-        'leave_type' => "{$leaveType['id']}",
-        'leave_amount' => "{$leaveAmount}",
-        'add_public_holidays' => "0",
-        "jobcontract_revision_id" => "{$revisionID}",
-        "jobcontract_id" => "{$contractID}",
-      ];
-    }
-
-    return $leaveRows;
   }
 }

--- a/hrjobcontract/CRM/Hrjobcontract/Import/FieldsProvider/Generic.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/FieldsProvider/Generic.php
@@ -16,6 +16,10 @@ class CRM_Hrjobcontract_Import_FieldsProvider_Generic extends CRM_Hrjobcontract_
   public function provide() {
     $entityName = 'CRM_Hrjobcontract_BAO_' . $this->getEntityName();
 
+    if ($this->getEntityName() == 'HRJobLeave') {
+      return [];
+    }
+
     $importableFields = call_user_func(array(
       $entityName,
       'importableFields'

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Parser/Api.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Parser/Api.php
@@ -660,7 +660,9 @@ class CRM_Hrjobcontract_Import_Parser_Api extends CRM_Hrjobcontract_Import_Parse
       default:
         $importExportUtility = ImportExportUtility::singleton();
         $leaveTypes = $importExportUtility->getLeaveTypes();
-        $leaveTypes = array_map(function ($value) { return filter_var($value, FILTER_SANITIZE_STRING); }, array_column($leaveTypes, 'title'));
+        $leaveTypes = array_map(function ($value) {
+          return filter_var($value, FILTER_SANITIZE_STRING);
+        }, array_column($leaveTypes, 'title'));
 
         if (in_array($key, $leaveTypes)) {
           if (!is_numeric($value)) {
@@ -673,7 +675,7 @@ class CRM_Hrjobcontract_Import_Parser_Api extends CRM_Hrjobcontract_Import_Parse
   }
 
   /**
-   * Checks if given field requires returntype to be 'value', 'label' or 'id'
+   * Checks if given field requires return type to be 'value', 'label' or 'id'
    * and obtains its value in DB for given $value.
    *
    * @param string $key

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Parser/Api.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Parser/Api.php
@@ -46,11 +46,14 @@ class CRM_Hrjobcontract_Import_Parser_Api extends CRM_Hrjobcontract_Import_Parse
       if(!isset($fieldProviders[$entity])) {
         $fieldProviders[$entity] = new CRM_Hrjobcontract_Import_FieldsProvider_Generic($entity);
       }
-      $entityFields[$entity] = $fieldProviders[$entity]->provide();
 
-      $this->handleSpecialFields($entityFields, $entity);
+      $providedFields = $fieldProviders[$entity]->provide();
+      if($providedFields) {
+        $entityFields[$entity] = $providedFields;
 
-      $this->_allFields = array_merge($entityFields[$entity], $this->_allFields);
+        $this->handleSpecialFields($entityFields, $entity);
+        $this->_allFields = array_merge($entityFields[$entity], $this->_allFields);
+      }
     }
 
     $this->_entityFields = $entityFields;
@@ -642,35 +645,6 @@ class CRM_Hrjobcontract_Import_Parser_Api extends CRM_Hrjobcontract_Import_Parse
         }
         else  {
           $errorMessage = "{$this->_fields[$key]->_title} with ID [$value] is not an existing provider";
-        }
-        break;
-      case 'HRJobLeave-leave_amount':
-        $convertedValue = array();
-        $leaveAmounts = explode(',', $value);
-        if (!empty($leaveAmounts))  {
-          foreach($leaveAmounts as $leave)  {
-            $typeAndAmount = explode(':', $leave);
-            if (!empty($typeAndAmount))  {
-              $leaveType = trim($typeAndAmount[0]);
-              $leaveAmount = trim($typeAndAmount[1]);
-              if ( filter_var($leaveAmount, FILTER_VALIDATE_INT) === FALSE  || $leaveAmount < 0 )  {
-                $errorMessage = "Leave Amount values should be positive integers";
-                break;
-              }
-              $typeID = $this->getOptionID('HRJobLeave-leave_type', $leaveType);
-              if ($typeID === FALSE) {
-                $errorMessage = "({$leaveType}) is not a valid leave type";
-              }
-              $convertedValue[$typeID] = $leaveAmount;
-            }
-            else {
-              $errorMessage = "{$this->_fields[$key]->_title} format is not correct";
-              break;
-            }
-          }
-        }
-        else {
-          $errorMessage = "{$this->_fields[$key]->_title} format is not correct";
         }
         break;
       case 'HRJobPay-annual_benefits':

--- a/hrjobcontract/CRM/Hrjobcontract/SelectValues.php
+++ b/hrjobcontract/CRM/Hrjobcontract/SelectValues.php
@@ -242,21 +242,21 @@ class CRM_Hrjobcontract_SelectValues {
   }
 
   /**
-   * Get leave types .
+   * Get leave types.
+   *
    * @return array
    */
   public static function buildLeaveTypes() {
-    $result = civicrm_api3('HRAbsenceType', 'get', array(
+    $result = civicrm_api3('AbsenceType', 'get', [
       'sequential' => 1,
-      'is_active' => 1,
-      'options' => array('limit' => 0),
-    ));
+      'is_active' => 1
+    ]);
     $result = $result['values'];
-    $options = array();
+    $options = [];
     foreach ($result as $item) {
-      $label = $item['title'];
-      $options[] =  array( 'id'=>$item['id'], 'label'=> $label);
+      $options[] =  ['id'=>$item['id'], 'label'=> $item['title']];
     }
+
     return $options;
   }
 }

--- a/hrjobcontract/CRM/Hrjobcontract/SelectValues.php
+++ b/hrjobcontract/CRM/Hrjobcontract/SelectValues.php
@@ -254,7 +254,7 @@ class CRM_Hrjobcontract_SelectValues {
     $result = $result['values'];
     $options = [];
     foreach ($result as $item) {
-      $options[] =  ['id'=>$item['id'], 'label'=> $item['title']];
+      $options[] = ['id' => $item['id'], 'label' => $item['title']];
     }
 
     return $options;

--- a/hrjobcontract/tests/phpunit/CRM/Hrjobcontract/Import/Parser/ApiTest.php
+++ b/hrjobcontract/tests/phpunit/CRM/Hrjobcontract/Import/Parser/ApiTest.php
@@ -23,7 +23,7 @@ class CRM_Hrjobcontract_Import_Parser_ApiTest extends CiviUnitTestCase implement
   public function setUpHeadless() {
     return \Civi\Test::headless()
       ->install('uk.co.compucorp.civicrm.hrcore')
-      ->install('org.civicrm.hrabsence')
+      ->install('uk.co.compucorp.civicrm.hrleaveandabsences')
       ->installMe(__DIR__)
       ->apply();
   }


### PR DESCRIPTION
## Overview
Contract Entitlements are imported along with the contract information for a contact via the job Contract Importer. However, the contract entitlements to be imported are still pointing to the absence/leave types of the old Absence extension. Also the contract entitlements for all the leave types are imported as a comma separated value in the `Contract Leave Amount` column of the CSV which is not a very intuitive way to import the entitlements.
## Before
The contract entitlements are pointing to the old absence extension leave types and the contract entitlements for all the leave types are imported as a comma separated values in the `Contract Leave Amount` column.

## After
The contract entitlements are pointing to L&A absence/leave types and the contract entitlements for all the leave types are imported using a column for each of the leave/absence types.
_Sample CSV is attached to the [ticket](https://compucorp.atlassian.net/browse/PCHR-2482)_.

![importentitlement](https://user-images.githubusercontent.com/6951813/29045811-c8e928a4-7bbc-11e7-95aa-8095d901c19e.gif)


## Technical Details
- The active L&A absence types are fetched and added as part of the importable fields for the Job contract importer. 
- The Importer will only import Leave amounts for the absence Types columns present in CSV and mapped in the Importer Upload page since they are not required fields. For example If Sick and TOIL absence Types are present as columns in the CSV and only Sick column  is mapped, then only the leave amount for the Sick Absence Type is imported. If none of the Absence Type columns are present or If they are present and not mapped, then leave amounts are not imported for any Absence type.
- Also  when importing contractual entitlements the setting to add public holiday to entitlement or not is gotten from the absence type `add_public_holiday_to_entitlement` property and added appropriately.
## Comments
Note that
 [] Tests Pass
