### PR TITLE
PCHR-2665: Add validation for unique Absence Type titles

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -241,7 +241,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
           'Invalid Request Cancelation Option'
       );
     }
-
+    self::validateAbsenceTypeTitle($params);
     self::validateTOIL($params);
     self::validateCarryForward($params);
   }
@@ -282,6 +282,37 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
     if(!self::fieldIsUnique('must_take_public_holiday_as_leave', 1, $params)) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException(
         'There is already one Absence Type where "Must staff take public holiday as leave" is selected'
+      );
+    }
+  }
+
+  /**
+   * Checks if another Absence Type exists with same title as
+   * the Absence Type being created/updated and throws an exception if found.
+   *
+   * @param array $params
+   *
+   * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
+   */
+  private static function validateAbsenceTypeTitle($params) {
+    $title = CRM_Utils_Array::value('title', $params);
+    if (!$title) {
+      return;
+    }
+
+    $absenceType = new self();
+    $absenceType->title = $title;
+
+    if (!empty($params['id'])) {
+      $id = (int) $params['id'];
+      $absenceType->whereAdd("id <> $id");
+    }
+
+    $absenceType->find(true);
+
+    if ($absenceType->id) {
+      throw new InvalidAbsenceTypeException(
+        'Absence Type with same title already exists!'
       );
     }
   }


### PR DESCRIPTION
## Overview
When trying to create an Absence Type with same title as one already existing in the database, A db error is shown on the screen.

## Before
![localhost-8954-civicrm-admin-leaveandabsences-work_patterns 2017-09-25 16-21-53 1](https://user-images.githubusercontent.com/6951813/30863650-7f132890-a2c9-11e7-9e13-3132b2784d01.png)


## After
- When trying to create an Absence Type with same title as one already existing in the database, rather than a Db error, A user friendly error is shown on the Absence Type listing page.

![absencetype](https://user-images.githubusercontent.com/6951813/30863710-9980052c-a2c9-11e7-8a4e-3292311b5749.gif)


---

- [X] Tests Pass
