### PR TITLE
PCHR-2544: Add the LeaveRequest.getBreakdown API

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -1266,4 +1266,31 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
 
     return $balances;
   }
+
+  /**
+   * Returns a list of LeaveBalanceChange instances linked to the given
+   * LeaveRequestDate instances.
+   *
+   * The results are indexed by the LeaveRequestDates ID.
+   *
+   * @param CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate[]
+   *
+   * @return CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange[]
+   */
+  public static function getForLeaveRequestDates($dates) {
+    $balanceChanges = [];
+
+    $datesIDs = CRM_Utils_Array::collect('id', $dates);
+
+    $balanceChange = new self();
+    $balanceChange->source_type = self::SOURCE_LEAVE_REQUEST_DAY;
+    $balanceChange->whereAdd('source_id IN (' . implode(',', $datesIDs) . ')');
+    $balanceChange->find();
+
+    while($balanceChange->fetch()) {
+      $balanceChanges[$balanceChange->source_id] = clone $balanceChange;
+    }
+
+    return $balanceChanges;
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -308,4 +308,43 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
       $this->leaveBalanceChangeService->recalculateExpiredBalanceChangesForLeaveRequestPastDates($leaveRequest);
     }
   }
+
+  /**
+   * Returns the breakdown of the Leave Request with the given ID.
+   *
+   * The breakdown is a list of the Request's dates, together with the amount
+   * of days deducted for it.
+   *
+   * @param int $leaveRequestID
+   *
+   * @return array
+   *   An array of breakdown items, where each one is:
+   *   [
+   *     'id' => 1,
+   *     'type' => 1,
+   *     'label' => 'All Day',
+   *     'date' => '2017-09-06',
+   *     'amount' => -1
+   *   ]
+   */
+  public function getBreakdown($leaveRequestID) {
+    $leaveRequestDayTypes = LeaveRequestDate::buildOptions('type');
+
+    $dates = LeaveRequestDate::getDatesForLeaveRequest($leaveRequestID);
+    $balanceChanges = LeaveBalanceChange::getForLeaveRequestDates($dates);
+
+    $breakdown = [];
+
+    foreach($dates as $date) {
+      $breakdown[] = [
+        'id' => $date->id,
+        'type' => $date->type,
+        'label' => $date->type ? $leaveRequestDayTypes[$date->type] : '',
+        'date' => date('Y-m-d', strtotime($date->date)),
+        'amount' => $balanceChanges[$date->id]->amount
+      ];
+    }
+
+    return $breakdown;
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -300,25 +300,12 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    * @param \CRM_HRLeaveAndAbsences_BAO_LeaveRequest $leaveRequest
    */
   private function recalculateExpiredBalanceChange(LeaveRequest $leaveRequest) {
-    $leaveStatuses = $this->getLeaveRequestStatuses();
+    $leaveStatuses = LeaveRequest::getStatuses();
     $today = new DateTime();
     $leaveRequestDate = new DateTime($leaveRequest->from_date);
 
     if($leaveRequestDate < $today && $leaveRequest->status_id == $leaveStatuses['approved']) {
       $this->leaveBalanceChangeService->recalculateExpiredBalanceChangesForLeaveRequestPastDates($leaveRequest);
     }
-  }
-
-  /**
-   * Returns the array of the option values for the LeaveRequest status_id field.
-   *
-   * @return array
-   */
-  private function getLeaveRequestStatuses() {
-    if (is_null($this->leaveStatuses)) {
-      $this->leaveStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
-    }
-
-    return $this->leaveStatuses;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveBalanceChange.php
@@ -48,10 +48,15 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveBalanceChange {
   }
 
   private static function fabricateForLeaveRequestDates(LeaveRequest $leaveRequest) {
+    $leaveRequestDayTypes = array_flip(LeaveRequestDate::buildOptions('type', 'validate'));
+
     LeaveBalanceChange::deleteAllForLeaveRequest($leaveRequest);
     $dates = $leaveRequest->getDates();
     foreach($dates as $date) {
       self::fabricateForLeaveRequestDate($date);
+
+      $date->type = $leaveRequestDayTypes['all_day'];
+      $date->save();
     }
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -693,3 +693,41 @@ function civicrm_api3_leave_request_deleteattachment($params) {
   $leaveRequestAttachmentService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachment();
   return $leaveRequestAttachmentService->delete($params);
 }
+
+/**
+ * LeaveRequest.getBreakdown API spec
+ *
+ * @param array $spec
+ */
+function _civicrm_api3_leave_request_getbreakdown_spec(&$spec) {
+  $spec['leave_request_id'] = [
+    'name' => 'leave_request_id',
+    'type' => CRM_Utils_Type::T_INT,
+    'title' => 'LeaveRequest ID',
+    'description' => 'The Leave Request ID to get the breakdown for',
+    'api.required' => 1
+  ];
+}
+
+/**
+ * LeaveRequest.getBreakdown API
+ *
+ * @param array $params
+ *
+ * @return array
+ */
+function civicrm_api3_leave_request_getbreakdown($params) {
+  $params['id'] = $params['leave_request_id'];
+  $query = new CRM_HRLeaveAndAbsences_API_Query_LeaveRequestSelect($params);
+  $leaveRequest = $query->run();
+  $leaveRequest = reset($leaveRequest);
+
+  if(empty($leaveRequest)) {
+    return civicrm_api3_create_success([]);
+  }
+
+  $leaveRequestService = CRM_HRLeaveAndAbsences_Factory_LeaveRequestService::create();
+  $breakdown = $leaveRequestService->getBreakdown($leaveRequest['id']);
+
+  return civicrm_api3_create_success($breakdown);
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -133,6 +133,7 @@ function hrleaveandabsences_civicrm_alterAPIPermissions($entity, $action, &$para
     'deletecomment' => ['leave_request'],
     'getattachments' => ['leave_request'],
     'deleteattachment' => ['leave_request'],
+    'getbreakdown' => ['leave_request'],
   ];
 
   foreach ($actionEntities as $action => $entities) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -3675,6 +3675,33 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $this->assertEquals(-1, $result[$contract2['contact_id']][$absenceTypeID]);
   }
 
+  public function testGetForLeaveRequestDatesReturnsOnTheBalanceChangesLinkedToTheGiveLeaveRequestDates() {
+    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => 1,
+      'contact_id' => 1,
+      'from_date' => date('YmdHis', strtotime('-4 days')),
+      'to_date' => date('YmdHis', strtotime('-3 days'))
+    ], true);
+
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => 1,
+      'contact_id' => 1,
+      'from_date' => date('YmdHis', strtotime('-5 days')),
+      'to_date' => date('YmdHis', strtotime('-5 days'))
+    ], true);
+
+    $dates = $leaveRequest1->getDates();
+    $balanceChanges = LeaveBalanceChange::getForLeaveRequestDates($dates);
+    $this->assertCount(2, $balanceChanges);
+    $this->assertNotNull($balanceChanges[$dates[0]->id]);
+    $this->assertNotNull($balanceChanges[$dates[1]->id]);
+
+    $dates = $leaveRequest2->getDates();
+    $balanceChanges = LeaveBalanceChange::getForLeaveRequestDates($dates);
+    $this->assertCount(1, $balanceChanges);
+    $this->assertNotNull($balanceChanges[$dates[0]->id]);
+  }
+
   private function getBalanceChangesForPeriodEntitlement($leavePeriodEntitlement) {
     $record = new LeaveBalanceChange();
     $record->source_id = $leavePeriodEntitlement->id;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChangeTest.php
@@ -6,6 +6,7 @@ use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
 use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange as LeaveBalanceChangeService;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod as AbsencePeriodFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest as PublicHolidayLeaveRequestFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern as WorkPatternFabricator;
@@ -65,6 +66,11 @@ class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChangeTest extends BaseHeadless
 
   public function testCanSetTheTypeOfTheLeaveRequestDatesToWhichItCreatesTheBalanceChangesTo() {
     $contact = ContactFabricator::fabricate();
+
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2017-09-04'),
+      'end_date' => CRM_Utils_Date::processDate('2017-12-31'),
+    ]);
 
     HRJobContractFabricator::fabricate(
       ['contact_id' => $contact['id']],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ApiPermissionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/ApiPermissionTest.php
@@ -44,6 +44,7 @@ class api_v3_ApiPermissionTest extends BaseHeadlessTest {
       ['LeaveRequest', 'getattachments'],
       ['LeaveRequest', 'deleteattachment'],
       ['LeaveRequest', 'delete'],
+      ['LeaveRequest', 'getbreakdown'],
       ['WorkPattern', 'getcalendar'],
       ['AbsenceType', 'get'],
       ['AbsencePeriod', 'get'],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -3859,7 +3859,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertCount(3, $result['values']);
   }
 
-  public function testGetBreakdownShouldNotReturnIfAnAdminTriesToAccessTheBreakdownOfAnyLeaveRequest() {
+  public function testGetBreakdownReturnsResultsIfAnAdminTriesToAccessTheBreakdownOfAnyLeaveRequest() {
     $admin = ContactFabricator::fabricate();
     $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -3749,6 +3749,162 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     civicrm_api3('LeaveRequest', 'deleteattachment', ['leave_request_id' => 1]);
   }
 
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage Mandatory key(s) missing from params array: leave_request_id
+   */
+  public function testGetBreakdownShouldThrowAnExceptionIfTheLeaveRequestIDIsMissing() {
+    civicrm_api3('LeaveRequest', 'getbreakdown', []);
+  }
+
+  public function testGetBreakdownShouldReturnEmptyIfTheGiveLeaveRequestDoesnExist() {
+    $result = civicrm_api3('LeaveRequest', 'getbreakdown', ['leave_request_id' => 1]);
+
+    $this->assertEmpty($result['values']);
+  }
+
+  public function testGetBreakdownShouldReturnEmptyIfAStaffMemberTriesToGetTheBreakdownOfAnotherStaffMember() {
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    $this->setPermissions(['access AJAX API']);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => CRM_Utils_Date::processDate('+5 days')]
+    );
+
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => 1,
+      'contact_id' => $contact2['id'],
+      'from_date' => CRM_Utils_Date::processDate('+5 days'),
+      'to_date' =>  CRM_Utils_Date::processDate('+7 days'),
+    ], true);
+
+    $this->registerCurrentLoggedInContactInSession($contact1['id']);
+
+    // Contact1 should not be able to get the breakdown for a leave request of
+    // Contact2
+    $result = civicrm_api3('LeaveRequest', 'getBreakdown', [
+      'leave_request_id' => $leaveRequest->id,
+      'check_permissions' => true,
+    ]);
+    $this->assertEmpty($result['values']);
+
+    $this->registerCurrentLoggedInContactInSession($contact2['id']);
+
+    // Contact2 should be able to get the breakdown for their own leave request
+    $result = civicrm_api3('LeaveRequest', 'getBreakdown', [
+      'leave_request_id' => $leaveRequest->id,
+      'check_permissions' => true,
+    ]);
+    $this->assertCount(3, $result['values']);
+  }
+
+  public function testGetBreakdownShouldReturnEmptyIfAManagerTriesToGetTheBreakdownOfSomeoneWhoTheyDontManage() {
+    $manager = ContactFabricator::fabricate();
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => CRM_Utils_Date::processDate('+5 days')]
+    );
+
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => 1,
+      'contact_id' => $contact2['id'],
+      'from_date' => CRM_Utils_Date::processDate('+5 days'),
+      'to_date' =>  CRM_Utils_Date::processDate('+7 days'),
+    ], true);
+
+    $this->registerCurrentLoggedInContactInSession($manager['id']);
+    $this->setContactAsLeaveApproverOf($manager, $contact1);
+    $this->setPermissions(['access AJAX API']);
+
+    // Manager only manages Contact 1, so they should not be able to get the
+    // breakdown for a leave request of Contact2
+    $result = civicrm_api3('LeaveRequest', 'getBreakdown', [
+      'leave_request_id' => $leaveRequest->id,
+      'check_permissions' => true,
+    ]);
+    $this->assertEmpty($result['values']);
+  }
+
+  public function testGetBreakdownShouldNotReturnEmptyIfAManagerTriesToGetTheBreakdownOfSomeoneTheyManage() {
+    $manager = ContactFabricator::fabricate();
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => CRM_Utils_Date::processDate('+5 days')]
+    );
+
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => 1,
+      'contact_id' => $contact2['id'],
+      'from_date' => CRM_Utils_Date::processDate('+5 days'),
+      'to_date' =>  CRM_Utils_Date::processDate('+7 days'),
+    ], true);
+
+    $this->registerCurrentLoggedInContactInSession($manager['id']);
+    $this->setContactAsLeaveApproverOf($manager, $contact2);
+    $this->setPermissions(['access AJAX API']);
+
+    $result = civicrm_api3('LeaveRequest', 'getBreakdown', [
+      'leave_request_id' => $leaveRequest->id,
+      'check_permissions' => true,
+    ]);
+    $this->assertCount(3, $result['values']);
+  }
+
+  public function testGetBreakdownShouldNotReturnIfAnAdminTriesToAccessTheBreakdownOfAnyLeaveRequest() {
+    $admin = ContactFabricator::fabricate();
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      ['period_start_date' => CRM_Utils_Date::processDate('+5 days')]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => CRM_Utils_Date::processDate('+5 days')]
+    );
+
+    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => 1,
+      'contact_id' => $contact1['id'],
+      'from_date' => CRM_Utils_Date::processDate('+5 days'),
+      'to_date' =>  CRM_Utils_Date::processDate('+7 days'),
+    ], true);
+
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => 1,
+      'contact_id' => $contact2['id'],
+      'from_date' => CRM_Utils_Date::processDate('+8 days'),
+      'to_date' =>  CRM_Utils_Date::processDate('+8 days'),
+    ], true);
+
+    $this->registerCurrentLoggedInContactInSession($admin['id']);
+    // Admins have the view all contacts permission
+    $this->setPermissions(['access AJAX API', 'view all contacts']);
+
+    $result = civicrm_api3('LeaveRequest', 'getBreakdown', [
+      'leave_request_id' => $leaveRequest1->id,
+      'check_permissions' => true,
+    ]);
+    $this->assertCount(3, $result['values']);
+
+    $result = civicrm_api3('LeaveRequest', 'getBreakdown', [
+      'leave_request_id' => $leaveRequest2->id,
+      'check_permissions' => true,
+    ]);
+    $this->assertCount(1, $result['values']);
+  }
+
   private function getExpectedArrayForIsValidError($field, $code) {
     return [
       'is_error' => 0,


### PR DESCRIPTION
## Overview
When opening an existing Leave Request, we should show its breakdown (the list of each of its dates, together with a number of days deducted for each of them). 

This is information is stored in the database, but scattered in a few tables. This new API should be used to expose an easy way to fetch it while avoiding to expose too many data structure details.

## Before
There's no easy way to get the breakdown of a Leave Request

## After
The `LeaveRequest.getBreakdown` is available to be used to fetch the breakdown of a Leave Request.
It has a mandatory `leave_request_id` param, that should be used to give the ID of the Leave Request to which we want to get the breakdown to.

The breakdown of a Leave Request is just a list of its dates together with the number of days deduct for it. Here is a sample response:

```json
{
    "is_error": 0,
    "version": 3,
    "count": 8,
    "values": [
        {
            "id": "99",
            "type": "1",
            "label": "All Day",
            "date": "2017-06-09",
            "amount": "-1.00"
        },
        {
            "id": "100",
            "type": "4",
            "label": "Weekend",
            "date": "2017-06-10",
            "amount": "0.00"
        },
        {
            "id": "101",
            "type": "4",
            "label": "Weekend",
            "date": "2017-06-11",
            "amount": "0.00"
        },
        {
            "id": "102",
            "type": "1",
            "label": "All Day",
            "date": "2017-06-12",
            "amount": "-1.00"
        }
    ]
}

```

The response will be empty either when trying to get the breakdown of a non-existing Leave Request or of a Leave Request to which you don't have access to (for example, a staff member trying to access the request of another staff member or a manager trying to access the request of another manager managee).

## Technical Details
It's possible to get all the information for the breakdown with a single SQL, but I opted to not do that. The reason is that the information comes from 2 different tables, so it would be hard to decide to each of the BAOs this query should belong to, so I decided to do this in 2 separate steps. First we get the dates of a Leave Request, then next we pass those dates to the new `LeaveBalanceChange::getForLeaveRequestDates()` method, which will return the Balance Changes linked to the given dates. Finally, inside the `LeaveRequestService.getBreakdown()` we merge the all the data and create the breakdown array.

---

- [x] Tests Pass
