### PR TITLE
PCHR-2170: Fix issue null value for brought forward when absence type…

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/EntitlementCalculation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/EntitlementCalculation.php
@@ -107,8 +107,9 @@ class CRM_HRLeaveAndAbsences_Service_EntitlementCalculation {
     }
 
     $broughtForward = $this->getNumberOfDaysRemainingInThePreviousPeriod();
-    if($broughtForward > $this->absenceType->max_number_of_days_to_carry_forward) {
-      return $this->absenceType->max_number_of_days_to_carry_forward;
+    $maxDaysToCarryForward = $this->absenceType->max_number_of_days_to_carry_forward;
+    if($maxDaysToCarryForward && ($broughtForward > $maxDaysToCarryForward)) {
+      return $maxDaysToCarryForward;
     }
 
     return $broughtForward;


### PR DESCRIPTION
## Overview
When an absence Type allows unlimited number of days to be carried forward, the `Brought Forward From Previous Period` column is blank for any contact on the Manage entitlement page irrespective of the balance for the previous year entitlement.

## Before
The Brought Forward From Previous Period` column is blank for any contact on the Manage entitlement page irrespective of the Previous year entitlement amount.

![manage leave entitlements for period -2017- - 01-01-2017 to 31-12-2017 - l_and_a 2017-08-10 17-25-10](https://user-images.githubusercontent.com/6951813/29180833-f0e2276c-7df0-11e7-9b8f-03ce8cb3024a.png)

The reason for this is that the Absence Type `max_number_of_days_to_carry_forward` column has a NULL value when it allows unlimited number of days to be carried or brought forward and [HERE](https://github.com/civicrm/civihr/blob/0531c5bbae1bac74503e603bebade6ef4f434406/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/EntitlementCalculation.php#L110-L110), This statement will always be true when the absence type allows unlimited days to be brought forward and NULL will always be returned since the column will be NULL on unlimited brought forward.
## After
The statement [here](https://github.com/civicrm/civihr/blob/0531c5bbae1bac74503e603bebade6ef4f434406/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/EntitlementCalculation.php#L110-L110) was modified to make sure that the balance for the previous period entitlement is returned when the absence type allows unlimited days to be brought forward.

![manage leave entitlements for period -2017- - 01-01-2017 to 31-12-2017 - l_and_a 2017-08-10 17-23-11](https://user-images.githubusercontent.com/6951813/29180859-01316d58-7df1-11e7-95b9-b820d5e1dff3.png)

---

- [X] Tests Pass
