### PR TITLE
PCHR-2503: Make Contract ID compulsory when importing Contract Entitlements

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Import/Form/SummaryBaseClass.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Form/SummaryBaseClass.php
@@ -33,6 +33,8 @@
  *
  */
 
+use CRM_Hrjobcontract_Import_Parser as Import_Parser;
+
 /**
  * This class summarizes the import results
  */
@@ -53,6 +55,7 @@ class CRM_Hrjobcontract_Import_Form_SummaryBaseClass extends CRM_Import_Form_Sum
   public function preProcess() {
     // set the error message path to display
     $errorFile = $this->assign('errorFile', $this->get('errorFile'));
+    $this->_importMode = $this->get('importMode');
 
     $totalRowCount = $this->get('totalRowCount');
     $relatedCount = $this->get('relatedCount');
@@ -104,5 +107,12 @@ class CRM_Hrjobcontract_Import_Form_SummaryBaseClass extends CRM_Import_Form_Sum
     foreach ($properties as $property) {
       $this->assign($property, $this->get($property));
     }
+
+    $isEntitlementUpdate = $this->_importMode == Import_Parser::UPDATE_ENTITLEMENTS;
+    $entitlementPageUrl = CRM_Utils_System::url(
+      'civicrm/admin/leaveandabsences/periods/manage_entitlements'
+    );
+    $this->assign('isEntitlementUpdate', $isEntitlementUpdate);
+    $this->assign('entitlementPageUrl', $entitlementPageUrl);
   }
 }

--- a/hrjobcontract/templates/CRM/Hrjobcontract/Import/Form/Summary.tpl
+++ b/hrjobcontract/templates/CRM/Hrjobcontract/Import/Form/Summary.tpl
@@ -34,6 +34,10 @@
 <div id="help">
     <p>
     <strong>{ts}Import has completed successfully.{/ts}</strong> {ts}The information below summarizes the results.{/ts}
+      {if $isEntitlementUpdate }
+        <br/>
+        <strong>{ts 1=$entitlementPageUrl}Please Visit the Entitlement Calculation Page <a href="%1">HERE</a> to update Period Entitlements{/ts}</strong>
+      {/if}
     </p>
 
    {if $unMatchCount }


### PR DESCRIPTION
## Overview
When importing Contract entitlements for Contacts with existing Contract, Only the Contact ID field is required and entitlements are imported for the latest revision of the Contact's current Contact. However since Entitlement Calculation needs to be done after the import, there is a flaw in this process as the Entitlement calculation considers all active Contracts within a Period for the contact, so it is necessary to update entitlements for all the Contact's Contracts.
Also a message informing the user of the need to go to the Entitlement calculation after a successful Contract entitlement update is added in this PR.

## Before
- When importing Contract entitlements for a Contact, the Contact ID field is required
- There is no message prompting the user to go to the entitlement calculation page after successfully importing Contract entitlements.

## After
- When importing Contract entitlements for a Contact, the Contract ID field is now required.
- There is now a  message prompting the user to go to the entitlement calculation page after successfully importing Contract entitlements.
![import job contracts - civihr 1 7 demo 2017-09-14 18-13-22](https://user-images.githubusercontent.com/6951813/30444339-849786ba-997a-11e7-927a-cb92b56b4f62.png)

---

- [X] Tests Pass
