### PR TITLE
PCHR-2543: Add missing white space on admin table headers

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.tpl
@@ -7,11 +7,11 @@
         {strip}
           <table cellpadding="0" cellspacing="0" border="0" class="table table-responsive hrleaveandabsences-entity-list">
             <thead class="sticky">
-            <th>{ts}Title{/ts}</th>
-            <th>{ts}Start Date{/ts}</th>
-            <th>{ts}End Date{/ts}</th>
-            <th>{ts}Order{/ts}</th>
-            <th></th>
+              <th>{ts}Title{/ts}</th>
+              <th>{ts}Start Date{/ts}</th>
+              <th>{ts}End Date{/ts}</th>
+              <th>{ts}Order{/ts}</th>
+              <th>&nbsp;</th>
             </thead>
             {foreach from=$rows item=row}
               <tr id="AbsencePeriod-{$row.id}" class="crm-entity {$row.class}{if NOT $row.is_active} disabled{/if}">

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/PublicHoliday.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/PublicHoliday.tpl
@@ -12,7 +12,7 @@
             <th>{ts}Title{/ts}</th>
             <th>{ts}Date{/ts}</th>
             <th>{ts}Enabled/Disabled{/ts}</th>
-            <th></th>
+            <th>&nbsp;</th>
           </thead>
           {foreach from=$rows item=row}
             <tr id="PublicHoliday-{$row.id}" class="crm-entity {$row.class}{if NOT $row.is_active} disabled{/if}">

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/WorkPattern.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/WorkPattern.tpl
@@ -16,7 +16,7 @@
             <th>{ts}Is Default{/ts}</th>
             <th>{ts}Order{/ts}</th>
             <th>{ts}Enabled/Disabled{/ts}</th>
-            <th></th>
+            <th>&nbsp;</th>
           </thead>
           {foreach from=$rows item=row}
             <tr id="WorkPattern-{$row.id}" class="crm-entity {$row.class}{if NOT $row.is_active} disabled{/if}">


### PR DESCRIPTION
## Overview
This PR adds blank space characters to admin table headers so they can be displayed correctly when they are in sticky mode.

This PR is linked to https://github.com/compucorp/org.civicrm.shoreditch/pull/50

## Before
![download 40](https://user-images.githubusercontent.com/1642119/30671534-f18e347e-9e13-11e7-9dbe-6160360ccc0b.png)

## After
![download 41](https://user-images.githubusercontent.com/1642119/30671588-4279d410-9e14-11e7-939d-4ef5b459c2ef.png)

## Technical Details
When sticky table headers are empty (`<th></th>`) they are displayed incorrectly. To fix this issue a blank space character was added (`&nbsp;`).

## Comments
* BackstopJS tests were run on the Shoreditch PR.
* Indentation was fixed on `Page/AbsencePeriod.tpl`. Since it was only 5 lines total it was not added in a separate commit.

---

- [x] Tests Pass
