### PR TITLE
PCHR-2223: Fix HRAbsence upgrader 1404

### DIFF
--- a/hrabsence/CRM/HRAbsence/Upgrader.php
+++ b/hrabsence/CRM/HRAbsence/Upgrader.php
@@ -631,5 +631,7 @@ class CRM_HRAbsence_Upgrader extends CRM_HRAbsence_Upgrader_Base {
    */
   public function upgrade_1404() {
     _hrabsence_delete_processentitlementrecalculationqueue_scheduled_job();
+
+    return TRUE;
   }
 }


### PR DESCRIPTION
## Overview
On https://github.com/civicrm/civihr/pull/2096/ a new upgrader was added in other to remove a scheduled job used to update the entitlements on the old extension, which one be necessary anymore with 1.7. However, Civi wasn't able to execute the upgrader because it didn't return `TRUE`, which is considered as a failure by the upgrade process.

## Before
Civi wasn't able to run the upgrader to remove the scheduled job

## After
The upgrader now returns `TRUE` and civi is able to run it successfully.

---

- [ ] Tests Pass
(No tests involved in this)