### PR TITLE
PCHR-2353: Fix issues with Modal Form after fixing unresolved conflicts

### DIFF
--- a/hrjobcontract/views/modalForm.html
+++ b/hrjobcontract/views/modalForm.html
@@ -1,8 +1,7 @@
 <form novalidate class="form-horizontal {{prefix}}wizard" name="contractForm" role="form" ng-submit="save()" hrjc-loader>
   <div class="modal-header">
-    <button type="button" class="close" ng-click="cancel()">
-      <span aria-hidden="true">&times;</span><span class="sr-only">Close</span>
-    </button>
+    <button type="button" class="close" ng-click="cancel()"><span aria-hidden="true">&times;</span><span
+      class="sr-only">Close</span></button>
     <h4 class="modal-title">{{copy.title}}</h4>
   </div>
   <div class="modal-body clearfix">
@@ -23,7 +22,7 @@
                   <input type="text" class="form-control" id="{{prefix}}position" name="detailsPosition" ng-model="entity.details.position" ng-disabled="isDisabled" required>
                 </div>
               </div>
-              <div class="form-group required"  hrjc-validate>
+              <div class="form-group required" hrjc-validate>
                 <label for="{{prefix}}title" class="col-sm-4 control-label">Title (if different)</label>
                 <div class="col-sm-8">
                   <input type="text" class="form-control" id="{{prefix}}title" name="detailsTitle" ng-model="entity.details.title" ng-disabled="isDisabled" required>
@@ -43,9 +42,7 @@
                 </div>
               </div>
               <div class="form-group">
-                <label for="{{prefix}}location" class="col-sm-4 control-label">
-                  Normal Place of Work
-                </label>
+                <label for="{{prefix}}location" class="col-sm-4 control-label">Normal Place of Work</label>
                 <div class="col-sm-5">
                   <div class="chr_custom-select chr_custom-select--full">
                     <select id="{{prefix}}location" class="form-control no-select2"
@@ -58,9 +55,7 @@
                 </div>
               </div>
               <div class="form-group" ng-show="showIsPrimary">
-                <label for="{{prefix}}is-primary" class="col-sm-4 control-label control-label-checkbox">
-                  Is Primary?
-                </label>
+                <label for="{{prefix}}is-primary" class="col-sm-4 control-label control-label-checkbox">Is Primary?</label>
                 <div class="col-sm-5">
                   <input type="checkbox" id="{{prefix}}is-primary"
                     ng-true-value="1"
@@ -70,9 +65,7 @@
                 </div>
               </div>
               <div class="form-group required" hrjc-validate>
-                <label for="{{prefix}}period-start-date" class="col-sm-4 control-label">
-                  Contract Start Date
-                </label>
+                <label for="{{prefix}}period-start-date" class="col-sm-4 control-label">Contract Start Date</label>
                 <div class="col-sm-4">
                   <div class="input-group input-group-unstyled">
                     <input placeholder="{{format}}"
@@ -92,9 +85,7 @@
                 </div>
               </div>
               <div class="form-group">
-                <label for="{{prefix}}period-end-date" class="col-sm-4 control-label">
-                  Contract End Date
-                </label>
+                <label for="{{prefix}}period-end-date" class="col-sm-4 control-label">Contract End Date</label>
                 <div class="col-sm-4">
                   <div class="input-group input-group-unstyled">
                     <input placeholder="{{format}}"
@@ -112,9 +103,7 @@
                 </div>
               </div>
               <div class="form-group required" hrjc-validate ng-show="!!entity.details.period_end_date">
-                <label for="{{prefix}}end-reason" class="col-sm-4 control-label">
-                  Contract End Reason
-                </label>
+                <label for="{{prefix}}end-reason" class="col-sm-4 control-label">Contract End Reason</label>
                 <div class="col-sm-5">
                   <div class="chr_custom-select chr_custom-select--full">
                     <select id="{{prefix}}end-reason" class="form-control no-select2" name="detailsEndReason"
@@ -134,9 +123,7 @@
                 </div>
               </div>
               <div class="form-group" hrjc-validate>
-                <label for="{{prefix}}notice-amount" class="col-sm-4 control-label">
-                  Notice Period from Employer
-                </label>
+                <label for="{{prefix}}notice-amount" class="col-sm-4 control-label">Notice Period from Employer</label>
                 <div class="col-sm-8">
                   <div class="form-inline">
                     <input type="text" class="form-control input-inline-sm" id="{{prefix}}notice-amount"
@@ -156,31 +143,27 @@
                 </div>
               </div>
               <div class="form-group" hrjc-validate>
-                <label for="{{prefix}}notice-amount-employee" class="col-sm-4 control-label">
-                  Notice Period from Employee
-                </label>
+                <label for="{{prefix}}notice-amount-employee" class="col-sm-4 control-label">Notice Period from Employee</label>
                 <div class="col-sm-8">
                   <div class="form-inline">
                     <input type="text" class="form-control input-inline-sm" id="{{prefix}}notice-amount-employee"
                       hrjc-number="0"
                       ng-model="entity.details.notice_amount_employee"
                       ng-disabled="isDisabled">
-                      <div class="chr_custom-select">
-                        <select id="{{prefix}}notice-unit-employee" class="form-control no-select2" name="detailsNoticeUnitEmployee"
-                          ng-model="entity.details.notice_unit_employee"
-                          ng-options="key as value for (key, value) in options.details.notice_unit_employee"
-                          ng-disabled="isDisabled"
-                          ng-required="entity.details.notice_amount_employee && entity.details.notice_amount_employee != '0'">
-                          <option value="">- select -</option>
-                        </select>
-                      </div>
+                    <div class="chr_custom-select">
+                      <select id="{{prefix}}notice-unit-employee" class="form-control no-select2" name="detailsNoticeUnitEmployee"
+                        ng-model="entity.details.notice_unit_employee"
+                        ng-options="key as value for (key, value) in options.details.notice_unit_employee"
+                        ng-disabled="isDisabled"
+                        ng-required="entity.details.notice_amount_employee && entity.details.notice_amount_employee != '0'">
+                        <option value="">- select -</option>
+                      </select>
+                    </div>
                   </div>
                 </div>
               </div>
               <div class="form-group" ng-class="{'has-error':(contractForm.$error.maxFile)}">
-                <label for="{{prefix}}contract-file" class="col-sm-4 control-label control-label-line-2">
-                  Contract File(s)<br>(max. file size {{fileMaxSize/1024/1024}} MB)
-                </label>
+                <label for="{{prefix}}contract-file" class="col-sm-4 control-label control-label-line-2">Contract File(s)<br>(max. file size {{fileMaxSize/1024/1024}} MB)</label>
                 <div class="col-sm-8">
                   <input type="file" class="form-control-file" id="{{prefix}}contract-file"
                     nv-file-select
@@ -206,31 +189,26 @@
                       <tr ng-repeat="file in files.details">
                         <td><strong>{{$index+1}}</strong></td>
                         <td><strong><a ng-href="{{file.url}}">{{file.name}}</a></strong></td>
-                        <td ng-show="uploader.details.contract_file.isHTML5" nowrap>
-                          <span>{{file.fileSize ? (file.fileSize/1024/1024|number:2) : '0.00' }} MB</span>
-                        </td>
+                        <td ng-show="uploader.details.contract_file.isHTML5" nowrap><span>{{file.fileSize ? (file.fileSize/1024/1024|number:2) : '0.00' }} MB</span></td>
                         <td nowrap>
                           <button type="button" class="btn btn-danger btn-xs" ng-click="fileMoveToTrash($index, 'details')" ng-disabled="isDisabled">
-                            <span class="glyphicon glyphicon-trash"></span> Remove
+                          <span class="glyphicon glyphicon-trash"></span> Remove
                           </button>
                         </td>
                       </tr>
                       <tr ng-repeat="item in uploader.details.contract_file.queue" ng-class="{'danger':(item.file.size > fileMaxSize)}">
-                        <td>
-                          <strong>{{files.details.length + $index+1}}</strong>
+                        <td><strong>{{files.details.length + $index+1}}</strong>
                           <span ng-if="(item.file.size > fileMaxSize)">
-                            <a uib-tooltip-html="tooltips.fileSize">
-                              <i class="fa fa-question-circle"></i>
-                            </a>
+                          <a uib-tooltip-html="tooltips.fileSize">
+                          <i class="fa fa-question-circle"></i>
+                          </a>
                           </span>
                         </td>
                         <td><strong>{{ item.file.name }}</strong></td>
-                        <td ng-show="uploader.details.contract_file.isHTML5" nowrap>
-                          {{ item.file.size/1024/1024|number:2 }} MB
-                        </td>
+                        <td ng-show="uploader.details.contract_file.isHTML5" nowrap>{{ item.file.size/1024/1024|number:2 }} MB</td>
                         <td nowrap>
                           <button type="button" class="btn btn-danger btn-xs" ng-click="item.remove(); filesValidate();">
-                            <span class="glyphicon glyphicon-trash"></span> Remove
+                          <span class="glyphicon glyphicon-trash"></span> Remove
                           </button>
                         </td>
                       </tr>
@@ -294,10 +272,10 @@
                 </div>
                 <div class="form-group required" ng-show="+entity.hour.hours_type">
                   <label for="{{prefix}}fte" class="col-sm-4 control-label">FTE
-                    <a tooltip-placement="right" uib-tooltip-html="tooltips.fte">
-                      <i class="fa fa-question-circle"></i>
-                    </a>
-                  </label>
+                  <a tooltip-placement="right"
+                    uib-tooltip-html="tooltips.fte">
+                  <i class="fa fa-question-circle"></i>
+                  </a></label>
                   <div class="col-sm-8">
                     <div class="form-inline">
                       <input type="text" class="form-control input-inline-sm" id="{{prefix}}fte"
@@ -372,9 +350,8 @@
               </div>
             </div>
             <div class="form-group">
-              <label for="{{prefix}}pay-estimate-annual" class="col-sm-4 control-label control-label-line-2">
-                Annual pay estimate before benefits and deductions
-              </label>
+              <label for="{{prefix}}pay-estimate-annual" class="col-sm-4 control-label control-label-line-2">Annual pay estimate before
+              benefits and deductions</label>
               <div class="col-sm-3">
                 <input type="text" id="{{prefix}}pay-estimate-annual" class="form-control disabled" ng-model="entity.pay.pay_annualized_est" ng-disabled="isDisabled || true">
               </div>
@@ -382,8 +359,7 @@
             <div class="form-group">
               <label for="{{prefix}}pay-cycle" class="col-sm-4 control-label">Pay cycle</label>
               <div class="col-sm-3">
-                <select id="{{prefix}}pay-cycle"
-                  class="form-control no-select2"
+                <select id="{{prefix}}pay-cycle" class="form-control no-select2"
                   ng-change="calcPayPerCycleGross(); calcBenefitsPerCycle(); calcDeductionsPerCycle();"
                   ng-options="key as value for (key, value) in options.pay.pay_cycle"
                   ng-model="entity.pay.pay_cycle"
@@ -393,9 +369,8 @@
             </div>
             <div class="well">
               <div class="form-group">
-                <label for="{{prefix}}pay-cycle-gross" class="col-sm-4 control-label control-label-line-2">
-                  Gross Pay per cycle<br/>
-                  <small>(before benefits and deductions)</small>
+                <label for="{{prefix}}pay-cycle-gross" class="col-sm-4 control-label control-label-line-2">Gross Pay per cycle<br/>
+                <small>(before benefits and deductions)</small>
                 </label>
                 <div class="col-sm-3">
                   <input type="text" id="{{prefix}}pay-cycle-gross" class="form-control disabled" ng-model="entity.pay.pay_per_cycle_gross" disabled>
@@ -405,9 +380,7 @@
             <div class="row">
               <div class="col-sm-12">
                 <a class="btn btn-collapse" ng-click="collapseBenDed = !collapseBenDed">
-                  <h4><i ng-class="{fa: true, 'fa-caret-down': !collapseBenDed, 'fa-caret-right': collapseBenDed }"></i>
-                    Benefits and deductions
-                  </h4>
+                  <h4><i ng-class="{fa: true, 'fa-caret-down': !collapseBenDed, 'fa-caret-right': collapseBenDed }"></i> Benefits and deductions</h4>
                 </a>
               </div>
             </div>
@@ -427,12 +400,12 @@
                       </colgroup>
                       <thead ng-show="entity.pay.annual_benefits.length">
                         <tr>
-                            <th>#</th>
-                            <th>Benefit</th>
-                            <th>Type</th>
-                            <th>% Amount</th>
-                            <th>Absolute amount</th>
-                            <th class="action">&nbsp;</th>
+                          <th>#</th>
+                          <th>Benefit</th>
+                          <th>Type</th>
+                          <th>% Amount</th>
+                          <th>Absolute amount</th>
+                          <th class="action">&nbsp;</th>
                         </tr>
                       </thead>
                       <tbody>
@@ -454,27 +427,22 @@
                               <option value="">- select -</option>
                             </select>
                           </td>
-                          <td>
-                            <input type="text" class="form-control"
-                              hrjc-number
-                              hrjc-number-float="true"
-                              ng-if="benefit.type == '2'"
-                              ng-model="benefit.amount_pct"
-                              ng-disabled="isDisabled">
-                          </td>
-                          <td>
-                            <input type="text" class="form-control" hrjc-number ng-model="benefit.amount_abs" ng-disabled="isDisabled || benefit.type == '2'">
-                          </td>
-                          <td class="action">
-                            <a class="btn btn-default btn-sm btn-danger" ng-click="remove(entity.pay.annual_benefits, $index)" ng-disabled="isDisabled">
-                              <span class="fa fa-remove" aria-hidden="true"></span>
+                          <td><input type="text" class="form-control"
+                            hrjc-number
+                            hrjc-number-float="true"
+                            ng-if="benefit.type == '2'"
+                            ng-model="benefit.amount_pct"
+                            ng-disabled="isDisabled"></td>
+                          <td><input type="text" class="form-control" hrjc-number ng-model="benefit.amount_abs" ng-disabled="isDisabled || benefit.type == '2'"></td>
+                          <td class="action"><a class="btn btn-default btn-sm btn-danger" ng-click="remove(entity.pay.annual_benefits, $index)" ng-disabled="isDisabled">
+                            <span class="fa fa-remove" aria-hidden="true"></span>
                             </a>
                           </td>
                         </tr>
                         <tr ng-if="!isDisabled">
                           <td colspan="6" class="text-right">
                             <a class="btn btn-default btn-sm btn-primary" ng-click="add(entity.pay.annual_benefits)">
-                              <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Add
+                            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Add
                             </a>
                           </td>
                         </tr>
@@ -498,12 +466,12 @@
                       </colgroup>
                       <thead ng-show="entity.pay.annual_deductions.length">
                         <tr>
-                            <th>#</th>
-                            <th>Deduction</th>
-                            <th>Type</th>
-                            <th>% Amount</th>
-                            <th>Absolute amount</th>
-                            <th class="action">&nbsp;</th>
+                          <th>#</th>
+                          <th>Deduction</th>
+                          <th>Type</th>
+                          <th>% Amount</th>
+                          <th>Absolute amount</th>
+                          <th class="action">&nbsp;</th>
                         </tr>
                       </thead>
                       <tbody>
@@ -525,27 +493,22 @@
                               <option value="">- select -</option>
                             </select>
                           </td>
-                          <td>
-                            <input type="text" class="form-control"
-                              hrjc-number
-                              hrjc-number-float="true"
-                              ng-if="deduction.type == '2'"
-                              ng-model="deduction.amount_pct"
-                              ng-disabled="isDisabled">
-                          </td>
-                          <td>
-                            <input type="text" class="form-control" hrjc-number ng-model="deduction.amount_abs" ng-disabled="isDisabled || deduction.type == '2'">
-                          </td>
-                          <td class="action">
-                            <a class="btn btn-default btn-sm btn-danger" ng-click="remove(entity.pay.annual_deductions, $index)" ng-disabled="isDisabled">
-                              <span class="fa fa-remove" aria-hidden="true"></span>
+                          <td><input type="text" class="form-control"
+                            hrjc-number
+                            hrjc-number-float="true"
+                            ng-if="deduction.type == '2'"
+                            ng-model="deduction.amount_pct"
+                            ng-disabled="isDisabled"></td>
+                          <td><input type="text" class="form-control" hrjc-number ng-model="deduction.amount_abs" ng-disabled="isDisabled || deduction.type == '2'"></td>
+                          <td class="action"><a class="btn btn-default btn-sm btn-danger" ng-click="remove(entity.pay.annual_deductions, $index)" ng-disabled="isDisabled">
+                            <span class="fa fa-remove" aria-hidden="true"></span>
                             </a>
                           </td>
                         </tr>
                         <tr ng-if="!isDisabled">
                           <td colspan="6" class="text-right">
                             <a class="btn btn-default btn-sm btn-primary" ng-click="add(entity.pay.annual_deductions)">
-                              <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Add
+                            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Add
                             </a>
                           </td>
                         </tr>
@@ -572,7 +535,7 @@
             <div class="well">
               <div class="form-group">
                 <label for="{{prefix}}pay-cycle-net" class="col-sm-4 control-label control-label-line-2">Net Pay per cycle<br/>
-                  <small>(after benefits and deductions)</small>
+                <small>(after benefits and deductions)</small>
                 </label>
                 <div class="col-sm-3">
                   <input type="hidden" ng-model="benefits_per_cycle_net" disabled>
@@ -584,31 +547,48 @@
         </div>
       </uib-tab>
       <uib-tab heading="Leave">
-        <div class="row">
-          <div class="col-xs-12">
-            <h4>Leave</h4>
-            <hr>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-xs-12">
-            <div class="form-group">
-              <div class="col-sm-4 text-right">
-                Leave type
-              </div>
-              <div class="col-sm-4">
-                Days per year
-              </div>
+        <div ng-controller="FormLeaveCtrl as leaveCtrl">
+          <div class="row">
+            <div class="col-xs-12">
+              <h4>Leave</h4>
+              <hr>
             </div>
-            <div class="form-group" ng-repeat="leaveEntry in entity.leave">
-              <label for="{{prefix}}leave-{{leaveEntry.leave_type}}" class="col-sm-4 control-label">
+          </div>
+          <div class="row">
+            <div class="col-xs-12">
+              <p>Enter in here the contractual entitlement of leave of each type that the employee will receive for a full leave period. The system will automatically pro-rate this for joiners and leavers during the leave period. For employees who work flexible hours please enter the pro rata amount of leave they would receive if they worked for a full leave period.</p>
+              <p>When entering in the amount for annual leave or vacation, you can chose to either enter the amount including public holidays or ask the system to add them automatically.</p>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-xs-12">
+              <div class="form-group">
+                <div class="col-sm-3 control-label">Leave type</div>
+                <div class="col-sm-3 control-label">Basic Annual Contractual Leave Entitlement</div>
+                <div class="col-sm-3 control-label">Add Public Holidays?</div>
+                <div class="col-sm-3 control-label">Estimated Annual Contractual Leave Entitlement</div>
+              </div>
+              <div class="form-group" ng-repeat="leaveEntry in entity.leave">
+                <label for="{{prefix}}leave-{{leaveEntry.leave_type}}" class="col-sm-3 control-label">
                 {{options.leave.leave_type[leaveEntry.leave_type]}}
-              </label>
-              <div class="col-sm-2">
-                <input type="text" id="{{prefix}}leave-{{leaveEntry.leave_type}}"
-                  name="leave-{{leaveEntry.leave_type}}" class="form-control"
-                  hrjc-number="2" ng-model="leaveEntry.leave_amount"
-                  ng-disabled="isDisabled" hrjc-number-float="true">
+                </label>
+                <div class="col-sm-3">
+                  <input type="text" id="{{prefix}}leave-{{leaveEntry.leave_type}}"
+                    name="leave-{{leaveEntry.leave_type}}"
+                    class="form-control"
+                    hrjc-number="2"
+                    hrjc-number-float="true"
+                    ng-model="leaveEntry.leave_amount" ng-disabled="isDisabled">
+                </div>
+                <div class="col-sm-3">
+                  <div class="btn-group">
+                    <label class="btn btn-gray" ng-model="leaveEntry.add_public_holidays" uib-btn-radio="true">Yes</label>
+                    <label class="btn btn-gray" ng-model="leaveEntry.add_public_holidays" uib-btn-radio="false">No</label>
+                  </div>
+                </div>
+                <div class="col-sm-3">
+                  {{ leaveEntry.getEstimatedLeaveAmount(leaveCtrl.numberOfPublicHolidays) }} Days
+                </div>
               </div>
             </div>
           </div>
@@ -626,10 +606,10 @@
             <div class="col-xs-12">
               <div class="form-group">
                 <label class="col-sm-4 control-label">Provider
-                  <a tooltip-placement="right" uib-tooltip="The name of the health insurance company.">
-                    <i class="fa fa-question-circle"></i>
-                  </a>
-                </label>
+                <a tooltip-placement="right"
+                  uib-tooltip="The name of the health insurance company.">
+                <i class="fa fa-question-circle"></i>
+                </a></label>
                 <div class="col-sm-6">
                   <div class="input-group">
                     <ui-select
@@ -639,11 +619,8 @@
                       ng-model="entity.health.provider">
                       <ui-select-match
                         prevent-animations
-                        placeholder="Start typing a name or email...">
-                        {{$select.selected.label}}
-                      </ui-select-match>
-                      <ui-select-choices
-                        repeat="contact.id as contact in contacts.Health_Insurance_Provider | filter: $select.search"
+                        placeholder="Start typing a name or email...">{{$select.selected.label}}</ui-select-match>
+                      <ui-select-choices  repeat="contact.id as contact in contacts.Health_Insurance_Provider | filter: $select.search"
                         refresh="refreshContacts($select.search, 'Health_Insurance_Provider')"
                         refresh-delay="0"
                         prevent-animations>
@@ -652,10 +629,10 @@
                       </ui-select-choices>
                     </ui-select>
                     <span class="input-group-btn">
-                      <a ng-disabled="isDisabled"
-                        ng-click="entity.health.provider = ''" class="btn btn-default">
-                        <span class="fa fa-remove"></span>
-                      </a>
+                    <a ng-disabled="isDisabled"
+                      ng-click="entity.health.provider = ''" class="btn btn-default">
+                    <span class="fa fa-remove"></span>
+                    </a>
                     </span>
                   </div>
                 </div>
@@ -677,21 +654,21 @@
                 <label for="health-health-desc" class="col-sm-4 control-label">Description</label>
                 <div class="col-sm-8">
                   <textarea id="health-health-desc" name="health-health-desc" class="form-control"
-                    rows="3" ng-model="entity.health.description" ng-disabled="isDisabled">
-                  </textarea>
+                    rows="3" ng-model="entity.health.description" ng-disabled="isDisabled"></textarea>
                 </div>
               </div>
               <div class="form-group">
                 <label for="health-health-deps" class="col-sm-4 control-label">Dependents
-                  <a tooltip-placement="right"
-                    uib-tooltip="For a family plan, please list the names of all dependents who are also covered, along with their relationships to the individual.">
-                    <i class="fa fa-question-circle"></i>
-                  </a>
+                <a tooltip-placement="right"
+                  uib-tooltip="For a family plan, please list
+                  the names of all dependents who are also covered, along
+                  with their relationships to the individual.">
+                <i class="fa fa-question-circle"></i>
+                </a>
                 </label>
                 <div class="col-sm-8">
                   <textarea id="health-health-deps" name="health-health-deps" class="form-control"
-                    rows="3" ng-model="entity.health.dependents" ng-disabled="isDisabled">
-                  </textarea>
+                    rows="3" ng-model="entity.health.dependents" ng-disabled="isDisabled"></textarea>
                 </div>
               </div>
             </div>
@@ -715,11 +692,8 @@
                       ng-model="entity.health.provider_life_insurance">
                       <ui-select-match
                         prevent-animations
-                        placeholder="Start typing a name or email...">
-                        {{$select.selected.label}}
-                      </ui-select-match>
-                      <ui-select-choices
-                        repeat="contact.id as contact in contacts.Life_Insurance_Provider | filter: $select.search"
+                        placeholder="Start typing a name or email...">{{$select.selected.label}}</ui-select-match>
+                      <ui-select-choices  repeat="contact.id as contact in contacts.Life_Insurance_Provider | filter: $select.search"
                         refresh="refreshContacts($select.search, 'Life_Insurance_Provider')"
                         refresh-delay="0"
                         prevent-animations>
@@ -728,10 +702,10 @@
                       </ui-select-choices>
                     </ui-select>
                     <span class="input-group-btn">
-                      <a ng-disabled="isDisabled"
-                        ng-click="entity.health.provider_life_insurance = ''" class="btn btn-default">
-                        <span class="fa fa-remove"></span>
-                      </a>
+                    <a ng-disabled="isDisabled"
+                      ng-click="entity.health.provider_life_insurance = ''" class="btn btn-default">
+                    <span class="fa fa-remove"></span>
+                    </a>
                     </span>
                   </div>
                 </div>
@@ -753,21 +727,21 @@
                 <label for="health-life-desc" class="col-sm-4 control-label">Description</label>
                 <div class="col-sm-8">
                   <textarea id="health-life-desc" name="health-life-desc" class="form-control"
-                    rows="3" ng-model="entity.health.description_life_insurance" ng-disabled="isDisabled">
-                  </textarea>
+                    rows="3" ng-model="entity.health.description_life_insurance" ng-disabled="isDisabled"></textarea>
                 </div>
               </div>
               <div class="form-group">
                 <label for="health-life-deps" class="col-sm-4 control-label">Dependents
-                  <a tooltip-placement="right"
-                    uib-tooltip="For a family plan, please list the names of all dependents who are also covered, along with their relationships to the individual.">
-                    <i class="fa fa-question-circle"></i>
-                  </a>
+                <a tooltip-placement="right"
+                  uib-tooltip="For a family plan, please list
+                  the names of all dependents who are also covered, along
+                  with their relationships to the individual.">
+                <i class="fa fa-question-circle"></i>
+                </a>
                 </label>
                 <div class="col-sm-8">
                   <textarea id="health-life-deps" name="health-life-deps" class="form-control"
-                    rows="3" ng-model="entity.health.dependents_life_insurance" ng-disabled="isDisabled">
-                  </textarea>
+                    rows="3" ng-model="entity.health.dependents_life_insurance" ng-disabled="isDisabled"></textarea>
                 </div>
               </div>
             </div>
@@ -799,20 +773,19 @@
               </div>
               <div class="form-group">
                 <label class="col-sm-4 control-label">Pension Provider
-                  <a tooltip-placement="right"
-                    uib-tooltip="The name of the pension provider.">
-                    <i class="fa fa-question-circle"></i>
-                  </a></label>
+                <a tooltip-placement="right"
+                  uib-tooltip="The name of the pension provider.">
+                <i class="fa fa-question-circle"></i>
+                </a></label>
                 <div class="col-sm-6">
                   <div class="input-group">
-                    <ui-select allow-clear
+                    <ui-select
+                      allow-clear
                       ng-disabled="isDisabled"
                       ng-model="entity.pension.pension_type">
-                      <ui-select-match placeholder="Start typing a name or email...">
-                        {{$select.selected.label}}
-                      </ui-select-match>
-                      <ui-select-choices
-                        repeat="contact.id as contact in contacts.Pension_Provider | filter: $select.search"
+                      <ui-select-match
+                        placeholder="Start typing a name or email...">{{$select.selected.label}}</ui-select-match>
+                      <ui-select-choices  repeat="contact.id as contact in contacts.Pension_Provider | filter: $select.search"
                         refresh="refreshContacts($select.search, 'Pension_Provider')"
                         refresh-delay="0">
                         <div ng-bind="contact.label"></div>
@@ -820,20 +793,20 @@
                       </ui-select-choices>
                     </ui-select>
                     <span class="input-group-btn">
-                      <a ng-disabled="isDisabled"
-                         ng-click="entity.pension.pension_type = ''" class="btn btn-default">
-                          <span class="fa fa-remove"></span>
-                      </a>
+                    <a ng-disabled="isDisabled"
+                      ng-click="entity.pension.pension_type = ''" class="btn btn-default">
+                    <span class="fa fa-remove"></span>
+                    </a>
                     </span>
                   </div>
                 </div>
               </div>
               <div class="form-group">
                 <label for="pension-contrib-emplr" class="col-sm-4 control-label">
-                  Employer Contribution (%)
-                  <a tooltip-placement="right" uib-tooltip="The contribution paid by the employer as a percentage of gross salary.">
-                    <i class="fa fa-question-circle"></i>
-                  </a>
+                Employer Contribution (%)
+                <a tooltip-placement="right" uib-tooltip="The contribution paid by the employer as a percentage of gross salary.">
+                <i class="fa fa-question-circle"></i>
+                </a>
                 </label>
                 <div class="col-sm-3">
                   <input type="text" id="pension-contrib-emplr" name="pension-contrib-emplr" class="form-control"
@@ -845,10 +818,10 @@
               </div>
               <div class="form-group">
                 <label for="pension-contrib-emple" class="col-sm-4 control-label">
-                  Employee Contribution (%)
-                  <a tooltip-placement="right" uib-tooltip="The contribution paid by the employee as a percentage of gross salary.">
-                    <i class="fa fa-question-circle"></i>
-                  </a>
+                Employee Contribution (%)
+                <a tooltip-placement="right" uib-tooltip="The contribution paid by the employee as a percentage of gross salary.">
+                <i class="fa fa-question-circle"></i>
+                </a>
                 </label>
                 <div class="col-sm-3">
                   <input type="text" id="pension-contrib-emple" name="pension-contrib-emple" class="form-control"
@@ -860,7 +833,7 @@
               </div>
               <div class="form-group">
                 <label for="pension-contrib-emple-abs" class="col-sm-4 control-label control-label-line-2">
-                  Employee Contribution (absolute amount)
+                Employee Contribution (absolute amount)
                 </label>
                 <div class="col-sm-3">
                   <input type="text" id="pension-contrib-emple-abs" hrjc-number name="pension-contrib-emple-abs"
@@ -868,9 +841,7 @@
                 </div>
               </div>
               <div class="form-group">
-                <label for="{{prefix}}pension-evidence-file" class="col-sm-4 control-label">
-                  Evidence File<br>(max. file size {{fileMaxSize/1024/1024}} MB)
-                </label>
+                <label for="{{prefix}}pension-evidence-file" class="col-sm-4 control-label">Evidence File<br>(max. file size {{fileMaxSize/1024/1024}} MB)</label>
                 <div class="col-sm-8">
                   <input type="file" class="form-control-file" id="{{prefix}}pension-evidence-file"
                     nv-file-select
@@ -898,7 +869,7 @@
                         <td ng-show="uploader.pension.contract_file.isHTML5" nowrap><span>{{ file.size ? (file.size/1024/1024|number:2) : '0.00' }} MB</span></td>
                         <td nowrap>
                           <button type="button" class="btn btn-danger btn-xs" ng-click="fileMoveToTrash($index, 'pension')" ng-disabled="isDisabled">
-                            <span class="glyphicon glyphicon-trash"></span> Remove
+                          <span class="glyphicon glyphicon-trash"></span> Remove
                           </button>
                         </td>
                       </tr>
@@ -906,16 +877,16 @@
                         <td>
                           <strong>{{$index+1}}</strong>
                           <span ng-if="(item.file.size > fileMaxSize)">
-                            <a uib-tooltip-html="tooltips.fileSize">
-                              <i class="fa fa-question-circle"></i>
-                            </a>
+                          <a uib-tooltip-html="tooltips.fileSize">
+                          <i class="fa fa-question-circle"></i>
+                          </a>
                           </span>
                         </td>
                         <td><strong>{{ item.file.name }}</strong></td>
                         <td ng-show="uploader.pension.evidence_file.isHTML5" nowrap>{{ item.file.size/1024/1024|number:2 }} MB</td>
                         <td nowrap>
                           <button type="button" class="btn btn-danger btn-xs" ng-click="item.remove(); filesValidate();">
-                            <span class="glyphicon glyphicon-trash"></span> Remove
+                          <span class="glyphicon glyphicon-trash"></span> Remove
                           </button>
                         </td>
                       </tr>
@@ -947,8 +918,7 @@
               <label for="pension-funding-notes" class="col-sm-4 control-label">Funding Notes</label>
               <div class="col-sm-8">
                 <textarea id="pension-funding-notes" name="pension-funding-notes" class="form-control"
-                  rows="3" ng-model="entity.details.funding_notes" ng-disabled="isDisabled">
-                </textarea>
+                  rows="3" ng-model="entity.details.funding_notes" ng-disabled="isDisabled"></textarea>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Overview

After an unsuccessful attempt (https://github.com/civicrm/civihr/pull/2067) to fix unresolved conflicts after sync (https://github.com/civicrm/civihr/commit/365e785a77c0aa1f166a5f13b91880fee1d3bb35) the Leave tab in the Contract Modal Form had 1.6 interface view instead of 1.7.

This PR fixes this issue.

## Before

![image](https://user-images.githubusercontent.com/3973243/29369177-c915ceca-8299-11e7-850b-e0c92ccc0b57.png)

## After

![image](https://user-images.githubusercontent.com/3973243/29369221-de96b868-8299-11e7-956f-fe35640a0134.png)

## Technical Details

1. The latest stable version of the modalForm.html file was taken from (https://github.com/civicrm/civihr/blob/53ea41a5b9ee4e20fb1023d896ae63b479ce4f8d/hrjobcontract/views/modalForm.html)
2. Commits from https://github.com/compucorp/org.civicrm.shoreditch/pull/24 related to the modalForm.html file were applied manually (except re-indentation)
3. Re-indentation was made manually
4. Backstop was run

Backstop between https://github.com/civicrm/civihr/commit/53ea41a5b9ee4e20fb1023d896ae63b479ce4f8d (healthy commit) and la-milestone-3:

![image](https://user-images.githubusercontent.com/3973243/29369599-f6ee607c-829a-11e7-90ab-ce5b218e80e8.png)


Backstop between https://github.com/civicrm/civihr/commit/53ea41a5b9ee4e20fb1023d896ae63b479ce4f8d (healthy commit) and this PR:

![image](https://user-images.githubusercontent.com/3973243/29369697-3ef9820c-829b-11e7-8d99-3ca71730f106.png)


![image](https://user-images.githubusercontent.com/3973243/29369645-1c258db6-829b-11e7-801a-b4bf243bcfe9.png)

---

- [x] Tests Pass
