### PR TITLE
PCHR-2503: Fix issues with being unable to export Contract Entitlements

### DIFF
--- a/hrjobcontract/CRM/Export/BAO/Export.php
+++ b/hrjobcontract/CRM/Export/BAO/Export.php
@@ -209,7 +209,7 @@ class CRM_Export_BAO_Export {
     if ($queryMode & CRM_Contact_BAO_Query::MODE_CONTACTS &&
       !empty($returnProperties['hrjobcontract_leave_leave_amount']))
     {
-      $groupBy = " GROUP BY contact_a.id";
+      $groupBy = ' GROUP BY contact_a.id';
     }
 
     $groupBy = !empty($groupBy) ? $groupBy : '';

--- a/hrjobcontract/CRM/Export/BAO/Export.php
+++ b/hrjobcontract/CRM/Export/BAO/Export.php
@@ -206,6 +206,12 @@ class CRM_Export_BAO_Export {
       $groupBy = " GROUP BY civicrm_activity.id ";
     }
 
+    if ($queryMode & CRM_Contact_BAO_Query::MODE_CONTACTS &&
+      !empty($returnProperties['hrjobcontract_leave_leave_amount']))
+    {
+      $groupBy = " GROUP BY contact_a.id";
+    }
+
     $groupBy = !empty($groupBy) ? $groupBy : '';
 
     return $groupBy;

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/Query.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/Query.php
@@ -63,6 +63,8 @@ class CRM_Hrjobcontract_BAO_Query extends CRM_Contact_BAO_Query_Interface {
           'type'  => CRM_Utils_Type::T_INT,
           'where' => 'hrjobcontract.id'
       );
+
+      self::$_hrjobFields['hrjobcontract_leave_leave_amount']['type'] = CRM_Utils_Type::T_STRING;
     }
 
     return self::$_hrjobFields;

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/Query.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/Query.php
@@ -73,7 +73,14 @@ class CRM_Hrjobcontract_BAO_Query extends CRM_Contact_BAO_Query_Interface {
       $fields = $this->getFields();
       foreach ($fields as $fldName => $params) {
         if (!empty($query->_returnProperties[$fldName])) {
-          $query->_select[$fldName]  = "{$params['where']} as $fldName";
+          if ($fldName == 'hrjobcontract_leave_leave_amount') {
+            $query->_select[$fldName] = "GROUP_CONCAT(civicrm_hrjobcontract_leave.leave_type,
+            ':', civicrm_hrjobcontract_leave.leave_amount) as $fldName";
+          }
+          else{
+            $query->_select[$fldName] = "{$params['where']} as $fldName";
+          }
+
           $query->_element[$fldName] = 1;
           list($tableName, $dnc) = explode('.', $params['where'], 2);
           $query->_tables[$tableName]  = $query->_whereTables[$tableName] = 1;

--- a/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobLeave.php
+++ b/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobLeave.php
@@ -174,7 +174,7 @@ class CRM_Hrjobcontract_DAO_HRJobLeave extends CRM_Hrjobcontract_DAO_Base
               ) ,
               'hrjobcontract_leave_leave_amount' => array(
                 'name' => 'leave_amount',
-                'type' => CRM_Utils_Type::T_STRING,
+                'type' => CRM_Utils_Type::T_INT,
                 'title' => ts('Contract Leave Amount') ,
                 'import' => true,
                 'where' => 'civicrm_hrjobcontract_leave.leave_amount',

--- a/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobLeave.php
+++ b/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobLeave.php
@@ -174,7 +174,7 @@ class CRM_Hrjobcontract_DAO_HRJobLeave extends CRM_Hrjobcontract_DAO_Base
               ) ,
               'hrjobcontract_leave_leave_amount' => array(
                 'name' => 'leave_amount',
-                'type' => CRM_Utils_Type::T_INT,
+                'type' => CRM_Utils_Type::T_STRING,
                 'title' => ts('Contract Leave Amount') ,
                 'import' => true,
                 'where' => 'civicrm_hrjobcontract_leave.leave_amount',

--- a/hrjobcontract/CRM/Hrjobcontract/Export/Converter.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Export/Converter.php
@@ -69,6 +69,9 @@ class CRM_Hrjobcontract_Export_Converter {
               $contractEntitlementsArray[trim($leaveType)] = trim($entitlement);
             }
             foreach ($leaveTypes as $type => $typeId) {
+              //The exported file will always have columns for all the absence type, so we need
+              //to add a blank value for contacts that don't have entitlement for a particular
+              //absence type.
               $row[$type] = !empty($contractEntitlementsArray[$type]) ? $contractEntitlementsArray[$type] : '';
             }
           }

--- a/hrjobcontract/CRM/Hrjobcontract/ExportImportValuesConverter.php
+++ b/hrjobcontract/CRM/Hrjobcontract/ExportImportValuesConverter.php
@@ -575,4 +575,13 @@ class CRM_Hrjobcontract_ExportImportValuesConverter
 
         return $contactId;
     }
+
+    /**
+     * Returns the flipped leave types array.
+     *
+     * @return array
+     */
+    public function getLeaveTypesFlipped() {
+        return $this->_leaveTypesFlipped;
+    }
 }


### PR DESCRIPTION
## Overview
Currently, trying to export contract leave entitlements when exporting a contact information does not work, the resulting CSV downloaded contains a blank column or inaccurate data for the Contract Leave Amount column.
Also since the import format for Contract entitlements has been changed in CiviHR 1.7, there is need also to allow Contract entitlements to be exported in this format to allow clients migrating entitlements data from 1.6 to 1.7 to do so seamlessly.

## Before
Exporting the contract leave entitlement data is broken and does not give accurate data. The export format is not compatible for import into a CiviHR 1.7 site

## After
Exporting the contract leave entitlement now gives accurate data and it also exports data in a format that is compatible for import into 1.7 in addition to the format compatible with 1.6.

![exportentitlement](https://user-images.githubusercontent.com/6951813/29576243-0efeaa00-875f-11e7-96e8-fc4b2139c9cc.gif)


## Technical Details
- The [function](https://github.com/civicrm/civihr/blob/d1a60dd47bc4eab84e4a5475947b2302027963f7/hrjobcontract/CRM/Hrjobcontract/ExportImportValuesConverter.php#L254-L254) responsible for formatting the `Contract Leave Amount` column was expecting data in the form `Leave Type ID 1: Entitlement Amount1, Leave Type ID 2 : Entitlement Amount2` but was currently receiving data in the form `Entitlement Amount1` with each Leave entitlement amount in its own row rather than the whole contract entitlement being concatenated on a single row for the contact. 
The query responsible for fetching the associated exportable columns for the Job contract extension was modified to GROUP concatenate the Leave Type ID with the Leave entitlement amount in the format expected by the `leave_amount` export formatter whenever the Contract Entitlements are to be exported.
- The `hrjobcontract_leave_leave_amount` [type](https://github.com/civicrm/civihr/blob/7b1567bb5f9135c8574b707967409a6ee7614c91/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobLeave.php#L177-L177) was modified to a string. This type is used by Civi to determine the column type and length when creating a temporary table to store the results of the export. Was getting a `Data too long for column 'hrjobcontract_leave_leave_amount` error before changing the type to String. Technically the type is supposed to be  a string because when importing Contract entitlements, the contract entitlements are imported as comma separated pairs of Leave type/Entitlement amount.
- After fixing the contract entitlements to export data in the format `Leave Type Name 1: Entitlement Amount1, Leave Type Name 2 : Entitlement Amount2`, the overall results was intercepted to also return these entitlements as actual columns with accompanying data in a [format](https://github.com/civicrm/civihr/pull/2044) supported in CiviHR 1.7.

## Comments
- This solution has also been tested to work on a 1.7 site, tested by locally syncing  1.6 with 1.7.

- [X] Tests Pass
