### PR TITLE
PCHR-2480: Fix bug in unassigned filter when contact has multiple relationships

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
@@ -103,22 +103,13 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
       $conditions[] = "NOT (" . implode(' AND ', $this->hasActiveLeaveManagerCondition()) . ") 
                        OR (r.is_active IS NULL AND rt.is_active IS NULL)";
 
-      $contactID = false;
-      $contactPassedAsArray = !empty($this->params['contact_id']['IN']);
-      $contactPassedAsID = isset($this->params['contact_id']) && is_numeric($this->params['contact_id']);
 
-      if($contactPassedAsArray) {
-        $contactID = $this->params['contact_id']['IN'];
-      }
-
-      if($contactPassedAsID) {
-        $contactID = [$this->params['contact_id']];
-      }
 
       $query = "a.contact_id NOT IN(SELECT contact_id_a FROM civicrm_relationship r LEFT JOIN
                        civicrm_relationship_type rt ON rt.id = r.relationship_type_id WHERE
                        ". implode(' AND ', $this->hasActiveLeaveManagerCondition());
 
+      $contactID = $this->getContactIdFromParams();
       if ($contactID) {
         $query .= " AND r.contact_id_a IN(" . implode(',', $contactID) . "))";
       }
@@ -336,5 +327,27 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
     $conditions[] = "(r.end_date IS NULL OR r.end_date >= {$today})";
 
     return $conditions;
+  }
+
+  /**
+   * Gets the contactID from the params array and
+   * returns it as an array.
+   *
+   * @return array|bool
+   */
+  private function getContactIdFromParams() {
+    $contactID = false;
+    $contactPassedAsArray = !empty($this->params['contact_id']['IN']);
+    $contactPassedAsID = isset($this->params['contact_id']) && is_numeric($this->params['contact_id']);
+
+    if($contactPassedAsArray) {
+      $contactID = $this->params['contact_id']['IN'];
+    }
+
+    if($contactPassedAsID) {
+      $contactID = [$this->params['contact_id']];
+    }
+
+    return $contactID;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
@@ -102,6 +102,9 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
     if($hasUnassignedAsTrue) {
       $conditions[] = "NOT (" . implode(' AND ', $this->hasActiveLeaveManagerCondition()) . ") 
                        OR (r.is_active IS NULL AND rt.is_active IS NULL)";
+      $conditions[] = "a.contact_id NOT IN(SELECT contact_id_a FROM civicrm_relationship r LEFT JOIN
+                       civicrm_relationship_type rt ON rt.id = r.relationship_type_id WHERE
+                       ". implode(' AND ', $this->hasActiveLeaveManagerCondition()) .")";
     }
 
     if(!empty($this->params['managed_by'])) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
@@ -103,8 +103,6 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
       $conditions[] = "NOT (" . implode(' AND ', $this->hasActiveLeaveManagerCondition()) . ") 
                        OR (r.is_active IS NULL AND rt.is_active IS NULL)";
 
-
-
       $query = "a.contact_id NOT IN(SELECT contact_id_a FROM civicrm_relationship r LEFT JOIN
                        civicrm_relationship_type rt ON rt.id = r.relationship_type_id WHERE
                        ". implode(' AND ', $this->hasActiveLeaveManagerCondition());
@@ -333,10 +331,10 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
    * Gets the contactID from the params array and
    * returns it as an array.
    *
-   * @return array|bool
+   * @return array
    */
   private function getContactIdFromParams() {
-    $contactID = false;
+    $contactID = [];
     $contactPassedAsArray = !empty($this->params['contact_id']['IN']);
     $contactPassedAsID = isset($this->params['contact_id']) && is_numeric($this->params['contact_id']);
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -12,6 +12,8 @@ use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricato
 use CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest as PublicHolidayLeaveRequestFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern as WorkPatternFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_ContactWorkPattern as ContactWorkPatternFabricator;
+use CRM_HRCore_Test_Fabricator_RelationshipType as RelationshipTypeFabricator;
+use CRM_HRCore_Test_Fabricator_Relationship as RelationshipFabricator;
 use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 
 /**
@@ -1459,6 +1461,48 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals(2, $resultGetFull['count']);
     $this->assertNotEmpty($resultGetFull['values'][$leaveRequest2->id]);
     $this->assertNotEmpty($resultGetFull['values'][$leaveRequest3->id]);
+  }
+
+  public function testGetAndGetFullShouldReturnNoInformationForContactWithActiveLeaveManagerAndOtherRelationshipWhenUnassignedIsTrue() {
+    $this->setLeaveApproverRelationshipTypes([
+      'has Leaves Approved By',
+    ]);
+
+    $manager = ContactFabricator::fabricate();
+    $staffMember = ContactFabricator::fabricate();
+
+    $relationshipType = RelationshipTypeFabricator::fabricate();
+
+    //Add a neutral relationship between contact and manager that is not of
+    //type leave approver.
+    RelationshipFabricator::fabricate([
+      'contact_id_a' => $staffMember['id'],
+      'contact_id_b' => $manager['id'],
+      'relationship_type_id' => $relationshipType['id']
+    ]);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $staffMember['id']],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    $this->setContactAsLeaveApproverOf($manager, $staffMember, null, null, true, 'has Leaves Approved By');
+
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $staffMember['id'],
+      'type_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'from_date_type' => 1,
+      'to_date_type' => 1
+    ]);
+
+    $result = civicrm_api3('LeaveRequest', 'get', ['unassigned' => true]);
+    $resultGetFull = civicrm_api3('LeaveRequest', 'getFull', ['unassigned' => true]);
+
+    $this->assertEquals(0, $result['count']);
+
+    $this->assertEquals(0, $resultGetFull['count']);
   }
 
   public function testGetAndGetFullShouldReturnInformationForContactsWithActiveLeaveManagersWhenUnassignedIsFalse() {


### PR DESCRIPTION
## Overview
The unassigned filter on the Leave and Absence Dashboard page does not work as it should. For example leave requests for a contact with an active leave approver relationship also having another relationship will show up when the unassigned tab is clicked. The unassigned tab is only supposed to show leave requests for contacts without an active leave approver relationship.

## Before
The unassigned filter when clicked will return leave request results for a contact having an active leave approver relationship and other relationships.

## After
The unassigned filter when clicked returns only results contacts without an active leave approver relationship.

## Technical Details
- The query responsible for fetching results for `LeaveRequest.get` and `LeaveRequest.getFull` Api's joins directly to the `relationship` table via the leave request `contact_id`, This will make a Join to all relationships that the contact has, For the case of when unassigned is true, the query does not factor in the scenario where a contact already has leave manager relationship and the contact is returned with the results because it has other relationships that are not leave manager relationships.
- The query is modified to filter off contacts that already have active leave manager relationship and the results returned.

---

- [X] Tests Pass
