### PR TITLE
PCHR-2554: Fix Admin TOIL & Sick Leave Request creation

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/absence-tab/components/absence-tab-custom-work-pattern-modal.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/absence-tab/components/absence-tab-custom-work-pattern-modal.html
@@ -34,6 +34,7 @@
             <div class="col-sm-8">
               <div class="crm_custom-select crm_custom-select--full">
                 <select
+                  class="no-select2"
                   ng-options="workPatterns.label for workPatterns in workPatternModal.workPatterns"
                   ng-model="workPatternModal.selected.workPattern"
                   ng-change="workPatternModal.refresh()">
@@ -52,6 +53,7 @@
             <div class="col-sm-8">
               <div class="crm_custom-select crm_custom-select--full">
                 <select
+                  class="no-select2"
                   ng-options="changeReasons.value as changeReasons.label for changeReasons in workPatternModal.changeReasons"
                   ng-model="workPatternModal.selected.changeReason"
                   ng-change="workPatternModal.refresh()">

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-balance-tab-filters.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-balance-tab-filters.html
@@ -10,14 +10,14 @@
       <div class="row">
         <div class="form-group col-sm-4">
           <label>Periods</label>
-          <select class="form-control"
+          <select class="form-control no-select2"
             ng-model="balanceFilters.filters.absence_period"
             ng-options="period.id as period.title for period in balanceFilters.absencePeriods | orderBy:'title'">
           </select>
         </div>
         <div class="form-group col-sm-4">
           <label>Leave Type</label>
-          <select class="form-control"
+          <select class="form-control no-select2"
             ng-model="balanceFilters.filters.absence_type"
             ng-options="type.id as type.title for type in balanceFilters.absenceTypes | orderBy:'title'">
           </select>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-request-popup/details-tab/common.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-request-popup/details-tab/common.html
@@ -53,6 +53,7 @@
           class="chr_leave-request-modal__small_spinner">
           <div class="crm_custom-select crm_custom-select--full">
             <select
+              class="no-select2"
               name="fromDayTypeSelect"
               ng-disabled="!detailsTab.isRole('admin') &&
                 (detailsTab.isMode('view') || (detailsTab.isRole('manager') && !detailsTab.isMode('create') && !detailsTab.isLeaveType('sickness')))"
@@ -106,6 +107,7 @@
           class="chr_leave-request-modal__small_spinner">
           <div class="crm_custom-select crm_custom-select--full">
             <select
+              class="no-select2"
               name="toDayTypeSelect"
               ng-disabled="!detailsTab.isRole('admin') &&
                 (detailsTab.isMode('view') || !detailsTab.request.from_date || (detailsTab.isRole('manager') && !detailsTab.isMode('create') && !detailsTab.isLeaveType('sickness')))"

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-request-popup/details-tab/sickness.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-request-popup/details-tab/sickness.html
@@ -6,6 +6,7 @@
       <div class="col-sm-8">
         <div class="crm_custom-select crm_custom-select--full">
           <select
+            class="no-select2"
             name="reason"
             ng-disabled="!detailsTab.isRole('admin') &&
               (detailsTab.isMode('view') || (detailsTab.isRole('manager') && !detailsTab.isLeaveType('sickness')))"

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-request-popup/details-tab/toil.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-request-popup/details-tab/toil.html
@@ -5,6 +5,7 @@
       <div class="col-xs-6 col-sm-4 chr_leave-request-modal__input-shift-left">
         <div class="crm_custom-select crm_custom-select--full">
           <select name="hours" ng-model="detailsTab.request.toilDurationHours"
+            class="no-select2"
             ng-disabled="!detailsTab.isRole('admin') &&
               (detailsTab.isMode('view') || (detailsTab.isRole('manager') && !detailsTab.isMode('create')))"
             ng-change="detailsTab.request.updateDuration()">
@@ -28,6 +29,7 @@
       <div class="col-xs-6 col-sm-4">
         <div class="crm_custom-select crm_custom-select--full">
           <select name="minutes" ng-model="detailsTab.request.toilDurationMinutes"
+            class="no-select2"
             ng-change="detailsTab.request.updateDuration()"
             ng-disabled="!detailsTab.isRole('admin') &&
               (detailsTab.isMode('view') || (detailsTab.isRole('manager') && !detailsTab.isMode('create')))">
@@ -56,6 +58,7 @@
       <div class="col-xs-12">
         <div class="crm_custom-select crm_custom-select--full">
           <select
+            class="no-select2"
             name="toilAmount"
             ng-disabled="detailsTab.isMode('view')"
             ng-options="amount.value as amount.label for amount in detailsTab.toilAmounts"

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-request-popup/leave-request-popup-body.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-request-popup/leave-request-popup-body.html
@@ -27,6 +27,7 @@
       <div class="col-xs-12">
         <div class="crm_custom-select crm_custom-select--full">
           <select
+            class="no-select2"
             ng-hide="$ctrl.absenceTypes.length === 0"
             ng-disabled="!$ctrl.isRole('admin') && ($ctrl.isMode('view') || ($ctrl.isRole('manager') && !$ctrl.isMode('create')))"
             name="absenceTypeSelect"
@@ -34,6 +35,7 @@
             ng-model="$ctrl.request.type_id"
             ng-change="$ctrl.updateBalance()"></select>
           <select
+            class="no-select2"
             ng-show="$ctrl.absenceTypes.length === 0"
             disabled="disabled">
             <option>You don't have any leave entitlement</option>
@@ -77,6 +79,7 @@
           <div class="col-sm-8">
             <div class="crm_custom-select crm_custom-select--full">
               <select
+                class="no-select2"
                 name="statusSelect"
                 ng-options="status.value as status.label for status in $ctrl.getStatuses()"
                 ng-model="$ctrl.newStatusOnSave">

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/manage-leave-requests.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/manage-leave-requests.html
@@ -6,6 +6,7 @@
         <div class="col-md-3 chr_manage_leave_requests__leave_type_filter">
           <div class="crm_custom-select crm_custom-select--full">
             <select
+              class="no-select2"
               ng-options="types.title for types in vm.absenceTypes track by types.id"
               ng-model="vm.filters.leaveRequest.selectedAbsenceTypes"
               ng-change="vm.refresh()">
@@ -28,6 +29,7 @@
         <div class="hidden-md hidden-lg col-md-4 col-md-offset-1 chr_manage_leave_requests__assignee_filter text-center" ng-if="vm.isAdmin">
           <div class="crm_custom-select crm_custom-select--full">
             <select
+              class="no-select2"
               ng-options="filter as filter.label for filter in vm.filtersByAssignee"
               ng-model="vm.filters.leaveRequest.assignedTo"
               ng-change="vm.refresh()">
@@ -42,12 +44,13 @@
             ng-class="{ 'col-lg-8 col-lg-offset-2' : vm.isAdmin }"
             class="col-md-10 chr_manage_leave_requests__period_and_all_filters">
           <div class="crm_custom-select crm_custom-select--full">
-              <select
-                ng-options="period as vm.labelPeriod(period) for period in vm.absencePeriods track by period.id"
-                ng-model="vm.filters.leaveRequest.selectedPeriod"
-                ng-change="vm.refresh()">
-              </select>
-              <span class="crm_custom-select__arrow"></span>
+            <select
+              class="no-select2"
+              ng-options="period as vm.labelPeriod(period) for period in vm.absencePeriods track by period.id"
+              ng-model="vm.filters.leaveRequest.selectedPeriod"
+              ng-change="vm.refresh()">
+            </select>
+            <span class="crm_custom-select__arrow"></span>
           </div>
         </div>
           <div class="col-md-2 chr_manage_leave_requests__filter pointer" ng-click="vm.isFilterExpanded = !vm.isFilterExpanded">
@@ -71,6 +74,7 @@
         <div class="col-md-4 col-lg-2">
           <div class="crm_custom-select crm_custom-select--full">
             <select
+              class="no-select2"
               ng-options="region.value as region.label for region in vm.regions track by region.id"
               ng-model="vm.filters.contact.region"
               ng-change="vm.refresh(region)">
@@ -82,6 +86,7 @@
         <div class="col-md-4 col-lg-2">
           <div class="crm_custom-select crm_custom-select--full">
             <select
+              class="no-select2"
               ng-options="department.value as department.label for department in vm.departments track by department.id"
               ng-model="vm.filters.contact.department"
               ng-change="vm.refresh()">
@@ -93,6 +98,7 @@
         <div class="col-md-4 col-lg-2 no_gutter">
           <div class="crm_custom-select crm_custom-select--full">
             <select
+              class="no-select2"
               ng-options="levelType.value as levelType.value for levelType in vm.levelTypes track by levelType.id"
               ng-model="vm.filters.contact.level_type"
               ng-change="vm.refresh()">
@@ -104,6 +110,7 @@
         <div class="col-md-4 col-lg-2 no_gutter">
           <div class="crm_custom-select crm_custom-select--full">
             <select
+              class="no-select2"
               ng-options="location.value as location.label for location in vm.locations track by location.id"
               ng-model="vm.filters.contact.location"
               ng-change="vm.refresh()">
@@ -140,6 +147,7 @@
             <div>
               <div class="crm_custom-select crm_custom-select--full">
                 <select
+                  class="no-select2"
                   ng-options="status.label for status in vm.leaveRequestStatuses | filter: vm.countLeaveRequestByStatus"
                   ng-model="vm.filters.leaveRequest.leaveStatus"
                   ng-change="vm.refresh(1, false, 'table')">


### PR DESCRIPTION
## Overview

In Absence Tab Admin cannot create neither TOIL nor Sick leave request. This PR fixes this issue.

## Before

![1](https://user-images.githubusercontent.com/3973243/30032977-78231bd4-9190-11e7-9ca5-18488abd797e.gif)

## After

![2](https://user-images.githubusercontent.com/3973243/30032981-7c83ff18-9190-11e7-9250-a8f370caf1bc.gif)

## Technical Details

This happens because in Admin section the `<select>` element behaviour  was overridden. The class "no-select2" prevent the selector element from being overridden. **The "broken" selectors do not write values to components via ng-model!**

```html
<select>...</select>
``` 

![image](https://user-images.githubusercontent.com/3973243/30032564-9558589c-918e-11e7-8432-cd55f61a3fe4.png)


```html
<select class="no-select2">...</select>
``` 
![image](https://user-images.githubusercontent.com/3973243/30032590-b362110c-918e-11e7-82e7-2149eb3860f3.png)

This PR also fixes the styling of selectors in other places in L&A:

**Before**: only 6 selectors out of 27 had "no-select2" class.
![image](https://user-images.githubusercontent.com/3973243/30033071-e91306f6-9190-11e7-8a68-8a3595b7fcc0.png)

**After**: all files containing selectors have the "no-select2" class.
![image](https://user-images.githubusercontent.com/3973243/30033025-b0b8e1ea-9190-11e7-8ca8-cce32e200fc1.png)

## Comments

This PR also fixes the styling of selectors in other places in L&A:

### Work Patterns

**Before**
![image](https://user-images.githubusercontent.com/3973243/30033115-38ac988a-9191-11e7-86e9-20233dc66558.png)

**After**
![image](https://user-images.githubusercontent.com/3973243/30033150-75fe9d5a-9191-11e7-831f-5e92d83f4c9f.png)

This PR also prevents such a behaviour in the future for other components:
- Leave Balance Tab Filters
- Manager Leave Requests

---

- [x] Tests Pass
