### PR TITLE
PCHR-2495: Do not return results indexed by contact ID

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveBalancesSelect.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Query/LeaveBalancesSelect.php
@@ -206,7 +206,7 @@ class CRM_HRLeaveAndAbsences_API_Query_LeaveBalancesSelect {
     }
 
     foreach ($contacts as $i => $result) {
-      $newResults[$i] = [
+      $newResults[] = [
         'contact_id' => $result['id'],
         'contact_display_name' => $result['display_name'],
         'absence_types' => $payload[$result['id']]


### PR DESCRIPTION
## Overview
The results of the `LeavePeriodEntitlement.getLeaveBalances` API are currently being indexed by the contact ID, as if it is returning a list of contacts. However, as mentioned on https://github.com/civicrm/civihr/pull/2105, the API is actually a way to aggregate data from multiple different APIs/Entities to return it in a more performant way and in an easier to parse format. So, given each record is actually a mix of data from different places, they don't really have an ID and the response should not be indexed by the contact one.

## Before
The results are indexed by the contact ID:

```json
{
    "is_error": 0,
    "version": 3,
    "count": 4,
    "values": {
        "4": {
            "contact_id": "4",
            "contact_display_name": "civihr_staff@compucorp.co.uk",
            "absence_types": [
                {
                    "id": 1,
                    "entitlement": "28.00",
                    "used": 13.5,
                    "balance": 14.5,
                    "requested": 0
                },
                {
                    "id": 2,
                    "entitlement": "0.00",
                    "used": 0,
                    "balance": 0,
                    "requested": 0
                },
                {
                    "id": 3,
                    "entitlement": "0.00",
                    "used": 0,
                    "balance": 0,
                    "requested": 0
                }
            ]
        }
   }
}
```

## After
The results are not indexed by the contact ID anymore (Note how now the result is an array instead of a json object):

```json
{
    "is_error": 0,
    "version": 3,
    "count": 4,
    "values": [
        {
            "contact_id": "4",
            "contact_display_name": "civihr_staff@compucorp.co.uk",
            "absence_types": [
                {
                    "id": 1,
                    "entitlement": "28.00",
                    "used": 13.5,
                    "balance": 14.5,
                    "requested": 0
                },
                {
                    "id": 2,
                    "entitlement": "0.00",
                    "used": 0,
                    "balance": 0,
                    "requested": 0
                },
                {
                    "id": 3,
                    "entitlement": "0.00",
                    "used": 0,
                    "balance": 0,
                    "requested": 0
                }
            ]
        }
   ]
}
```

---

- [x] Tests Pass
