### PR TITLE
PCHR-2510: Fix my leave calendar

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/scss/components/_leave-calendar.scss
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/scss/components/_leave-calendar.scss
@@ -17,6 +17,7 @@ $chr-leave-calendar-legend-size:                  20px;
 
 .chr_leave-calendar__names-container {
   .chr_leave-calendar {
+    margin-bottom: 0;
     table-layout: fixed;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-calendar-month.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-calendar-month.html
@@ -10,7 +10,7 @@
         </div>
 
         <div class="row chr_leave-calendar__month-container">
-          <div class="col-xs-4 col-md-3 col-lg-2 chr_leave-calendar__names-container">
+          <div ng-if="month.showContactName" class="col-xs-4 col-md-3 col-lg-2 chr_leave-calendar__names-container">
             <table ng-switch-when="true" class="table table-bordered chr_leave-calendar">
               <thead>
               <tr class="chr_leave-calendar__days">
@@ -24,7 +24,7 @@
               </tbody>
             </table>
           </div>
-          <div class="col-xs-8 col-md-9 col-lg-10 chr_leave-calendar__dates-container">
+          <div ng-class="{'col-xs-8 col-md-9 col-lg-10': month.showContactName}" class="chr_leave-calendar__dates-container">
             <table ng-switch-when="true" class="table table-bordered chr_leave-calendar">
               <thead>
               <tr class="chr_leave-calendar__days">


### PR DESCRIPTION
## Overview
As part of this PR(and https://github.com/compucorp/civihr-employee-portal-theme/pull/213), responsive design has been implemented for the My Leave calendar.

## Technical Details
My Leave calendar got broken from https://github.com/civicrm/civihr/pull/2100
1. Added `ng-if` statement to hide `chr_leave-calendar__names-container`
2. Added `ng-class` to add the bootstrap classes only for manager leave.
3. Added `margin-bottom` to remove unwanted bottom padding.
![manager_leave___hr17-2](https://user-images.githubusercontent.com/5058867/29907169-747fbea8-8e37-11e7-82d5-e8dc80cdc527.png)


## Before
![my_leave___hr17-2](https://user-images.githubusercontent.com/5058867/29907105-2a755d36-8e37-11e7-910a-0b9ee30c6a27.png)

## After
![my_leave___hr17-2](https://user-images.githubusercontent.com/5058867/29907132-4a32dbf8-8e37-11e7-96da-d322dada14c8.png)

## Screenshots
### iPhone 6 Landscape
![my-leave iphone 6 -land](https://user-images.githubusercontent.com/5058867/29907235-d405ac84-8e37-11e7-9c3e-9e85f8a56c45.png)

### iPhone 6 Portrait
![my-leave iphone 6](https://user-images.githubusercontent.com/5058867/29907244-da2a57ae-8e37-11e7-822f-b1eef74ef8b6.png)

### iPad Landscape
![my-leave ipad -land](https://user-images.githubusercontent.com/5058867/29907298-3799799c-8e38-11e7-9795-aecd1e7294b5.png)

### iPad Portrait
![my-leave ipad](https://user-images.githubusercontent.com/5058867/29907249-e093ab2c-8e37-11e7-8393-6e7bf29368a1.png)

### Desktop
![my-leave](https://user-images.githubusercontent.com/5058867/29907255-e3b3262a-8e37-11e7-9eaf-29b0dc31d491.png)

---

- [x] Tests Pass
