### PR TITLE
PCHR-2464: Additional post-amnesty-merge fixes 

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
@@ -16,13 +16,13 @@
   </div>
   <div class="col-sm-4">
     <div class="override-filters">
-      <input type="radio" id="override_filter_overridden" name="override-filter" class="override-filter" value="1">
+      <input type="radio" id="override_filter_overridden" name="override-filter" class="old-radiocheckbox-style override-filter" value="1">
       <label for="override_filter_overridden">Overridden</label>
 
-      <input type="radio" id="override_filter_not_overridden" name="override-filter" class="override-filter" value="2">
+      <input type="radio" id="override_filter_not_overridden" name="override-filter" class="old-radiocheckbox-style override-filter" value="2">
       <label for="override_filter_not_overridden">Not Overridden</label>
 
-      <input type="radio" id="override_filter_both" name="override-filter" class="override-filter" value="3" checked="checked">
+      <input type="radio" id="override_filter_both" name="override-filter" class="old-radiocheckbox-style override-filter" value="3" checked="checked">
       <label for="override_filter_both">Both</label>
     </div>
   </div>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-calendar.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-calendar.html
@@ -14,6 +14,7 @@
         </div>
         <div class="crm_custom-select">
           <select
+            class="no-select2"
             ng-options="region.label for region in calendar.filters.optionValues.regions track by region.id"
             ng-model="calendar.filters.userSettings.region"
             ng-change="calendar.refresh('contacts')">
@@ -23,6 +24,7 @@
         </div>
         <div class="crm_custom-select">
           <select
+            class="no-select2"
             ng-options="department.label for department in calendar.filters.optionValues.departments track by department.id"
             ng-model="calendar.filters.userSettings.department"
             ng-change="calendar.refresh('contacts')">
@@ -32,6 +34,7 @@
         </div>
         <div class="crm_custom-select">
           <select
+            class="no-select2"
             ng-options="levelType.value for levelType in calendar.filters.optionValues.levelTypes track by levelType.id"
             ng-model="calendar.filters.userSettings.level_type"
             ng-change="calendar.refresh('contacts')">
@@ -41,6 +44,7 @@
         </div>
         <div class="crm_custom-select">
           <select
+            class="no-select2"
             ng-options="location.label for location in calendar.filters.optionValues.locations track by location.id"
             ng-model="calendar.filters.userSettings.location"
             ng-change="calendar.refresh('contacts')">
@@ -69,6 +73,7 @@
           <div class="col-sm-offset-1 col-sm-3">
             <div class="crm_custom-select crm_custom-select--full">
               <select
+                class="no-select2"
                 ng-options="period as calendar.labelPeriod(period) for period in calendar.absencePeriods track by period.id"
                 ng-model="calendar.selectedPeriod"
                 ng-change="calendar.refresh('period')">

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/staff-leave-report.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/staff-leave-report.html
@@ -8,6 +8,7 @@
           <div class="col-sm-3">
             <div class="crm_custom-select crm_custom-select--full">
               <select
+                class="no-select2"
                 ng-options="period as report.labelPeriod(period) for period in report.absencePeriods track by period.id"
                 ng-model="report.selectedPeriod"
                 ng-change="report.refresh()">


### PR DESCRIPTION
## Overview
This PR adds the "class markers" to avoid the [enable-select2.js](https://github.com/civicrm/org.civicrm.shoreditch/blob/master/js/enable-select2.js) and [radio-checkbox.js](https://github.com/civicrm/org.civicrm.shoreditch/blob/master/js/radio-checkbox.js) scripts to the marked radio/select elements, that was resulting in broken styles

## Before
<img width="500" alt="tab-calendar-before" src="https://user-images.githubusercontent.com/6400898/29513548-fde19ad8-8665-11e7-8699-4b3d46f6efb8.png">
<img width="500" alt="tab-report-before" src="https://user-images.githubusercontent.com/6400898/29513550-fde7798a-8665-11e7-81a2-cd3e1a93aa48.png">
<img width="1000" alt="radio-before" src="https://user-images.githubusercontent.com/6400898/29513549-fde6f32a-8665-11e7-9892-f8c2a25b6ef2.png">

## After
<img width="450" alt="tab-report-after" src="https://user-images.githubusercontent.com/6400898/29513570-0e47f73c-8666-11e7-9f5b-1e1fd0643319.png">
<img width="1174" alt="tab-calendar-after" src="https://user-images.githubusercontent.com/6400898/29513571-0e4b7894-8666-11e7-8858-d1140284d3c7.png">
<img width="850" alt="radio-after" src="https://user-images.githubusercontent.com/6400898/29513572-0e54432a-8666-11e7-98fc-6decc7451549.png">

---

- [x] Tests Pass
