### PR TITLE
PCHR-2558: Add change_balance parameter to LeaveRequest.create API.

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -1097,15 +1097,25 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    *   Returns null for when a leave request is newly
    *   created.
    */
-  private static function datesChanged($params) {
+  public static function datesChanged($params) {
     if(!empty($params['id'])) {
       $leaveRequest = self::findById($params['id']);
       $fromDate = new DateTime($params['from_date']);
+      $fromDateType = $params['from_date_type'];
       $toDate = new DateTime($params['to_date']);
+      $toDateType = $params['to_date_type'];
       $leaveRequestFromDate = new DateTime($leaveRequest->from_date);
+      $leaveRequestFromDateType = $leaveRequest->from_date_type;
       $leaveRequestToDate = new DateTime($leaveRequest->to_date);
+      $leaveRequestToDateType = $leaveRequest->to_date_type;
 
-      return $leaveRequestFromDate != $fromDate || $leaveRequestToDate != $toDate;
+      $isNotSameFromDate = $leaveRequestFromDate != $fromDate;
+      $isNotSameFromDateType = $leaveRequestFromDateType != $fromDateType;
+      $isNotSameToDate = $leaveRequestToDate != $toDate;
+      $isNotSameToDateType = $leaveRequestToDateType != $toDateType;
+
+      return ($isNotSameFromDate || $isNotSameFromDateType) ||
+        ($isNotSameToDate || $isNotSameToDateType);
     }
 
     return null;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -767,7 +767,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
       return;
     }
 
-    $this->deleteDates();
+    $this->deleteDatesAndBalanceChanges();
 
     $datePeriod = new BasicDatePeriod($this->from_date, $this->to_date);
 
@@ -780,9 +780,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
   }
 
   /**
-   * Deletes all the dates related to this LeaveRequest
+   * Deletes all the dates and balance changes related to this LeaveRequest
    */
-  private function deleteDates() {
+  private function deleteDatesAndBalanceChanges() {
+    LeaveBalanceChange::deleteAllForLeaveRequest($this);
     LeaveRequestDate::deleteDatesForLeaveRequest($this->id);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChange.php
@@ -2,15 +2,18 @@
 
 use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
-use CRM_HRLeaveAndAbsences_BAO_TOILRequest as TOILRequest;
 
 class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange {
 
   /**
    * Creates LeaveBalanceChange instances for each of the dates of the given
-   * LeaveRequest
+   * LeaveRequest.
+   *
+   * @param CRM_HRLeaveAndAbsences_BAO_LeaveRequest $leaveRequest
    */
   public function createForLeaveRequest(LeaveRequest $leaveRequest) {
+    LeaveBalanceChange::deleteAllForLeaveRequest($leaveRequest);
+
     if($leaveRequest->request_type == LeaveRequest::REQUEST_TYPE_TOIL) {
       $this->createForTOILRequest($leaveRequest);
       return;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -264,10 +264,21 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    * @return \CRM_HRLeaveAndAbsences_BAO_LeaveRequest|NULL
    */
   protected function createRequestWithBalanceChanges($params) {
+    $skipBalanceChangeUpdate = false;
+    $updateBalanceChange = !empty($params['change_balance']);
     $leaveRequest = LeaveRequest::create($params, false);
-    $this->leaveBalanceChangeService->createForLeaveRequest($leaveRequest);
 
+    if(!empty($params['id'])) {
+      if(!$this->datesChanged($params) && !$updateBalanceChange) {
+        $skipBalanceChangeUpdate = true;
+      }
+    }
+
+    if(!$skipBalanceChangeUpdate) {
+      $this->leaveBalanceChangeService->createForLeaveRequest($leaveRequest);
+    }
     $this->recalculateExpiredBalanceChange($leaveRequest);
+
     return $leaveRequest;
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveBalanceChange.php
@@ -24,6 +24,7 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange {
   }
 
   private static function fabricateForTOILRequest(LeaveRequest $leaveRequest) {
+    LeaveBalanceChange::deleteAllForLeaveRequest($leaveRequest);
     $dates = $leaveRequest->getDates();
     $firstDate = array_shift($dates);
 
@@ -47,6 +48,7 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange {
   }
 
   private static function fabricateForLeaveRequestDates(LeaveRequest $leaveRequest) {
+    LeaveBalanceChange::deleteAllForLeaveRequest($leaveRequest);
     $dates = $leaveRequest->getDates();
     foreach($dates as $date) {
       self::fabricateForLeaveRequestDate($date);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -1,15 +1,18 @@
 <?php
 
 /**
- * LeaveRequest.create API specification (optional)
- * This is used for documentation and validation.
+ * LeaveRequest.create API specification
  *
- * @param array $spec description of fields supported by this API call
- * @return void
- * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ * @param array $spec
  */
 function _civicrm_api3_leave_request_create_spec(&$spec) {
-  // $spec['some_parameter']['api.required'] = 1;
+  $spec['change_balance'] = [
+    'name' => 'change_balance',
+    'title' => 'Update Balance Change?',
+    'description' => 'Update Leave Request Balance Change?',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+    'api.required' => 0,
+  ];
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -2873,4 +2873,36 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $params['to_date'] = CRM_Utils_Date::processDate('2016-01-08');
     LeaveRequestFabricator::fabricate($params, true);
   }
+
+  public function testLeaveDatesAreNotDeletedAndRecreatedWhenUpdatingALeaveRequestAndLeaveDatesDidNotChange() {
+    $fromDate = CRM_Utils_Date::processDate('2016-01-08');
+    $toDate = CRM_Utils_Date::processDate('2016-01-10');
+    $params = [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate,
+      'from_date_type' => 1,
+      'to_date' => $toDate,
+      'to_date_type' => 1,
+    ];
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    $dates = $leaveRequest->getDates();
+    $beforeDatesID = [];
+    foreach($dates as $date) {
+      $beforeDatesID[] = $date->id;
+    }
+
+    //update leave request without changing the dates
+    $params['id'] = $leaveRequest->id;
+    $dates = $leaveRequest->getDates();
+    $afterDatesID = [];
+    foreach($dates as $date) {
+      $afterDatesID[] = $date->id;
+    }
+
+    //the leave dates were not deleted because the ID's are still the same.
+    $this->assertEquals($beforeDatesID, $afterDatesID);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -2906,4 +2906,184 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     //the leave dates were not deleted because the ID's are still the same.
     $this->assertEquals($beforeDatesID, $afterDatesID);
   }
+
+  public function testDatesChangedReturnsTrueWhenOnlyFromDateTypeChanges(){
+    $fromDate = CRM_Utils_Date::processDate('2016-01-08');
+    $toDate = CRM_Utils_Date::processDate('2016-01-10');
+    $params = [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate,
+      'from_date_type' => 1,
+      'to_date' => $toDate,
+      'to_date_type' => 1,
+    ];
+
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    //update leave request
+    $params['id'] = $leaveRequest->id;
+    $params['from_date_type'] = 2;
+
+    $this->assertTrue(LeaveRequest::datesChanged($params));
+  }
+
+  public function testDatesChangedReturnsTrueWhenOnlyToDateTypeChanges(){
+    $fromDate = CRM_Utils_Date::processDate('2016-01-08');
+    $toDate = CRM_Utils_Date::processDate('2016-01-10');
+    $params = [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate,
+      'from_date_type' => 1,
+      'to_date' => $toDate,
+      'to_date_type' => 1,
+    ];
+
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    //update leave request
+    $params['id'] = $leaveRequest->id;
+    $params['to_date_type'] = 2;
+
+    $this->assertTrue(LeaveRequest::datesChanged($params));
+  }
+
+  public function testDatesChangedReturnsTrueWhenOnlyToDateChanges(){
+    $fromDate = CRM_Utils_Date::processDate('2016-01-08');
+    $toDate = CRM_Utils_Date::processDate('2016-01-10');
+    $params = [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate,
+      'from_date_type' => 1,
+      'to_date' => $toDate,
+      'to_date_type' => 1,
+    ];
+
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    //update leave request
+    $params['id'] = $leaveRequest->id;
+    $params['to_date'] = CRM_Utils_Date::processDate('2016-01-18');
+
+    $this->assertTrue(LeaveRequest::datesChanged($params));
+  }
+
+  public function testDatesChangedReturnsTrueWhenOnlyFromDateChanges(){
+    $fromDate = CRM_Utils_Date::processDate('2016-01-08');
+    $toDate = CRM_Utils_Date::processDate('2016-01-10');
+    $params = [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate,
+      'from_date_type' => 1,
+      'to_date' => $toDate,
+      'to_date_type' => 1,
+    ];
+
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    //update leave request
+    $params['id'] = $leaveRequest->id;
+    $params['from_date'] = CRM_Utils_Date::processDate('2016-01-09');
+
+    $this->assertTrue(LeaveRequest::datesChanged($params));
+  }
+
+  public function testDatesChangedReturnsTrueWhenAllTheDateParameterChanges(){
+    $fromDate = CRM_Utils_Date::processDate('2016-01-08');
+    $toDate = CRM_Utils_Date::processDate('2016-01-10');
+    $params = [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate,
+      'from_date_type' => 1,
+      'to_date' => $toDate,
+      'to_date_type' => 1,
+    ];
+
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    //update leave request
+    $params['id'] = $leaveRequest->id;
+    $params['from_date'] = CRM_Utils_Date::processDate('2016-01-09');
+    $params['to_date'] = CRM_Utils_Date::processDate('2016-01-15');
+    $params['to_date_type'] = 2;
+    $params['from_date_type'] = 2;
+
+    $this->assertTrue(LeaveRequest::datesChanged($params));
+  }
+
+  public function testDatesChangedReturnsTrueWhenOnlyToDateAndToDateTypeChanges(){
+    $fromDate = CRM_Utils_Date::processDate('2016-01-08');
+    $toDate = CRM_Utils_Date::processDate('2016-01-10');
+    $params = [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate,
+      'from_date_type' => 1,
+      'to_date' => $toDate,
+      'to_date_type' => 1,
+    ];
+
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    //update leave request
+    $params['id'] = $leaveRequest->id;
+    $params['to_date'] = CRM_Utils_Date::processDate('2016-01-15');
+    $params['to_date_type'] = 2;
+
+    $this->assertTrue(LeaveRequest::datesChanged($params));
+  }
+
+  public function testDatesChangedReturnsTrueWhenOnlyFromDateAndFromDateTypeChanges(){
+    $fromDate = CRM_Utils_Date::processDate('2016-01-08');
+    $toDate = CRM_Utils_Date::processDate('2016-01-10');
+    $params = [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate,
+      'from_date_type' => 1,
+      'to_date' => $toDate,
+      'to_date_type' => 1,
+    ];
+
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    //update leave request
+    $params['id'] = $leaveRequest->id;
+    $params['from_date'] = CRM_Utils_Date::processDate('2016-01-15');
+    $params['from_date_type'] = 2;
+
+    $this->assertTrue(LeaveRequest::datesChanged($params));
+  }
+
+  public function testDatesChangedReturnsFalseWhenAllTheDateParameterDoesNotChange(){
+    $fromDate = CRM_Utils_Date::processDate('2016-01-08');
+    $toDate = CRM_Utils_Date::processDate('2016-01-10');
+    $params = [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'status_id' => 1,
+      'from_date' => $fromDate,
+      'from_date_type' => 1,
+      'to_date' => $toDate,
+      'to_date_type' => 1,
+    ];
+
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    //update leave request without changing any date parameter
+    $params['id'] = $leaveRequest->id;
+
+    $this->assertFalse(LeaveRequest::datesChanged($params));
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -2896,6 +2896,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     //update leave request without changing the dates
     $params['id'] = $leaveRequest->id;
+    LeaveRequestFabricator::fabricateWithoutValidation($params);
     $dates = $leaveRequest->getDates();
     $afterDatesID = [];
     foreach($dates as $date) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -8,6 +8,9 @@ use CRM_HRLeaveAndAbsences_Service_LeaveRequest as LeaveRequestService;
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern as WorkPatternFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod as AbsencePeriodFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_ContactWorkPattern as ContactWorkPatternFabricator;
+
 
 /**
  * Class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest
@@ -363,5 +366,127 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
     ];
     return array_merge($defaultParams, $params);
+  }
+
+  public function testBalanceChangeIsUpdatedForAlreadyCreatedLeaveRequestWhenBalanceHasChangedAndChangeBalanceParameterIsTrueAndLeaveRequestDatesDidNotChange() {
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $this->leaveContact],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => true]);
+
+    //Leave dates on Monday to Friday, all working days
+    $leaveDates = [
+      'from_date' => CRM_Utils_Date::processDate('2016-02-08'),
+      'to_date' => CRM_Utils_Date::processDate('2016-02-12')
+    ];
+
+    $params = $this->getDefaultParams($leaveDates);
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params, true);
+
+    //Just to make sure that we have the expected balance change for the leave request
+    $previousBalance = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
+    $this->assertEquals(-5, $previousBalance);
+
+    //Add a work pattern for the contact with effective date before the leave dates
+    $workPattern1 = WorkPatternFabricator::fabricateWithTwoWeeksAnd31AndHalfHours();
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $this->leaveContact,
+      'pattern_id' => $workPattern1->id,
+      'effective_date' => CRM_Utils_Date::processDate('2016-02-01')
+    ]);
+
+    //If the leave request is to be updated with new balance change, the balance would have changed.
+    $result = LeaveRequest::calculateBalanceChange($this->leaveContact,
+      new DateTime($params['from_date']),
+      $params['from_date_type'],
+      new DateTime($params['to_date']),
+      $params['to_date_type']
+    );
+
+    $newBalance = $result['amount'];
+
+    //The balance for leave request has changed since the contact work pattern has
+    //been changed for the date range that the leave was initially requested.
+    $this->assertNotEquals($previousBalance, $newBalance);
+
+    //update leave request and request a change in balance to the new balance
+    $params['id'] = $leaveRequest->id;
+    $params['change_balance'] = 1;
+
+    $leaveRequest = $this->getleaveRequestService()->create(
+      $params,
+      false
+    );
+
+    $balance = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
+    $this->assertEquals($newBalance, $balance);
+  }
+
+  public function testBalanceChangeIsNotUpdatedForAlreadyCreatedLeaveRequestWhenChangeBalanceParameterIsFalseAndLeaveRequestDatesDidNotChange() {
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $this->leaveContact],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => true]);
+
+    //Leave dates on Monday to Friday, all working days
+    $leaveDates = [
+      'from_date' => CRM_Utils_Date::processDate('2016-02-08'),
+      'to_date' => CRM_Utils_Date::processDate('2016-02-12')
+    ];
+
+    $params = $this->getDefaultParams($leaveDates);
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params, true);
+
+    //Just to make sure that we have the expected balance change for the leave request
+    $previousBalance = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
+    $this->assertEquals(-5, $previousBalance);
+
+    //Add a work pattern for the contact with effective date before the leave dates
+    $workPattern1 = WorkPatternFabricator::fabricateWithTwoWeeksAnd31AndHalfHours();
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $this->leaveContact,
+      'pattern_id' => $workPattern1->id,
+      'effective_date' => CRM_Utils_Date::processDate('2016-02-01')
+    ]);
+
+    //If the leave request is to be updated with new balance change, the balance would have changed.
+    $result = LeaveRequest::calculateBalanceChange($this->leaveContact,
+      new DateTime($params['from_date']),
+      $params['from_date_type'],
+      new DateTime($params['to_date']),
+      $params['to_date_type']
+    );
+    $newBalance = $result['amount'];
+
+    //The balance for leave request has changed since the contact work pattern has
+    //been changed for the date range that the leave was initially requested.
+    $this->assertNotEquals($previousBalance, $newBalance);
+
+    //update leave request and request that the previous balance be retained
+    //even though the balance has changed
+    $params['id'] = $leaveRequest->id;
+    $params['change_balance'] = 0;
+
+    $leaveRequest = $this->getleaveRequestService()->create(
+      $params,
+      false
+    );
+
+    $balance = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
+    $this->assertEquals($previousBalance, $balance);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -368,7 +368,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     return array_merge($defaultParams, $params);
   }
 
-  public function testBalanceChangeIsUpdatedForAlreadyCreatedLeaveRequestWhenBalanceHasChangedAndChangeBalanceParameterIsTrueAndLeaveRequestDatesDidNotChange() {
+  public function testBalanceChangeIsUpdatedForAnExistingLeaveRequestWhenChangeBalanceParameterIsTrueAndDatesDidNotChange() {
     HRJobContractFabricator::fabricate(
       ['contact_id' => $this->leaveContact],
       ['period_start_date' => '2016-01-01']
@@ -429,7 +429,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals($newBalance, $balance);
   }
 
-  public function testBalanceChangeIsNotUpdatedForAlreadyCreatedLeaveRequestWhenChangeBalanceParameterIsFalseAndLeaveRequestDatesDidNotChange() {
+  public function testBalanceChangeIsNotUpdatedForAnExistingLeaveRequestWhenChangeBalanceParameterIsFalseAndDatesDidNotChange() {
     HRJobContractFabricator::fabricate(
       ['contact_id' => $this->leaveContact],
       ['period_start_date' => '2016-01-01']
@@ -488,5 +488,150 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
 
     $balance = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
     $this->assertEquals($previousBalance, $balance);
+  }
+
+  public function testBalanceChangeIsUpdatedForAnExistingLeaveRequestWhenChangeBalanceParameterIsTrueAndDatesChanged() {
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $this->leaveContact],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => true]);
+
+    //Leave dates on Monday to Friday, all working days
+    $leaveDates = [
+      'from_date' => CRM_Utils_Date::processDate('2016-02-08'),
+      'to_date' => CRM_Utils_Date::processDate('2016-02-12')
+    ];
+
+    $params = $this->getDefaultParams($leaveDates);
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params, true);
+
+    //Just to make sure that we have the expected balance change for the leave request
+    $previousBalance = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
+    $this->assertEquals(-5, $previousBalance);
+
+    //Add a work pattern for the contact with effective date before the leave dates
+    $workPattern1 = WorkPatternFabricator::fabricateWithTwoWeeksAnd31AndHalfHours();
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $this->leaveContact,
+      'pattern_id' => $workPattern1->id,
+      'effective_date' => CRM_Utils_Date::processDate('2016-02-01')
+    ]);
+
+    //If the leave request is to be updated with new balance change, the balance would have changed.
+    $result = LeaveRequest::calculateBalanceChange($this->leaveContact,
+      new DateTime($params['from_date']),
+      $params['from_date_type'],
+      new DateTime($params['to_date']),
+      $params['to_date_type']
+    );
+
+    $newBalance = $result['amount'];
+
+    //The balance for leave request has changed since the contact work pattern has
+    //been changed for the date range that the leave was initially requested.
+    $this->assertNotEquals($previousBalance, $newBalance);
+
+    //update leave request date and request a change in balance to the new balance
+    $params['id'] = $leaveRequest->id;
+    $params['change_balance'] = 1;
+    $params['to_date'] = CRM_Utils_Date::processDate('2016-02-15');
+
+    //The expected balance change after changing the dates.
+    $result = LeaveRequest::calculateBalanceChange($this->leaveContact,
+      new DateTime($params['from_date']),
+      $params['from_date_type'],
+      new DateTime($params['to_date']),
+      $params['to_date_type']
+    );
+    $balanceAfterDateChange = $result['amount'];
+
+    $leaveRequest = $this->getLeaveRequestServiceWhenCurrentUserIsAdmin()->create(
+      $params,
+      false
+    );
+
+    //The leave request balance has been updated to pick from the current work pattern
+    $balance = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
+    $this->assertEquals($balanceAfterDateChange, $balance);
+  }
+
+  public function testBalanceChangeIsUpdatedForAnExistingLeaveRequestWhenChangeBalanceParameterIsFalseAndDatesChanged() {
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $this->leaveContact],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => true]);
+
+    //Leave dates on Monday to Friday, all working days
+    $leaveDates = [
+      'from_date' => CRM_Utils_Date::processDate('2016-02-08'),
+      'to_date' => CRM_Utils_Date::processDate('2016-02-12')
+    ];
+
+    $params = $this->getDefaultParams($leaveDates);
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params, true);
+
+    //Just to make sure that we have the expected balance change for the leave request
+    $previousBalance = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
+    $this->assertEquals(-5, $previousBalance);
+
+    //Add a work pattern for the contact with effective date before the leave dates
+    $workPattern1 = WorkPatternFabricator::fabricateWithTwoWeeksAnd31AndHalfHours();
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $this->leaveContact,
+      'pattern_id' => $workPattern1->id,
+      'effective_date' => CRM_Utils_Date::processDate('2016-02-01')
+    ]);
+
+    //If the leave request is to be updated with new balance change, the balance would have changed.
+    $result = LeaveRequest::calculateBalanceChange($this->leaveContact,
+      new DateTime($params['from_date']),
+      $params['from_date_type'],
+      new DateTime($params['to_date']),
+      $params['to_date_type']
+    );
+
+    $newBalance = $result['amount'];
+
+    //The balance for leave request has changed since the contact work pattern has
+    //been changed for the date range that the leave was initially requested.
+    $this->assertNotEquals($previousBalance, $newBalance);
+
+    //update leave request date and request the old balance to be retained
+    $params['id'] = $leaveRequest->id;
+    $params['change_balance'] = 0;
+    $params['to_date'] = CRM_Utils_Date::processDate('2016-02-15');
+
+    //The expected balance change after changing the dates.
+    $result = LeaveRequest::calculateBalanceChange($this->leaveContact,
+      new DateTime($params['from_date']),
+      $params['from_date_type'],
+      new DateTime($params['to_date']),
+      $params['to_date_type']
+    );
+    $balanceAfterDateChange = $result['amount'];
+
+    $leaveRequest = $this->getLeaveRequestServiceWhenCurrentUserIsAdmin()->create(
+      $params,
+      false
+    );
+
+    //The leave request balance has been updated to pick from the current work pattern
+    //even though the old balance was asked to be retained.
+    $balance = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
+    $this->assertEquals($balanceAfterDateChange, $balance);
   }
 }


### PR DESCRIPTION
## Overview
When a user edits an already created leave and changes any other thing apart from the date, the user can decide to either use the balance change as of when the leave request was created or recalculate if the balance change is now different. This PR implements the Backend changes needed to achieve this.

## Before
There is no way for the `LeaveRequest.create` API to know whether the leave balance for an already created request should be retained or recalculated. 

## After
The `LeaveRequest.create` API was modified to accept a new parameter called `change_balance`. This parameter when present and true will allow the leave request balance changes to be updated using the current work pattern for the contact. If not present or if present and false means that the leave request balance will remain untouched.


---

- [X] Tests Pass
