### PR TITLE
PCHR-2495: Add the LeavePeriodEntitlement.getLeaveBalances API

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveBalancesSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveBalancesSelect.php
@@ -1,0 +1,91 @@
+<?php
+
+use CRM_Contact_BAO_Contact as Contact;
+use CRM_Contact_BAO_Relationship as Relationship;
+use CRM_Contact_BAO_RelationshipType as RelationshipType;
+use CRM_Hrjobcontract_BAO_HRJobContract as HRJobContract;
+use CRM_Hrjobcontract_BAO_HRJobDetails as HRJobDetails;
+use CRM_Hrjobcontract_BAO_HRJobContractRevision as HRJobContractRevision;
+use CRM_HRLeaveAndAbsences_API_Query_Select as SelectQuery;
+
+class CRM_HRLeaveAndAbsences_API_Query_LeaveBalancesSelect {
+
+  use CRM_HRLeaveAndAbsences_Service_SettingsManagerTrait;
+
+  public function __construct($params) {
+    $this->params = $params;
+    $this->buildCustomQuery();
+  }
+
+  private function buildCustomQuery() {
+    $customQuery = CRM_Utils_SQL_Select::from(Contact::getTableName() . ' as a');
+
+    $this->addJoins($customQuery);
+    $this->addWhere($customQuery);
+
+    $this->query = new SelectQuery('Contact', $this->params);
+    $this->query->merge($customQuery);
+  }
+
+  private function addJoins(CRM_Utils_SQL_Select $query) {
+    $joins = [
+      'INNER JOIN ' . HRJobContract::getTableName() . ' jc ON a.id = jc.contact_id',
+      'INNER JOIN ' . HRJobContractRevision::getTableName() . ' jcr ON jcr.id = (SELECT id
+                    FROM ' . HRJobContractRevision::getTableName() . ' jcr2
+                    WHERE
+                    jcr2.jobcontract_id = jc.id
+                    ORDER BY jcr2.effective_date DESC
+                    LIMIT 1)',
+      'INNER JOIN ' . HRJobDetails::getTableName() . ' jd ON jd.jobcontract_revision_id = jcr.details_revision_id'
+    ];
+
+    if(!empty($this->params['managed_by'])) {
+      $joins[] = 'LEFT JOIN ' . Relationship::getTableName() . ' r ON r.contact_id_a = a.id';
+      $joins[] = 'LEFT JOIN ' . RelationshipType::getTableName() . ' rt ON rt.id = r.relationship_type_id';
+    }
+
+    $query->join(null, $joins);
+  }
+
+  private function addWhere($customQuery) {
+    $conditions = [
+      'a.is_deleted = 0',
+      'jc.deleted = 0',
+    ];
+
+    if(!empty($this->params['managed_by'])) {
+      $managerID = (int)$this->params['managed_by'];
+
+      if(!isset($this->params['unassigned'])) {
+        $activeLeaveManagerCondition = $this->hasActiveLeaveManagerCondition();
+        $activeLeaveManagerCondition[] = "r.contact_id_b = {$managerID}";
+        $conditions = array_merge($conditions, $activeLeaveManagerCondition);
+      }
+    }
+
+
+    $customQuery->where($conditions);
+  }
+
+  public function run() {
+    $results = $this->query->run();
+
+    return $results;
+  }
+
+
+  private function hasActiveLeaveManagerCondition() {
+    $today =  '"' . date('Y-m-d') . '"';
+    $leaveApproverRelationshipTypes = $this->getLeaveApproverRelationshipsTypesForWhereIn();
+
+    $conditions = [];
+    $conditions[] = 'rt.is_active = 1';
+    $conditions[] = 'rt.id IN(' . implode(',', $leaveApproverRelationshipTypes) . ')';
+    $conditions[] = 'r.is_active = 1';
+    $conditions[] = "(r.start_date IS NULL OR r.start_date <= {$today})";
+    $conditions[] = "(r.end_date IS NULL OR r.end_date >= {$today})";
+
+    return $conditions;
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveBalancesSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveBalancesSelect.php
@@ -111,13 +111,7 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveBalancesSelect {
       "(
         (jd.period_end_date IS NOT NULL AND jd.period_start_date <= '{$absencePeriod->end_date}' AND jd.period_end_date >= '{$absencePeriod->start_date}')
           OR
-        (jd.period_end_date IS NULL AND 
-          (
-            (jd.period_start_date >= '{$absencePeriod->start_date}' AND jd.period_start_date <= '{$absencePeriod->end_date}')
-            OR
-            jd.period_start_date <= '{$absencePeriod->end_date}'
-          )
-        )
+        (jd.period_end_date IS NULL AND jd.period_start_date <= '{$absencePeriod->end_date}')
       )"
     ];
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveBalancesSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveBalancesSelect.php
@@ -7,9 +7,19 @@ use CRM_Hrjobcontract_BAO_HRJobContract as HRJobContract;
 use CRM_Hrjobcontract_BAO_HRJobDetails as HRJobDetails;
 use CRM_Hrjobcontract_BAO_HRJobContractRevision as HRJobContractRevision;
 use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
+use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
+use CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement as LeavePeriodEntitlement;
 use CRM_HRLeaveAndAbsences_API_Query_Select as SelectQuery;
 use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
 
+/**
+ * This is the Query class behind the LeavePeriodEntitlement.getLeaveBalances
+ * API.
+ *
+ * It encapsulates a SelectQuery object that does queries on the contact table.
+ * After the results are fetched, it queries the Leave Balances for all the
+ * returned Contacts and format everything in the format expected by the API.
+ */
 class CRM_HRLeaveAndAbsences_API_Query_LeaveBalancesSelect {
 
   use CRM_HRLeaveAndAbsences_Service_SettingsManagerTrait;
@@ -24,22 +34,37 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveBalancesSelect {
    */
   private $leaveManagerService;
 
+  /**
+   * CRM_HRLeaveAndAbsences_API_Query_LeaveBalancesSelect constructor.
+   *
+   * @param array $params
+   * @param CRM_HRLeaveAndAbsences_Service_LeaveManager $leaveManagerService
+   */
   public function __construct($params, LeaveManagerService $leaveManagerService) {
     $this->params = $params;
     $this->leaveManagerService = $leaveManagerService;
     $this->buildCustomQuery();
   }
 
+  /**
+   * Builds the custom query (add joins, where clauses, set params etc)
+   */
   private function buildCustomQuery() {
     $customQuery = CRM_Utils_SQL_Select::from(Contact::getTableName() . ' as a');
 
     $this->addJoins($customQuery);
     $this->addWhere($customQuery);
+    $this->setReturnFields();
 
     $this->query = new SelectQuery('Contact', $this->params);
     $this->query->merge($customQuery);
   }
 
+  /**
+   * Adds all the JOINs necessary for this query.
+   *
+   * @param CRM_Utils_SQL_Select $query
+   */
   private function addJoins(CRM_Utils_SQL_Select $query) {
     $absencePeriod = $this->getAbsencePeriod();
 
@@ -69,7 +94,15 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveBalancesSelect {
     $query->join(null, $joins);
   }
 
-  private function addWhere($customQuery) {
+  /**
+   * Add all the where clauses of the query.
+   *
+   * This method works in combination with addJoins() (that is, it references
+   * tables added by the join clauses).
+   *
+   * @param CRM_Utils_SQL_Select $customQuery
+   */
+  private function addWhere(CRM_Utils_SQL_Select $customQuery) {
     $absencePeriod = $this->getAbsencePeriod();
 
     $conditions = [
@@ -98,13 +131,105 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveBalancesSelect {
     $customQuery->where($conditions);
   }
 
+  /**
+   * Runs the query.
+   *
+   * The query works in 2 steps:
+   * 1. Get all the Contacts matching the criteria passed to the API
+   * 2. For each contacts, get their Leave Balances and add it to the returned
+   * result
+   *
+   * This method also has a shortcut for is_count queries. When the client only
+   * wants the number of records, the second step isn't necessary and won't be
+   * executed.
+   *
+   * @return array
+   */
   public function run() {
     $results = $this->query->run();
 
-    return $results;
+    if($this->isCount()) {
+      return $results;
+    }
+
+    $leaveBalances = $this->getLeaveBalances($results);
+
+    return $leaveBalances;
   }
 
+  /**
+   * Whether this is a count query or not
+   *
+   * @return bool
+   */
+  private function isCount() {
+    return !empty($this->params['options']['is_count']);
+  }
 
+  /**
+   * Gets the Leave Balances for the contacts in the given array.
+   *
+   * @param array $contacts
+   *
+   * @return array
+   */
+  private function getLeaveBalances($contacts) {
+    $contactIDs = array_column($contacts, 'id');
+
+    $absenceTypeID = isset($this->params['type_id']) ? $this->params['type_id'] : null;
+    $absencePeriodID = $this->params['period_id'];
+
+    $entitlements = LeavePeriodEntitlement::getEntitlementsForContacts(
+      $contactIDs,
+      $absencePeriodID,
+      $absenceTypeID
+    );
+    $balances = LeaveBalanceChange::getBalanceForContacts(
+      $contactIDs,
+      $absencePeriodID,
+      $absenceTypeID
+    );
+    $requestedBalances = LeaveBalanceChange::getOpenLeaveRequestBalanceForContacts(
+      $contactIDs,
+      $absencePeriodID,
+      $absenceTypeID
+    );
+
+    $newResults = [];
+    $payload = [];
+    foreach ($entitlements as $contactID => $contactEntitlements) {
+      foreach ($contactEntitlements as $absenceTypeID => $entitlement) {
+        $balance = isset($balances[$contactID][$absenceTypeID]) ? $balances[$contactID][$absenceTypeID] : 0;
+        $requested = isset($requestedBalances[$contactID][$absenceTypeID]) ? $requestedBalances[$contactID][$absenceTypeID] : 0;
+        $used = $entitlement - $balance;
+
+        $payload[$contactID][] = [
+          'id' => $absenceTypeID,
+          'entitlement' => $entitlement,
+          'used' => $used,
+          'balance' => abs($balance),
+          'requested' => abs($requested)
+        ];
+      }
+    }
+
+    foreach ($contacts as $i => $result) {
+      $newResults[$i] = [
+        'contact_id' => $result['id'],
+        'contact_display_name' => $result['display_name'],
+        'absence_types' => $payload[$result['id']]
+      ];
+    }
+
+    return $newResults;
+  }
+
+  /**
+   * Returns the where clauses that will be added to the query to make sure that
+   * managers can only see their managees.
+   *
+   * @return array
+   */
   private function hasActiveLeaveManagerCondition() {
     $today =  '"' . date('Y-m-d') . '"';
     $leaveApproverRelationshipTypes = $this->getLeaveApproverRelationshipsTypesForWhereIn();
@@ -119,6 +244,12 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveBalancesSelect {
     return $conditions;
   }
 
+  /**
+   * Returns an instance of the AbsencePeriod BAO, representing the period with
+   * the id passed via the period_id param.
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_AbsencePeriod|object
+   */
   private function getAbsencePeriod() {
     if(!$this->absencePeriod) {
       $this->absencePeriod = AbsencePeriod::findById($this->params['period_id']);
@@ -127,6 +258,17 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveBalancesSelect {
     return $this->absencePeriod;
   }
 
+  /**
+   * Returns the Manager ID that will be used by the query.
+   *
+   * If the current user is an admin, they can see all the contacts. In that
+   * case the ID will be null by default or the value passed to the managed_by
+   * param. Other users can only see their managees, so the ID will always be
+   * the ID of the current logged in user, regardless of the value passed to the
+   * managed_by param.
+   *
+   * @return int|mixed|null
+   */
   private function getManagerID() {
     $managerID = null;
 
@@ -137,6 +279,13 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveBalancesSelect {
     }
 
     return $managerID;
+  }
+
+  /**
+   * Sets the fields that should be returned by the main Contact query.
+   */
+  private function setReturnFields() {
+    $this->params['return'] = ['id', 'display_name'];
   }
 
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveBalancesSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveBalancesSelect.php
@@ -61,8 +61,10 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveBalancesSelect {
       'INNER JOIN ' . HRJobDetails::getTableName() . ' jd ON jd.jobcontract_revision_id = jcr.details_revision_id'
     ];
 
-    $joins[] = 'LEFT JOIN ' . Relationship::getTableName() . ' r ON r.contact_id_a = a.id';
-    $joins[] = 'LEFT JOIN ' . RelationshipType::getTableName() . ' rt ON rt.id = r.relationship_type_id';
+    if($this->getManagerID()) {
+      $joins[] = 'LEFT JOIN ' . Relationship::getTableName() . ' r ON r.contact_id_a = a.id';
+      $joins[] = 'LEFT JOIN ' . RelationshipType::getTableName() . ' rt ON rt.id = r.relationship_type_id';
+    }
 
     $query->join(null, $joins);
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveBalancesSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveBalancesSelect.php
@@ -152,9 +152,7 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveBalancesSelect {
       return $results;
     }
 
-    $leaveBalances = $this->getLeaveBalances($results);
-
-    return $leaveBalances;
+    return $this->getLeaveBalances($results);
   }
 
   /**
@@ -175,6 +173,10 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveBalancesSelect {
    */
   private function getLeaveBalances($contacts) {
     $contactIDs = array_column($contacts, 'id');
+
+    if (empty($contactIDs)) {
+      return [];
+    }
 
     $absenceTypeID = isset($this->params['type_id']) ? $this->params['type_id'] : null;
     $absencePeriodID = $this->params['period_id'];

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -1064,22 +1064,28 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
 
   /**
    * Returns a the current balance (i.e. not including balance changes caused by
-   * open leave requests) for the given Contacts and Absence Type during
-   * the given Absence Period.
+   * open leave requests) for the given Contacts during the given Absence Period.
+   * Optionally, it can return balances only for a specific Absence Type.
    *
    * @param array $contactIDs
    * @param int $absencePeriodID
-   * @param int $absenceTypeID
+   * @param int|null $absenceTypeID
    *
    * @return array
-   *  An array with the given format:
    *  [
-   *    $contactID1 => 'balance',
-   *    $contactID2 => 'balance',
-   *    ...
+   *     contact_id_1 => [
+   *        absence_type1_id => balance,
+   *        absence_type2_id => balance,
+   *        ...
+   *     ],
+   *     contact_id_2 => [
+   *      absence_type1_id => balance,
+   *      ...
+   *     ]
+   *     ...
    *  ]
    */
-  public static function getBalanceForContacts($contactIDs, $absencePeriodID, $absenceTypeID) {
+  public static function getBalanceForContacts($contactIDs, $absencePeriodID, $absenceTypeID = null) {
     $balances = [];
 
     $absencePeriod = AbsencePeriod::findById($absencePeriodID);
@@ -1100,9 +1106,18 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
     $contractDetailsTable = HRJobDetails::getTableName();
     $periodEntitlementTable = LeavePeriodEntitlement::getTableName();
 
+    $whereLeaveRequestAbsenceType = '';
+    $wherePeriodEntitlementAbsenceType = '';
+    if($absenceTypeID) {
+      $absenceTypeID = (int)$absenceTypeID;
+      $whereLeaveRequestAbsenceType = "leave_request.type_id = {$absenceTypeID} AND";
+      $wherePeriodEntitlementAbsenceType = "period_entitlement.type_id = {$absenceTypeID} AND";
+    }
+
     $query = "
         SELECT 
            COALESCE(leave_request.contact_id, period_entitlement.contact_id) as contact_id,
+           COALESCE(leave_request.type_id, period_entitlement.type_id) as type_id,
            SUM(leave_balance_change.amount) as balance
         FROM {$balanceChangeTable} leave_balance_change
           LEFT JOIN {$periodEntitlementTable} period_entitlement
@@ -1128,6 +1143,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
             ON contract_revision.details_revision_id = contract_details.jobcontract_revision_id
 
         WHERE ((
+          {$whereLeaveRequestAbsenceType}
           leave_request.status_id IN(" . implode(', ', $approvedStatuses) . ") AND 
           (leave_request_date.date >= %1 AND leave_request_date.date <= %2) AND
           contract.deleted = 0 AND
@@ -1139,28 +1155,26 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
             leave_request.to_date >= contract_details.period_start_date OR
             (leave_request.to_date IS NULL AND leave_request.from_date >= contract_details.period_start_date)
           ) AND
-          leave_request.type_id = %3 AND
           leave_request.contact_id IN(". implode(', ', $contactIDs) .")
         ) OR (
+            {$wherePeriodEntitlementAbsenceType}
             period_entitlement.contact_id IN(". implode(', ', $contactIDs) .") AND
-            period_entitlement.period_id = %4 AND
-            period_entitlement.type_id = %3
+            period_entitlement.period_id = %3
           )
         )
-        GROUP BY contact_id
+        GROUP BY contact_id, type_id
     ";
 
     $params = [
       1 => [$absencePeriod->start_date, 'String'],
       2 => [$absencePeriod->end_date, 'String'],
-      3 => [$absenceTypeID, 'Positive'],
-      4 => [$absencePeriodID, 'Positive']
+      3 => [$absencePeriodID, 'Positive']
     ];
 
     $result = CRM_Core_DAO::executeQuery($query, $params);
 
     while($result->fetch()) {
-      $balances[$result->contact_id] = $result->balance;
+      $balances[$result->contact_id][$result->type_id] = $result->balance;
     }
 
     return $balances;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -1063,7 +1063,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
   }
 
   /**
-   * Returns a the current balance (i.e. not including balance changes caused by
+   * Returns the current balance (i.e. not including balance changes caused by
    * open leave requests) for the given Contacts during the given Absence Period.
    * Optionally, it can return balances only for a specific Absence Type.
    *

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -662,7 +662,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
    * @return array
    */
   private static function getDatesOverlappingBalanceChangesToExpire($balanceChangesToExpire) {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $leaveRequestTable = LeaveRequest::getTableName();
     $leaveRequestDateTable = LeaveRequestDate::getTableName();
@@ -813,12 +813,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
    * @return float
    */
   public static function getTotalApprovedToilForPeriod(AbsencePeriod $period, $contactID, $typeID) {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
-
-    $leaveRequestStatusFilter = [
-      $leaveRequestStatuses['approved'],
-      $leaveRequestStatuses['admin_approved']
-    ];
+    $leaveRequestStatusFilter = LeaveRequest::getApprovedStatuses();
 
     $totalApprovedTOIL = self::getTotalTOILBalanceChangeForContact(
       $contactID,
@@ -1092,12 +1087,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
 
     array_walk($contactIDs, 'intval');
 
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
-    $approvedStatuses = [
-      $leaveRequestStatuses['approved'],
-      $leaveRequestStatuses['admin_approved']
-    ];
-
     $balanceChangeTable = self::getTableName();
     $leaveRequestDateTable = LeaveRequestDate::getTableName();
     $leaveRequestTable = LeaveRequest::getTableName();
@@ -1144,7 +1133,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
 
         WHERE ((
           {$whereLeaveRequestAbsenceType}
-          leave_request.status_id IN(" . implode(', ', $approvedStatuses) . ") AND 
+          leave_request.status_id IN(" . implode(', ', LeaveRequest::getApprovedStatuses()) . ") AND 
           (leave_request_date.date >= %1 AND leave_request_date.date <= %2) AND
           contract.deleted = 0 AND
           (
@@ -1219,12 +1208,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
     $contractRevisionTable = HRJobContractRevision::getTableName();
     $contractDetailsTable = HRJobDetails::getTableName();
 
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
-    $openStatuses = [
-      $leaveRequestStatuses['awaiting_approval'],
-      $leaveRequestStatuses['more_information_required']
-    ];
-
     $absencePeriod = AbsencePeriod::findById($absencePeriodID);
 
     $whereAbsenceType = '';
@@ -1267,7 +1250,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
         ) AND  
         leave_balance_change.expired_balance_change_id IS NULL AND {$whereAbsenceType}
         leave_request.contact_id IN(" . implode(', ', $contactIDs) . ") AND
-        leave_request.status_id IN(" . implode(', ', $openStatuses) . ")
+        leave_request.status_id IN(" . implode(', ', LeaveRequest::getOpenStatuses()) . ")
       GROUP BY leave_request.contact_id, leave_request.type_id
     ";
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
@@ -388,11 +388,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
    * @return float
    */
   public function getBalance() {
-    $leaveRequestStatus = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
-    $filterStatuses = [
-      $leaveRequestStatus['approved'],
-      $leaveRequestStatus['admin_approved'],
-    ];
+    $filterStatuses = LeaveRequest::getApprovedStatuses();
+
     return LeaveBalanceChange::getBalanceForEntitlement($this, $filterStatuses);
   }
 
@@ -406,13 +403,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
    * @return float
    */
   public function getFutureBalance() {
-    $leaveRequestStatus = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
-    $filterStatuses = [
-      $leaveRequestStatus['approved'],
-      $leaveRequestStatus['admin_approved'],
-      $leaveRequestStatus['awaiting_approval'],
-      $leaveRequestStatus['more_information_required'],
-    ];
+    $filterStatuses = array_merge(
+      LeaveRequest::getApprovedStatuses(),
+      LeaveRequest::getOpenStatuses()
+    );
     return LeaveBalanceChange::getBalanceForEntitlement($this, $filterStatuses);
   }
 
@@ -589,11 +583,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
    * @return float
    */
   public function getLeaveRequestBalance() {
-    $leaveRequestStatus = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
-    $filterStatuses = [
-      $leaveRequestStatus['approved'],
-      $leaveRequestStatus['admin_approved'],
-    ];
+    $filterStatuses = LeaveRequest::getApprovedStatuses();
 
     return LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($this, $filterStatuses);
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -500,7 +500,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
    */
   private static function validateNoOverlappingLeaveRequests($params) {
-    $leaveRequestStatuses = array_flip(self::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = self::getStatuses();
 
     $leaveRequestStatusFilter = [
       $leaveRequestStatuses['approved'],
@@ -596,7 +596,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
    */
   private static function validateAbsenceTypeAllowRequestCancellationForLeaveRequestCancellation($params, $absenceType) {
-    $leaveRequestStatuses = array_flip(self::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = self::getStatuses();
     $leaveRequestIsForCurrentUser = CRM_Core_Session::getLoggedInContactID() == $params['contact_id'];
     $isACancellationRequest = ($params['status_id'] == $leaveRequestStatuses['cancelled']);
 
@@ -740,6 +740,15 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
       $overlappingLeaveRequests[] = clone $leaveRequest;
     }
     return $overlappingLeaveRequests;
+  }
+
+  /**
+   * Returns a list of all possible statuses for a Leave Request
+   *
+   * @return array
+   */
+  public static function getStatuses() {
+    return array_flip(self::buildOptions('status_id', 'validate'));
   }
 
   /**
@@ -1018,14 +1027,36 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
   }
 
   /**
-   * Returns Statuses considered to be Approval statuses for a Leave Request
+   * Returns Statuses on which a Leave Request is considered to be Approved
    *
    * @return array
    */
-  private static function getApprovalStatuses() {
-    $leaveStatuses = array_flip(self::buildOptions('status_id', 'validate'));
+  public static function getApprovedStatuses() {
+    $leaveStatuses = self::getStatuses();
 
     return [$leaveStatuses['approved'], $leaveStatuses['admin_approved']];
+  }
+
+  /**
+   * Returns Statuses on which a Leave Request is considered to be Open
+   *
+   * @return array
+   */
+  public static function getOpenStatuses() {
+    $leaveStatuses = self::getStatuses();
+
+    return [$leaveStatuses['awaiting_approval'], $leaveStatuses['more_information_required']];
+  }
+
+  /**
+   * Returns Statuses on which a Leave Request is considered to be Cancelled
+   *
+   * @return array
+   */
+  public static function getCancelledStatuses() {
+    $leaveStatuses = self::getStatuses();
+
+    return [$leaveStatuses['cancelled'], $leaveStatuses['rejected']];
   }
 
   /**
@@ -1038,7 +1069,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
   private static function isAlreadyApproved(LeaveRequest $leaveRequest) {
     $oldStatus = $leaveRequest->status_id;
 
-    return in_array($oldStatus, self::getApprovalStatuses());
+    return in_array($oldStatus, self::getApprovedStatuses());
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeavePeriodEntitlement.php
@@ -241,6 +241,13 @@ function civicrm_api3_leave_period_entitlement_getentitlement($params) {
   return $results;
 }
 
+/**
+ * LeavePeriodEntitlement.getLeaveBalances specification
+ *
+ * @param array $spec
+ *
+ * @return void
+ */
 function _civicrm_api3_leave_period_entitlement_getleavebalances_spec(&$spec) {
   $spec['managed_by'] = [
     'name' => 'managed_by',
@@ -273,6 +280,54 @@ function _civicrm_api3_leave_period_entitlement_getleavebalances_spec(&$spec) {
   ];
 }
 
+/**
+ * LeavePeriodEntitlement.getLeaveBalances API
+ *
+ * This API accepts requires a period_id as a param and it will return a list of
+ * Leave Balances for this period to all the contacts with an active contract
+ * during that period.
+ *
+ * The return format is:
+ *
+ * [
+ *   'is_error' => 0,
+ *   'version' => 3,
+ *   'count' => 2,
+ *   'values' => [
+ *     [
+ *       'contact_id' => 1,
+ *       'contact_display_name' => 'Joe',
+ *       'absence_types': [
+ *          [
+ *            'id' => 1,
+ *            'entitlement' => 4,
+ *            'balance' => 2,
+ *            'used' => 2,
+ *            'requested' => 1
+ *          ],
+ *          [
+ *            'id' => 2,
+ *            'entitlement' => 10.5,
+ *            'balance' => 5.25,
+ *            'used' => 6,
+ *            'requested' => 3.5
+ *          ],
+ *          ...
+ *       ]
+ *     ],
+ *     ...
+ *   ]
+ * ]
+ *
+ * It also support filters to return only contacts with specific IDs or managed
+ * by specific managers.
+ *
+ * @param array $params
+ *
+ * @return array API result descriptor
+ *
+ * @throws CiviCRM_API3_Exception
+ */
 function civicrm_api3_leave_period_entitlement_getleavebalances($params) {
   // We need to set check_permissions to false so as to disable default Civi ACL checks for
   // this endpoint. ACL checks needed are already in the LeaveBalancesSelect Query class.

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeavePeriodEntitlement.php
@@ -264,6 +264,13 @@ function _civicrm_api3_leave_period_entitlement_getleavebalances_spec(&$spec) {
 }
 
 function civicrm_api3_leave_period_entitlement_getleavebalances($params) {
-  return civicrm_api3_create_success((new CRM_HRLeaveAndAbsences_API_Query_LeaveBalancesSelect($params))->run());
+  // We need to set check_permissions to false so as to disable default Civi ACL checks for
+  // this endpoint. ACL checks needed are already in the LeaveBalancesSelect Query class.
+  $params['check_permissions'] = false;
+
+  $leaveManagerService = new CRM_HRLeaveAndAbsences_Service_LeaveManager();
+  $query = new CRM_HRLeaveAndAbsences_API_Query_LeaveBalancesSelect($params, $leaveManagerService);
+
+  return civicrm_api3_create_success($query->run());
 }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeavePeriodEntitlement.php
@@ -280,7 +280,12 @@ function civicrm_api3_leave_period_entitlement_getleavebalances($params) {
 
   $leaveManagerService = new CRM_HRLeaveAndAbsences_Service_LeaveManager();
   $query = new CRM_HRLeaveAndAbsences_API_Query_LeaveBalancesSelect($params, $leaveManagerService);
+  $result = $query->run();
 
-  return civicrm_api3_create_success($query->run());
+  if(empty($params['options']['is_count'])) {
+    return civicrm_api3_create_success($result);
+  }
+
+  return $result ?: 0;
 }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeavePeriodEntitlement.php
@@ -255,8 +255,8 @@ function _civicrm_api3_leave_period_entitlement_getleavebalances_spec(&$spec) {
     'description' => 'Include only Leave Balances for contacts managed by the contact with the given ID',
     'type' => CRM_Utils_Type::T_INT,
     'api.required' => 0,
-    'FKClassName'  => 'CRM_Contact_DAO_Contact',
-    'FKApiName'    => 'Contact',
+    'FKClassName' => 'CRM_Contact_DAO_Contact',
+    'FKApiName' => 'Contact',
   ];
 
   $spec['period_id'] = [
@@ -265,8 +265,8 @@ function _civicrm_api3_leave_period_entitlement_getleavebalances_spec(&$spec) {
     'description' => 'Include only Balances from Leave Requests taken during the Period with the given ID',
     'type' => CRM_Utils_Type::T_INT,
     'api.required' => 1,
-    'FKClassName'  => 'CRM_HRLeaveAndAbsences_BAO_AbsencePeriod',
-    'FKApiName'    => 'AbsencePeriod',
+    'FKClassName' => 'CRM_HRLeaveAndAbsences_BAO_AbsencePeriod',
+    'FKApiName' => 'AbsencePeriod',
   ];
 
   $spec['contact_id'] = [
@@ -275,8 +275,8 @@ function _civicrm_api3_leave_period_entitlement_getleavebalances_spec(&$spec) {
     'description' => 'Include only Leave Balances for contacts with the given ID',
     'type' => CRM_Utils_Type::T_INT,
     'api.required' => 0,
-    'FKClassName'  => 'CRM_Contact_DAO_Contact',
-    'FKApiName'    => 'Contact',
+    'FKClassName' => 'CRM_Contact_DAO_Contact',
+    'FKApiName' => 'Contact',
   ];
 
   $spec['type_id'] = [
@@ -285,8 +285,8 @@ function _civicrm_api3_leave_period_entitlement_getleavebalances_spec(&$spec) {
     'title' => 'Absence Type ID',
     'description' => 'Include only Balances for the Given Absence Type',
     'api.required' => 0,
-    'FKClassName'  => 'CRM_HRLeaveAndAbsences_BAO_AbsenceType',
-    'FKApiName'    => 'AbsenceType',
+    'FKClassName' => 'CRM_HRLeaveAndAbsences_BAO_AbsenceType',
+    'FKApiName' => 'AbsenceType',
   ];
 }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeavePeriodEntitlement.php
@@ -261,6 +261,16 @@ function _civicrm_api3_leave_period_entitlement_getleavebalances_spec(&$spec) {
     'FKClassName'  => 'CRM_HRLeaveAndAbsences_BAO_AbsencePeriod',
     'FKApiName'    => 'AbsencePeriod',
   ];
+
+  $spec['contact_id'] = [
+    'name' => 'contact_id',
+    'title' => 'Contact ID',
+    'description' => 'Include only Leave Balances for contacts with the given ID',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 0,
+    'FKClassName'  => 'CRM_Contact_DAO_Contact',
+    'FKApiName'    => 'Contact',
+  ];
 }
 
 function civicrm_api3_leave_period_entitlement_getleavebalances($params) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeavePeriodEntitlement.php
@@ -278,6 +278,16 @@ function _civicrm_api3_leave_period_entitlement_getleavebalances_spec(&$spec) {
     'FKClassName'  => 'CRM_Contact_DAO_Contact',
     'FKApiName'    => 'Contact',
   ];
+
+  $spec['type_id'] = [
+    'name' => 'type_id',
+    'type' => CRM_Utils_Type::T_INT,
+    'title' => 'Absence Type ID',
+    'description' => 'Include only Balances for the Given Absence Type',
+    'api.required' => 0,
+    'FKClassName'  => 'CRM_HRLeaveAndAbsences_BAO_AbsenceType',
+    'FKApiName'    => 'AbsenceType',
+  ];
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeavePeriodEntitlement.php
@@ -241,4 +241,29 @@ function civicrm_api3_leave_period_entitlement_getentitlement($params) {
   return $results;
 }
 
+function _civicrm_api3_leave_period_entitlement_getleavebalances_spec(&$spec) {
+  $spec['managed_by'] = [
+    'name' => 'managed_by',
+    'title' => 'Managed By',
+    'description' => 'Include only Leave Balances for contacts managed by the contact with the given ID',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 0,
+    'FKClassName'  => 'CRM_Contact_DAO_Contact',
+    'FKApiName'    => 'Contact',
+  ];
+
+  $spec['period_id'] = [
+    'name' => 'period_id',
+    'title' => 'Absence Period ID',
+    'description' => 'Include only Balances from Leave Requests taken during the Period with the given ID',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 1,
+    'FKClassName'  => 'CRM_HRLeaveAndAbsences_BAO_AbsencePeriod',
+    'FKApiName'    => 'AbsencePeriod',
+  ];
+}
+
+function civicrm_api3_leave_period_entitlement_getleavebalances($params) {
+  return civicrm_api3_create_success((new CRM_HRLeaveAndAbsences_API_Query_LeaveBalancesSelect($params))->run());
+}
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -140,6 +140,8 @@ function hrleaveandabsences_civicrm_alterAPIPermissions($entity, $action, &$para
       $permissions[$entity][$action] = ['access AJAX API'];
     }
   }
+
+  $permissions['leave_period_entitlement']['getleavebalances'][] = 'manage leave and absences in ssp';
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -2974,7 +2974,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     ));
   }
 
-  public function testGetBalanceForContactsIncludesBalanceChangesFromLeaveRequestsNotOverlappingAContract() {
+  public function testGetBalanceForContactsDoesNotIncludeBalanceChangesFromLeaveRequestsNotOverlappingAContract() {
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-10 days'),
       'end_date' => CRM_Utils_Date::processDate('+10 days')
@@ -3052,7 +3052,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'to_date' => date('YmdHis', strtotime('+6 days'))
     ], true);
 
-
     // 5.25 (Entitlement) + -1 (2nd leave request) + -2 (3rd leave request) + -1 (5th leave request)
     $expectedResult = [
       $entitlement->contact_id => [
@@ -3107,7 +3106,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     ));
   }
 
-  public function testGetBalanceForContactsOverriddenEntitlement() {
+  public function testGetBalanceForContactsIncludesOverriddenEntitlement() {
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-10 days'),
       'end_date' => CRM_Utils_Date::processDate('+10 days')
@@ -3596,7 +3595,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
     $absenceTypeID = 1;
 
-    // before the first contract, won't be included
+    // within first contract, will be included
     LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => $absenceTypeID,
       'contact_id' => $contract1['contact_id'],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -113,7 +113,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testBalanceForEntitlementCanSumOnlyTheBalanceChangesForLeaveRequestWithSpecificStatuses() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
     $entitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
       new DateTime('-10 days'),
       new DateTime('+10 days')
@@ -179,10 +179,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $this->assertEquals(4, LeaveBalanceChange::getBalanceForEntitlement($entitlement));
 
     // Only Include balance changes from approved leave requests
-    $statusesToInclude = [
-      $leaveRequestStatuses['approved'],
-      $leaveRequestStatuses['admin_approved'],
-    ];
+    $statusesToInclude = LeaveRequest::getApprovedStatuses();
     $this->assertEquals(8, LeaveBalanceChange::getBalanceForEntitlement($entitlement, $statusesToInclude));
 
     // Only Include balance changes from cancelled/rejected leave requests
@@ -202,7 +199,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testBalanceForEntitlementDoesNotSumForSoftDeletedLeaveRequests() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
     $entitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
       new DateTime('-10 days'),
       new DateTime('+10 days')
@@ -231,7 +228,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testBalanceForEntitlementDoesNotSumForLeaveRequestsNotOverlappingAContract() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
     $entitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
       new DateTime('-10 days'),
       new DateTime('+10 days')
@@ -277,7 +274,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testBalanceForEntitlementIncludesExpiredBroughtForwardAndTOIL() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
     $entitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
       new DateTime('-10 days'),
       new DateTime('+10 days')
@@ -313,7 +310,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testBalanceForEntitlementCanIncludeOnlyTheExpiredBalanceChanges() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
     $entitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
       new DateTime('-10 days'),
       new DateTime('+10 days')
@@ -349,7 +346,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testBalanceForEntitlementCanIncludeOnlyTheExpiredBalanceChangesForTOILRequestsWithSpecificStatuses() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
     $entitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
       new DateTime('-10 days'),
       new DateTime('+10 days')
@@ -452,7 +449,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testTheEntitlementBreakdownSumsOnlyThePositiveLeaveBroughtForwardAndPublicHolidayChangesWithoutASource() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
     $entitlement = $this->createLeavePeriodEntitlement();
 
     $this->createLeaveBalanceChange($entitlement->id, 23.5);
@@ -484,7 +481,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testLeaveRequestBalanceForEntitlementOnlySumBalanceChangesCreatedByLeaveRequestsWithSpecificStatus() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
     $entitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
       new DateTime(),
       new DateTime('+20 days')
@@ -585,7 +582,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testLeaveRequestBalanceForEntitlementCanSumBalanceChangesCreatedByLeaveRequestsUpToASpecificDate() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
     $entitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
       new DateTime(),
       new DateTime('+20 days')
@@ -647,7 +644,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testLeaveRequestBalanceForEntitlementCanSumBalanceChangesCreatedByLeaveRequestsOnASpecificDateRange() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
     $entitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
       new DateTime(),
       new DateTime('+20 days')
@@ -707,7 +704,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testLeaveRequestBalanceForEntitlementCanExcludeBalanceChangesForPublicHolidayLeaveRequests() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
     $entitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
       new DateTime('today'),
       new DateTime('+100 days')
@@ -741,7 +738,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testLeaveRequestBalanceForEntitlementCanIncludeOnlyBalanceChangesForPublicHolidayLeaveRequests() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
     $entitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
       new DateTime('today'),
       new DateTime('+100 days')
@@ -786,7 +783,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testLeaveRequestBalanceForEntitlementWithParamsToBothExcludeAndIncludePublicHolidaysShouldReturnZero() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
     $entitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
       new DateTime('today'),
       new DateTime('+100 days')
@@ -942,7 +939,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testLeaveRequestBalanceForEntitlementDoesNotIncludeBalanceFromLeaveRequestsNotOverlappingContracts() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $entitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
       new DateTime('-10 days'),
@@ -1342,7 +1339,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'type_id' => 1,
     ]);
 
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $balanceChange = $this->createBroughtForwardBalanceChange(
       $periodEntitlement->id,
@@ -1407,7 +1404,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'type_id' => 1,
     ]);
 
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $balanceChange1 = $this->createBroughtForwardBalanceChange(
       $periodEntitlement->id,
@@ -1466,7 +1463,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'type_id' => 1,
     ]);
 
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $balanceChange = $this->createBroughtForwardBalanceChange(
       $periodEntitlement->id,
@@ -1517,7 +1514,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'type_id' => 1,
     ]);
 
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $balanceChange1 = $this->createBroughtForwardBalanceChange(
       $periodEntitlement1->id,
@@ -1594,7 +1591,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'type_id' => 2,
     ]);
 
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $balanceChange = $this->createBroughtForwardBalanceChange(
       $periodEntitlement2->id,
@@ -1714,7 +1711,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testCreateExpiryRecordsCanExpireTOILRequests() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-30 days'),
@@ -2008,7 +2005,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testCreateExpiryRecordsConsidersOnlyTheApprovedLeaveRequestsBetweenTheTOILRequestDateAndTOILExpiryDateToExpireTOILRequests() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-30 days'),
@@ -2202,7 +2199,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $contactID = 1;
     $absenceTypeID = 1;
     $absenceTypeID2 = 2;
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => $absenceTypeID,
@@ -2277,7 +2274,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   public function testGetTotalApprovedToilForPeriodShouldOnlyAccountForApprovedRequests() {
     $contactID = 1;
     $absenceTypeID = 1;
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $period = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-06-01'),
@@ -2338,7 +2335,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'type_id' => 1,
     ]);
 
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $broughtForwardPeriod1 = $this->createExpiredBroughtForwardBalanceChange(
       $periodEntitlement1->id,
@@ -2417,7 +2414,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'type_id' => 1,
     ]);
 
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $balanceChangePeriod1 = $this->createExpiredBroughtForwardBalanceChange(
       $periodEntitlement1->id,
@@ -2462,7 +2459,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'type_id' => 1,
     ]);
 
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $balanceChangePeriod1 = $this->createExpiredBroughtForwardBalanceChange(
       $periodEntitlement1->id,
@@ -2502,7 +2499,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'type_id' => 1,
     ]);
 
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $balanceChangePeriod1 = $this->createExpiredBroughtForwardBalanceChange(
       $periodEntitlement1->id,
@@ -2545,7 +2542,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'type_id' => 1,
     ]);
 
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $balanceChangePeriod1 = $this->createExpiredBroughtForwardBalanceChange(
       $periodEntitlement1->id,
@@ -2590,7 +2587,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'type_id' => 2,
     ]);
 
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $balanceChangePeriod1 = $this->createExpiredBroughtForwardBalanceChange(
       $periodEntitlement1->id,
@@ -2930,7 +2927,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testGetBalanceForContactsIncludesBalanceChangesFromExpiredToil() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-10 days'),
@@ -3133,7 +3130,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testGetBalanceForContactsIncludesOnlyTheBalanceChangesOfApprovedRequests() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-10 days'),
@@ -3217,7 +3214,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testGetBalanceForContactsCanReturnTheBalanceForMultipleContacts() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-10 days'),
@@ -3294,7 +3291,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testGetOpenLeaveRequestBalanceForContactsCanReturnBalancesForMultipleAbsenceTypes() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-10 days'),
@@ -3352,7 +3349,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testGetOpenLeaveRequestBalanceForContactsShouldIncludeOnlyTheBalanceChangesFromOpenLeaveRequests() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-10 days'),
@@ -3430,7 +3427,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testGetOpenLeaveRequestBalanceForContactsShouldIncludeOnlyTheBalanceChangesRequestsOverlappingAContract() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-10 days'),
@@ -3502,7 +3499,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testGetOpenLeaveRequestBalanceForContactsShouldIncludeOnlyTheBalanceChangesRequestsWithinTheGivenAbsencePeriod() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $absencePeriod1 = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-10 days'),
@@ -3573,7 +3570,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testGetOpenLeaveRequestBalanceForContactsShouldIncludeOnlyTheBalanceChangesForMultipleContacts() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-10 days'),

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -3192,6 +3192,264 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $this->assertEquals(15, $balances[$entitlement2->contact_id]);
   }
 
+  public function testGetOpenLeaveRequestBalanceForContactsShouldIncludeOnlyTheBalanceChangesFromOpenLeaveRequests() {
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-10 days'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days')
+    ]);
+
+    $contract = HRJobContractFabricator::fabricate(
+      ['contact_id' => 1],
+      ['period_start_date' => $absencePeriod->start_date]
+    );
+
+    $absenceTypeID = 1;
+
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contract['contact_id'],
+      'status_id' => $leaveRequestStatuses['approved'],
+      'from_date' => date('YmdHis', strtotime('-10 days')),
+      'to_date' => date('YmdHis', strtotime('-9 days'))
+    ], true);
+
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contract['contact_id'],
+      'status_id' => $leaveRequestStatuses['admin_approved'],
+      'from_date' => date('YmdHis', strtotime('-8 days')),
+      'to_date' => date('YmdHis', strtotime('-7 days'))
+    ], true);
+
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contract['contact_id'],
+      'status_id' => $leaveRequestStatuses['awaiting_approval'],
+      'from_date' => date('YmdHis', strtotime('-6 days')),
+      'to_date' => date('YmdHis', strtotime('-5 days'))
+    ], true);
+
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contract['contact_id'],
+      'status_id' => $leaveRequestStatuses['more_information_required'],
+      'from_date' => date('YmdHis', strtotime('-4 days')),
+      'to_date' => date('YmdHis', strtotime('-3 days'))
+    ], true);
+
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contract['contact_id'],
+      'status_id' => $leaveRequestStatuses['cancelled'],
+      'from_date' => date('YmdHis', strtotime('-2 days')),
+      'to_date' => date('YmdHis', strtotime('-1 day'))
+    ], true);
+
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contract['contact_id'],
+      'status_id' => $leaveRequestStatuses['rejected'],
+      'from_date' => date('YmdHis', strtotime('+1 day')),
+      'to_date' => date('YmdHis', strtotime('+2 days'))
+    ], true);
+
+    // -2 From the awaiting approval request and -2 from the more information
+    // required request
+    $expectedResult = [$contract['contact_id'] => -4];
+
+    $this->assertEquals($expectedResult, LeaveBalanceChange::getOpenLeaveRequestBalanceForContacts(
+      [$contract['contact_id']],
+      $absencePeriod->id,
+      $absenceTypeID
+    ));
+  }
+
+  public function testGetOpenLeaveRequestBalanceForContactsShouldIncludeOnlyTheBalanceChangesRequestsOverlappingAContract() {
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-10 days'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days')
+    ]);
+
+    $contract = HRJobContractFabricator::fabricate(
+      ['contact_id' => 1],
+      [
+        'period_start_date' => CRM_Utils_Date::processDate('-5 days'),
+        'period_end_date' => CRM_Utils_Date::processDate('-1 day')
+      ]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => 1],
+      ['period_start_date' => CRM_Utils_Date::processDate('+5 days')]
+    );
+
+    $absenceTypeID = 1;
+
+    // before the first contract, won't be included
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contract['contact_id'],
+      'status_id' => $leaveRequestStatuses['awaiting_approval'],
+      'from_date' => date('YmdHis', strtotime('-10 days')),
+      'to_date' => date('YmdHis', strtotime('-9 days'))
+    ], true);
+
+    // within first contract, will be included
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contract['contact_id'],
+      'status_id' => $leaveRequestStatuses['more_information_required'],
+      'from_date' => date('YmdHis', strtotime('-4 days')),
+      'to_date' => date('YmdHis', strtotime('-3 days'))
+    ], true);
+
+    // within the gap between contracts, won't be included
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contract['contact_id'],
+      'status_id' => $leaveRequestStatuses['more_information_required'],
+      'from_date' => date('YmdHis', strtotime('+2 days')),
+      'to_date' => date('YmdHis', strtotime('+4 days'))
+    ], true);
+
+    // within the second contract, will be included
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contract['contact_id'],
+      'status_id' => $leaveRequestStatuses['awaiting_approval'],
+      'from_date' => date('YmdHis', strtotime('+7 days')),
+      'to_date' => date('YmdHis', strtotime('+8 days'))
+    ], true);
+
+    $expectedResult = [$contract['contact_id'] => -4];
+
+    $this->assertEquals($expectedResult, LeaveBalanceChange::getOpenLeaveRequestBalanceForContacts(
+      [$contract['contact_id']],
+      $absencePeriod->id,
+      $absenceTypeID
+    ));
+  }
+
+  public function testGetOpenLeaveRequestBalanceForContactsShouldIncludeOnlyTheBalanceChangesRequestsWithinTheGivenAbsencePeriod() {
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+
+    $absencePeriod1 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-10 days'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days')
+    ]);
+
+    $absencePeriod2 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('+11 days'),
+      'end_date' => CRM_Utils_Date::processDate('+21 days')
+    ]);
+
+    //Contract spanning the two absence periods
+    $contract = HRJobContractFabricator::fabricate(
+      ['contact_id' => 1],
+      ['period_start_date' => $absencePeriod1->start_date]
+    );
+
+    $absenceTypeID = 1;
+
+    //Within the first Absence Period
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contract['contact_id'],
+      'status_id' => $leaveRequestStatuses['awaiting_approval'],
+      'from_date' => date('YmdHis', strtotime('-10 days')),
+      'to_date' => date('YmdHis', strtotime('-5 days')),
+    ], true);
+
+    //Within the second Absence Period
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contract['contact_id'],
+      'status_id' => $leaveRequestStatuses['more_information_required'],
+      'from_date' => date('YmdHis', strtotime('+15 days')),
+      'to_date' => date('YmdHis', strtotime('+17 days'))
+    ], true);
+
+    // Not within any of the absence periods and it will not be included
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contract['contact_id'],
+      'status_id' => $leaveRequestStatuses['more_information_required'],
+      'from_date' => date('YmdHis', strtotime('+40 days')),
+      'to_date' => date('YmdHis', strtotime('+41 days'))
+    ], true);
+
+    $expectedResult = [$contract['contact_id'] => -6];
+    $this->assertEquals($expectedResult, LeaveBalanceChange::getOpenLeaveRequestBalanceForContacts(
+      [$contract['contact_id']],
+      $absencePeriod1->id,
+      $absenceTypeID
+    ));
+
+    $expectedResult = [$contract['contact_id'] => -3];
+    $this->assertEquals($expectedResult, LeaveBalanceChange::getOpenLeaveRequestBalanceForContacts(
+      [$contract['contact_id']],
+      $absencePeriod2->id,
+      $absenceTypeID
+    ));
+  }
+
+  public function testGetOpenLeaveRequestBalanceForContactsShouldIncludeOnlyTheBalanceChangesForMultipleContacts() {
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-10 days'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days')
+    ]);
+
+    $contract1 = HRJobContractFabricator::fabricate(
+      ['contact_id' => 1],
+      [
+        'period_start_date' => CRM_Utils_Date::processDate('-5 days'),
+        'period_end_date' => CRM_Utils_Date::processDate('-1 day')
+      ]
+    );
+
+    $contract2 = HRJobContractFabricator::fabricate(
+      ['contact_id' => 2],
+      ['period_start_date' => CRM_Utils_Date::processDate('+5 days')]
+    );
+
+    $absenceTypeID = 1;
+
+    // before the first contract, won't be included
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contract1['contact_id'],
+      'status_id' => $leaveRequestStatuses['awaiting_approval'],
+      'from_date' => date('YmdHis', strtotime('-4 days')),
+      'to_date' => date('YmdHis', strtotime('-2 days'))
+    ], true);
+
+    // within first contract, will be included
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contract2['contact_id'],
+      'status_id' => $leaveRequestStatuses['more_information_required'],
+      'from_date' => date('YmdHis', strtotime('+6 days')),
+      'to_date' => date('YmdHis', strtotime('+6 days'))
+    ], true);
+
+
+    $result = LeaveBalanceChange::getOpenLeaveRequestBalanceForContacts(
+      [$contract1['contact_id'], $contract2['contact_id']],
+      $absencePeriod->id,
+      $absenceTypeID
+    );
+
+    $this->assertCount(2, $result);
+    $this->assertEquals(-3, $result[$contract1['contact_id']]);
+    $this->assertEquals(-1, $result[$contract2['contact_id']]);
+  }
+
   private function getBalanceChangesForPeriodEntitlement($leavePeriodEntitlement) {
     $record = new LeaveBalanceChange();
     $record->source_id = $leavePeriodEntitlement->id;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -3086,4 +3086,42 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     $this->assertFalse(LeaveRequest::datesChanged($params));
   }
+
+  public function testCanReturnTheListOfAllStatuses() {
+    $leaveStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+
+    $statuses = LeaveRequest::getStatuses();
+
+    $this->assertEquals($leaveStatuses, $statuses);
+  }
+
+  public function testCanReturnTheListOfApprovedStatuses() {
+    $leaveStatuses = LeaveRequest::getStatuses();
+
+    $approvedStatuses = LeaveRequest::getApprovedStatuses();
+
+    $this->assertCount(2, $approvedStatuses);
+    $this->assertContains($leaveStatuses['approved'], $approvedStatuses);
+    $this->assertContains($leaveStatuses['admin_approved'], $approvedStatuses);
+  }
+
+  public function testCanReturnTheListOfOpenStatuses() {
+    $leaveStatuses = LeaveRequest::getStatuses();
+
+    $openStatuses = LeaveRequest::getOpenStatuses();
+
+    $this->assertCount(2, $openStatuses);
+    $this->assertContains($leaveStatuses['awaiting_approval'], $openStatuses);
+    $this->assertContains($leaveStatuses['more_information_required'], $openStatuses);
+  }
+
+  public function testCanReturnTheListOfCancelledStatuses() {
+    $leaveStatuses = LeaveRequest::getStatuses();
+
+    $cancelledStatuses = LeaveRequest::getCancelledStatuses();
+
+    $this->assertCount(2, $cancelledStatuses);
+    $this->assertContains($leaveStatuses['cancelled'], $cancelledStatuses);
+    $this->assertContains($leaveStatuses['rejected'], $cancelledStatuses);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ApiPermissionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ApiPermissionTest.php
@@ -12,12 +12,12 @@ class api_v3_ApiPermissionTest extends BaseHeadlessTest {
   /**
    * @dataProvider apiPermissionsDataProvider
    */
-  public function testAPIPermissions($entity, $action) {
+  public function testAPIPermissions($entity, $action, $permission = 'access AJAX API') {
     $contactID = 1;
     $this->registerCurrentLoggedInContactInSession($contactID);
     CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
 
-    $this->setExpectedException('CiviCRM_API3_Exception', "API permission check failed for {$entity}/{$action} call; insufficient permission: require access AJAX API");
+    $this->setExpectedException('CiviCRM_API3_Exception', "API permission check failed for {$entity}/{$action} call; insufficient permission: require {$permission}");
 
     $payload = ['check_permissions' => true];
 
@@ -50,6 +50,7 @@ class api_v3_ApiPermissionTest extends BaseHeadlessTest {
       ['OptionGroup', 'get'],
       ['OptionValue', 'get'],
       ['LeavePeriodEntitlement', 'get'],
+      ['LeavePeriodEntitlement', 'getleavebalances', 'manage leave and absences in ssp'],
       ['PublicHoliday', 'get'],
       ['Comment', 'get'],
       ['Comment', 'create'],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeavePeriodEntitlementTest.php
@@ -878,6 +878,15 @@ class api_v3_LeavePeriodEntitlementTest extends BaseHeadlessTest {
 
     $this->assertCount(1, $result);
     $this->assertNotEmpty($result[$contact2['id']]);
+
+    // If Manager 2 tries to get the managees of Manager 1, an empty result will
+    // be returned
+    $result = civicrm_api3('LeavePeriodEntitlement', 'getLeaveBalances', [
+      'period_id' => $absencePeriod->id,
+      'managed_by' => $manager1['id']
+    ])['values'];
+
+    $this->assertEmpty($result);
   }
 
   public function testGetLeaveBalancesShouldThrowAnErrorIfAInvalidAbsencePeriodIsGiven() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeavePeriodEntitlementTest.php
@@ -1,7 +1,10 @@
 <?php
 
 use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
+use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeavePeriodEntitlement as LeavePeriodEntitlementFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod as AbsencePeriodFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
 
@@ -526,5 +529,402 @@ class api_v3_LeavePeriodEntitlementTest extends BaseHeadlessTest {
     $this->assertEquals(2, $result['count']);
     $this->assertEquals($contactID1, $result['values'][0]['contact_id']);
     $this->assertEquals($contactID2, $result['values'][1]['contact_id']);
+  }
+
+  public function testGetLeaveBalancesReturnsTheBalancesForAllContactsWithAContractDuringTheGivenPeriod() {
+    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-10 days'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days')
+    ]);
+
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+    $contact3 = ContactFabricator::fabricate();
+
+    $contract1 = HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      [
+        'period_start_date' => CRM_Utils_Date::processDate('-5 days'),
+        'period_end_date' => CRM_Utils_Date::processDate('-1 day')
+      ]
+    );
+
+    $contract2 = HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => CRM_Utils_Date::processDate('+5 days')]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact3['id']],
+      ['period_start_date' => CRM_Utils_Date::processDate('+15 days')]
+    );
+
+    $absenceTypeID = 1;
+
+    $entitlement1 = LeavePeriodEntitlementFabricator::fabricate([
+      'period_id' => $absencePeriod->id,
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contact1['id'],
+    ]);
+
+    $entitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+      'period_id' => $absencePeriod->id,
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contact2['id'],
+    ]);
+
+    $entitlement3 = LeavePeriodEntitlementFabricator::fabricate([
+      'period_id' => $absencePeriod->id,
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contact3['id'],
+    ]);
+
+    $this->createLeaveBalanceChange($entitlement1->id, 15.25);
+    $this->createLeaveBalanceChange($entitlement2->id, 5.5);
+    $this->createLeaveBalanceChange($entitlement3->id, 7);
+
+    // within the first contract, will be included
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contract1['contact_id'],
+      'status_id' => $leaveRequestStatuses['approved'],
+      'from_date' => date('YmdHis', strtotime('-4 days')),
+      'to_date' => date('YmdHis', strtotime('-2 days'))
+    ], true);
+
+    // within second contract, will be included
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contract2['contact_id'],
+      'status_id' => $leaveRequestStatuses['awaiting_approval'],
+      'from_date' => date('YmdHis', strtotime('+6 days')),
+      'to_date' => date('YmdHis', strtotime('+6 days'))
+    ], true);
+
+    // within the third contract, which is outside the absence period, so it
+    // won't be included
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contract2['contact_id'],
+      'status_id' => $leaveRequestStatuses['more_information_required'],
+      'from_date' => date('YmdHis', strtotime('+16 days')),
+      'to_date' => date('YmdHis', strtotime('+16 days'))
+    ], true);
+
+    $result = civicrm_api3('LeavePeriodEntitlement', 'getLeaveBalances', [
+      'period_id' => $absencePeriod->id
+    ])['values'];
+
+    $this->assertCount(2, $result);
+
+    $contact1ExpectedBalances = [
+      'contact_id' => $contact1['id'],
+      'contact_display_name' => $contact1['display_name'],
+      'absence_types' => [
+        [
+          'id' => $absenceTypeID,
+          'entitlement' => 15.25,
+          'used' => 3,
+          'balance' => 12.25,
+          'requested' => 0
+        ]
+      ]
+    ];
+    $this->assertEquals($contact1ExpectedBalances, $result[$contact1['id']]);
+
+    $contact2ExpectedBalances = [
+      'contact_id' => $contact2['id'],
+      'contact_display_name' => $contact2['display_name'],
+      'absence_types' => [
+        [
+          'id' => $absenceTypeID,
+          'entitlement' => 5.5,
+          'used' => 0,
+          'balance' => 5.5,
+          'requested' => 1
+        ]
+      ]
+    ];
+    $this->assertEquals($contact2ExpectedBalances, $result[$contact2['id']]);
+  }
+
+  public function testGetLeaveBalancesCanReturnBalancesForASpecificContact() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-10 days'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days')
+    ]);
+
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      ['period_start_date' => $absencePeriod->start_date]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => $absencePeriod->start_date]
+    );
+
+    $absenceTypeID = 1;
+
+    $entitlement1 = LeavePeriodEntitlementFabricator::fabricate([
+      'period_id' => $absencePeriod->id,
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contact1['id'],
+    ]);
+
+    $entitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+      'period_id' => $absencePeriod->id,
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contact2['id'],
+    ]);
+
+    $this->createLeaveBalanceChange($entitlement1->id, 7.75);
+    $this->createLeaveBalanceChange($entitlement2->id, 5.5);
+
+    $result = civicrm_api3('LeavePeriodEntitlement', 'getLeaveBalances', [
+      'period_id' => $absencePeriod->id,
+      'contact_id' => $contact1['id']
+    ])['values'];
+
+    $this->assertCount(1, $result);
+
+    $expectedResult = [
+      'contact_id' => $contact1['id'],
+      'contact_display_name' => $contact1['display_name'],
+      'absence_types' => [
+        [
+          'id' => $absenceTypeID,
+          'entitlement' => 7.75,
+          'used' => 0,
+          'balance' => 7.75,
+          'requested' => 0
+        ]
+      ]
+    ];
+    $this->assertEquals($expectedResult, $result[$contact1['id']]);
+
+    $result = civicrm_api3('LeavePeriodEntitlement', 'getLeaveBalances', [
+      'period_id' => $absencePeriod->id,
+      'contact_id' => $contact2['id']
+    ])['values'];
+
+    $this->assertCount(1, $result);
+
+    $expectedResult = [
+      'contact_id' => $contact2['id'],
+      'contact_display_name' => $contact2['display_name'],
+      'absence_types' => [
+        [
+          'id' => $absenceTypeID,
+          'entitlement' => 5.5,
+          'used' => 0,
+          'balance' => 5.5,
+          'requested' => 0
+        ]
+      ]
+    ];
+    $this->assertEquals($expectedResult, $result[$contact2['id']]);
+  }
+
+  public function testGetLeaveBalancesCanReturnBalancesForContactsManagedByASpecificManager() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-10 days'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days')
+    ]);
+
+    $manager1 = ContactFabricator::fabricate();
+    $manager2 = ContactFabricator::fabricate();
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    $this->setContactAsLeaveApproverOf($manager1, $contact1);
+    $this->setContactAsLeaveApproverOf($manager1, $contact2);
+    $this->setContactAsLeaveApproverOf($manager2, $contact2);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      ['period_start_date' => $absencePeriod->start_date]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => $absencePeriod->start_date]
+    );
+
+    $absenceTypeID = 1;
+
+    $entitlement1 = LeavePeriodEntitlementFabricator::fabricate([
+      'period_id' => $absencePeriod->id,
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contact1['id'],
+    ]);
+
+    $entitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+      'period_id' => $absencePeriod->id,
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contact2['id'],
+    ]);
+
+    $this->createLeaveBalanceChange($entitlement1->id, 7.75);
+    $this->createLeaveBalanceChange($entitlement2->id, 5.5);
+
+    // Manager 1 manages both contacts, so they all should be returned
+    $result = civicrm_api3('LeavePeriodEntitlement', 'getLeaveBalances', [
+      'period_id' => $absencePeriod->id,
+      'managed_by' => $manager1['id']
+    ])['values'];
+
+    $this->assertCount(2, $result);
+    $this->assertNotEmpty($result[$contact1['id']]);
+    $this->assertNotEmpty($result[$contact2['id']]);
+
+    // Manager 2 manages only contact 2, so that's the only one returned
+    $result = civicrm_api3('LeavePeriodEntitlement', 'getLeaveBalances', [
+      'period_id' => $absencePeriod->id,
+      'managed_by' => $manager2['id']
+    ])['values'];
+
+    $this->assertCount(1, $result);
+    $this->assertNotEmpty($result[$contact2['id']]);
+  }
+
+  public function testGetLeaveBalancesOnlyReturnBalancesForContactsManagedByTheCurrentUser() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-10 days'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days')
+    ]);
+
+    $manager1 = ContactFabricator::fabricate();
+    $manager2 = ContactFabricator::fabricate();
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    $this->setContactAsLeaveApproverOf($manager1, $contact1);
+    $this->setContactAsLeaveApproverOf($manager2, $contact2);
+
+    $this->registerCurrentLoggedInContactInSession($manager2['id']);
+    $this->setPermissions([]);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      ['period_start_date' => $absencePeriod->start_date]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => $absencePeriod->start_date]
+    );
+
+    $absenceTypeID = 1;
+
+    $entitlement1 = LeavePeriodEntitlementFabricator::fabricate([
+      'period_id' => $absencePeriod->id,
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contact1['id'],
+    ]);
+
+    $entitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+      'period_id' => $absencePeriod->id,
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contact2['id'],
+    ]);
+
+    $this->createLeaveBalanceChange($entitlement1->id, 7.75);
+    $this->createLeaveBalanceChange($entitlement2->id, 5.5);
+
+    // Currently logged in as Manager 2, so only Contact 2 should be returned
+    $result = civicrm_api3('LeavePeriodEntitlement', 'getLeaveBalances', [
+      'period_id' => $absencePeriod->id
+    ])['values'];
+
+    $this->assertCount(1, $result);
+    $this->assertNotEmpty($result[$contact2['id']]);
+  }
+
+  public function testGetLeaveBalancesShouldThrowAnErrorIfAInvalidAbsencePeriodIsGiven() {
+    $randomID = rand(1, 500);
+
+    $this->setExpectedException(
+      'CiviCRM_API3_Exception',
+      "Unable to find a CRM_HRLeaveAndAbsences_BAO_AbsencePeriod with id {$randomID}."
+    );
+
+    civicrm_api3('LeavePeriodEntitlement', 'getLeaveBalances', [
+      'period_id' => $randomID
+    ]);
+  }
+
+  public function testGetLeaveBalancesShouldThrowAnErrorIfAnAbsencePeriodIsNotGiven() {
+    $this->setExpectedException(
+      'CiviCRM_API3_Exception',
+      'Mandatory key(s) missing from params array: period_id'
+    );
+
+    civicrm_api3('LeavePeriodEntitlement', 'getLeaveBalances', []);
+  }
+
+  public function testGetLeaveBalanceShouldReturnTheNumberOfRecordsWhenIsCountIsPresent() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-10 days'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days')
+    ]);
+
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      ['period_start_date' => $absencePeriod->start_date]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => $absencePeriod->start_date]
+    );
+
+    $absenceTypeID = 1;
+
+    $entitlement1 = LeavePeriodEntitlementFabricator::fabricate([
+      'period_id' => $absencePeriod->id,
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contact1['id'],
+    ]);
+
+    $entitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+      'period_id' => $absencePeriod->id,
+      'type_id' => $absenceTypeID,
+      'contact_id' => $contact2['id'],
+    ]);
+
+    $this->createLeaveBalanceChange($entitlement1->id, 7.75);
+    $this->createLeaveBalanceChange($entitlement2->id, 5.5);
+
+    // Balances for both contacts will be returned
+    $result = civicrm_api3('LeavePeriodEntitlement', 'getLeaveBalances', [
+      'period_id' => $absencePeriod->id,
+      'options' => ['is_count' => 1]
+    ]);
+    $this->assertEquals(2, $result);
+
+    // There's no manager with ID 100, so count will be 0
+    $result = civicrm_api3('LeavePeriodEntitlement', 'getLeaveBalances', [
+      'period_id' => $absencePeriod->id,
+      'managed_by' => 100,
+      'options' => ['is_count' => 1]
+    ]);
+    $this->assertEquals(0, $result);
+
+    // Querying for a single specific contact, count will be 1
+    $result = civicrm_api3('LeavePeriodEntitlement', 'getLeaveBalances', [
+      'period_id' => $absencePeriod->id,
+      'contact_id' => $contact1['id'],
+      'options' => ['is_count' => 1]
+    ]);
+    $this->assertEquals(1, $result);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
@@ -195,7 +195,8 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
       FROM {$balanceChangeTable} balance_change
       INNER JOIN {$leaveRequestDateTable} as leave_request_date 
         ON leave_request_date.id = balance_change.source_id AND balance_change.source_type = %1
-      WHERE leave_request_date.leave_request_id = %2
+      WHERE leave_request_date.leave_request_id = %2 AND
+            balance_change.expired_balance_change_id IS NULL 
       ORDER BY leave_request_date.date ASC 
       LIMIT 1
     ";


### PR DESCRIPTION
## Overview
This PR adds the `LeavePeriodEntitlement.getLeaveBalances` API. This new API aggregates data that is already available via other APIs like `LeavePeriodEntitlement.getRemainder` and `LeavePeriodEntitlement.getEntitlement`, but it does this with a much better performance and reduced number of queries, especially because it can be used to get information for multiple contacts with a single request.

## Before

To get the same information provided by the new API, one would need a chained API call similar to this one:

```javascript
CRM.api3('Contact', 'getleavemanagees', {
  "sequential": 1,
  "managed_by": 205,
  "api.LeavePeriodEntitlement.getentitlement": {"contact_id":"$value.id","period_id":2},
  "api.LeavePeriodEntitlement.getremainder": {"contact_id":"$value.id","period_id":2,"include_future":1}
})
```

As you can see, we have three chained API in that request. Even worse, the two inner call are executed once for each result returned by the parent call to `Contact.getLeaveManagess`. In a scenario where `getLeaveManagees` would return 100 contacts, we would end up with 201 API calls, not to mention the internal SQL queries executed by each of these API calls.

Besides that, the format in which the data is returned isn't easy to loop through, as the chained API call results in a deeply nested data structure. Something like this:

```json
{
            "contact_id": "4",
            "display_name": "civihr_staff@compucorp.co.uk",
            "hrjobroles_id": "1",
            "id": "1",
            "contact_is_deleted": "0",
            "api.LeavePeriodEntitlement.getentitlement": {
                "is_error": 0,
                "version": 3,
                "count": 3,
                "values": [
                    {
                        "id": "7",
                        "entitlement": 28
                    },
                    {
                        "id": "8",
                        "entitlement": 0
                    },
                    {
                        "id": "9",
                        "entitlement": 0
                    }
                ]
            },
            "api.LeavePeriodEntitlement.getremainder": {
                "is_error": 0,
                "version": 3,
                "count": 3,
                "values": [
                    {
                        "id": "7",
                        "remainder": {
                            "current": 14.5,
                            "future": 14.5
                        }
                    },
                    {
                        "id": "8",
                        "remainder": {
                            "current": 0,
                            "future": 0
                        }
                    },
                    {
                        "id": "9",
                        "remainder": {
                            "current": 0,
                            "future": 0
                        }
                    }
                ]
            }
        },
```

## After

The new API requires a single API call. Here is an example of how to do the same thing as the previous example of a chained call:

```javascript
CRM.api3('LeavePeriodEntitlement', 'getleavebalances', {
  "sequential": 1,
  "period_id": 2,
  "managed_by": 205
})
```

The API response is also simpler and easier to loop through:

```json
{
    "is_error": 0,
    "version": 3,
    "count": 4,
    "values": {
        "4": {
            "contact_id": "4",
            "contact_display_name": "civihr_staff@compucorp.co.uk",
            "absence_types": [
                {
                    "id": 1,
                    "entitlement": "28.00",
                    "used": 13.5,
                    "balance": 14.5,
                    "requested": 0
                },
                {
                    "id": 2,
                    "entitlement": "0.00",
                    "used": 0,
                    "balance": 0,
                    "requested": 0
                },
                {
                    "id": 3,
                    "entitlement": "0.00",
                    "used": 0,
                    "balance": 0,
                    "requested": 0
                }
            ]
        }
   }
}
```
A few things to note:
- All the balances are aggregate together inside the `absence_types` property, instead of separatedely in each chain response.
- We now have a `used` property for each absence type. On a chained call, we would have to obtain that value manually, by subtracting the balance/remainder from the entitlement.

This API also supports the `is_count` option, which will return the number of contacts matching the given criteria. This is how it can be used:

```javascript
CRM.api3('LeavePeriodEntitlement', 'getleavebalances', {
  "sequential": 1,
  "period_id": 2,
  "options": {"is_count":1}
})
```
And this is how its response looks like:

```json
{
    "is_error": 0,
    "result": 5
}
```
Result is the number of contacts that would be returned on a non is count query.

## Technical Details
Three new methods were created to make it possible for the API get the data with the minimum number of SQL queries as possible. The methods are:
- `LeavePeriodEntitlement::getEntitlementsForContacts`
- `LeaveBalanceChange::getBalanceForContacts`
- `LeaveBalanceChange::getOpenLeaveRequestBalanceForContacts`

The most important thing about them is that they all accept a list of Contact IDs and return the entitlement/balance for all the received contacts with a single Query. Those classes already have methods to get the same information, but they were built to get it for a single contact.

After the new methods were created, I tried to refactor the existing methods to use the new ones, but it turned out to be a too complex task and I gave up. The main difficulty is that the existing methods work based on a LeavePeriodEntitlement instance instead of a contact ID. Another difficulty is that some of the existing methods (`LeaveBalanceChange::getBalanceForEntitlement` for example) have a lot of filters (like filter by status, by public holidays, by future balance etc) that were really not necessary for this API. In order to use the new methods to do the work of the old ones, I would have to implement all of those filters in them, which would increase the scope of the PR.

---

- [x] Tests Pass