### PR TITLE
PCHR-2493: Disable hrvisa and hrident extensions

### DIFF
--- a/bin/civihr-crm-api-tests.sh
+++ b/bin/civihr-crm-api-tests.sh
@@ -65,7 +65,6 @@ fi
 runTest hrreport org.civicrm.hrabsence,org.civicrm.hrjob,org.civicrm.hrreport CRM_AllTests
 runTest hrjob org.civicrm.hrjob api_v3_AllTests
 runTest hrjob org.civicrm.hrjob CRM_AllTests
-runTest hrvisa org.civicrm.hrjob,org.civicrm.hrvisa CRM_AllTests
 runTest hrabsence org.civicrm.hrabsence api_v3_AllTests
 runTest hrrecruitment org.civicrm.hrrecruitment CRM_AllTests
 

--- a/bin/civihr-webtests.sh
+++ b/bin/civihr-webtests.sh
@@ -5,12 +5,10 @@ HASERROR=0
 ## List of extensions defining basic entity types
 ENTITY_EXTS=( hrbank \
 hrcareer \
-hrident \
 hrjob \
 hrmed \
 hrqual \
 hrstaffdir \
-hrvisa \
 hrrecruitment \
 )
 

--- a/bin/drush-install.sh
+++ b/bin/drush-install.sh
@@ -12,13 +12,11 @@ uk.co.compucorp.civicrm.hremails
 ENTITY_EXTS=\
 org.civicrm.hrbank,\
 org.civicrm.hrdemog,\
-org.civicrm.hrident,\
 org.civicrm.hrjobcontract,\
 com.civicrm.hrjobroles,\
 org.civicrm.hrabsence,\
 org.civicrm.hrmed,\
 org.civicrm.hrqual,\
-org.civicrm.hrvisa,\
 org.civicrm.hremergency,\
 org.civicrm.hrcareer,\
 uk.co.compucorp.contactaccessrights,\

--- a/bin/git-release.sh
+++ b/bin/git-release.sh
@@ -7,7 +7,6 @@ hrbank \
 hrcareer \
 hrcase \
 hrdemog \
-hrident \
 hrim \
 hrmed \
 hrprofile \
@@ -17,7 +16,6 @@ hrreport \
 uk.co.compucorp.civicrm.hrsampledata \
 hrstaffdir \
 hrui \
-hrvisa \
 org.civicrm.bootstrapcivihr \
 hrjobcontract \
 contactsummary \

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -63,8 +63,7 @@ individually:
  * org.civicrm.hrqual: Qualifications
  * org.civicrm.hrreport: Reporting
  * org.civicrm.hrstaffdir: Staff Directory
- * org.civicrm.hrvisa: Immigration
- * org.civicrm.hrcase: Case
+  * org.civicrm.hrcase: Case
  * org.civicrm.hrcaseutils: Case Utils
  * org.civicrm.hrim: Instant messanger link
  * org.civicrm.hrrecruitment: Recruitment

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -56,7 +56,6 @@ individually:
  * org.civicrm.hrcareer: Career History
  * org.civicrm.hrdemog: Extended Demographics
  * org.civicrm.hremerg: Emergency Contacts
- * org.civicrm.hrident: Identification
  * org.civicrm.hrabsence: Absences
  * org.civicrm.hrjobcontract: Job Contracts
  * org.civicrm.hrmed: Medical and Disability

--- a/hrreport/CRM/HRReport/Form/Contact/HRSummary.php
+++ b/hrreport/CRM/HRReport/Form/Contact/HRSummary.php
@@ -474,8 +474,6 @@ class CRM_HRReport_Form_Contact_HRSummary extends CRM_Report_Form {
     $customFieldsToRetain =
       array(
         'Career'         => array('Occupation Type', 'Full-time / Part-time', 'Paid / Unpaid'),
-        'Immigration'    => array('Visa Type'),
-        'Identification' => array('Type', 'Country', 'State/Province'),
         'Qualifications' => array('Category of Skill', 'Name of Skill', 'Level of Skill', 'Certification Acquired?'),
         'Medical & Disability' => array('Type', 'Special Requirements'),
       );

--- a/hrui/CRM/HRUI/Upgrader/Steps/4701.php
+++ b/hrui/CRM/HRUI/Upgrader/Steps/4701.php
@@ -46,6 +46,12 @@ trait CRM_HRUI_Upgrader_Steps_4701 {
     $identTableName = $this->up4701_getIdentTableName();
     $identFieldName = $this->up4701_getIdentFieldName();
 
+    $isEnabled = _hrui_is_extension_enabled('org.civicrm.hrident');
+
+    if (!$isEnabled) {
+      return TRUE;
+    }
+
     $query = "
       UPDATE {$inlineCustomGroup['table_name']}, $identTableName
          SET {$niSSNField['column_name']} = $identFieldName

--- a/hrui/CRM/HRUI/Upgrader/Steps/4701.php
+++ b/hrui/CRM/HRUI/Upgrader/Steps/4701.php
@@ -43,14 +43,14 @@ trait CRM_HRUI_Upgrader_Steps_4701 {
     $createResult = civicrm_api3('CustomField', 'create', $fieldData);
     $niSSNField = array_shift($createResult['values']);
 
-    $identTableName = $this->up4701_getIdentTableName();
-    $identFieldName = $this->up4701_getIdentFieldName();
-
     $isEnabled = _hrui_is_extension_enabled('org.civicrm.hrident');
 
     if (!$isEnabled) {
       return TRUE;
     }
+
+    $identTableName = $this->up4701_getIdentTableName();
+    $identFieldName = $this->up4701_getIdentFieldName();
 
     $query = "
       UPDATE {$inlineCustomGroup['table_name']}, $identTableName

--- a/hrui/hrui.php
+++ b/hrui/hrui.php
@@ -1040,5 +1040,5 @@ function _hrui_is_extension_enabled($key) {
     'full_name'
   );
 
-  return  !empty($isEnabled) ? true : false;
+  return !empty($isEnabled) ? true : false;
 }

--- a/hrui/js/src/hrui.js
+++ b/hrui/js/src/hrui.js
@@ -2,7 +2,7 @@
 (function ($, _) {
 
   /**
-   * Adds the Government ID field on the Personal Details page and on the Edit 
+   * Adds the Government ID field on the Personal Details page and on the Edit
    * Contact form.
    */
   function addGovernmentIdField() {
@@ -59,15 +59,6 @@
     if ($('tr#Phone_Block_2', 'form#Contact').length < 1) {
       $('#addPhone').click();
     }
-  }
-
-  function fetchGovernmentId() {
-    return $.ajax({
-      url: CRM.url('civicrm/contact/government/detail'),
-      data: { cid: CRM.cid },
-      type: 'GET',
-      dataType: "json",
-    });
   }
 
   /**


### PR DESCRIPTION
## Overview
Since the functionality offered by the hrvisa and hrident extensions is planned to be replaced by the improved documents feature these extensions are not required going forward. However, as they are potentially used by existing clients we will not remove them from the code.

## Before
For new installations the hrvisa and hrident extensions are enabled.

## After
The hrvisa and hrident extensions will not be enabled for new installations. References to code that depends on these extensions will be removed or altered.

## Technical Details
This PR changes the installation script, but also adds a conditional for anywhere outside the hrvisa and hrident extensions that their code is used, or anywhere that uses custom groups, fields, activities or anything that is normally created by these extensions.

---

- [ ] Tests Pass
hrvisa tests are broken on staging :cry: 
hrident has only a single skipped test :crying_cat_face: 