### PR TITLE
PCHR-2538: Fix issue with not being able to update an already Approved Leave when Entitlement Balance is Zero

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -58,10 +58,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
    *   When this param is set to true, the method will consider only the expired
    *   Balance Changes. Otherwise, it will consider all the Balance Changes,
    *   including the expired ones.
+   * @param array $excludeLeaveIds
+   *   An array of Leave request ID's to be excluded from
+   *   the entitlement balance calculation.
    *
    * @return float
    */
-  public static function getBalanceForEntitlement(LeavePeriodEntitlement $periodEntitlement, $leaveRequestStatus = [], $expiredOnly = false) {
+  public static function getBalanceForEntitlement(LeavePeriodEntitlement $periodEntitlement, $leaveRequestStatus = [], $expiredOnly = false, $excludeLeaveIds = []) {
     $balanceChangeTable = self::getTableName();
     $leaveRequestDateTable = LeaveRequestDate::getTableName();
     $leaveRequestTable = LeaveRequest::getTableName();
@@ -75,6 +78,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
     if(is_array($leaveRequestStatus) && !empty($leaveRequestStatus)) {
       array_walk($leaveRequestStatus, 'intval');
       $whereLeaveRequestStatus = ' AND leave_request.status_id IN('. implode(', ', $leaveRequestStatus) .')';
+    }
+
+    $whereExcludeLeaveRequestIds = '';
+    if(is_array($excludeLeaveIds) && !empty($excludeLeaveIds)) {
+      $whereExcludeLeaveRequestIds = ' AND leave_request.id NOT IN('. implode(', ', $excludeLeaveIds) .')';
     }
 
     $query = "
@@ -112,6 +120,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
               leave_request.type_id = {$periodEntitlement->type_id} AND
               leave_request.contact_id = {$periodEntitlement->contact_id}
               $whereLeaveRequestStatus
+              $whereExcludeLeaveRequestIds
             )
             OR
             (

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
@@ -385,12 +385,16 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
    * - Expired Balance Changes
    * - Approved Leave Requests
    *
+   * @param array $excludeLeaveIds
+   *   An array of Leave request ID's to be excluded from
+   *   the entitlement balance calculation.
+   *
    * @return float
    */
-  public function getBalance() {
+  public function getBalance($excludeLeaveIds = []) {
     $filterStatuses = LeaveRequest::getApprovedStatuses();
 
-    return LeaveBalanceChange::getBalanceForEntitlement($this, $filterStatuses);
+    return LeaveBalanceChange::getBalanceForEntitlement($this, $filterStatuses, false, $excludeLeaveIds);
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -475,15 +475,16 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
       );
     }
 
-    $currentBalance = $leavePeriodEntitlement->getBalance();
-
+    $requestsToExcludeFromBalance = [];
     if (!empty($params['id'])) {
       $oldLeaveRequest = self::findById($params['id']);
 
-      if ($oldLeaveRequest && $oldLeaveRequest->id && self::isAlreadyApproved($oldLeaveRequest)) {
-        $currentBalance = $leavePeriodEntitlement->getBalance([$oldLeaveRequest->id]);
+      if (self::isAlreadyApproved($oldLeaveRequest)) {
+        $requestsToExcludeFromBalance[] = $oldLeaveRequest->id;
       }
     }
+
+    $currentBalance = $leavePeriodEntitlement->getBalance($requestsToExcludeFromBalance);
 
     if(!$absenceType->allow_overuse && $leaveRequestBalance > $currentBalance) {
       throw new InvalidLeaveRequestException(

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -477,6 +477,20 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
 
     $currentBalance = $leavePeriodEntitlement->getBalance();
 
+    if (!empty($params['id'])) {
+      $oldLeaveRequest = self::findById($params['id']);
+
+      if ($oldLeaveRequest && $oldLeaveRequest->id && self::isAlreadyApproved($oldLeaveRequest)) {
+        $periodContainingOldLeaveDates = self::getPeriodContainingDates($oldLeaveRequest);
+        $isSamePeriodWithOldLeave = $periodContainingOldLeaveDates->id == $period->id;
+
+        if ($isSamePeriodWithOldLeave) {
+          $oldLeaveRequestBalance = abs(LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($oldLeaveRequest));
+          $currentBalance += $oldLeaveRequestBalance;
+        }
+      }
+    }
+
     if(!$absenceType->allow_overuse && $leaveRequestBalance > $currentBalance) {
       throw new InvalidLeaveRequestException(
         'There are only '. $currentBalance .' days leave available. This request cannot be made or approved',

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -3313,7 +3313,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertNotNull($leaveRequest->id);
   }
 
-  public function testAlreadyApprovedLeaveRequestCanNotBeUpdatedWhenDatesChangeAndLeaveBalanceGreaterPreviousLeaveBalanceAndEntitlementBalanceIsZero() {
+  public function testApprovedRequestCanNotBeUpdatedWhenCurrentBalanceIsZeroAndDatesChangeAndBalanceChangeIsGreaterThanPreviousBalanceChange() {
     $period = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
@@ -3359,7 +3359,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $params['from_date'] = CRM_Utils_Date::processDate('2016-11-14');
     $params['to_date'] = CRM_Utils_Date::processDate('2016-11-17');
 
-    //Since the dates as changed, the request is treated as a fresh request as if it is just being requested
+    //Since the dates are changed, the request is treated as a fresh request as if it is just being requested
     //with entitlement balance change being same as it was before it was requested.
     $this->setExpectedException(
       'CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException',
@@ -3422,7 +3422,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals(0, $periodEntitlement1->getBalance());
 
     //Update Leave Request dates with dates being in the second period.
-    //The balance deducted when leave request was made will not be added to the entitlement balance
+    //The balance deducted when leave request was made will not be added to $entitlement2Balance
     //since the leave request was not initially approved in the second period.
     //But the entitlement balance is Zero in second period, so an exception will be thrown.
     $params['id'] = $leaveRequest->id;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Import/Parser/BaseTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Import/Parser/BaseTest.php
@@ -265,10 +265,11 @@ class CRM_HRLeaveAndAbsences_Import_Parser_BaseTest extends BaseHeadlessTest {
       'qty' => 4,
       'start_date' => '2016-01-01',
       'end_date' => '2016-01-01',
-      'total_qty' => 4
+      'total_qty' => 4,
+      'status' => 1
     ];
 
-    $leaveStatuses = self::buildOptions('status_id');
+    $leaveStatuses = LeaveRequest::buildOptions('status_id');
     $fields = array_keys($row1);
     $importObject = $this->getImportObject($fields);
     //Since the request type is TOIL, balance change validation will not


### PR DESCRIPTION
## Overview
When trying to update an already approved leave request, e.g trying to change the status or add a comment, or upload a file and the Entitlement Balance is Zero, an error: ` 'There are only 0 days leave available. This request cannot be made or approved` is returned to the manager/user trying to update the Leave.

## Before
Trying to update an already approved leave request e.g trying to change the status or add a comment, or upload a file returns an error when the Entitlement Balance is Zero.
- The reason for the error returned is that when validating an already approved leave, the already approved leave is considered as a fresh leave request not minding the fact that its balance change has previously been deducted from the entitlement Balance.
- Since the approved leave to be updated is treated as a fresh leave request, once the leave balance is greater than the entitlement balance not only when it is Zero, an error is thrown.

## After
- An already approved leave request is no longer treated as a fresh leave request, Instead leave request ID is passed to the `getBalance` method to exclude the balance of that leave request from the entitlement balance calculation.
- In the case when the dates has changed and the new leave balance is now greater than the old leave balance, an error is thrown inasmuch as the leave balance is greater than the entitlement balance.
- In the case when the Work Pattern has changed and the change_balance parameter is true and the new leave balance is now greater than the old leave balance, an error is thrown inasmuch as the leave balance is greater than the entitlement balance.
- The change_balance parameter is taken into consideration during leave request validation. 

## Comments
- A broken test for Leave Import was also fixed as part of this PR
---

- [X] Tests Pass
