### PR TITLE
PCHR-2535: Fix Leave Request cancellation or rejection by Manager

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -448,6 +448,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
       return;
     }
 
+    // Leave Request is able to be rejected or cancelled disregarding the balance
+    if (in_array($params['status_id'], self::getCancelledStatuses())) {
+      return;
+    }
+
     $leaveRequestBalance = self::calculateBalanceChangeFromCreateParams($params);
     if ($leaveRequestBalance == 0) {
       throw new InvalidLeaveRequestException(
@@ -708,7 +713,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
 
     $query = "
       SELECT DISTINCT lr.* FROM {$leaveRequestTable} lr
-      INNER JOIN {$leaveRequestDateTable} lrd 
+      INNER JOIN {$leaveRequestDateTable} lrd
         ON lrd.leave_request_id = lr.id
       INNER JOIN {$leaveBalanceChangeTable} lbc
         ON lbc.source_id = lrd.id AND lbc.source_type = %1
@@ -955,14 +960,14 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     $leaveRequestTable = self::getTableName();
     $leaveRequestDateTable = LeaveRequestDate::getTableName();
 
-    $query = "DELETE bc, lrd, lr 
+    $query = "DELETE bc, lrd, lr
               FROM {$leaveRequestTable} lr
-              INNER JOIN {$leaveRequestDateTable} lrd 
-                ON lrd.leave_request_id = lr.id 
-              INNER JOIN {$leaveBalanceChangeTable} bc 
-                ON bc.source_id = lrd.id AND bc.source_type = %1 
-              WHERE lr.type_id = %2 AND 
-                    lr.from_date >= %3 AND 
+              INNER JOIN {$leaveRequestDateTable} lrd
+                ON lrd.leave_request_id = lr.id
+              INNER JOIN {$leaveBalanceChangeTable} bc
+                ON bc.source_id = lrd.id AND bc.source_type = %1
+              WHERE lr.type_id = %2 AND
+                    lr.from_date >= %3 AND
                     lr.request_type = %4 AND
                     lr.toil_expiry_date > %5
               ";


### PR DESCRIPTION
## Overview

At the moment Manager cannot reject or cancel a leave request if the leave request balance change is greater than the current entitlement balance.

_The simple use case is the following:_
1) Staff creates a single day Overtime TOIL
2) This Overtime TOIL is approved by Manager
3) Staff creates two single day Leave Requests and in both uses the balance of Overtime TOIL (1)
4) One of the Leave Requests mentioned above is then approved by Manager
5) Manager now cannot cancel or reject the second Leave Request since the Overtime TOIL balance is now (0)

This PR fixes this issue.

## Before

Manager cannot approve the second Leave Request, but also cannot cancel (or reject) it.

![1](https://user-images.githubusercontent.com/3973243/30062901-b264c932-9244-11e7-8282-196d42515c4a.gif)

## After

Manager cannot approve the second Leave Request, but **can** cancel (or reject) it.

![2](https://user-images.githubusercontent.com/3973243/30062905-b6b2b0c6-9244-11e7-82eb-161f65e383d8.gif)

## Technical Details

A check for a status was added in the function that checks the balance:

```php
private static function validateEntitlementAndWorkingDayAndBalanceChange($params, $absenceType, $period) {
  // ...
  // Leave Request is able to be rejected or cancelled disregarding the balance
  if (in_array($params['status_id'], self::getCancelledStatuses())) {
    return;
  }
  // ...
}
```
`self::getCancelledStatuses()` returns an array that corresponds to Cancelled and Rejected statuses.

---

- [x] Tests Pass
