### PR TITLE
PCHR-2049:  Fix issues with Non Working Links On Absence Type And Work Pattern Listing Page

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/AbsenceType.php
@@ -39,7 +39,7 @@ class CRM_HRLeaveAndAbsences_Page_AbsenceType extends CRM_Core_Page_Basic {
 
     CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/leaveandabsence.css');
     CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/crm/hrleaveandabsences.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
-
+    CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'js/jquery/jquery.crmEditable.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
     $this->assign('rows', $rows);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/WorkPattern.php
@@ -47,6 +47,7 @@ class CRM_HRLeaveAndAbsences_Page_WorkPattern extends CRM_Core_Page_Basic {
 
     CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/leaveandabsence.css');
     CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/crm/hrleaveandabsences.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
+    CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'js/jquery/jquery.crmEditable.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
 
     $this->assign('rows', $rows);
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsenceType.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsenceType.tpl
@@ -10,7 +10,7 @@
         {strip}
           {* handle enable/disable actions*}
           {include file="CRM/common/enableDisableApi.tpl"}
-          <table cellpadding="0" cellspacing="0" border="0" class="table table-responsive">
+          <table cellpadding="0" cellspacing="0" border="0" class="table table-responsive hrleaveandabsences-entity-list">
             <thead class="sticky">
               <th>{ts}Title{/ts}</th>
               <th>{ts}Allow Accruals?{/ts}</th>


### PR DESCRIPTION
## Overview
The `Set As Default` and `Delete` links are not working on the Absence Type Listing Page.

## Before
- The `Set As Default` and `Delete` links are not working on the Absence Type Listing Page. On clicking the links, nothing happens.
- Also clicking the `Set As Default` link on the Work Pattern listing page throws an error in the console.
![work patterns - civihr 1 7 demo 2017-09-27 11-13-27](https://user-images.githubusercontent.com/6951813/30910071-442d5e50-a37b-11e7-9412-09b5a9d97b8a.png)
## After
- A missing class  in the Absence Type template page was added and also the `jquery.crmEditable.js` file was added to the Absence Type listing page file to fix the `Set As Default` and `Delete` links.
The missing class needed to be present to allow this variable to get its expected value
[Here](https://github.com/civicrm/civihr/blob/a2ea576b469094608c91504777816af0e442f259/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsenceType.tpl#L49-L49)
- The  `jquery.crmEditable.js` file was added to the Work Pattern listing page file to fix the console error.
![absencetypelist](https://user-images.githubusercontent.com/6951813/30910613-4f42ea60-a37d-11e7-99c8-a85c39807fd1.gif)


## Comments
- After fixing the issues above, I discovered that links that appear on the popup after clicking the "..." ellipsis does not work at all. However when these links appear on the page and not on the ellipsis, they work well. Issue has been reported to @reneolivo.

---

This change does not affect any test.
- [ ] Tests Pass
