### PR TITLE
PCHR-2563: Fix bug when validating Balance Change on Leave Request Import

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -22,23 +22,28 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
   const REQUEST_TYPE_TOIL = 'toil';
   const REQUEST_TYPE_PUBLIC_HOLIDAY = 'public_holiday';
 
+  //Validations Mode for the create method
+  const VALIDATIONS_ON = 1;
+  const VALIDATIONS_OFF = 2;
+  const IMPORT_VALIDATION = 3;
+
   /**
    * Create a new LeaveRequest based on array-data
    *
    * @param array $params key-value pairs
+   * @param int $validationMode
+   *
    * @return \CRM_HRLeaveAndAbsences_BAO_LeaveRequest|NULL
    *
    * @throws \Exception
    */
-  public static function create($params, $validate = true) {
+  public static function create($params, $validationMode = self::VALIDATIONS_ON) {
     $entityName = 'LeaveRequest';
     $hook = empty($params['id']) ? 'create' : 'edit';
 
     CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
 
-    if($validate){
-      self::validateParams($params);
-    }
+    self::validateParams($params, $validationMode);
     unset($params['is_deleted']);
 
     $datesChanged = self::datesChanged($params);
@@ -67,10 +72,14 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    *
    * @param array $params
    *   The params array received by the create method
+   * @param int $validationMode
    *
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
    */
-  public static function validateParams($params) {
+  public static function validateParams($params, $validationMode = self::VALIDATIONS_ON) {
+    if($validationMode == self::VALIDATIONS_OFF) {
+      return;
+    }
     self::validateMandatory($params);
     self::validateLeaveRequestSoftDeleteDuringUpdate($params);
     self::validateRequestType($params);
@@ -86,7 +95,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     self::validateLeaveDaysAgainstAbsenceTypeMaxConsecutiveLeaveDays($params, $absenceType);
     self::validateAbsenceTypeAllowRequestCancellationForLeaveRequestCancellation($params, $absenceType);
     self::validateAbsencePeriod($params, $absencePeriod);
-    self::validateEntitlementAndWorkingDayAndBalanceChange($params, $absenceType, $absencePeriod);
+
+    if($validationMode != self::IMPORT_VALIDATION) {
+      self::validateEntitlementAndWorkingDayAndBalanceChange($params, $absenceType, $absencePeriod);
+    }
+
 
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Import/Parser/Base.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Import/Parser/Base.php
@@ -632,7 +632,7 @@ class CRM_HRLeaveAndAbsences_Import_Parser_Base extends CRM_HRLeaveAndAbsences_I
 
     if(!$absenceType->allow_overuse && $leaveRequestBalance > $currentBalance) {
       throw new InvalidLeaveRequestException(
-        'There are only '. $currentBalance .' days leave available. This request cannot be made or approved',
+        'There are only '. $currentBalance .' days leave available. This request cannot be imported',
         'leave_request_balance_change_greater_than_remaining_balance',
         'type_id'
       );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Import/Parser/Base.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Import/Parser/Base.php
@@ -3,7 +3,10 @@
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
+use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
+use CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement as LeavePeriodEntitlement;
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestComment as LeaveRequestCommentService;
+use CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException as InvalidLeaveRequestException;
 
 /**
  * Class to parse activity csv files.
@@ -459,8 +462,13 @@ class CRM_HRLeaveAndAbsences_Import_Parser_Base extends CRM_HRLeaveAndAbsences_I
 
   /**
    * Creates a leave request from the params array.
+   * Also it validates the balance change and entitlement
+   * before making the call to LeaveRequest::create with
+   * the validation mode being of type IMPORT.
    *
    * @param array $params
+   *
+   * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
    *
    * @return LeaveRequest
    */
@@ -492,7 +500,9 @@ class CRM_HRLeaveAndAbsences_Import_Parser_Base extends CRM_HRLeaveAndAbsences_I
       $payload['sickness_reason'] = $sicknessReasons['other'];
     }
 
-    return LeaveRequest::create($payload);
+    $params['request_type'] = $payload['request_type'];
+    $this->validateLeaveParams($params);
+    return LeaveRequest::create($payload, LeaveRequest::IMPORT_VALIDATION);
   }
 
   /**
@@ -562,5 +572,82 @@ class CRM_HRLeaveAndAbsences_Import_Parser_Base extends CRM_HRLeaveAndAbsences_I
     $oldAbsenceStatusesMap = ['Requested' => $absenceStatuses['Awaiting Approval']];
 
     return array_merge($oldAbsenceStatusesMap, $absenceStatuses);
+  }
+
+  /**
+   * Returns the calculated entitlement for a Contact within
+   * the AbsencePeriod for the AbsenceType.
+   *
+   * @param array $params
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement|null
+   */
+  private function getPeriodEntitlementForContact($params) {
+    $startDate = CRM_Utils_Date::formatDate($params['start_date'], $this->dateFormatType);
+    $endDate = CRM_Utils_Date::formatDate($params['end_date'], $this->dateFormatType);
+    $period = AbsencePeriod::getPeriodContainingDates(new DateTime($startDate), new DateTime($endDate));
+
+    $leavePeriodEntitlement = LeavePeriodEntitlement::getPeriodEntitlementForContact(
+      $params['contact_id'],
+      $period->id,
+      $params['type_id']
+    );
+
+    return $leavePeriodEntitlement;
+  }
+
+  /**
+   * This method checks and ensures that the balance change for the leave request to
+   * be created is not greater than the remaining balance of the period if the
+   * Request’s AbsenceType do not allow overuse.
+   * In case the contact does not have a period entitlement for the absence type, an
+   * appropriate exception is thrown.
+   *
+   * @param array $params
+   *
+   * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
+   **/
+  private function validateEntitlementAndBalanceChange($params) {
+    $isToil = $params['request_type'] == LeaveRequest::REQUEST_TYPE_TOIL;
+    $isCancelled = in_array($params['status_id'], LeaveRequest::getCancelledStatuses());
+
+    //TOIL accrual is independent of Current Balance.
+    //Leave Request is able to be rejected or cancelled disregarding the balance
+    if($isToil || $isCancelled) {
+      return;
+    }
+
+    $leavePeriodEntitlement = $this->getPeriodEntitlementForContact($params);
+    if(!$leavePeriodEntitlement) {
+      throw new InvalidLeaveRequestException(
+        'Contact does not have period entitlement for the absence type',
+        'leave_request_contact_has_no_entitlement',
+        'type_id'
+      );
+    }
+
+    $leaveRequestBalance = $params['total_qty'];
+    $currentBalance = $leavePeriodEntitlement->getBalance();
+    $absenceType = AbsenceType::findById($params['type_id']);
+
+    if(!$absenceType->allow_overuse && $leaveRequestBalance > $currentBalance) {
+      throw new InvalidLeaveRequestException(
+        'There are only '. $currentBalance .' days leave available. This request cannot be made or approved',
+        'leave_request_balance_change_greater_than_remaining_balance',
+        'type_id'
+      );
+    }
+  }
+
+  /**
+   * A method for validating the params before creating the Leave Request
+   * from the CSV parameters.
+   *
+   * @param array $params
+   *
+   * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
+   */
+  public function validateLeaveParams($params) {
+    $this->validateEntitlementAndBalanceChange($params);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -271,7 +271,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
     $updateBalanceChange = !empty($params['change_balance']);
     $skipBalanceChangeUpdate = !empty($params['id']) &&
       !$this->datesChanged($params) && !$updateBalanceChange;
-    $leaveRequest = LeaveRequest::create($params, false);
+    $leaveRequest = LeaveRequest::create($params, LeaveRequest::VALIDATIONS_OFF);
 
     if(!$skipBalanceChangeUpdate) {
       $this->leaveBalanceChangeService->createForLeaveRequest($leaveRequest);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -170,7 +170,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
       'to_date'        => CRM_Utils_Date::processDate($publicHoliday->date),
       'to_date_type'   => $leaveRequestDayTypes['all_day'],
       'request_type'   => LeaveRequest::REQUEST_TYPE_PUBLIC_HOLIDAY
-    ], false);
+    ], LeaveRequest::VALIDATIONS_OFF);
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/LeaveRequest.php
@@ -29,7 +29,7 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest {
    */
   public static function fabricateWithoutValidation($params = [], $withBalanceChanges = false) {
     $params = self::mergeDefaultParams($params);
-    $leaveRequest =  LeaveRequest::create($params, false);
+    $leaveRequest =  LeaveRequest::create($params, LeaveRequest::VALIDATIONS_OFF);
 
     if ($withBalanceChanges) {
       LeaveBalanceChangeFabricator::fabricateForLeaveRequest($leaveRequest);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Import/Parser/BaseTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Import/Parser/BaseTest.php
@@ -1,0 +1,288 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod as AbsencePeriodFabricator;
+use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_LeavePeriodEntitlement as LeavePeriodEntitlementFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern as WorkPatternFabricator;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestComment as LeaveRequestCommentService;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Import_Parser_BaseTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_Import_Parser_BaseTest extends BaseHeadlessTest {
+
+  use CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait;
+
+  private $absenceType;
+
+  public function setUp() {
+    $session = CRM_Core_Session::singleton();
+    $session->set('dateTypes', 1);
+    $this->absenceType = AbsenceTypeFabricator::fabricate(['title' => 'Holiday']);
+  }
+
+  private function getImportObject($fields)  {
+    $importObject = new CRM_HRLeaveAndAbsences_Import_Parser_Base($fields);
+    $importObject->init();
+
+    return $importObject;
+  }
+
+  public function testLeaveRequestWithBalanceChangeAndCommentsCanBeCreatedFromImportParameters() {
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $this->absenceType->id,
+      'contact_id' => 1,
+      'period_id' => $period->id
+    ]);
+
+    $this->createLeaveBalanceChange($periodEntitlement->id, 3);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $periodEntitlement->contact_id],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
+
+    $contactId = 1;
+
+    $row1 = [
+      'contact_id' => $contactId,
+      'absence_id' => 1,
+      'absence_type' => $this->absenceType->title,
+      'absence_date' => '2016-01-01',
+      'qty' => 2,
+      'start_date' => '2016-01-01',
+      'end_date' => '2016-01-02',
+      'total_qty' => 3,
+      'status' => 'Approved',
+      'comments' => 'Test Comment',
+    ];
+
+    $fields = array_keys($row1);
+    $importObject = $this->getImportObject($fields);
+
+    $row2 = $row1;
+    $row2['qty'] = 1;
+    $row2['absence_date'] = '2016-01-02';
+
+    $valuesRow1 = array_values($row1);
+    $valuesRow2 = array_values($row2);
+    $response1 = $importObject->import(NULL, $valuesRow1);
+    $response2 = $importObject->import(NULL, $valuesRow2);
+
+    $this->assertEquals(CRM_Import_Parser::VALID, $response1);
+    $this->assertEquals(CRM_Import_Parser::VALID, $response2);
+
+    $leaveRequest = new LeaveRequest();
+    $leaveRequest->from_date = CRM_Utils_Date::processDate('2016-01-01');
+    $leaveRequest->to_date = CRM_Utils_Date::processDate('2016-01-02');
+    $leaveRequest->contact_id = $contactId;
+    $leaveRequest->find(true);
+
+    $this->assertNotNull($leaveRequest->id);
+    //a total balance change of -3 is expected, i.e the value in total_qty field
+    $balanceChange = LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest);
+    $this->assertEquals(-3, $balanceChange);
+
+    //Check that comment was properly created
+    $leaveRequestCommentService = new LeaveRequestCommentService();
+    $result = $leaveRequestCommentService->get(['leave_request_id' => $leaveRequest->id, 'sequential' => 1]);
+    $this->assertEquals($result['values'][0]['text'], $row1['comments']);
+    $this->assertEquals($result['values'][0]['contact_id'], $row1['contact_id']);
+    $commentDate = new DateTime('2016-01-01');
+    $expectedCommentDate = new DateTime($result['values'][0]['created_at']);
+    $this->assertEquals($expectedCommentDate, $commentDate);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
+   * @expectedExceptionMessage Contact does not have period entitlement for the absence type
+   */
+  public function testValidateLeaveParamsThrowsExceptionWhenContactHasNoPeriodEntitlementForTheAbsenceType() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    $contactId = 1;
+    $row1 = [
+      'contact_id' => $contactId,
+      'absence_id' => 1,
+      'type_id' => $this->absenceType->id,
+      'absence_date' => '2016-01-01',
+      'qty' => 2,
+      'start_date' => '2016-01-01',
+      'end_date' => '2016-01-01',
+      'total_qty' => 3,
+      'status_id' => 1,
+      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE,
+    ];
+
+    $fields = array_keys($row1);
+    $importObject = $this->getImportObject($fields);
+    $importObject->validateLeaveParams($row1);
+  }
+
+  public function testValidateLeaveParamsThrowsExceptionWhenBalanceIsGreaterThanEntitlementBalanceAndAllowOveruseFalse() {
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'title' => 'Type 1',
+      'allow_overuse' => 0
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceType->id,
+      'contact_id' => 1,
+      'period_id' => $period->id
+    ]);
+
+    $entitlementBalanceChange = 3;
+    $this->createLeaveBalanceChange($periodEntitlement->id, $entitlementBalanceChange);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $periodEntitlement->contact_id],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
+
+    //This will create a balance change of 4 since the value for total_qty
+    //is 4
+    $row1 = [
+      'contact_id' => $periodEntitlement->contact_id,
+      'absence_id' => 1,
+      'type_id' => $absenceType->id,
+      'absence_date' => '2016-01-01',
+      'qty' => 4,
+      'start_date' => '2016-01-01',
+      'end_date' => '2016-01-01',
+      'total_qty' => 4,
+      'status_id' => 1,
+      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE,
+    ];
+
+    $this->setExpectedException(
+      'CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException',
+      'There are only '. $entitlementBalanceChange. ' days leave available. This request cannot be made or approved'
+    );
+
+    $fields = array_keys($row1);
+    $importObject = $this->getImportObject($fields);
+    $importObject->validateLeaveParams($row1);
+  }
+
+  public function testValidateLeaveParamsDoesNotThrowsExceptionWhenBalanceIsGreaterThanEntitlementBalanceWhenAllowOveruseFalseAndRequestTypeIsToil() {
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'title' => 'Type 1',
+      'allow_overuse' => 0
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceType->id,
+      'contact_id' => 1,
+      'period_id' => $period->id
+    ]);
+
+    $entitlementBalanceChange = 3;
+    $this->createLeaveBalanceChange($periodEntitlement->id, $entitlementBalanceChange);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $periodEntitlement->contact_id],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
+
+    //This will create a balance change of 4 since the value for total_qty
+    //is 4
+    $row1 = [
+      'contact_id' => $periodEntitlement->contact_id,
+      'absence_id' => 1,
+      'type_id' => $absenceType->id,
+      'absence_date' => '2016-01-01',
+      'qty' => 4,
+      'start_date' => '2016-01-01',
+      'end_date' => '2016-01-01',
+      'total_qty' => 4,
+      'status_id' => 1,
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL,
+    ];
+
+    $fields = array_keys($row1);
+    $importObject = $this->getImportObject($fields);
+    //Since the request type is TOIL, balance change validation will not
+    //be taken into account.
+    $importObject->validateLeaveParams($row1);
+  }
+
+  public function testValidateLeaveParamsDoesNotThrowsExceptionWhenBalanceIsGreaterThanEntitlementBalanceWhenAllowOveruseFalseAndRequestIsCancelled() {
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'title' => 'Type 1',
+      'allow_overuse' => 0
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceType->id,
+      'contact_id' => 1,
+      'period_id' => $period->id
+    ]);
+
+    $entitlementBalanceChange = 3;
+    $this->createLeaveBalanceChange($periodEntitlement->id, $entitlementBalanceChange);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $periodEntitlement->contact_id],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
+    LeaveRequest::getCancelledStatuses();
+    //This will create a balance change of 4 since the value for total_qty
+    //is 4
+    $row1 = [
+      'contact_id' => $periodEntitlement->contact_id,
+      'absence_id' => 1,
+      'type_id' => $absenceType->id,
+      'absence_date' => '2016-01-01',
+      'qty' => 4,
+      'start_date' => '2016-01-01',
+      'end_date' => '2016-01-01',
+      'total_qty' => 4,
+      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE,
+    ];
+
+    $fields = array_keys($row1);
+    $importObject = $this->getImportObject($fields);
+    //Since the request type is TOIL, balance change validation will not
+    //be taken into account.
+    foreach(LeaveRequest::getCancelledStatuses() as $status) {
+      $row1['status_id'] = $status;
+      $importObject->validateLeaveParams($row1);
+    }
+  }
+}


### PR DESCRIPTION
## Overview
Currently, when Importing Leave Requests the validations for balance change is buggy because it does use the amount to be deducted as it is in the CSV for the validation, rather it uses the amount calculated from the contact's work pattern for the dates to be imported for. 
This PR fixes this issue.

## Before
When importing Leave Requests, the leave request balance change amount used for validating balance change is the one gotten from the `LeaveRequest::calculateBalanceChange` method rather than the `total_qty` field in the CSV.

## After
- The second parameter passed to `LeaveRequest::create` was changed from `$validate` to `$validationMode` where the available validation Modes are: VALIDATIONS_ON, VALIDATIONS_OFF and IMPORT_VALIDATION.
- The validationMode is passed as  IMPORT_VALIDATION when creating LeaveRequests on import, this allows some Validations to be bypassed when Leave Requests are imported.
- The validations for Balance Change is now done in the `CRM_HRLeaveAndAbsences_Import_Parser_Base` class.

## Comments
Also there were no tests for the import functionality before. This PR adds some basic tests for the import functionality.

---

- [X] Tests Pass
