### PR TITLE
PCHR-2545: Fix Work Pattern issues

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/WorkPattern.php
@@ -304,7 +304,7 @@ class CRM_HRLeaveAndAbsences_Form_WorkPattern extends CRM_Core_Form
       $breakField = $this->getWorkDayFieldName($weekIndex, $dayIndex, 'break');
 
       if (!$hasTimeFrom) {
-        $errors[$timeFromField] = ts('Please inform the Time From');
+        $errors[$timeFromField] = ts('Please fill in the Time From');
       } else {
         if (!$this->isValidHour($day['time_from'])) {
           $errors[$timeFromField] = ts('Invalid hour');
@@ -312,7 +312,7 @@ class CRM_HRLeaveAndAbsences_Form_WorkPattern extends CRM_Core_Form
       }
 
       if (!$hasTimeTo) {
-        $errors[$timeToField] = ts('Please inform the Time To');
+        $errors[$timeToField] = ts('Please fill in the Time To');
       } else {
         if (!$this->isValidHour($day['time_to'])) {
           $errors[$timeToField] = ts('Invalid hour');
@@ -320,7 +320,7 @@ class CRM_HRLeaveAndAbsences_Form_WorkPattern extends CRM_Core_Form
       }
 
       if (!$hasBreak) {
-        $errors[$breakField] = ts('Please inform the Break');
+        $errors[$breakField] = ts('Please fill in the Break');
       } else {
         if (!is_numeric($day['break'])) {
           $errors[$breakField] = ts('Break should be a valid number');

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/WorkPattern/Calendar.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/WorkPattern/Calendar.tpl
@@ -1,4 +1,4 @@
-<div class="work-pattern-calendar">
+<div class="work-pattern-calendar no-select2">
   <div class="number-of-weeks form-inline">
     <div class="form-group">
       <label for="number_of_weeks">{ts}No. of Weeks{/ts}: </label>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/WebTest/WorkPattern/FormTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/WebTest/WorkPattern/FormTest.php
@@ -32,9 +32,9 @@ class WebTest_WorkPattern_FormTest extends CiviSeleniumTestCase {
         $this->submitAndWait('WorkPattern');
         $this->assertTrue($this->isTextPresent('Label is a required field.'));
         $this->clickOnTheCalendarTab();
-        $this->assertTrue($this->isTextPresent('Please inform the Time From'));
-        $this->assertTrue($this->isTextPresent('Please inform the Time To'));
-        $this->assertTrue($this->isTextPresent('Please inform the Break'));
+        $this->assertTrue($this->isTextPresent('Please fill in the Time From'));
+        $this->assertTrue($this->isTextPresent('Please fill in the Time To'));
+        $this->assertTrue($this->isTextPresent('Please fill in the Break'));
     }
 
     public function testCanAddTypeWithMinimumRequiredFields()


### PR DESCRIPTION
## Overview
This PR fixes the following issues on the Work Pattern admin form:

* It changes the wording of the validation messages from `Please inform the [field name]` to `Please fill in the [field name]`.
* Stopped select inputs from turning into select2 components by applying the fix introduced in this PR:
https://github.com/compucorp/org.civicrm.shoreditch/pull/52

## Validation messages
### Before
![download 51](https://user-images.githubusercontent.com/1642119/30867393-498c5a52-a288-11e7-9462-bee676a046db.png)

## After
![download 50](https://user-images.githubusercontent.com/1642119/30867207-cb37ece8-a287-11e7-814a-cf6ceead2d6c.png)

## Select2
Please check https://github.com/compucorp/org.civicrm.shoreditch/pull/52 for before and after screens of the fix for this issue.

## Technical Details
* Validation messages were updated in these files:
  - `CRM/HRLeaveAndAbsences/Form/WorkPattern.php`
  - `tests/phpunit/WebTest/WorkPattern/FormTest.php`

  The last one is a unit test that expects these messages to appear when the validation fails.

* The `no-select2` class was added only to the `Form/WorkPattern/Calendar.tpl` file so it doesn't affect other selects outside of the calendar form.

---

- [x] Tests Pass
