### PR TITLE
PCHR-2503: Fix Contract Export to Only Export Records for the Latest Contract Revision

### DIFF
--- a/hrjobcontract/CRM/Export/BAO/Export.php
+++ b/hrjobcontract/CRM/Export/BAO/Export.php
@@ -209,7 +209,7 @@ class CRM_Export_BAO_Export {
     if ($queryMode & CRM_Contact_BAO_Query::MODE_CONTACTS &&
       !empty($returnProperties['hrjobcontract_leave_leave_amount']))
     {
-      $groupBy = ' GROUP BY contact_a.id';
+      $groupBy = ' GROUP BY contact_a.id, hrjobcontract.id';
     }
 
     $groupBy = !empty($groupBy) ? $groupBy : '';

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/Query.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/Query.php
@@ -336,11 +336,15 @@ class CRM_Hrjobcontract_BAO_Query extends CRM_Contact_BAO_Query_Interface {
 
   function from($name, $mode, $side) {
     $from = '';
-    $todayDate = date('Y-m-d');
     switch ($name) {
       case 'civicrm_contact':
         $from .= " $side JOIN civicrm_hrjobcontract hrjobcontract ON hrjobcontract.contact_id = contact_a.id AND hrjobcontract.deleted = 0 ";
-        $from .= " $side JOIN civicrm_hrjobcontract_revision rev ON rev.jobcontract_id = hrjobcontract.id ";
+        $from .= " $side JOIN civicrm_hrjobcontract_revision rev ON rev.id = (SELECT id
+                    FROM civicrm_hrjobcontract_revision jcr2
+                    WHERE
+                    jcr2.jobcontract_id = hrjobcontract.id
+                    ORDER BY jcr2.effective_date DESC
+                    LIMIT 1)";
       break;
       case 'civicrm_hrjobcontract_details':
         $from .= " $side JOIN civicrm_hrjobcontract_details ON rev.details_revision_id = civicrm_hrjobcontract_details.jobcontract_revision_id ";


### PR DESCRIPTION
## Overview
When exporting Contract information via advanced search, records for all contract revisions are exported which is something we don't necessarily need, If we need it it can be exported via the export function on the Job contract page. 
Also when exporting contract entitlements, in the CSV the Contract Leave Amount column is messed up as it concatenates the contract entitlements for all contracts in same row.

## Before
- When exporting contract entitlements, in the CSV the Contract Leave Amount column concatenates the contract entitlements for all contracts in same row.
- When exporting contract information via advance search, the information is exported for all contract revisions.
![civihr_contact_search 38 2017-09-14 15-24-08](https://user-images.githubusercontent.com/6951813/30435096-d6314700-9960-11e7-8628-b872661a8353.png)

## After
- When exporting contract entitlements, in the CSV the Contract Leave Amount column concatenates the contract entitlements for the latest revision of each contract of the contact in separate rows.
- When exporting contract information via advance search, the information is exported for the latest contract revisions.
![civihr_contact_search 41 2017-09-14 15-23-07](https://user-images.githubusercontent.com/6951813/30435078-cf1b53fc-9960-11e7-9e70-a461afe3ed78.png)


## Technical Details
- The query that JOINS to the `civicrm_hrjobcontract_revision`table  was changed to JOIN to the contract table using the latest revision id of a contract.
- When exporting entitlements, the query now groups by contract ID in addition to contact ID.
---

- [X] Tests Pass
