### PR TITLE
PCHR-2664: Add validation for unique Work Pattern labels

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkPattern.php
@@ -156,18 +156,21 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPattern extends CRM_HRLeaveAndAbsences_DAO_
    */
   private static function validateWorkPatternTitle($params) {
     $label = CRM_Utils_Array::value('label', $params);
-    $workPattern = new self();
-    $workPattern->label = $label;
-    $workPattern->find(true);
-
-    if (!$workPattern->id) {
+    if (!$label) {
       return;
     }
 
-    $isCreate = empty($params['id']);
-    $isSeparateUpdate = !empty($params['id']) && $workPattern->id != $params['id'];
+    $workPattern = new self();
+    $workPattern->label = $label;
 
-    if ($isCreate || $isSeparateUpdate) {
+    if (!empty($params['id'])) {
+      $id = (int) $params['id'];
+      $workPattern->whereAdd("id <> $id");
+    }
+
+    $workPattern->find(true);
+
+    if ($workPattern->id) {
       throw new InvalidWorkPatternException(
         'Work Pattern with same label already exists!'
       );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
@@ -711,7 +711,7 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends BaseHeadlessTest {
     try{
       $workPattern = WorkPatternFabricator::fabricate($params);
       $this->assertEquals($workPattern->description, $params['description']);
-    }catch(CRM_HRLeaveAndAbsences_Exception_InvalidWorkPatternException $e) {
+    } catch(CRM_HRLeaveAndAbsences_Exception_InvalidWorkPatternException $e) {
       $this->fail($e->getMessage());
     }
   }


### PR DESCRIPTION
## Overview
When trying to create a Work Pattern with same label as one already existing in the database, An db error is shown on the screen.

## Before
![localhost-8954-civicrm-admin-leaveandabsences-work_patterns 2017-09-25 16-21-53 1](https://user-images.githubusercontent.com/6951813/30822915-63cdedf6-a222-11e7-9307-59fb614615a8.png)
## After
- When trying to create a Work Pattern with same label as one already existing in the database, rather than a Db error, A user friendly error is shown on the Work Pattern listing page
![workpattern](https://user-images.githubusercontent.com/6951813/30823050-e5c870ce-a222-11e7-81d2-e3b593439b6b.gif)


- [X] Tests Pass
