### PR TITLE
PCHR-2486: Fix issue with Advanced search not working when an option is selected in the Job Contract: Leave Tab

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/BAO/Query.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/Query.php
@@ -219,7 +219,7 @@ class CRM_Hrjobcontract_BAO_Query extends CRM_Contact_BAO_Query_Interface {
 
       case 'hrjobcontract_leave_leave_type':
         $query->_qill[$grouping][]  = 'Leave Type IN ' . implode(', ', $value) . '';
-        $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_hrjobcontract_leave.leave_type", 'IN', '(' . implode(',', $value) . ')');
+        $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_hrjobcontract_leave.leave_type", 'IN', $value);
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_hrjobcontract_leave.leave_amount", '>', 0);
         $query->_tables['civicrm_hrjobcontract_leave'] = $query->_whereTables['civicrm_hrjobcontract_leave'] = 1;
         return;


### PR DESCRIPTION
## Overview
When a leave type option is selected in the `Job Contract: Leave` tab in the advanced search page, No contact is returned even though contacts having contract entitlements for those leave types exist. This is observed for CiviHR 1.6. For 1.7 the `Job Contract: Leave` tab does not show any option at all but has been fixed by this [PR](https://github.com/civicrm/civihr/pull/2096).

## Before
When an option is selected in the `Job Contract: Leave` tab in the advanced search page, No contact is returned even though contacts having contract entitlements for those leave types exist

## After
When an option is selected in the `Job Contract: Leave` tab in the advanced search page,  contacts having contract entitlements for those leave types are returned.
![advanced search - civihr 1 7 demo 2017-08-28 13-54-02](https://user-images.githubusercontent.com/6951813/29774165-6cdb4712-8bf8-11e7-96c7-5a675935b5d1.png)


## Technical Details
- The where condition in the query that allows contacts having entitlements for the selected leave types was modified to `CRM_Contact_BAO_Query::buildClause("civicrm_hrjobcontract_leave.leave_type", 'IN', $value);`, It was formerly `CRM_Contact_BAO_Query::buildClause("civicrm_hrjobcontract_leave.leave_type", 'IN', '(' . implode(',', $value) . ')')`. The `CRM_Contact_BAO_Query::buildClause` expects the third parameter to be an array when the operation is` IN`, if not it converts it to an array. The way it was written before was generating a query like `WHERE civicrm_hrjobcontract_leave.leave_type IN ("(2,3)") `

## Comments
- After this PR is merged. CiviHR 1.7 will be synced with 1.6 so that the advanced search with `Job Contract: Leave` tab can also work for 1.7

---

- [X] Tests Pass
