### PR TITLE
PCHR-2549: Change to Contact Record Creation

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/AbstractDrupalInteractionTaskForm.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/AbstractDrupalInteractionTaskForm.php
@@ -38,7 +38,7 @@ abstract class CRM_HRCore_Form_AbstractDrupalInteractionTaskForm extends CRM_Con
   /**
    * Creates an array to store contact details
    */
-  private function initContactDetails() {
+  protected function initContactDetails() {
     $emailParams = [
       'contact_id' => '$value.id',
       'return' => ['email'],

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordSingleTaskForm.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordSingleTaskForm.php
@@ -17,7 +17,13 @@ class CRM_HRCore_Form_CreateUserRecordSingleTaskForm extends CreateUserRecordTas
    */
   public function preProcess() {
     $cid = CRM_Utils_Request::retrieve('cid', 'Integer');
-    $this->_contactIds = [$cid];
+
+    // set in session to use in post processing
+    if ($cid) {
+      $this->set('_contactIds', [$cid]);
+    }
+
+    $this->_contactIds = $this->get('_contactIds');
     $this->initContactDetails();
 
     if (empty($this->contactDetails)) {

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordSingleTaskForm.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordSingleTaskForm.php
@@ -1,0 +1,32 @@
+<?php
+
+use CRM_HRCore_Form_CreateUserRecordTaskForm as CreateUserRecordTaskForm;
+
+class CRM_HRCore_Form_CreateUserRecordSingleTaskForm extends CreateUserRecordTaskForm {
+
+  /**
+   * @inheritdoc
+   */
+  public function buildQuickForm() {
+    parent::buildQuickForm();
+    CRM_Utils_System::setTitle(ts('Create User Account'));
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function preProcess() {
+    $cid = CRM_Utils_Request::retrieve('cid', 'Integer');
+    $this->_contactIds = [$cid];
+    $this->initContactDetails();
+
+    if (empty($this->contactDetails)) {
+      throw new \Exception('No contact selected');
+    }
+
+    $this->assign('invalidEmailContacts', $this->getContactsWithInvalidEmail());
+    $this->assign('contactsWithAccount', $this->getContactsWithAccount());
+    $this->assign('contactsForCreation', $this->getValidContactsForCreation());
+    $this->assign('emailConflictContact', $this->getEmailConflictContacts());
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordTaskForm.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordTaskForm.php
@@ -82,7 +82,7 @@ class CRM_HRCore_Form_CreateUserRecordTaskForm extends AbstractDrupalInteraction
    *
    * @return array
    */
-  private function getValidContactsForCreation() {
+  protected function getValidContactsForCreation() {
     $missingEmail = $this->getContactsWithInvalidEmail();
     $haveNoAccount = $this->getContactsWithoutAttribute('uf_id');
     $emailConflict = $this->getEmailConflictContacts();
@@ -113,7 +113,7 @@ class CRM_HRCore_Form_CreateUserRecordTaskForm extends AbstractDrupalInteraction
    *
    * @return array
    */
-  private function getEmailConflictContacts() {
+  protected function getEmailConflictContacts() {
     $newAccounts = $this->getContactsWithoutAttribute('uf_id');
     $haveNoEmail = $this->getContactsWithoutAttribute('email');
     $newContactsWithEmail = array_diff_key($newAccounts, $haveNoEmail);
@@ -144,7 +144,7 @@ class CRM_HRCore_Form_CreateUserRecordTaskForm extends AbstractDrupalInteraction
   /**
    * @return array
    */
-  private function getContactsWithInvalidEmail() {
+  protected function getContactsWithInvalidEmail() {
     $invalid = [];
 
     foreach ($this->contactDetails as $contactID => $contact) {
@@ -162,7 +162,7 @@ class CRM_HRCore_Form_CreateUserRecordTaskForm extends AbstractDrupalInteraction
   /**
    * @return array
    */
-  private function getContactsWithAccount() {
+  protected function getContactsWithAccount() {
     $haveNoAccount = $this->getContactsWithoutAttribute('uf_id');
     $haveAccount = array_diff_key($this->contactDetails, $haveNoAccount);
 

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -38,6 +38,22 @@ function hrcore_civicrm_searchTasks($objectName, &$tasks) {
   }
 }
 
+function hrcore_civicrm_summaryActions( &$actions, $contactID ) {
+  $otherActions = CRM_Utils_Array::value('otherActions', $actions, []);
+  $userAdd = CRM_Utils_Array::value('user-add', $otherActions, []);
+
+  if (empty($userAdd)) {
+    return;
+  }
+
+  // replace default action with link to custom form
+  $userAdd['title'] = ts('Create User Account');
+  $userAdd['description'] = ts('Create User Account');
+  $link = '/civicrm/user/create-account?cid=%d';
+  $userAdd['href'] = sprintf($link, $contactID);
+  $actions['otherActions']['user-add'] = $userAdd;
+}
+
 /**
  * Implements hook_civicrm_container().
  *

--- a/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/CreateUserRecordSingleTaskForm.tpl
+++ b/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/CreateUserRecordSingleTaskForm.tpl
@@ -1,0 +1,109 @@
+<div id="bootstrap-theme">
+
+  <h3>
+    {ts 1=$totalSelectedContacts}
+      You have selected %1 contacts
+    {/ts}
+  </h3>
+
+  {if !empty($contactsForCreation) }
+    <h4>
+      {ts 1=$contactsForCreation|@count}
+        %1 contacts will have user accounts(s) created
+      {/ts}
+    </h4>
+    {include file="CRM/HRCore/Common/ContactTable.tpl" contacts=$contactsForCreation}
+    <br/>
+  {/if}
+
+  {if !empty($invalidEmailContacts) }
+    <p>
+      {ts}
+        Some contacts have invalid emails. Contacts must have a primary e-mail,
+        and it cannot contain punctuation except for periods, hyphens,
+        apostrophes and underscores.
+      {/ts}
+    </p>
+    <p>
+      {ts 1=$invalidEmailContacts|@count}%1 contact(s) have invalid emails:{/ts}
+    </p>
+    {include file="CRM/HRCore/Common/ContactTable.tpl" contacts=$invalidEmailContacts}
+    <br/>
+  {/if}
+
+  {if !empty($contactsWithAccount) }
+    <p>
+      {ts 1=$contactsWithAccount|@count}
+        %1 contact(s) already have an account:
+      {/ts}
+    </p>
+    {include file="CRM/HRCore/Common/ContactTable.tpl" contacts=$contactsWithAccount}
+    <br/>
+  {/if}
+
+  {if !empty($emailConflictContact) }
+    <p>
+      {ts}
+        Email conflicts can be caused by trying to create two new users with the
+        same email, or by trying to create a new user with an email that is already
+        in use.
+      {/ts}
+    </p>
+    <p>
+      {ts 1=$emailConflictContact|@count}
+        %1 contact(s) have email conflicts:
+      {/ts}
+    </p>
+    {include file="CRM/HRCore/Common/ContactTable.tpl" contacts=$emailConflictContact}
+    <br/>
+  {/if}
+
+  <br/>
+
+  <div class="panel">
+
+    {if !empty($form.roles)}
+      <div class="panel-body">
+        <label>User Roles</label>
+        <p class = "description">
+          {ts}
+            Select any of the following user roles to add to the user accounts:
+          {/ts}
+        </p>
+        <div>
+          {foreach from=$form.roles item=role}
+            {$role.html}
+            {$role.label}
+          {/foreach}
+        </div>
+      </div>
+    {/if}
+
+    <div class="panel-body">
+      {$form.sendEmail.html}
+      {$form.sendEmail.label}
+      <br/>
+      <p class = "description">
+        {ts 1='/civicrm/tasksassignments/dashboard#/tasks'}
+          By selecting this option, a welcome email containing a link to the
+          staff onboarding wizard will be sent to all staff who already have a
+          user account and those who meet the criteria of creating a user
+          account. It is recommended to <a href="%1">create onboarding tasks</a>
+          and documents for the selected staff before this action.
+        {/ts}
+      </p>
+    </div>
+
+  </div>
+
+  <div class="spacer"></div>
+
+  <div class="panel">
+    <div class="panel-body">
+      <div class="crm-inline-button crm-submit-buttons">
+        {include file="CRM/common/formButtons.tpl"}
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/CreateUserRecordTaskForm.tpl
+++ b/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/CreateUserRecordTaskForm.tpl
@@ -60,7 +60,6 @@
 
   <br/>
 
-
   <div class="panel">
 
     {if !empty($form.roles)}
@@ -68,7 +67,7 @@
       <label>User Roles</label>
       <p class = "description">
         {ts}
-          Select any of the following user roles to add to the new user accounts:
+          Select any of the following user roles to add to the user accounts:
         {/ts}
       </p>
       <div>

--- a/uk.co.compucorp.civicrm.hrcore/xml/Menu/hrcore.xml
+++ b/uk.co.compucorp.civicrm.hrcore/xml/Menu/hrcore.xml
@@ -1,33 +1,39 @@
 <?xml version="1.0"?>
 <menu>
   <item>
-     <path>civicrm</path>
-     <title>CiviCRM</title>
-     <access_callback>CRM_Core_Permission::checkMenu</access_callback>
-     <access_arguments>access CiviCRM</access_arguments>
-     <page_callback>CRM_HRCore_Page_Error404Checker</page_callback>
-     <page_arguments>null</page_arguments>
-     <is_ssl>false</is_ssl>
-     <weight>0</weight>
+    <path>civicrm</path>
+    <title>CiviCRM</title>
+    <access_callback>CRM_Core_Permission::checkMenu</access_callback>
+    <access_arguments>access CiviCRM</access_arguments>
+    <page_callback>CRM_HRCore_Page_Error404Checker</page_callback>
+    <page_arguments>null</page_arguments>
+    <is_ssl>false</is_ssl>
+    <weight>0</weight>
   </item>
   <item>
-     <path>civicrm/dashboard</path>
-     <title>CiviCRM</title>
-     <access_callback>CRM_Core_Permission::checkMenu</access_callback>
-     <access_arguments>access CiviCRM</access_arguments>
-     <page_callback>CRM_HRCore_Page_Error404Checker</page_callback>
-     <page_arguments>null</page_arguments>
-     <is_ssl>false</is_ssl>
-     <weight>0</weight>
+    <path>civicrm/dashboard</path>
+    <title>CiviCRM</title>
+    <access_callback>CRM_Core_Permission::checkMenu</access_callback>
+    <access_arguments>access CiviCRM</access_arguments>
+    <page_callback>CRM_HRCore_Page_Error404Checker</page_callback>
+    <page_arguments>null</page_arguments>
+    <is_ssl>false</is_ssl>
+    <weight>0</weight>
   </item>
   <item>
-     <path>civicrm/default/dashboard</path>
-     <title>CiviCRM</title>
-     <access_callback>CRM_Core_Permission::checkMenu</access_callback>
-     <access_arguments>access CiviCRM</access_arguments>
-     <page_callback>CRM_Contact_Page_DashBoard</page_callback>
-     <page_arguments>null</page_arguments>
-     <is_ssl>false</is_ssl>
-     <weight>0</weight>
+    <path>civicrm/default/dashboard</path>
+    <title>CiviCRM</title>
+    <access_callback>CRM_Core_Permission::checkMenu</access_callback>
+    <access_arguments>access CiviCRM</access_arguments>
+    <page_callback>CRM_Contact_Page_DashBoard</page_callback>
+    <page_arguments>null</page_arguments>
+    <is_ssl>false</is_ssl>
+    <weight>0</weight>
+  </item>
+  <item>
+    <path>civicrm/user/create-account</path>
+    <page_callback>CRM_HRCore_Form_CreateUserRecordSingleTaskForm</page_callback>
+    <title>Create User Record</title>
+    <access_arguments>create users</access_arguments>
   </item>
 </menu>

--- a/uk.co.compucorp.civicrm.hrcore/xml/Menu/hrcore.xml
+++ b/uk.co.compucorp.civicrm.hrcore/xml/Menu/hrcore.xml
@@ -33,7 +33,7 @@
   <item>
     <path>civicrm/user/create-account</path>
     <page_callback>CRM_HRCore_Form_CreateUserRecordSingleTaskForm</page_callback>
-    <title>Create User Record</title>
+    <title>Create User Account</title>
     <access_arguments>create users</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
## Overview
The "Create User Record" action links to a Drupal screen to create the user account. To keep it more consistent we will use the "Create User Record" screen from #2101 to create the user account and set up roles.

## Before

The actions menu on the user profile page shows a link to "Create User Record" which leads to the Drupal user creation page.

![image](https://user-images.githubusercontent.com/6374064/30271541-99ff4e50-96e8-11e7-9bf3-d8b1a8a65f87.png)


## After
The actions menu on the user profile page shows a link to "Create User Account" which leads to the form from #2101 

![image](https://user-images.githubusercontent.com/6374064/30271511-7be68424-96e8-11e7-9a92-4aac07ac4107.png)

## Technical Details

This builds on the work done in #2101 by extending from the parent form. It operates differently by getting the contact ID from the request query string. It also uses a separate template, since some changes will likely be made when creating a user account for a single contact.

---

- [x] Tests Pass
