### PR TITLE
PCHR-2330: Add notes to request controller's initRoles function

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/controllers/request.controller.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/controllers/request.controller.js
@@ -494,11 +494,19 @@ define([
     }
 
     /**
-     * Initialises roles
+     * Initialises the user role to either *admin*, *manager*, or *staff*
+     * depending on the user permissions and whether they are managing their own
+     * leave or not.
+     *
+     * @return {Promise}
      */
     function initRoles () {
       role = 'staff';
 
+      /**
+       * If the user is creating or editing their own leave, they will be
+       * treated as a staff regardless of their actual role.
+       */
       if ($rootScope.section === 'my-leave') {
         return;
       }


### PR DESCRIPTION
## Overview
The `initRoles` function on `request.controllers.js` is missing a few key comments such as the return value of the function and a comment on an exception where the user role is set to staff if they are managing their own leave.

## Technical Details
Just added the missing comments. This doesn't affect minified files nor tests.

