### PR TITLE
PCHR-2353: Add the ContactHrJobRoles.get API

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/API/Query/ContactHrJobRolesSelect.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/API/Query/ContactHrJobRolesSelect.php
@@ -1,0 +1,125 @@
+<?php
+
+use CRM_Hrjobroles_API_Query_VirtualEntitySelectQuery as VirtualEntitySelectQuery;
+use CRM_Hrjobroles_BAO_HrJobRoles as HRJobRoles;
+use CRM_Hrjobcontract_BAO_HRJobContract as HRJobContract;
+
+/**
+ * This is a special class created mainly to support the ContactHrJobRoles.get
+ * API. Its main objective is to return a list of Job Roles, but with a reduced
+ * set of properties, and also include the id of the contact the role belongs to,
+ * which is an information that is not stored together with the Job Role. It does
+ * this by creating a query that joins the Job Roles table with the Contract
+ * table, where the contact ID exists.
+ *
+ * Internally it uses a child class of the Api3SelectQuery class, which means
+ * it can support everything that a normal .get query can like:
+ * - Different operators (IN, LIKE, <>, etc)
+ * - Limit and Offset operations
+ * - Sorting
+ */
+class CRM_Hrjobroles_API_Query_ContactHrJobRolesSelect {
+
+  /**
+   * @var array
+   *   An array of params passed to an API endpoint
+   */
+  private $params;
+
+  /**
+   * @var \CRM_HRLeaveAndAbsences_API_Query_Select
+   *  The SelectQuery instance wrapped by this class
+   */
+  private $query;
+
+  /**
+   * @var array
+   *  A list of fields that are supported by the entity + their names as they
+   *  should be added to the SELECT query. Usually the internal classes can
+   *  build this by themselves, but here we need to do it manually because not
+   *  all the fields are from the same database table
+   */
+  private $selectableFields = [
+    'id' => 'a.id',
+    'title' => 'a.title',
+    'description' => 'a.description',
+    'region' => 'a.region',
+    'department' => 'a.department',
+    'level_type' => 'a.level_type',
+    'functional_area' => 'a.functional_area',
+    'location' => 'a.location',
+    'contact_id' => 'jc.contact_id'
+  ];
+
+  public function __construct($params) {
+    $this->params = $params;
+    $this->buildCustomQuery();
+  }
+
+  /**
+   * Build the custom query.
+   *
+   * Here is basically where we get the given $params and build the entire query,
+   * including the JOIN with the Contracts table
+   */
+  private function buildCustomQuery() {
+    $customQuery = CRM_Utils_SQL_Select::from(HRJobRoles::getTableName() . ' as a');
+
+    $this->addJoins($customQuery);
+
+    $this->query = $this->buildSelectQuery('ContactHrJobRoles');
+    $this->query->merge($customQuery);
+  }
+
+  /**
+   * This method parses the $params array passed to the API and build an instance
+   * of VirtualEntitySelectQuery, which is a child class of Api3SelectQuery and
+   * it's the class that will actually build the SQL query.
+   *
+   * @param string $entity
+   *
+   * @return \CRM_Hrjobroles_API_Query_VirtualEntitySelectQuery
+   */
+  private function buildSelectQuery($entity) {
+    $checkPermissions = !empty($this->params['check_permissions']);
+    $query = new VirtualEntitySelectQuery($entity, $this->selectableFields, $checkPermissions);
+
+    $query->where = $this->params;
+
+    $options = _civicrm_api3_get_options_from_params($this->params);
+
+    if ($options['is_count']) {
+      $query->select = ['count_rows'];
+    }
+    else {
+      $query->select  = array_keys(array_filter($options['return']));
+      $query->orderBy = $options['sort'];
+    }
+
+    $query->limit = $options['limit'];
+    $query->offset = $options['offset'];
+
+    return $query;
+  }
+
+  /**
+   * Add the clauses to JOIN the Job Roles table with other tables
+   *
+   * @param \CRM_Utils_SQL_Select $query
+   */
+  private function addJoins(CRM_Utils_SQL_Select $query) {
+    $joins[] = 'INNER JOIN ' . HRJobContract::getTableName() . ' jc ON jc.id = a.job_contract_id';
+
+    $query->join(null, $joins);
+  }
+
+  /**
+   * Executes the query
+   *
+   * @return array|int
+   */
+  public function run() {
+    return $this->query->run();
+  }
+}
+

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/API/Query/VirtualEntitySelectQuery.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/API/Query/VirtualEntitySelectQuery.php
@@ -1,0 +1,61 @@
+<?php
+
+use Civi\API\Api3SelectQuery;
+
+/**
+ * This is a specialization of the Api3SelectQuery, created to allow an entity
+ * to return fields that are not part of an entity's table.
+ *
+ * The original implementation of the buildSelectFields() on the Api3SelectQuery
+ * class makes sure that only fields of the entity's table will be returned by
+ * the query. That means that, even if this is a query with multiple joins, it
+ * won't be possible to return fields from any of the joined tables. This class
+ * works around this by overriding that method and making it filter out fields
+ * based on a list of "allowed" fields passed to the constructor.
+ */
+class CRM_Hrjobroles_API_Query_VirtualEntitySelectQuery extends Api3SelectQuery {
+
+  /**
+   * @var array|bool
+   *   The list of fields that can be selected/returned by the query
+   *   Format: 'field name' => 'field name on the select clause (e.g. contract.contact_id)'
+   */
+  protected $virtualEntityFields = [];
+
+  /**
+   * CRM_Hrjobroles_API_Query_VirtualEntitySelectQuery constructor.
+   *
+   * @param string $entity
+   * @param array $virtualEntityFields
+   *   The list of fields that can be selected/returned
+   * @param bool $checkPermissions
+   */
+  public function __construct($entity, $virtualEntityFields, $checkPermissions) {
+    parent::__construct($entity, $checkPermissions);
+    $this->virtualEntityFields = $virtualEntityFields;
+  }
+
+  /**
+   * Builds the list of fields that can be selected by the query, based on the
+   * list of fields passed to the constructor
+   */
+  protected function buildSelectFields() {
+    $returnAllFields = (empty($this->select) || !is_array($this->select));
+    $return = $returnAllFields ? $this->entityFieldNames : $this->select;
+    if ($returnAllFields) {
+      foreach (array_keys($this->apiFieldSpec) as $fieldName) {
+        $return[] = $fieldName;
+      }
+    }
+
+    // Always select the ID to keep some consistency with the API3 behavior
+    $this->selectFields[self::MAIN_TABLE_ALIAS . '.id'] = 'id';
+
+    foreach ($return as $fieldName) {
+      $field = $this->getField($fieldName);
+      if ($field && in_array($field['name'], $this->entityFieldNames)) {
+        $this->selectFields[$this->virtualEntityFields[$fieldName]] = $field['name'];
+      }
+    }
+  }
+}

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/ContactHrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/ContactHrJobRoles.php
@@ -1,0 +1,68 @@
+<?php
+
+use CRM_Hrjobroles_DAO_HrJobRoles as HrJobRoles;
+
+/**
+ * This is a virtual entity. Its main objective is to serve as the underlying
+ * entity for the ContactJobRole API.
+ *
+ * Originally, there's no direct connection between a Job Role and a Contact.
+ * A Job Role is linked to a Contract, which finally is the entity connect to
+ * a Contact. This means that, if we want to know which contacts work in the
+ * IT department, we need to:
+ * 1. Fetch all the Job Roles where the department == IT
+ * 2. Fetch all the Contracts linked to these Job Roles
+ * 3. Fetch all the Contacts linked to these Contracts
+ *
+ * The idea of this virtual entity is to expose both the Contact and Job Role
+ * information under a single place and reduce the number of API calls to get
+ * the data as exemplified above. The ContactJobRole.get custom API was created
+ * to create the query necessary for this. This virtual BAO is necessary to
+ * exposed which field will be available on the API.
+ *
+ * @see civicrm_api3_contact_job_role_get()
+ * @see CRM_Hrjobroles_API_Query_ContactHrJobRolesSelect
+ */
+class CRM_Hrjobroles_BAO_ContactHrJobRoles extends HrJobRoles {
+
+  /**
+   * @var array
+   *  To avoid exposing confidential information via de API, this entity exposes
+   *  just small set of all the HrJobRoles fields. Should a user have access to
+   *  all the fields, the HrJobRoles.get API should be used instead.
+   *  This is the list of fields exposed by the ContactJobRole.API
+   */
+  private static $allowedFields = [
+    'id',
+    'title',
+    'region',
+    'department',
+    'level_type',
+    'location'
+  ];
+
+  /**
+   * Returns the same information as HrJobRoles::fields(), but only for the
+   * fields listed on $allowedFields. Additionally, it returns a "fake"
+   * contact_id, which will actually come from the Job Contract.
+   *
+   * @return array
+   */
+  public static function &fields() {
+    $fields = [];
+    foreach(HrJobRoles::fields() as $key => $field) {
+      if(!empty($field['name']) && in_array($field['name'], self::$allowedFields)) {
+        $fields[$key] = $field;
+      }
+    }
+
+    $fields['contact_id'] = [
+      'name' => 'contact_id',
+      'type' => CRM_Utils_Type::T_INT,
+      'title' => ts('Contact ID'),
+    ];
+
+    return $fields;
+  }
+
+}

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Test/Fabricator/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Test/Fabricator/HrJobRoles.php
@@ -1,0 +1,27 @@
+<?php
+
+class CRM_Hrjobroles_Test_Fabricator_HrJobRoles {
+
+  protected static $defaultParams = [
+    'sequential' => 1
+  ];
+
+  /**
+   * @param array $params
+   *  An array of params that will be passed to the civicrm API
+   *
+   * @return array
+   *  The entity values as they are returned by the API call
+   *
+   * @throws \Exception
+   */
+  public static function fabricate($params) {
+    $result = civicrm_api3(
+      'HrJobRoles',
+      'create',
+      array_merge(self::$defaultParams, $params)
+    );
+
+    return array_shift($result['values']);
+  }
+}

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
@@ -50,23 +50,23 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
    */
   public function installCostCentreTypes() {
     try{
-      $result = civicrm_api3('OptionGroup', 'create', array(
+      $result = civicrm_api3('OptionGroup', 'create', [
           'sequential' => 1,
           'name' => "cost_centres",
           'title' => "Cost Centres",
           'is_active' => 1
-      ));
+      ]);
 
       $id = $result['id'];
 
       $val = 'Other';
-      civicrm_api3('OptionValue', 'create', array(
+      civicrm_api3('OptionValue', 'create', [
         'sequential' => 1,
         'option_group_id' => $id,
         'label' => $val,
         'value' => $val,
         'name' => $val,
-      ));
+      ]);
 
     } catch(Exception $e){
       // OptionGroup already exists

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
@@ -49,17 +49,6 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
    * Creates new Option Group for Cost Centres
    */
   public function installCostCentreTypes() {
-
-    function save($val, $key, $id){
-      civicrm_api3('OptionValue', 'create', array(
-          'sequential' => 1,
-          'option_group_id' => $id,
-          'label' => $val,
-          'value' => $val,
-          'name' => $val,
-      ));
-    }
-
     try{
       $result = civicrm_api3('OptionGroup', 'create', array(
           'sequential' => 1,
@@ -70,11 +59,14 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
 
       $id = $result['id'];
 
-      $options = array(
-          'Other' => 'Other'
-      );
-
-      array_walk($options, 'save', $id);
+      $val = 'Other';
+      civicrm_api3('OptionValue', 'create', array(
+        'sequential' => 1,
+        'option_group_id' => $id,
+        'label' => $val,
+        'value' => $val,
+        'name' => $val,
+      ));
 
     } catch(Exception $e){
       // OptionGroup already exists

--- a/com.civicrm.hrjobroles/api/v3/ContactHrJobRoles.php
+++ b/com.civicrm.hrjobroles/api/v3/ContactHrJobRoles.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * ContactJobRole.get API
+ *
+ * @param array $params
+ * @return array API result descriptor
+ * @throws API_Exception
+ */
+function civicrm_api3_contact_hr_job_roles_get($params) {
+  $query = new CRM_Hrjobroles_API_Query_ContactHrJobRolesSelect($params);
+
+  return civicrm_api3_create_success($query->run(), $params, 'ContactHrJobRoles', 'get');
+}
+
+/**
+ * This function is used internally, to respond to a call to
+ * ContactHrJobRoles.getFields. The CiviCRM will try to call a function with
+ * this name to get the DAO for this entity.
+ *
+ * This is necessary because there is no DAO for ContactHrJobRoles.
+ *
+ * @return string
+ */
+function _civicrm_api3_contact_hr_job_roles_DAO() {
+  return CRM_Hrjobroles_BAO_ContactHrJobRoles::class;
+}

--- a/com.civicrm.hrjobroles/api/v3/ContactHrJobRoles.php
+++ b/com.civicrm.hrjobroles/api/v3/ContactHrJobRoles.php
@@ -4,7 +4,9 @@
  * ContactJobRole.get API
  *
  * @param array $params
+ *
  * @return array API result descriptor
+ *
  * @throws API_Exception
  */
 function civicrm_api3_contact_hr_job_roles_get($params) {

--- a/com.civicrm.hrjobroles/hrjobroles.php
+++ b/com.civicrm.hrjobroles/hrjobroles.php
@@ -256,3 +256,16 @@ having value <> ''";
     }
 
 }
+
+/**
+ * Implements hook_civicrm_alterAPIPermissions to define the required
+ * permissions to this extension's APIs
+ *
+ * @param string $entity
+ * @param string $action
+ * @param array $params
+ * @param array $permissions
+ */
+function hrjobroles_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
+  $permissions['contact_hr_job_roles']['get'] = ['access AJAX API'];
+}

--- a/com.civicrm.hrjobroles/tests/phpunit/api/v3/ContactHRJobRoleTest.php
+++ b/com.civicrm.hrjobroles/tests/phpunit/api/v3/ContactHRJobRoleTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
+use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
+use CRM_Hrjobroles_BAO_HrJobRoles as HrJobRoles;
+use CRM_Hrjobroles_Test_Fabricator_HrJobRoles as HRJobRolesFabricator;
+
+/**
+ * Class api_v3_ContactHRJobRoleTest
+ *
+ * @group headless
+ */
+class api_v3_ContactHRJobRoleTest extends PHPUnit_Framework_TestCase implements HeadlessInterface, TransactionalInterface {
+
+  private $entity = 'ContactHrJobRoles';
+  private $action = 'get';
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+                     ->install('uk.co.compucorp.civicrm.hrcore')
+                     ->install('org.civicrm.hrjobcontract')
+                     ->installMe(__DIR__)
+                     ->apply();
+  }
+
+  public function testAccessAjaxPermissionIsRequiredToAccessTheGetAction() {
+    $contactID = 1;
+    $this->registerCurrentLoggedInContactInSession($contactID);
+
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
+
+    $this->setExpectedApiPermissionException('access AJAX API');
+    civicrm_api3($this->entity, $this->action, ['check_permissions' => true]);
+  }
+
+  public function testTheGetActionReturnsOnlyTheAllowedFields() {
+    $departments = HrJobRoles::buildOptions('department', 'validate');
+    $locations = HrJobRoles::buildOptions('location', 'validate');
+    $levelTypes = HrJobRoles::buildOptions('level_type', 'validate');
+
+    $contact = ContactFabricator::fabricate();
+    $contract = HRJobContractFabricator::fabricate(['contact_id' => $contact['id']]);
+    $jobRole = HRJobRolesFabricator::fabricate([
+      'title' => 'Title',
+      'description' => 'Description',
+      'start_date' => date('Y-m-d'),
+      'funder' => 'asddsa',
+      'job_contract_id' => $contract['id'],
+      'department' => $departments['IT'],
+      'location' => $locations['Home'],
+      'level_type' => $levelTypes['Senior Manager']
+    ]);
+
+    $contactJobRoles = civicrm_api3($this->entity, $this->action)['values'];
+
+    // Even though the description, start_date and funder were set,
+    // they won't be returned here, as they are not part of the allowed fields
+    $expected = [
+      $jobRole['id'] => [
+        'id' => $jobRole['id'],
+        'title' => $jobRole['title'],
+        'department' => $jobRole['department'],
+        'location' => $jobRole['location'],
+        'level_type' => $jobRole['level_type'],
+        'contact_id' => $contact['id'],
+      ]
+    ];
+    $this->assertEquals($expected, $contactJobRoles);
+  }
+
+  public function testTheGetActionReturnsMultipleJobRoles() {
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+    $contract1 = HRJobContractFabricator::fabricate(['contact_id' => $contact1['id']]);
+    $contract2 = HRJobContractFabricator::fabricate(['contact_id' => $contact2['id']]);
+    $jobRole1 = HRJobRolesFabricator::fabricate(['job_contract_id' => $contract1['id'],]);
+    $jobRole2 = HRJobRolesFabricator::fabricate(['job_contract_id' => $contract1['id'],]);
+    $jobRole3 = HRJobRolesFabricator::fabricate(['job_contract_id' => $contract2['id'],]);
+
+    $contactJobRoles = civicrm_api3($this->entity, $this->action)['values'];
+
+    $this->assertCount(3, $contactJobRoles);
+
+    // The CiviCRM only returns non-empty fields. Since we only set the job
+    // contract id, only the ID and the contact_id fields will be returned
+    $expectedJobRole1 = ['id' => $jobRole1['id'], 'contact_id' => $contact1['id']];
+    $expectedJobRole2 = ['id' => $jobRole2['id'], 'contact_id' => $contact1['id']];
+    $expectedJobRole3 = ['id' => $jobRole3['id'], 'contact_id' => $contact2['id']];
+
+    $this->assertEquals($expectedJobRole1, $contactJobRoles[$jobRole1['id']]);
+    $this->assertEquals($expectedJobRole2, $contactJobRoles[$jobRole2['id']]);
+    $this->assertEquals($expectedJobRole3, $contactJobRoles[$jobRole3['id']]);
+  }
+
+  private function setExpectedApiPermissionException($permission) {
+    $message = "API permission check failed for {$this->entity}/{$this->action} call; insufficient permission: require {$permission}";
+    $this->setExpectedException('CiviCRM_API3_Exception', $message);
+  }
+
+  private function registerCurrentLoggedInContactInSession($contactID) {
+    $session = CRM_Core_Session::singleton();
+    $session->set('userID', $contactID);
+  }
+}

--- a/com.civicrm.hrjobroles/tests/phpunit/api/v3/ContactHRJobRoleTest.php
+++ b/com.civicrm.hrjobroles/tests/phpunit/api/v3/ContactHRJobRoleTest.php
@@ -70,6 +70,40 @@ class api_v3_ContactHRJobRoleTest extends PHPUnit_Framework_TestCase implements 
     $this->assertEquals($expected, $contactJobRoles);
   }
 
+  public function testTheGetActionDoesntReturnsNotAllowedFieldsEvenWhenSpecified() {
+    $contact = ContactFabricator::fabricate();
+    $contract = HRJobContractFabricator::fabricate(['contact_id' => $contact['id']]);
+    $jobRole = HRJobRolesFabricator::fabricate([
+      'title' => 'Title',
+      'description' => 'Description',
+      'start_date' => date('Y-m-d'),
+      'funder' => 'asddsa',
+      'job_contract_id' => $contract['id'],
+    ]);
+
+    $contactJobRoles = civicrm_api3(
+      $this->entity,
+      $this->action,
+      [
+        'return' => [
+          'description',
+          'start_date',
+          'funder',
+          'cost_center'
+        ]
+      ]
+    )['values'];
+
+    // Since all the fields we asked are not allowed, the response will be empty,
+    // except for the ID, which is always returned
+    $expected = [
+      $jobRole['id'] => [
+        'id' => $jobRole['id'],
+      ]
+    ];
+    $this->assertEquals($expected, $contactJobRoles);
+  }
+
   public function testTheGetActionReturnsMultipleJobRoles() {
     $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();


### PR DESCRIPTION
## Overview
This PR Adds the `ContactHrJobRoles.get` API. Its main purpose is to allow getting the Job Roles of specific contacts without having to pass through the intermediary HRJobContract API.

A call to this API will return a list of fields from the Job Roles table (not all of them) + a contact_id, which is a field from the Job Contract table.

This API also addresses an issue related to permission. Without it, a user would need access to both HRJobRoles and HRJobContracts APIs, which both might have confidential data. With the new API, we can keep those APIs hidden behind more restrictive permissions and expose only ContactHrJobRoles, which, by the way, doesn't return any type of confidential data.

## Before
To get something like "All the contacts that work in the IT department", an API call like this would be necessary:

```php
civicrm_api3('HrJobRoles', 'get', array(
  'sequential' => 1,
  'department' => "IT",
  'api.HRJobContract.get' => array('id' => "\$value.job_contract_id"),
));
```

Which would give us a response like:

```json
{

    "is_error": 0,
    "version": 3,
    "count": 1,
    "id": 2,
    "values": [
        {
            "id": "2",
            "job_contract_id": "4",
            "title": "fdasfdasfdsafdsa",
            "hours": "0",
            "department": "IT",
            "level_type": "Junior Manager",
            "cost_center": "|",
            "cost_center_val_type": "|",
            "percent_pay_cost_center": "|",
            "amount_pay_cost_center": "|",
            "funder": "|",
            "funder_val_type": "|",
            "percent_pay_funder": "|",
            "amount_pay_funder": "|",
            "location": "Home",
            "start_date": "2016-11-01 00:00:00",
            "api.HRJobContract.get": {
                "is_error": 0,
                "version": 3,
                "count": 1,
                "id": 4,
                "values": [
                    {
                        "id": "4",
                        "contact_id": "9",
                        "is_primary": "1",
                        "deleted": "0",
                        "is_current": "1"
                    }
                ]
            }
        }
    ]
}
```

This presents a few problems:
- At least 2 API calls are necessary (they are chained on the example)
- You need permissions to the two APIs used
- As you can see, the HRJobRoles API has a lot of confidential information, like "funder", "amount funded", etc

## After
You can get the same information as before with a single API call:

```php
civicrm_api3('ContactHrJobRoles', 'get', array(
  'sequential' => 1,
  'department' => "IT"
));
```

Which will return something like:

```json
{

    "is_error": 0,
    "version": 3,
    "count": 1,
    "id": 2,
    "values": [
        {
            "id": "2",
            "title": "fdasfdasfdsafdsa",
            "department": "IT",
            "level_type": "Junior Manager",
            "location": "Home",
            "contact_id": "9"
        }
    ]
}
```

This is how it addresses the aforementioned problems:
- Only one API call is necessary. Internally, the number of queries was also optimized and only one query is required
- Permissions to access the HrJobRoles and HRJobContract APIs aren't necessary anymore. All you need is permission to access ContactHrJobRoles. The permission required to it is: `access AJAX API`
- It includes only a very minimal set of the Job Roles and the Job Contract fields. In fact, the example contains ALL the fields that the API can return. Basically, it only returns the option groups, which are usually useful for filtering + the contact_id

Also, since now we don't need a chained API call, the response format is much simpler and easier to parse.

## Technical Details

`ContactHrJobRoles` is not a real entity. Even though, we do have a `CRM_Hrjobroles_BAO_ContactHrJobRoles`. The reasons is that, internally, the classes that build the db query expect a BAO/DAO class and call some certain methods on them. One of these methods is `fields()`, which was overridden on the BAO to only return a minimum set of `HrJobRoles` fields and add the `contact_id` field, which originally belongs to the `HRJobContract` entity. Since `ContactHrJobRoles` is basically a Job Roles with less fields, the former extends the latter.

The query itself is done by `CRM_Hrjobroles_API_Query_ContactHrJobRolesSelect` class. This wraps a specialized version of the core's `Api3SelectQuery` class and builds a query joining the Job Roles table with the Job Contracts. This specialized version of `Api3SelectQuery` is the `CRM_Hrjobroles_API_Query_VirtualEntitySelectQuery` class. It's specialized in the way that it allows an API to return fields that don't originally belong to the entity being queried (In this case, the contact_id).

Finally, the `hook_civicrm_alterAPIPermissions` hook was used to make sure the required permissions for this API is `access AJAX API`.

---

- [ ] Tests Pass
The `CRM_Hrjobroles_BAO_HrJobRolesTest::testGetCurrentDepartmentsList` and `CRM_Hrjobroles_BAO_HrJobRolesTest::testGetCompactCurrentDepartmentsList` test are both failing and were like that before this PR. They will be fixed later.