### PR TITLE
PCHR-1830: Hide multiple language options on localization form

### DIFF
--- a/hrui/hrui.php
+++ b/hrui/hrui.php
@@ -103,6 +103,10 @@ function hrui_civicrm_buildForm($formName, &$form) {
   if ($formName === 'CRM_Admin_Form_Options' && $form->elementExists('value')) {
     $form->removeElement('value');
   }
+
+  if ($form instanceof CRM_Admin_Form_Setting_Localization) {
+    $form->removeElement('makeMultilingual');
+  }
 }
 
 /**
@@ -701,6 +705,16 @@ function hrui_civicrm_alterContent( &$content, $context, $tplName, &$object ) {
      });
    </script>";
   }
+
+  if ($tplName === 'CRM/Admin/Form/Setting/Localization.tpl') {
+    // hide multiple language description
+    $content = str_replace('<h3>Multiple Languages Support</h3>', '', $content);
+    $content .= sprintf(
+      '<script>%s</script>',
+      'CRM.$(".crm-localization-form-block-description").hide();'
+    );
+  }
+
 }
 
 /**


### PR DESCRIPTION
## Overview
CiviHR does not work with multiple language sites. This is because the Drupal views module will try to create views using hardcoded column names. These column names are changed by enabling a multiple language site, for example `civicrm_option_value.label` becomes `civicrm_option_value.label_en_US`

Enabling multiple language and clearing the cache will cause a total site failure because the required views columns will be missing when rebuilding the views. In order to avoid this problem (which happened on the demo site) we will hide the option to enable multiple language.

## Before
You could see "Multiple Languages Support" under Administer > Localization > Languages, Currency, Locations. Enabling it would kill your site.

![image](https://user-images.githubusercontent.com/6374064/29023003-9a3a8524-7b63-11e7-87ab-008a83253379.png)

## After
"Multiple Languages Support" is hidden from the form on Administer > Localization > Languages, Currency, Locations.

![image](https://user-images.githubusercontent.com/6374064/29022978-729ae0cc-7b63-11e7-8b0d-7ce306471c13.png)

## Technical Details
- I'm not 100% happy with the method of hiding the description in the form, but I didn't want to override the template. I've asked on Mattermost whether it would make sense to allow disabling this section in the template at form level, but have yet to receive a reply.

---

- [] Tests Pass

Tests are broken because of errors in the installer and other extensions. After talking to @davialexandre we decided to ignore these for now and fix them later.
