### PR TITLE
PCHR-2519: Fix BackstopJS for Manager leave calendar

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/ssp-leave-absences/manager/manager-leave-calendar_current-month-visible.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/ssp-leave-absences/manager/manager-leave-calendar_current-month-visible.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-my-leave-calendar');
+var page = require('../../../page-objects/ssp-leave-absences-manager-leave-calendar');
 
 module.exports = function (casper) {
   page.init(casper);

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-manager-leave-calendar.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-manager-leave-calendar.js
@@ -1,27 +1,13 @@
 var page = require('./page');
 
-var currentMonth = (new Date()).getMonth() + 1;
-
 module.exports = (function () {
   return page.extend({
     /**
-     * Wait for the page to be ready
+     * Wait for the page to be ready by looking at
+     * the visibility of a leave calendar item element
      */
     waitForReady: function () {
-      this.waitUntilVisible('.panel.panel-default:nth-of-type(' + currentMonth + ') .chr_leave-calendar__month-body');
-    },
-    /**
-     * Clear the months selected to show all months
-     */
-    showAllMonths: function () {
-      var casper = this.casper;
-      // If Current month is december then need to wait for November as it would be loaded last when all months load
-      var lastMonth = currentMonth === 12 ? 11 : 12;
-
-      casper.then(function () {
-        casper.click('.panel-subheading .close.ui-select-match-close');
-        casper.waitUntilVisible('.panel.panel-default:nth-of-type(' + lastMonth + ') .chr_leave-calendar__month-body');
-      });
+      this.waitUntilVisible('leave-calendar-month .chr_leave-calendar__item');
     }
   });
 })();

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-calendar.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-calendar.js
@@ -1,27 +1,13 @@
 var page = require('./page');
 
-var currentMonth = (new Date()).getMonth() + 1;
-
 module.exports = (function () {
   return page.extend({
     /**
-     * Wait for the page to be ready
+     * Wait for the page to be ready by looking at 
+     * the visibility of a leave calendar item element
      */
     waitForReady: function () {
-      this.waitUntilVisible('.panel.panel-default:nth-of-type(' + currentMonth + ') .chr_leave-calendar__month-body');
-    },
-    /**
-     * Clear the months selected to show all months
-     */
-    showAllMonths: function () {
-      var casper = this.casper;
-      // If Current month is december then need to wait for November as it would be loaded last when all months load
-      var lastMonth = currentMonth === 12 ? 11 : 12;
-
-      casper.then(function () {
-        casper.click('.panel-heading .close.ui-select-match-close');
-        casper.waitUntilVisible('.panel.panel-default:nth-of-type(' + lastMonth + ') .chr_leave-calendar__month-body');
-      });
+      this.waitUntilVisible('leave-calendar-month .chr_leave-calendar__item');
     }
   });
 })();

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-manager-leave-calendar.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-manager-leave-calendar.json
@@ -4,11 +4,6 @@
       "label": "Current Month: Manager Leave Calendar",
       "url": "manager-leave#/manager-leave/calendar",
       "onReadyScript": "ssp-leave-absences/manager/manager-leave-calendar_current-month-visible"
-    },
-    {
-      "label": "All Months: Manager Leave Calendar",
-      "url": "manager-leave#/manager-leave/calendar",
-      "onReadyScript": "ssp-leave-absences/manager/manager-leave-calendar_all-months-visible"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-my-leave-calendar.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-my-leave-calendar.json
@@ -4,11 +4,6 @@
       "label": "Current Month: My Leave Calendar",
       "url": "my-leave#/my-leave/calendar",
       "onReadyScript": "ssp-leave-absences/staff/my-leave-calendar_current-month-visible"
-    },
-    {
-      "label": "All Months: My Leave Calendar",
-      "url": "my-leave#/my-leave/calendar",
-      "onReadyScript": "ssp-leave-absences/staff/my-leave-calendar_all-months-visible"
     }
   ]
 }


### PR DESCRIPTION
## Overview

BackstopJS tests stopped working for calendar. This PR fixes this issue.

## Before

BackstopJS was hanging on the Manager Leave / My Leave calendars scenarios.

## After

![civihr_current_month_manager_leave_calendar_0_document_0_desktop](https://user-images.githubusercontent.com/3973243/29417128-0cd94bc0-8360-11e7-9896-fc497054af37.png)

## Technical Details

The selectors were not up-to-date. The fix was to update selectors and *not* rely on generic selectors like &lt;tr&gt;, but unique selector, such as `leave-calendar-month .chr_leave-calendar__item`. This decreases the probability breaking the test even if the markup structure changes. 

## Comments 

As per @AkA84 suggestion the screenshots of *all months* view are removed from BackstopJS for Manager Leave / My Leave calendars due to the lack of necessity.

---

- [x] Tests Pass
