### PR TITLE
PCHR-2535: Disallow transitions to non-cancelling statuses with a negative closing balance

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -88,32 +88,32 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
     $query = "
       SELECT SUM(leave_balance_change.amount) balance
       FROM {$balanceChangeTable} leave_balance_change
-      LEFT JOIN {$leaveRequestDateTable} leave_request_date 
-             ON leave_balance_change.source_id = leave_request_date.id AND 
+      LEFT JOIN {$leaveRequestDateTable} leave_request_date
+             ON leave_balance_change.source_id = leave_request_date.id AND
                 leave_balance_change.source_type = '". self::SOURCE_LEAVE_REQUEST_DAY ."'
-      LEFT JOIN {$leaveRequestTable} leave_request 
+      LEFT JOIN {$leaveRequestTable} leave_request
              ON leave_request_date.leave_request_id = leave_request.id AND
                 leave_request.is_deleted = 0
-      LEFT JOIN {$contractTable} contract 
+      LEFT JOIN {$contractTable} contract
              ON leave_request.contact_id = contract.contact_id
-      LEFT JOIN {$contractRevisionTable} contract_revision 
+      LEFT JOIN {$contractRevisionTable} contract_revision
             ON contract_revision.id = (
               SELECT id FROM {$contractRevisionTable} contract_revision2
               WHERE contract_revision2.jobcontract_id = contract.id
               ORDER BY contract_revision2.effective_date DESC
               LIMIT 1
             )
-      LEFT JOIN {$contractDetailsTable} contract_details 
+      LEFT JOIN {$contractDetailsTable} contract_details
              ON contract_revision.details_revision_id = contract_details.jobcontract_revision_id
-      
+
       WHERE ((
               $whereLeaveRequestDates AND
               contract.deleted = 0 AND
-              ( 
+              (
                 leave_request.from_date <= contract_details.period_end_date OR
                 contract_details.period_end_date IS NULL
               )  AND
-              ( 
+              (
                 leave_request.to_date >= contract_details.period_start_date OR
                 (leave_request.to_date IS NULL AND leave_request.from_date >= contract_details.period_start_date)
               )  AND
@@ -124,7 +124,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
             )
             OR
             (
-              leave_balance_change.source_id = {$periodEntitlement->id} AND 
+              leave_balance_change.source_id = {$periodEntitlement->id} AND
               leave_balance_change.source_type = '" . self::SOURCE_ENTITLEMENT . "'
             ))
     ";
@@ -272,34 +272,34 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
     $query = "
       SELECT SUM(leave_balance_change.amount) balance
       FROM {$balanceChangeTable} leave_balance_change
-      INNER JOIN {$leaveRequestDateTable} leave_request_date 
-              ON leave_balance_change.source_id = leave_request_date.id AND 
+      INNER JOIN {$leaveRequestDateTable} leave_request_date
+              ON leave_balance_change.source_id = leave_request_date.id AND
                  leave_balance_change.source_type = '" . self::SOURCE_LEAVE_REQUEST_DAY . "'
-      INNER JOIN {$leaveRequestTable} leave_request 
+      INNER JOIN {$leaveRequestTable} leave_request
               ON leave_request_date.leave_request_id = leave_request.id AND
                  leave_request.is_deleted = 0
-      INNER JOIN {$contractTable} contract 
+      INNER JOIN {$contractTable} contract
              ON leave_request.contact_id = contract.contact_id
-      INNER JOIN {$contractRevisionTable} contract_revision 
+      INNER JOIN {$contractRevisionTable} contract_revision
             ON contract_revision.id = (
               SELECT id FROM {$contractRevisionTable} contract_revision2
               WHERE contract_revision2.jobcontract_id = contract.id
               ORDER BY contract_revision2.effective_date DESC
               LIMIT 1
             )
-      INNER JOIN {$contractDetailsTable} contract_details 
+      INNER JOIN {$contractDetailsTable} contract_details
              ON contract_revision.details_revision_id = contract_details.jobcontract_revision_id
-             
+
       WHERE {$whereLeaveRequestDates} AND
             contract.deleted = 0 AND
-            ( 
+            (
               leave_request.from_date <= contract_details.period_end_date OR
               contract_details.period_end_date IS NULL
             )  AND
-            ( 
+            (
               leave_request.to_date >= contract_details.period_start_date OR
               (leave_request.to_date IS NULL AND leave_request.from_date >= contract_details.period_start_date)
-            ) AND  
+            ) AND
             leave_balance_change.expired_balance_change_id IS NULL AND
             leave_request.type_id = {$periodEntitlement->type_id} AND
             leave_request.contact_id = {$periodEntitlement->contact_id}
@@ -348,7 +348,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
     $query = "
       SELECT bc.*
       FROM {$balanceChangeTable} bc
-      INNER JOIN {$leaveRequestDateTable} lrd 
+      INNER JOIN {$leaveRequestDateTable} lrd
         ON bc.source_id = lrd.id AND bc.source_type = %1
       INNER JOIN {$leaveRequestTable} lr
         ON lrd.leave_request_id = lr.id
@@ -697,16 +697,16 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
           leave_request_date.date,
           leave_request.type_id,
           balance_change.amount
-        FROM {$leaveRequestDateTable} leave_request_date 
-        INNER JOIN {$leaveBalanceChangeTable} balance_change 
+        FROM {$leaveRequestDateTable} leave_request_date
+        INNER JOIN {$leaveBalanceChangeTable} balance_change
             ON balance_change.source_id = leave_request_date.id AND balance_change.source_type = %1
         INNER JOIN {$leaveRequestTable} leave_request
-            ON leave_request_date.leave_request_id = leave_request.id AND 
+            ON leave_request_date.leave_request_id = leave_request.id AND
                (leave_request.request_type IN(%2, %3, %9) AND leave_request.is_deleted = 0)
-        WHERE ({$wherePeriodEntitlementDates}) AND 
+        WHERE ({$wherePeriodEntitlementDates}) AND
               (leave_request_date.date BETWEEN %4 AND %5) AND
-              (leave_request.status_id IN (%6, %10)) AND 
-              (leave_request.contact_id = %7) AND 
+              (leave_request.status_id IN (%6, %10)) AND
+              (leave_request.contact_id = %7) AND
               (leave_request.type_id = %8)
       ";
 
@@ -764,7 +764,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
     $absencePeriodTable     = AbsencePeriod::getTableName();
 
     $query = "
-      SELECT 
+      SELECT
         balance_to_expire.*,
         coalesce(absence_period.start_date, leave_request.from_date) as start_date,
         coalesce(leave_request.contact_id, period_entitlement.contact_id) as contact_id,
@@ -858,15 +858,15 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
 
     $query = "SELECT SUM(bc.amount) balance
               FROM {$leaveBalanceChangeTable} bc
-              INNER JOIN {$leaveRequestDateTable} lrd 
+              INNER JOIN {$leaveRequestDateTable} lrd
                 ON bc.source_id = lrd.id AND bc.source_type = %1
-              INNER JOIN {$leaveRequestTable} lr 
+              INNER JOIN {$leaveRequestTable} lr
                 ON lrd.leave_request_id = lr.id AND lr.is_deleted = 0
-              WHERE 
+              WHERE
                 lr.contact_id = %2 AND
-                lr.from_date >= %3 AND 
-                lr.to_date <= %4 AND 
-                lr.type_id = %5 AND 
+                lr.from_date >= %3 AND
+                lr.to_date <= %4 AND
+                lr.type_id = %5 AND
                 lr.request_type = %6";
 
     if (is_array($statuses) && !empty($statuses)) {
@@ -943,7 +943,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
     );
 
     $query = "
-      SELECT 
+      SELECT
         bc.*,
         coalesce(absence_period.start_date, leave_request.from_date) as start_date
       FROM {$balanceChangeTable} bc
@@ -957,10 +957,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
             ON period_entitlement.period_id = absence_period.id
       WHERE bc.expiry_date IS NOT NULL AND
             (bc.expiry_date BETWEEN %3 AND %4) AND
-            bc.expiry_date >= %5 AND  
+            bc.expiry_date >= %5 AND
             bc.expired_balance_change_id IS NULL AND
             (leave_request.contact_id = %6 OR period_entitlement.contact_id = %6) AND
-            (leave_request.type_id = %7 OR period_entitlement.type_id = %7)    
+            (leave_request.type_id = %7 OR period_entitlement.type_id = %7)
       ORDER BY bc.expiry_date ASC, bc.id ASC";
 
     $params = [
@@ -1113,7 +1113,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
     }
 
     $query = "
-        SELECT 
+        SELECT
            COALESCE(leave_request.contact_id, period_entitlement.contact_id) as contact_id,
            COALESCE(leave_request.type_id, period_entitlement.type_id) as type_id,
            SUM(leave_balance_change.amount) as balance
@@ -1142,7 +1142,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
 
         WHERE ((
           {$whereLeaveRequestAbsenceType}
-          leave_request.status_id IN(" . implode(', ', LeaveRequest::getApprovedStatuses()) . ") AND 
+          leave_request.status_id IN(" . implode(', ', LeaveRequest::getApprovedStatuses()) . ") AND
           (leave_request_date.date >= %1 AND leave_request_date.date <= %2) AND
           contract.deleted = 0 AND
           (
@@ -1228,35 +1228,35 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
     $query = "
       SELECT leave_request.contact_id, leave_request.type_id, SUM(leave_balance_change.amount) balance
       FROM {$balanceChangeTable} leave_balance_change
-      INNER JOIN {$leaveRequestDateTable} leave_request_date 
-        ON leave_balance_change.source_id = leave_request_date.id AND 
+      INNER JOIN {$leaveRequestDateTable} leave_request_date
+        ON leave_balance_change.source_id = leave_request_date.id AND
                  leave_balance_change.source_type = '" . self::SOURCE_LEAVE_REQUEST_DAY . "'
-      INNER JOIN {$leaveRequestTable} leave_request 
+      INNER JOIN {$leaveRequestTable} leave_request
         ON leave_request_date.leave_request_id = leave_request.id AND
                  leave_request.is_deleted = 0
-      INNER JOIN {$contractTable} contract 
+      INNER JOIN {$contractTable} contract
         ON leave_request.contact_id = contract.contact_id
-      INNER JOIN {$contractRevisionTable} contract_revision 
+      INNER JOIN {$contractRevisionTable} contract_revision
         ON contract_revision.id = (
           SELECT id FROM {$contractRevisionTable} contract_revision2
           WHERE contract_revision2.jobcontract_id = contract.id
           ORDER BY contract_revision2.effective_date DESC
           LIMIT 1
         )
-      INNER JOIN {$contractDetailsTable} contract_details 
+      INNER JOIN {$contractDetailsTable} contract_details
         ON contract_revision.details_revision_id = contract_details.jobcontract_revision_id
-             
+
       WHERE contract.deleted = 0 AND
-        leave_request_date.date >= %1 AND 
+        leave_request_date.date >= %1 AND
         leave_request_date.date <= %2 AND
-        ( 
+        (
           leave_request.from_date <= contract_details.period_end_date OR
           contract_details.period_end_date IS NULL
         )  AND
-        ( 
+        (
           leave_request.to_date >= contract_details.period_start_date OR
           (leave_request.to_date IS NULL AND leave_request.from_date >= contract_details.period_start_date)
-        ) AND  
+        ) AND
         leave_balance_change.expired_balance_change_id IS NULL AND {$whereAbsenceType}
         leave_request.contact_id IN(" . implode(', ', $contactIDs) . ") AND
         leave_request.status_id IN(" . implode(', ', LeaveRequest::getOpenStatuses()) . ")

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -405,7 +405,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
       }
     }
 
-    return $balance;
+    return abs($balance);
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -405,7 +405,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
       }
     }
 
-    return abs($balance);
+    return $balance;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -486,7 +486,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
 
     $currentBalance = $leavePeriodEntitlement->getBalance($requestsToExcludeFromBalance);
 
-    if(!$absenceType->allow_overuse && $leaveRequestBalance > $currentBalance) {
+    if(!$absenceType->allow_overuse && ($currentBalance + $leaveRequestBalance) < 0) {
       throw new InvalidLeaveRequestException(
         'There are only '. $currentBalance .' days leave available. This request cannot be made or approved',
         'leave_request_balance_change_greater_than_remaining_balance',
@@ -513,7 +513,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
       $params['to_date_type']
     );
 
-    return abs($leaveRequestBalance['amount']);
+    return $leaveRequestBalance['amount'];
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -1120,7 +1120,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
     // The balance changes created by the fabricator deduct 1 day for each date,
     // so the total for the 4 days should be 4
-    $this->assertEquals(4, LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest));
+    $this->assertEquals(-4, LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest));
   }
 
   public function testTheTotalBalanceChangeForALeaveRequestWithoutBalanceChangesShouldBeZero() {
@@ -1151,7 +1151,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $this->createExpiryBalanceChangeForTOILRequest($leaveRequest->id, $numberOfExpiredDays);
 
     $expiredOnly = true;
-    $this->assertEquals(3, LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest, $expiredOnly));
+    $this->assertEquals(-3, LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest, $expiredOnly));
   }
 
   public function testTheTotalBalanceChangeForALeaveRequestShouldBeTheOriginalAmountWhenExpiredOnlyIsFalse() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -1120,7 +1120,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
     // The balance changes created by the fabricator deduct 1 day for each date,
     // so the total for the 4 days should be 4
-    $this->assertEquals(-4, LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest));
+    $this->assertEquals(4, LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest));
   }
 
   public function testTheTotalBalanceChangeForALeaveRequestWithoutBalanceChangesShouldBeZero() {
@@ -1151,7 +1151,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $this->createExpiryBalanceChangeForTOILRequest($leaveRequest->id, $numberOfExpiredDays);
 
     $expiredOnly = true;
-    $this->assertEquals(-3, LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest, $expiredOnly));
+    $this->assertEquals(3, LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest, $expiredOnly));
   }
 
   public function testTheTotalBalanceChangeForALeaveRequestShouldBeTheOriginalAmountWhenExpiredOnlyIsFalse() {
@@ -3775,4 +3775,3 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     return $record;
   }
 }
-

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -910,53 +910,35 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     }
   }
 
-  public function testManagerCanNotApproveLeaveRequestIfBalanceChangeIsMoreThanEntitlementBalanceWhenAllowOveruseFalse() {
-    $manager = ContactFabricator::fabricate();
-    $staff = ContactFabricator::fabricate();
-    $periodStartDate = CRM_Utils_Date::processDate('2016-01-01');
-    $periodEndDate = CRM_Utils_Date::processDate('2016-12-31');
+  public function testLeaveRequestCannotBeUpdatedIfBalanceChangeIsMoreThanEntitlementBalanceWhenAllowOveruseFalse() {
+    $contactId = 1;
     $requestDate = CRM_Utils_Date::processDate('2016-06-14');
     $requestDateType = $this->leaveRequestDayTypes['all_day']['value'];
 
-    $this->registerCurrentLoggedInContactInSession($manager['id']);
-    $this->setContactAsLeaveApproverOf($manager, $staff);
-
     $absencePeriod = AbsencePeriodFabricator::fabricate([
-      'start_date' => $periodStartDate,
-      'end_date'   => $periodEndDate,
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-06-14'),
     ]);
 
     $absenceType = AbsenceTypeFabricator::fabricate(['allow_overuse' => 0]);
 
     $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
       'type_id' => $absenceType->id,
-      'contact_id' => $staff['id'],
+      'contact_id' => $contactId,
       'period_id' => $absencePeriod->id
     ]);
 
     // Current balance must be less than the balance change
     $entitlementBalance = 0;
     $this->createLeaveBalanceChange($periodEntitlement->id, $entitlementBalance);
-    $periodStartDate = $absencePeriod->start_date;
 
-    HRJobContractFabricator::fabricate(
-      ['contact_id' => $periodEntitlement->contact_id],
-      ['period_start_date' => $periodStartDate]
-    );
-
-    $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
-    ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $staff['id'],
-      'pattern_id' => $workPattern->id
-    ]);
-
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     // Balance change is 1 since this is a single day leave request
     $leaveRequestData = [
       'type_id' => $absenceType->id,
       'contact_id' => $periodEntitlement->contact_id,
-      'status_id' => $leaveRequestStatuses['awaiting_approval'],
+      'status_id' => $leaveRequestStatuses['approved'],
       'from_date' => $requestDate,
       'from_date_type' => $requestDateType,
       'to_date' => $requestDate,
@@ -964,163 +946,19 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
     ];
 
-    $this->setExpectedException(
-      'CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException',
-      'There are only '. $entitlementBalance .' days leave available. This request cannot be made or approved'
-    );
-
-    // Create new request by staff with Awaiting Approval status
+    // Create new request
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($leaveRequestData, true);
-    // Approve leave request by manager
-    $updatedLeaveRequestData = $leaveRequestData;
-    $updatedLeaveRequestData['id'] = $leaveRequest->id;
-    $updatedLeaveRequestData['status_id'] = $leaveRequestStatuses['approved'];
-    $updatedLeaveRequest = LeaveRequest::create($updatedLeaveRequestData);
 
-    // Test that the status has not been changed
-    $this->assertEquals($updatedLeaveRequest->status_id, $leaveRequestStatuses['awaiting_approval']);
-  }
-
-  public function testManagerCanNotSetLeaveRequestStatusToMoreInformationRequiredIfBalanceChangeIsMoreThanEntitlementBalanceWhenAllowOveruseFalse() {
-    $manager = ContactFabricator::fabricate();
-    $staff = ContactFabricator::fabricate();
-    $periodStartDate = CRM_Utils_Date::processDate('2016-01-01');
-    $periodEndDate = CRM_Utils_Date::processDate('2016-12-31');
-    $requestDate = CRM_Utils_Date::processDate('2016-06-14');
-    $requestDateType = $this->leaveRequestDayTypes['all_day']['value'];
-
-    $this->registerCurrentLoggedInContactInSession($manager['id']);
-    $this->setContactAsLeaveApproverOf($manager, $staff);
-
-    $absencePeriod = AbsencePeriodFabricator::fabricate([
-      'start_date' => $periodStartDate,
-      'end_date'   => $periodEndDate,
-    ]);
-
-    $absenceType = AbsenceTypeFabricator::fabricate(['allow_overuse' => 0]);
-
-    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
-      'type_id' => $absenceType->id,
-      'contact_id' => $staff['id'],
-      'period_id' => $absencePeriod->id
-    ]);
-
-    // Current balance must be less than the balance change
-    $entitlementBalance = 0;
-    $this->createLeaveBalanceChange($periodEntitlement->id, $entitlementBalance);
-    $periodStartDate = $absencePeriod->start_date;
-
-    HRJobContractFabricator::fabricate(
-      ['contact_id' => $periodEntitlement->contact_id],
-      ['period_start_date' => $periodStartDate]
-    );
-
-    $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
-    ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $staff['id'],
-      'pattern_id' => $workPattern->id
-    ]);
-
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
-    $awaitingApprovalStatus = $leaveRequestStatuses['awaiting_approval'];
-
-    // Balance change is 1 since this is a single day leave request
-    $leaveRequestData = [
-      'type_id' => $absenceType->id,
-      'contact_id' => $periodEntitlement->contact_id,
-      'status_id' => $awaitingApprovalStatus,
-      'from_date' => $requestDate,
-      'from_date_type' => $requestDateType,
-      'to_date' => $requestDate,
-      'to_date_type' => $requestDateType,
-      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
-    ];
+    // Attempt to change leave request status
+    $leaveRequestData['id'] = $leaveRequest->id;
+    $leaveRequestData['status_id'] = $leaveRequestStatuses['awaiting_approval'];
 
     $this->setExpectedException(
       'CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException',
       'There are only '. $entitlementBalance .' days leave available. This request cannot be made or approved'
     );
 
-    // Create a new request by staff with Awaiting Approval status
-    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($leaveRequestData, true);
-    // Attempt to set the status to More Information Required by manager
-    $updatedLeaveRequestData = $leaveRequestData;
-    $updatedLeaveRequestData['id'] = $leaveRequest->id;
-    $updatedLeaveRequestData['status_id'] = $awaitingApprovalStatus;
-    $updatedLeaveRequest = LeaveRequest::create($updatedLeaveRequestData);
-
-    // Test that the status has not been changed
-    $this->assertEquals($updatedLeaveRequest->status_id, $awaitingApprovalStatus);
-  }
-
-  public function testStaffCanNotSetLeaveRequestStatusToAwaitingApprovalIfBalanceChangeIsMoreThanEntitlementBalanceWhenAllowOveruseFalse() {
-    $staff = ContactFabricator::fabricate();
-    $periodStartDate = CRM_Utils_Date::processDate('2016-01-01');
-    $periodEndDate = CRM_Utils_Date::processDate('2016-12-31');
-    $requestDate = CRM_Utils_Date::processDate('2016-06-14');
-    $requestDateType = $this->leaveRequestDayTypes['all_day']['value'];
-
-    $this->registerCurrentLoggedInContactInSession($staff['id']);
-
-    $absencePeriod = AbsencePeriodFabricator::fabricate([
-      'start_date' => $periodStartDate,
-      'end_date'   => $periodEndDate,
-    ]);
-
-    $absenceType = AbsenceTypeFabricator::fabricate(['allow_overuse' => 0]);
-
-    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
-      'type_id' => $absenceType->id,
-      'contact_id' => $staff['id'],
-      'period_id' => $absencePeriod->id
-    ]);
-
-    // Current balance must be less than the balance change
-    $entitlementBalance = 0;
-    $this->createLeaveBalanceChange($periodEntitlement->id, $entitlementBalance);
-    $periodStartDate = $absencePeriod->start_date;
-
-    HRJobContractFabricator::fabricate(
-      ['contact_id' => $periodEntitlement->contact_id],
-      ['period_start_date' => $periodStartDate]
-    );
-
-    $workPattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
-    ContactWorkPatternFabricator::fabricate([
-      'contact_id' => $staff['id'],
-      'pattern_id' => $workPattern->id
-    ]);
-
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
-    $moreInformationRequiredStatus = $leaveRequestStatuses['more_information_required'];
-
-    // Balance change is 1 since this is a single day leave request
-    $leaveRequestData = [
-      'type_id' => $absenceType->id,
-      'contact_id' => $periodEntitlement->contact_id,
-      'status_id' => $moreInformationRequiredStatus,
-      'from_date' => $requestDate,
-      'from_date_type' => $requestDateType,
-      'to_date' => $requestDate,
-      'to_date_type' => $requestDateType,
-      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
-    ];
-
-    $this->setExpectedException(
-      'CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException',
-      'There are only '. $entitlementBalance .' days leave available. This request cannot be made or approved'
-    );
-
-    // Imitate a request with More Information Required status
-    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($leaveRequestData, true);
-    // Attempt to set the status to Awaiting Approval by staff
-    $updatedLeaveRequestData = $leaveRequestData;
-    $updatedLeaveRequestData['id'] = $leaveRequest->id;
-    $updatedLeaveRequestData['status_id'] = $leaveRequestStatuses['awaiting_approval'];
-    $updatedLeaveRequest = LeaveRequest::create($updatedLeaveRequestData);
-
-    // Test that the status has not been changed
-    $this->assertEquals($updatedLeaveRequest->status_id, $moreInformationRequiredStatus);
+    LeaveRequest::create($leaveRequestData);
   }
 
   public function testFindOverlappingLeaveRequestsForMoreThanOneOverlappingLeaveRequests() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -899,7 +899,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     // Testing leave request rejection and cancelling
     foreach (LeaveRequest::getCancelledStatuses() as $statusId) {
       // Create new request with Awaiting Approval status
-      $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($leaveRequestData);
+      $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($leaveRequestData, true);
       // Change status of the leave request
       $updatedLeaveRequestData = $leaveRequestData;
       $updatedLeaveRequestData['id'] = $leaveRequest->id;


### PR DESCRIPTION
## Overview

At the moment is it possible to:

1) Set Leave Request status to More information required with a negative closing balance by Manager
2) Set Leave Request status to Awaiting for approval with a negative closing balance by Staff
3) Approve a Leave Request with a negative closing balance by manager

This PR fixes this issue.

## Before

![1](https://user-images.githubusercontent.com/3973243/30749559-b0fd6508-9fab-11e7-8d3c-6900ef9a204d.gif)

## After

![2](https://user-images.githubusercontent.com/3973243/30749569-b6f8bc5a-9fab-11e7-9fdb-1c3f59bfbd0a.gif)

## Technical Details

The problem was in the function that calculates the balance change for **existing** leave requests:

```php
public static function getTotalBalanceChangeForLeaveRequest(LeaveRequest $leaveRequest, $expiredOnly = false) {
  ...
  return $balance; // for Leave Requests using current TOIL balance this value was negative, though the actual calculation was correct
}
```
This lead to the following condition to pass while it should have been failing:

```php
//                                        v That expression will always be false
if(!$absenceType->allow_overuse && $leaveRequestBalance > $currentBalance) {
  throw new InvalidLeaveRequestException(
    'There are only X days leave available...'
  );
}
```
This issue was fixed by simply returning the original (not absolute) value in the balance calculation function for **new** requests:

```php
private static function calculateBalanceChangeFromCreateParams($params) {
  // ...
  return $leaveRequestBalance['amount']; // <-- remove abs()
}
```

## Comments

This PR also fixes trailing spaces.

This PR also fixes the existing test, which ignored the calculation of balance change. The test was still passing, however, if we remove the implementation this test actually checks, it will throw another error (no working days specified), not the error we expect to be thrown (negative closing balance).

---

- [x] Tests Pass