### PR TITLE
PCHR-2501: Allow Case Types with "&" in activity types

### DIFF
--- a/hrcase/CRM/Case/BAO/CaseType.php
+++ b/hrcase/CRM/Case/BAO/CaseType.php
@@ -1,9 +1,9 @@
 <?php
 /*
  +--------------------------------------------------------------------+
- | CiviCRM version 4.5                                                |
+ | CiviCRM version 4.7                                                |
  +--------------------------------------------------------------------+
- | Copyright CiviCRM LLC (c) 2004-2014                                |
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
  +--------------------------------------------------------------------+
  | This file is a part of CiviCRM.                                    |
  |                                                                    |
@@ -23,47 +23,41 @@
  | GNU Affero General Public License or the licensing of CiviCRM,     |
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
-*/
+ */
 
 /**
  *
  * @package CRM
- * @copyright CiviCRM LLC (c) 2004-2014
- * $Id$
- *
+ * @copyright CiviCRM LLC (c) 2004-2017
  */
 
 /**
- * This class contains the functions for Case Type management
- *
+ * This class contains the functions for Case Type management.
  */
 class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
 
   /**
-   * static field for all the case information that we can potentially export
+   * Static field for all the case information that we can potentially export.
    *
    * @var array
-   * @static
    */
   static $_exportableFields = NULL;
 
   /**
-   * takes an associative array and creates a Case Type object
+   * Takes an associative array and creates a Case Type object.
    *
    * the function extract all the params it needs to initialize the create a
    * case type object. the params array could contain additional unused name/value
    * pairs
    *
-   * @param array $params (reference ) an assoc array of name/value pairs
+   * @param array $params
+   *   (reference ) an assoc array of name/value pairs.
    *
-   * @internal param array $ids the array that holds all the db ids
+   * @throws CRM_Core_Exception
    *
-   * @return object CRM_Case_BAO_CaseType object
-   * @access public
-   * @static
+   * @return CRM_Case_BAO_CaseType
    */
-  static function add(&$params) {
-
+  public static function add(&$params) {
     $caseTypeDAO = new CRM_Case_DAO_CaseType();
 
     // form the name only if missing: CRM-627
@@ -89,27 +83,36 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
     return $caseTypeDAO->save();
   }
 
+  /**
+   * Generate and assign an arbitrary value to a field of a test object.
+   *
+   * @param string $fieldName
+   * @param array $fieldDef
+   * @param int $counter
+   *   The globally-unique ID of the test object.
+   */
   protected function assignTestValue($fieldName, &$fieldDef, $counter) {
-    if ($fieldName  == 'definition') {
+    if ($fieldName == 'definition') {
       $this->{$fieldName} = "<CaseType><name>TestCaseType{$counter}</name></CaseType>";
-    } else {
+    }
+    else {
       parent::assignTestValue($fieldName, $fieldDef, $counter);
     }
   }
 
 
   /**
-   * Function to format / convert submitted array to xml for case type definition
+   * Format / convert submitted array to xml for case type definition
    *
    * @param string $name
-   * @param array $definition the case-type defintion expressed as an array-tree
-   * @return string XML
-   * @static
-   * @access public
+   * @param array $definition
+   *   The case-type definition expressed as an array-tree.
+   * @return string
+   *   XML
    */
-  static function convertDefinitionToXML($name, $definition) {
+  public static function convertDefinitionToXML($name, $definition) {
     $xmlFile = '<?xml version="1.0" encoding="utf-8" ?>' . "\n\n<CaseType>\n";
-    $xmlFile .= "<name>{$name}</name>\n";
+    $xmlFile .= "<name>" . self::encodeXmlString($name) . "</name>\n";
 
     if (array_key_exists('forkable', $definition)) {
       $xmlFile .= "<forkable>" . ((int) $definition['forkable']) . "</forkable>\n";
@@ -120,11 +123,19 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
       foreach ($definition['activityTypes'] as $values) {
         $xmlFile .= "<ActivityType>\n";
         foreach ($values as $key => $value) {
-          $xmlFile .= "<{$key}>{$value}</{$key}>\n";
+          $xmlFile .= "<{$key}>" . self::encodeXmlString($value) . "</{$key}>\n";
         }
         $xmlFile .= "</ActivityType>\n";
       }
       $xmlFile .= "</ActivityTypes>\n";
+    }
+
+    if (!empty($definition['statuses'])) {
+      $xmlFile .= "<Statuses>\n";
+      foreach ($definition['statuses'] as $value) {
+        $xmlFile .= "<Status>$value</Status>\n";
+      }
+      $xmlFile .= "</Statuses>\n";
     }
 
     if (isset($definition['activitySets'])) {
@@ -139,21 +150,23 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
                 foreach ($setVal as $values) {
                   $xmlFile .= "<ActivityType>\n";
                   foreach ($values as $key => $value) {
-                    $xmlFile .= "<{$key}>{$value}</{$key}>\n";
+                    $xmlFile .= "<{$key}>" . self::encodeXmlString($value) . "</{$key}>\n";
                   }
                   $xmlFile .= "</ActivityType>\n";
                 }
                 $xmlFile .= "</ActivityTypes>\n";
               }
               break;
+
             case 'sequence': // passthrough
             case 'timeline':
               if ($setVal) {
                 $xmlFile .= "<{$index}>true</{$index}>\n";
               }
               break;
+
             default:
-              $xmlFile .= "<{$index}>{$setVal}</{$index}>\n";
+              $xmlFile .= "<{$index}>" . self::encodeXmlString($setVal) . "</{$index}>\n";
           }
         }
 
@@ -168,7 +181,7 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
       foreach ($definition['caseRoles'] as $values) {
         $xmlFile .= "<RelationshipType>\n";
         foreach ($values as $key => $value) {
-          $xmlFile .= "<{$key}>{$value}</{$key}>\n";
+          $xmlFile .= "<{$key}>" . self::encodeXmlString($value) . "</{$key}>\n";
         }
         $xmlFile .= "</RelationshipType>\n";
       }
@@ -180,14 +193,30 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
   }
 
   /**
-   * Function to get the case definition either from db or read from xml file
+   * Ugh. This shouldn't exist. Use a real XML-encoder.
    *
-   * @param SimpleXmlElement $xml a single case-type record
+   * Escape a string for use in XML.
    *
-   * @return array the definition of the case-type, expressed as PHP array-tree
-   * @static
+   * @param string $str
+   *   A string which should outputted to XML.
+   * @return string
+   * @deprecated
    */
-  static function convertXmlToDefinition($xml) {
+  protected static function encodeXmlString($str) {
+    // PHP 5.4: return htmlspecialchars($str, ENT_XML1, 'UTF-8')
+    return htmlspecialchars($str);
+  }
+
+  /**
+   * Get the case definition either from db or read from xml file.
+   *
+   * @param SimpleXmlElement $xml
+   *   A single case-type record.
+   *
+   * @return array
+   *   the definition of the case-type, expressed as PHP array-tree
+   */
+  public static function convertXmlToDefinition($xml) {
     // build PHP array based on definition
     $definition = array();
 
@@ -201,6 +230,11 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
       foreach ($xml->ActivityTypes->ActivityType as $activityTypeXML) {
         $definition['activityTypes'][] = json_decode(json_encode($activityTypeXML), TRUE);
       }
+    }
+
+    // set statuses
+    if (isset($xml->Statuses)) {
+      $definition['statuses'] = (array) $xml->Statuses->Status;
     }
 
     // set activity sets
@@ -243,16 +277,14 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
    * Given the list of params in the params array, fetch the object
    * and store the values in the values array
    *
-   * @param array $params input parameters to find object
-   * @param array $values output values of the object
-   *
-   * @internal param array $ids the array that holds all the db ids
+   * @param array $params
+   *   Input parameters to find object.
+   * @param array $values
+   *   Output values of the object.
    *
    * @return CRM_Case_BAO_CaseType|null the found object or null
-   * @access public
-   * @static
    */
-  static function &getValues(&$params, &$values) {
+  public static function &getValues(&$params, &$values) {
     $caseType = new CRM_Case_BAO_CaseType();
 
     $caseType->copyValues($params);
@@ -265,17 +297,14 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
   }
 
   /**
-   * takes an associative array and creates a case type object
+   * Takes an associative array and creates a case type object.
    *
-   * @param array $params (reference ) an assoc array of name/value pairs
+   * @param array $params
+   *   (reference ) an assoc array of name/value pairs.
    *
-   * @internal param array $ids the array that holds all the db ids
-   *
-   * @return object CRM_Case_BAO_CaseType object
-   * @access public
-   * @static
+   * @return CRM_Case_BAO_CaseType
    */
-  static function &create(&$params) {
+  public static function &create(&$params) {
     $transaction = new CRM_Core_Transaction();
 
     if (!empty($params['id'])) {
@@ -305,32 +334,30 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
   }
 
   /**
-   * Takes a bunch of params that are needed to match certain criteria and
-   * retrieves the relevant objects. We'll tweak this function to be more
-   * full featured over a period of time. This is the inverse function of
-   * create.  It also stores all the retrieved values in the default array
+   * Retrieve DB object based on input parameters.
    *
-   * @param array $params (reference ) an assoc array of name/value pairs
-   * @param array $defaults (reference ) an assoc array to hold the name / value pairs
+   * It also stores all the retrieved values in the default array.
+   *
+   * @param array $params
+   *   (reference ) an assoc array of name/value pairs.
+   * @param array $defaults
+   *   (reference ) an assoc array to hold the name / value pairs.
    *                        in a hierarchical manner
    *
-   * @internal param array $ids (reference) the array that holds all the db ids
-   *
-   * @return object CRM_Case_BAO_CaseType object
-   * @access public
-   * @static
+   * @return CRM_Case_BAO_CaseType
    */
-  static function retrieve(&$params, &$defaults) {
+  public static function retrieve(&$params, &$defaults) {
     $caseType = CRM_Case_BAO_CaseType::getValues($params, $defaults);
     return $caseType;
   }
 
   /**
-   * @param $caseTypeId
+   * @param int $caseTypeId
    *
+   * @throws CRM_Core_Exception
    * @return mixed
    */
-  static function del($caseTypeId) {
+  public static function del($caseTypeId) {
     $caseType = new CRM_Case_DAO_CaseType();
     $caseType->id = $caseTypeId;
     $refCounts = $caseType->getReferenceCounts();
@@ -349,17 +376,18 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
    * @param string $caseType
    * @return bool
    */
-  static function isValidName($caseType) {
-    return preg_match('/^[a-zA-Z0-9_]+$/',  $caseType);
+  public static function isValidName($caseType) {
+    return preg_match('/^[a-zA-Z0-9_]+$/', $caseType);
   }
 
   /**
    * Determine if the case-type has *both* DB and file-based definitions.
    *
    * @param int $caseTypeId
-   * @return bool|null TRUE if there are *both* DB and file-based definitions
+   * @return bool|null
+   *   TRUE if there are *both* DB and file-based definitions
    */
-  static function isForked($caseTypeId) {
+  public static function isForked($caseTypeId) {
     $caseTypeName = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', $caseTypeId, 'name', 'id', TRUE);
     if ($caseTypeName) {
       $dbDefinition = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', $caseTypeId, 'definition', 'id', TRUE);
@@ -373,17 +401,19 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
    * Determine if modifications are allowed on the case-type
    *
    * @param int $caseTypeId
-   * @return bool TRUE if the definition can be modified
+   * @return bool
+   *   TRUE if the definition can be modified
    */
-  static function isForkable($caseTypeId) {
+  public static function isForkable($caseTypeId) {
     $caseTypeName = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', $caseTypeId, 'name', 'id', TRUE);
     if ($caseTypeName) {
       // if file-based definition explicitly disables "forkable" option, then don't allow changes to definition
       $fileDefinition = CRM_Case_XMLRepository::singleton()->retrieveFile($caseTypeName);
       if ($fileDefinition && isset($fileDefinition->forkable)) {
-        return CRM_Utils_String::strtobool((string)$fileDefinition->forkable);
+        return CRM_Utils_String::strtobool((string) $fileDefinition->forkable);
       }
     }
     return TRUE;
   }
+
 }


### PR DESCRIPTION
## Overview
This is a recognized, and fixed issue in CiviCRM core, issue [CRM-16360](https://issues.civicrm.org/jira/browse/CRM-16360). Assignment types that use ampersands in the activity type names will not be interpreted correctly, since `&` is a reserved character. The definition will be saved to the database, but loading it on edit will cause the standard timeline tab to not be displayed, and any attempt to save on this screen will result in an empty definition.

## Before
After saving a case type with & in the definition, attempts to edit it would not show a standard timeline. Further saving would delete most of the definition from the database.

## After
The fix was applied to the overridden file. You can save case types with `&` in the definition and they will be correctly encoded before saving to the database.

## Comments
I copied and pasted the entirety of https://github.com/civicrm/civicrm-core/blob/4.7.18/CRM/Case/BAO/CaseType.php with the exception of the line to [schedule reconciliation](https://github.com/civicrm/civicrm-core/blob/4.7.22/CRM/Case/BAO/CaseType.php#L79), which is still an open issue for us related to the saving of managed entities.

---

- [x] Tests Pass

hrcase just had a single (skipped) test.
