### PR TITLE
PCHR-2545: Add missing active field and remove duplicate label field

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/WorkPattern/Details.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/WorkPattern/Details.tpl
@@ -8,8 +8,8 @@
     <div class="col-sm-3">{$form.description.html}</div>
   </div>
   <div class="form-group row">
-    <div class="col-sm-3">{$form.label.label}</div>
-    <div class="col-sm-3">{$form.label.html}</div>
+    <div class="col-sm-3">{$form.is_active.label}</div>
+    <div class="col-sm-3">{$form.is_active.html}</div>
   </div>
   <div class="form-group row">
     <div class="col-sm-3">{$form.is_default.label}</div>


### PR DESCRIPTION
## Overview
This PR removes a duplicate "label" field on work patterns and adds a missing "active" checkbox.

## Before
![download 44](https://user-images.githubusercontent.com/1642119/30704435-309af75c-9e9f-11e7-8641-bb7ebe9b5eb8.png)

## After
![download 43](https://user-images.githubusercontent.com/1642119/30704369-08fad0b4-9e9f-11e7-85ed-b970110b47b9.png)

## Comments
BackstopJS tests were run for work pattern screens.

---

- [x] Tests Pass
