### PR TITLE
PCHR-2536: Add unique leave request links in emails

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Message.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Message.php
@@ -140,10 +140,13 @@ class CRM_HRLeaveAndAbsences_Mail_Message {
    * @return string
    */
   private function getLeaveRequestURL($contactID) {
-    $leaveUrl = CRM_Utils_System::url('my-leave', [], true);
+    $queryString = '?leave-request-id=' . $this->leaveRequest->id;
+    $leaveUrl = CRM_Utils_System::url('my-leave#/my-leave/report' .
+      $queryString, [], true);
 
     if ($this->leaveRequest->contact_id != $contactID) {
-      $leaveUrl = CRM_Utils_System::url('manager-leave', [], true);
+      $leaveUrl = CRM_Utils_System::url('manager-leave#/manager-leave/requests' .
+        $queryString, [], true);
     }
 
     return $leaveUrl;
@@ -195,10 +198,10 @@ class CRM_HRLeaveAndAbsences_Mail_Message {
       SELECT r.contact_id_b
       FROM {$relationshipTable} r
       LEFT JOIN {$relationshipTypeTable} rt ON rt.id = r.relationship_type_id
-      WHERE r.is_active = 1 AND rt.is_active = 1 
+      WHERE r.is_active = 1 AND rt.is_active = 1
       AND rt.id IN(" . implode(',', $leaveApproverRelationships) . ")
       AND r.contact_id_a = {$this->leaveRequest->contact_id}
-      AND (r.start_date IS NULL OR r.start_date <= '$today') 
+      AND (r.start_date IS NULL OR r.start_date <= '$today')
       AND (r.end_date IS NULL OR r.end_date >= '$today')
     ";
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/apis/leave-request-api.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/apis/leave-request-api.js
@@ -192,7 +192,7 @@ define([
         find: function (id) {
           $log.debug('LeaveRequestAPI.find');
 
-          return this.sendGET('LeaveRequest', 'get', { id: id })
+          return this.sendGET('LeaveRequest', 'getFull', { id: id })
           .then(function (response) {
             if (response.values.length === 0) {
               return $q.reject('LeaveRequest not found with this ID');

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/apis/leave-request-api.spec.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/apis/leave-request-api.spec.js
@@ -525,7 +525,7 @@ define([
 
       it('calls the LeaveRequest.get endpoint', function () {
         promise.then(function () {
-          expect(LeaveRequestAPI.sendGET).toHaveBeenCalledWith('LeaveRequest', 'get', { id: id });
+          expect(LeaveRequestAPI.sendGET).toHaveBeenCalledWith('LeaveRequest', 'getFull', { id: id });
         });
       });
     });

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
@@ -139,32 +139,38 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
   }
 
   public function testGetTemplateParametersForLeaveContact() {
+    $leaveRequestId = 1;
     $templateParameters = [
       'status' => 'Mock Status',
       'date' => 'Test Date'
     ];
-    $expectedUrl = ['leaveRequestLink' => CRM_Utils_System::url('my-leave', [], true)];
+    $expectedUrl = ['leaveRequestLink' => CRM_Utils_System::url(
+      'my-leave#/my-leave/report?leave-request-id=' . $leaveRequestId, [], true)];
     $expectedParameters = array_merge($templateParameters, $expectedUrl);
     $leaveTemplate = $this->createLeaveTemplateMock($templateParameters);
     $notificationTemplateFactory = $this->createRequestNotificationTemplateFactoryMock($leaveTemplate);
 
     $leaveRequest = new LeaveRequest();
+    $leaveRequest->id = $leaveRequestId;
     $leaveRequest->contact_id = 1;
     $message = new Message($leaveRequest, $notificationTemplateFactory);
     $this->assertEquals($expectedParameters, $message->getTemplateParameters($leaveRequest->contact_id));
   }
 
   public function testGetTemplateParametersForManager() {
+    $leaveRequestId = 1;
     $templateParameters = [
       'status' => 'Mock Status',
       'date' => 'Test Date'
     ];
-    $expectedUrl = ['leaveRequestLink' => CRM_Utils_System::url('manager-leave', [], true)];
+    $expectedUrl = ['leaveRequestLink' => CRM_Utils_System::url(
+      'manager-leave#/manager-leave/requests?leave-request-id=' . $leaveRequestId, [], true)];
     $expectedParameters = array_merge($templateParameters, $expectedUrl);
     $leaveTemplate = $this->createLeaveTemplateMock($templateParameters);
     $notificationTemplateFactory = $this->createRequestNotificationTemplateFactoryMock($leaveTemplate);
 
     $leaveRequest = new LeaveRequest();
+    $leaveRequest->id = $leaveRequestId;
     $leaveRequest->contact_id = 1;
     $managerID = 2;
     $message = new Message($leaveRequest, $notificationTemplateFactory);


### PR DESCRIPTION
## Overview

This PR utilises https://github.com/civicrm/civihr/pull/2051 and makes links in leave requests email notifications lead directly to Leave Request Modal with a correct leave request opened.

## After

![1](https://user-images.githubusercontent.com/3973243/29870745-f7fa7cd0-8d80-11e7-9b8f-c714b612ea7a.gif)

## Technical Details

Links are now populated with a proper GET query containing leave request ID.

```php
$queryString = '?leave-request-id=' . $this->leaveRequest->id;
$leaveUrl = CRM_Utils_System::url('my-leave#/my-leave/report' .
  $queryString, [], true);
```

## Comments

This PR also fixes the issue with showing balance. The problem was happening because `LeaveRequest.find()` method utilised `get` API3 method which lacked **balance_change** and **dates** properties to be returned. Now `getFull` method is used for the `.find()` method, which is also already used in `.all()` method.

---

- [x] Tests Pass
