### PR TITLE
PCHR-2605: Don't delete the "has Leave Approved by" relationship type when hrabsence is uninstalled

### DIFF
--- a/hrabsence/hrabsence.php
+++ b/hrabsence/hrabsence.php
@@ -293,7 +293,6 @@ function hrabsence_civicrm_uninstall() {
   CRM_Core_DAO::executeQuery("DELETE FROM civicrm_option_value WHERE civicrm_option_value.id IN ({$absenceType})");
   CRM_Core_DAO::executeQuery("DELETE FROM civicrm_msg_template WHERE msg_title = 'Absence Email'");
 
-  _hrabsence_removeRelationshipTypes();
   _hrabsence_delete_processentitlementrecalculationqueue_scheduled_job();
 
   return _hrabsence_civix_civicrm_uninstall();
@@ -640,16 +639,4 @@ function _hrabsence_delete_processentitlementrecalculationqueue_scheduled_job()
   $dao->api_entity = 'HRAbsenceEntitlement';
   $dao->api_action = 'processentitlementrecalculationqueue';
   $dao->delete();
-}
-
-/** Remove any defined relationship type by this extension
- *
- */
-function _hrabsence_removeRelationshipTypes() {
-  civicrm_api3('RelationshipType', 'get', array(
-    'sequential' => 1,
-    'return' => array("id"),
-    'name_a_b' => "has Leave Approved by",
-    'api.RelationshipType.delete' => array(),
-  ));
 }


### PR DESCRIPTION
## Overview
In CiviHR 1.6, the hrabsence is responsible to manage the "has Leave Approved by" relationship, which means:
- When the extension is installed, it creates the relationship type
- When the extension is uninstalled, it deletes the relationship type

For 1.7, the new L&A extension should be the one responsible for this. Otherwise, if someone uninstalls hrabsence after L&A is installed, it will remove the relationship type and may cause problems in L&A (e.g, losing existing relationships between managers and staff members)

## Before

When hrabsence is uninstalled it deletes the "has Leave Approved by" relationship type

## After

When hrabsence is uninstalled it DOES NOT delete the "has Leave Approved by" relationship type

---

- [ ] Tests Pass
(No tests affected by this)