### PR TITLE
PCHR-2601: Fix issue with TOIL not being Accrued properly when TOIL dates do not change and Toil to Accrue changes.

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -1180,6 +1180,29 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
   }
 
   /**
+   * Checks If the toil_to_accrue value for a TOIL request to be updated
+   * changed since when it was created.
+   *
+   * Returns NULL for a freshly created Leave request or a request type
+   * is not a TOIL type.
+   *
+   * @param array $params
+   *
+   * @return bool|null
+   */
+  public static function toilToAccrueChanged($params) {
+    if($params['request_type'] != self::REQUEST_TYPE_TOIL || empty($params['id'])) {
+      return null;
+    }
+
+    $toilRequest = self::findById($params['id']);
+    $toilToAccrue = $toilRequest->toil_to_accrue;
+    $newToilToAccrue = $params['toil_to_accrue'];
+
+    return $toilToAccrue != $newToilToAccrue;
+  }
+
+  /**
    * Returns the balance change for the leave request.
    *
    * If its an already created leave request and the dates did not change

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -3730,4 +3730,75 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $leaveRequest = LeaveRequest::create($params);
     $this->assertNotNull($leaveRequest->id);
   }
+
+  public function testToilToAccrueChangedReturnsTrueWhenToilToAccrueChanges(){
+    $date = CRM_Utils_Date::processDate('2016-01-10');
+    $params = [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'from_date' => $date,
+      'to_date' => $date,
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL,
+      'toil_to_accrue' => 2
+    ];
+
+    $toilRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    //update Toil request
+    $params['id'] = $toilRequest->id;
+    $params['toil_to_accrue'] = 1;
+
+    $this->assertTrue(LeaveRequest::toilToAccrueChanged($params));
+  }
+
+  public function testToilToAccrueChangedReturnsFalseWhenToilToAccrueDoesNotChange(){
+    $date = CRM_Utils_Date::processDate('2016-01-08');
+    $params = [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'from_date' => $date,
+      'to_date' => $date,
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL,
+      'toil_to_accrue' => 1
+    ];
+
+    $toilRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    //update Toil request
+    $params['id'] = $toilRequest->id;
+
+    $this->assertFalse(LeaveRequest::toilToAccrueChanged($params));
+  }
+
+  public function testToilToAccrueChangedReturnsNullWhenRequestTypeIsNotToil(){
+    $date = CRM_Utils_Date::processDate('2016-01-08');
+    $params = [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'from_date' => $date,
+      'to_date' => $date,
+      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE,
+    ];
+
+    $toilRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    //update Toil request
+    $params['id'] = $toilRequest->id;
+
+    $this->assertNUll(LeaveRequest::toilToAccrueChanged($params));
+  }
+
+  public function testToilToAccrueChangedReturnsNullWhenCreatingANewRequest(){
+    $date = CRM_Utils_Date::processDate('2016-01-08');
+    $params = [
+      'type_id' => 1,
+      'contact_id' => 1,
+      'from_date' => $date,
+      'to_date' => $date,
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL,
+      'toil_to_accrue' => 1
+    ];
+
+    $this->assertNull(LeaveRequest::toilToAccrueChanged($params));
+  }
 }


### PR DESCRIPTION
## Overview
This [#2103](https://github.com/civicrm/civihr/pull/2103) made some changes to the way Balance changes are updated. Basically, If the dates of a leave request do not change and the `change_balance` parameter is false or not present, the balance change does not get updated. However it fails to factor in TOIL requests because the balance changes are created more differently than for a Leave Request.

## Before
- Balance changes for a TOIL request is equivalent to the value of the `toil_to_accrue` parameter and does not depend on the TOIL request dates. The validation for skipping a balance change update when the dates of a leave request does not change was causing issues in Accruing TOIL especially when the TOIL dates does not change but the Toil to Accrue changes.

## After
- The logic for skipping a balance change update was updated to factor in a TOIL request and its peculiar way of creating its own balance changes.

---

- [X] Tests Pass
