### PR TITLE
PCHR-2503: Fix issues with Contract Entitlement Import

### DIFF
--- a/hrjobcontract/CRM/Export/BAO/Export.php
+++ b/hrjobcontract/CRM/Export/BAO/Export.php
@@ -355,6 +355,10 @@ class CRM_Export_BAO_Export {
         if (!$fieldName) {
           continue;
         }
+
+        if($fieldName == 'hrjobcontract_leave_leave_amount') {
+          $returnProperties['contact_id'] = 1;
+        }
         // get phoneType id and IM service provider id separately
         if ($fieldName == 'phone') {
           $phoneTypeId = CRM_Utils_Array::value(3, $value);

--- a/hrjobcontract/CRM/Hrjobcontract/Export/Converter.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Export/Converter.php
@@ -70,9 +70,9 @@ class CRM_Hrjobcontract_Export_Converter {
             }
             foreach ($leaveTypes as $type => $typeId) {
               //The exported file will always have columns for all the absence type, so we need
-              //to add a blank value for contacts that don't have entitlement for a particular
+              //to add a zero value for contacts that don't have entitlement for a particular
               //absence type.
-              $row[$type] = !empty($contractEntitlementsArray[$type]) ? $contractEntitlementsArray[$type] : '';
+              $row[$type] = !empty($contractEntitlementsArray[$type]) ? $contractEntitlementsArray[$type] : 0;
             }
           }
         }


### PR DESCRIPTION
## Overview
This PR fixes issues with contract entitlements export. The issues are:
- When exporting contract entitlements, the contact ID is also needed in order for this information to be imported to CiviHR 1.6 but currently there is no way to select Contact ID as a field to be exported when exporting Contact Information via advanced search.
- Currently, when Contract entitlements is exported for a contact, a default blank value is added in the CSV for the case where the contact does not have entitlement for a particular leave type. However this was causing issues when importing these blank values into CiviHR 1.7 as it is considered an invalid leave amount type.

## Before
Contact ID field cannot be exported along with entitlement data.
Blank values are added in CSV to represent when a contact does not have contract entitlement for a particular leave type.

## After
Contact ID field is now exported along with contract entitlement data. When the Contract leave amount field is to be exported the `contact_id` field is added as part of the fields to be returned by the Query.
Zero values are now used in CSV to represent when a contact does not have contract entitlement for a particular leave type to avoid import errors when importing into CivHR 1.7.
![civihr_contact_search 29 2017-09-07 18-12-45](https://user-images.githubusercontent.com/6951813/30176531-ab7cc7f2-93fa-11e7-93b0-fa6be5e7fea9.png)


---

- [X] Tests Pass
