### PR TITLE
PCHR-2482: Fix bug when creating and updating a contact with last name as Zero in Job Contract tests

### DIFF
--- a/hrjobcontract/tests/phpunit/HRJobContractTestTrait.php
+++ b/hrjobcontract/tests/phpunit/HRJobContractTestTrait.php
@@ -74,9 +74,9 @@ trait HRJobContractTestTrait {
     for($i = $numberOfCreatedContacts; $i < $numberOfCreatedContacts + $numberOfContacts; $i++) {
       $result = civicrm_api3('Contact', 'create', [
         'contact_type' => 'Individual',
-        'first_name' => 'Name ',
+        'first_name' => 'First',
         'middle_name' => 'N. ',
-        'last_name' => $i,
+        'last_name' => 'Last' . $i,
         'email' => 'name_'.$i.'@example.org',
       ]);
 


### PR DESCRIPTION
## Overview
Some tests were failing in the job contract extension with errors while trying to assert the display_name of some contacts created for the failing tests.
The tests were failing on CiviHR 1.7 and after merging this PR, will sync 1.7 with 1.6

## Before
The error observed in the tests were traced to a behaviour in the core Contact.create API.
If you try to create a contact with last name as `0`, it creates just fine and civi sets the display_name by concatenating the `first_name` and the `last_name`. For the example below, `display_name` is `Name 0`
```php

    $contact = civicrm_api3('Contact', 'create', [
      'contact_type' => 'Individual',
      'first_name' => 'Name',
      'middle_name' => 'N.',
      'last_name' => 0,
      'email' => 'name_0@example.org',
    ]);
```
However if you try to update the contact e.g
```php
civicrm_api3('Contact', 'create', array(
  'id' => 15,
));
```
Subsequent call to retrieve the contact from the database will return the `display_name` as `Name` 
with the last name chopped off from the display_name.

E.g one of the Jobcontract tests were creating contacts [Here](https://github.com/civicrm/civihr/blob/233f8018e35ccd76a4d8198df93c6cd33d3badd5/hrjobcontract/tests/phpunit/CRM/Hrjobcontract/BAO/HRJobContractTest.php#L335-L335), and then creating contracts for the contacts, the call to create the contracts triggers an update to the contact leading to the bug described above. The function responsible for creating the contacts [here](https://github.com/civicrm/civihr/blob/b92b81e63e986e6057c5c8cbb8f39840362a936c/hrjobcontract/tests/phpunit/HRJobContractTestTrait.php#L79-L79) creates contacts with the last name as sequential numbers and the bug is observed when `$i=0`

The issue was traced to the core [HERE](https://github.com/civicrm/civicrm-core/blob/0f03f337533bb76fb7fe6dcc25cdd624daef24f3/CRM/Contact/BAO/Individual.php#L137)
because civi is checking if the value variable is true or not. `0 == FALSE` in php, so that was why the last_name was chopped off from the `display_name`.

## After
A ticket has been created for the bug described [CRM-21048](https://issues.civicrm.org/jira/browse/CRM-21048).
To fix the failing test, the function creating the contacts was modified to create contacts with strings as last names.


- [X] Tests Pass
