### PR TITLE
PCHR-2556: Contact.getLeaveManagees API to support the unassigned parameter.

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/ContactSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/ContactSelect.php
@@ -12,7 +12,7 @@ use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
  */
 class CRM_HRLeaveAndAbsences_API_Query_ContactSelect {
 
-  use CRM_HRLeaveAndAbsences_Service_SettingsManagerTrait;
+  use CRM_HRLeaveAndAbsences_ACL_LeaveInformationTrait;
 
   /**
    * @var array
@@ -149,26 +149,6 @@ class CRM_HRLeaveAndAbsences_API_Query_ContactSelect {
       unset($returnFields['created_date'], $returnFields['modified_date'], $returnFields['hash']);
       $this->params['return'] = array_flip($returnFields);
     }
-  }
-
-  /**
-   * Returns the conditions needed to add to the Where clause for
-   * contacts that have active leave managers
-   *
-   * @return array
-   */
-  private function activeLeaveManagerCondition() {
-    $today = date('Y-m-d');
-    $leaveApproverRelationshipTypes = $this->getLeaveApproverRelationshipsTypesForWhereIn();
-
-    $conditions = [];
-    $conditions[] = 'rt.is_active = 1';
-    $conditions[] = 'rt.id IN(' . implode(',', $leaveApproverRelationshipTypes) . ')';
-    $conditions[] = 'r.is_active = 1';
-    $conditions[] = "(r.start_date IS NULL OR r.start_date <= '$today')";
-    $conditions[] = "(r.end_date IS NULL OR r.end_date >= '$today')";
-
-    return $conditions;
   }
 }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveRequestSelect.php
@@ -25,7 +25,7 @@ use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
  */
 class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
 
-  use CRM_HRLeaveAndAbsences_Service_SettingsManagerTrait;
+  use CRM_HRLeaveAndAbsences_ACL_LeaveInformationTrait;
 
   /**
    * @var array
@@ -96,16 +96,16 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
     ];
 
     if($hasUnassignedAsFalse) {
-      $conditions = array_merge($conditions, $this->hasActiveLeaveManagerCondition());
+      $conditions = array_merge($conditions, $this->activeLeaveManagerCondition());
     }
 
     if($hasUnassignedAsTrue) {
-      $conditions[] = "NOT (" . implode(' AND ', $this->hasActiveLeaveManagerCondition()) . ") 
+      $conditions[] = "NOT (" . implode(' AND ', $this->activeLeaveManagerCondition()) . ") 
                        OR (r.is_active IS NULL AND rt.is_active IS NULL)";
 
       $query = "a.contact_id NOT IN(SELECT contact_id_a FROM civicrm_relationship r LEFT JOIN
                        civicrm_relationship_type rt ON rt.id = r.relationship_type_id WHERE
-                       ". implode(' AND ', $this->hasActiveLeaveManagerCondition());
+                       ". implode(' AND ', $this->activeLeaveManagerCondition());
 
       $contactID = $this->getContactIdFromParams();
       if ($contactID) {
@@ -126,7 +126,7 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
       }
 
       if(!isset($this->params['unassigned'])) {
-        $activeLeaveManagerCondition = $this->hasActiveLeaveManagerCondition();
+        $activeLeaveManagerCondition = $this->activeLeaveManagerCondition();
         $activeLeaveManagerCondition[] = "r.contact_id_b = {$managerID}";
         $conditions = array_merge($conditions, $activeLeaveManagerCondition);
       }
@@ -305,26 +305,6 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect {
   private function shouldReturnField($field) {
     return empty($this->params['return']) ||
            (is_array($this->params['return']) && in_array($field, $this->params['return']));
-  }
-
-  /**
-   * Returns the conditions needed to add to the Where clause for
-   * contacts that have active leave managers
-   *
-   * @return array
-   */
-  private function hasActiveLeaveManagerCondition() {
-    $today =  '"' . date('Y-m-d') . '"';
-    $leaveApproverRelationshipTypes = $this->getLeaveApproverRelationshipsTypesForWhereIn();
-
-    $conditions = [];
-    $conditions[] = 'rt.is_active = 1';
-    $conditions[] = 'rt.id IN(' . implode(',', $leaveApproverRelationshipTypes) . ')';
-    $conditions[] = 'r.is_active = 1';
-    $conditions[] = "(r.start_date IS NULL OR r.start_date <= {$today})";
-    $conditions[] = "(r.end_date IS NULL OR r.end_date >= {$today})";
-
-    return $conditions;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/Contact/Getleavemanagees.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/Contact/Getleavemanagees.php
@@ -11,9 +11,17 @@ function _civicrm_api3_contact_getleavemanagees_spec(&$spec) {
     'title' => 'Managed By',
     'description' => 'Only information for contacts managed by the contact with the given ID are returned',
     'type' => CRM_Utils_Type::T_INT,
-    'api.required' => 1,
+    'api.required' => 0,
     'FKClassName'  => 'CRM_Contact_DAO_Contact',
     'FKApiName'    => 'Contact',
+  ];
+
+  $spec['unassigned'] = [
+    'name' => 'unassigned',
+    'title' => 'Unassigned only?',
+    'description' => 'Include only contacts without active leave managers?',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+    'api.required' => 0,
   ];
 }
 
@@ -29,11 +37,33 @@ function _civicrm_api3_contact_getleavemanagees_spec(&$spec) {
  * @throws API_Exception
  */
 function civicrm_api3_contact_getleavemanagees($params) {
+  _civicrm_api3_contact_getleavemanagees_validate_params($params);
+
   // We need to set check_permissions to false so as to disable default Civi ACL checks for
   // this endpoint. ACL checks needed are already in the ContactSelect Query class.
   $params['check_permissions'] = false;
   $leaveManagerService = new CRM_HRLeaveAndAbsences_Service_LeaveManager();
   $query = new CRM_HRLeaveAndAbsences_API_Query_ContactSelect($params, $leaveManagerService);
   return civicrm_api3_create_success($query->run(), $params);
+}
+
+/**
+ * Validates the parameters passed to the Contact.GetLeaveManagees API
+ *
+ * @param array $params
+ *
+ * @throws API_Exception
+ */
+function _civicrm_api3_contact_getleavemanagees_validate_params($params) {
+  $hasUnassignedAsTrue = !empty($params['unassigned']);
+  $hasManagedBy = isset($params['managed_by']);
+
+  if (!$hasUnassignedAsTrue && !$hasManagedBy) {
+    throw new API_Exception('Either unassigned must be true or managed_by parameter present');
+  }
+
+  if ($hasUnassignedAsTrue && $hasManagedBy) {
+    throw new API_Exception('Unassigned cannot be true and managed_by parameter also present');
+  }
 }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ContactTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ContactTest.php
@@ -142,14 +142,6 @@ class api_v3_ContactTest extends BaseHeadlessTest {
     $this->assertEquals($result['values'][$this->contact2['id']]['id'], $this->contact2['id']);
   }
 
-  /**
-   * @expectedException CiviCRM_API3_Exception
-   * @expectedExceptionMessage Mandatory key(s) missing from params array: managed_by
-   */
-  public function testGetLeaveManageesThrowsAnExceptionWhenManagedByParameterIsNotPresent() {
-    civicrm_api3('Contact', 'getleavemanagees');
-  }
-
   public function testGetLeaveManageesReturnsEmptyWhenALoggedInManagerIsTryingToAccessTheManageesOfAnotherManager() {
     $manager2 = ContactFabricator::fabricate();
 
@@ -189,5 +181,29 @@ class api_v3_ContactTest extends BaseHeadlessTest {
     $result = $this->callAPI('Contact', 'getleavemanagees', ['managed_by' => $this->manager['id']]);
 
     $this->assertEquals(0, $result['count']);
+  }
+
+  /**
+   * @expectedExceptionMessage Either unassigned must be true or managed_by parameter present
+   * @expectedException CiviCRM_API3_Exception
+   */
+  public function testGetLeaveManageesThrowsAnExceptionWhenUnassignedIsFalseAndManagedByIsAbsent() {
+    $this->callAPI('Contact', 'getleavemanagees', ['unassigned' => false]);
+  }
+
+  /**
+   * @expectedExceptionMessage Unassigned cannot be true and managed_by parameter also present
+   * @expectedException CiviCRM_API3_Exception
+   */
+  public function testGetLeaveManageesThrowsAnExceptionWhenUnassignedIsTrueAndManagedByParameterIsPresent() {
+    $this->callAPI('Contact', 'getleavemanagees', ['unassigned' => true, 'managed_by' => 1]);
+  }
+
+  /**
+   * @expectedExceptionMessage Either unassigned must be true or managed_by parameter present
+   * @expectedException CiviCRM_API3_Exception
+   */
+  public function testGetLeaveManageesThrowsAnExceptionWhenUnassignedAndManagedByParameterIsAbsent() {
+    $this->callAPI('Contact', 'getleavemanagees', []);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ContactTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ContactTest.php
@@ -213,52 +213,47 @@ class api_v3_ContactTest extends BaseHeadlessTest {
   }
 
   public function testGetLeaveManageesReturnsOnlyContactsWithoutActiveLeaveApproverRelationshipWhenUnassignedTrue() {
-    $contact1 = $this->contact1;
-    $contact2 = $this->contact2;
     $contact3 = ContactFabricator::fabricate();
-    $manager = $this->manager;
 
     $relationshipType = RelationshipTypeFabricator::fabricate();
+    //Contact3 has a relationship with manager but the relationship is not
+    //of type leave approver.
     RelationshipFabricator::fabricate([
       'contact_id_a' => $contact3['id'],
-      'contact_id_b' => $manager['id'],
+      'contact_id_b' => $this->manager['id'],
       'relationship_type_id' => $relationshipType['id']
     ]);
 
-    $this->setContactAsLeaveApproverOf($manager, $contact1);
+    $this->setContactAsLeaveApproverOf($this->manager, $this->contact1);
 
     $result = $this->callAPI('Contact', 'getleavemanagees', ['unassigned' => true]);
 
     //The manager, contact2 and contact3 does not have an active leave approver
     //relationship.
     $this->assertEquals(3, $result['count']);
-    $this->assertEquals($result['values'][$contact2['id']]['id'], $contact2['id']);
+    $this->assertEquals($result['values'][$this->contact2['id']]['id'], $this->contact2['id']);
     $this->assertEquals($result['values'][$contact3['id']]['id'], $contact3['id']);
-    $this->assertEquals($result['values'][$manager['id']]['id'], $manager['id']);
+    $this->assertEquals($result['values'][$this->manager['id']]['id'], $this->manager['id']);
   }
 
   public function testGetLeaveManageesReturnsNoInformationForContactWithActiveLeaveManagerAndOtherRelationshipWhenUnassignedIsTrue() {
-    $contact1 = $this->contact1;
-    $contact2 = $this->contact2;
-    $manager = $this->manager;
-
-    $this->setContactAsLeaveApproverOf($manager, $contact1);
+    $this->setContactAsLeaveApproverOf($this->manager, $this->contact1);
     $relationshipType = RelationshipTypeFabricator::fabricate();
 
     //Add a neutral relationship between contact1 and manager that is not of
     //type leave approver.
     RelationshipFabricator::fabricate([
-      'contact_id_a' => $contact1['id'],
-      'contact_id_b' => $manager['id'],
+      'contact_id_a' => $this->contact1['id'],
+      'contact_id_b' => $this->manager['id'],
       'relationship_type_id' => $relationshipType['id']
     ]);
 
     $result = $this->callAPI('Contact', 'getleavemanagees', ['unassigned' => true]);
 
-    //contact2 and and manager will be returned because they are without active leave
-    //approver relationdip.
+    //contact2 and manager will be returned because they are without active leave
+    //approver relationship.
     $this->assertEquals(2, $result['count']);
-    $this->assertEquals($result['values'][$contact2['id']]['id'], $contact2['id']);
-    $this->assertEquals($result['values'][$manager['id']]['id'], $manager['id']);
+    $this->assertEquals($result['values'][$this->contact2['id']]['id'], $this->contact2['id']);
+    $this->assertEquals($result['values'][$this->manager['id']]['id'], $this->manager['id']);
   }
 }


### PR DESCRIPTION
## Overview
Currently the Contact.getLeaveManagees API only supports one mandatory parameter: `managed_by` which allows the API to returned contacts managed by the contact ID passed in the managed_by parameter. To make the API more flexible, the unassigned parameter is introduced in this PR to allow the API to return contacts that do not have an active Leave Approver relationship.

## Before
The Contact.getLeaveManageesAPI does not support the unassigned parameter.

## After
The Contact.getLeaveManageesAPI now supports the unassigned parameter. 
These are the rules that guide the new unassigned parameter in relation to the existing managed_by parameter:
- If the `unassigned` parameter isn't present in the request, then `managed_by` must be required.
- If `unassigned` is false, then `managed_by` must be required.
- If `unassigned` is true, then `managed_by` must not be passed.

---

- [X] Tests Pass
