### PR TITLE
PCHR-2694:  Add absence type calculation unit option group.

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/option_groups/absence_type_calculation_unit_install.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/option_groups/absence_type_calculation_unit_install.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="iso-8859-1" ?>
+
+<CustomData>
+  <OptionGroups>
+    <OptionGroup>
+      <name>hrleaveandabsences_absence_type_calculation_unit</name>
+      <title>Absence Type Calculation Units</title>
+      <is_reserved>1</is_reserved>
+      <is_active>1</is_active>
+    </OptionGroup>
+  </OptionGroups>
+
+  <OptionValues>
+    <OptionValue>
+      <label>Days</label>
+      <value>1</value>
+      <name>days</name>
+      <is_default>0</is_default>
+      <weight>1</weight>
+      <is_optgroup>0</is_optgroup>
+      <is_reserved>1</is_reserved>
+      <is_active>1</is_active>
+      <option_group_name>hrleaveandabsences_absence_type_calculation_unit</option_group_name>
+    </OptionValue>
+
+    <OptionValue>
+      <label>Hours</label>
+      <value>2</value>
+      <name>hours</name>
+      <is_default>0</is_default>
+      <weight>2</weight>
+      <is_optgroup>0</is_optgroup>
+      <is_reserved>1</is_reserved>
+      <is_active>1</is_active>
+      <option_group_name>hrleaveandabsences_absence_type_calculation_unit</option_group_name>
+    </OptionValue>
+  </OptionValues>
+</CustomData>


### PR DESCRIPTION
## Overview
This PR adds the Absence Type Calculation unit option group. The options would determine what unit to calculate entitlements, leave requests for an Absence type.
The available options are Days, Hours.

## After
![absence type calculation units options - civihr 1 7 demo 2017-10-02 15-42-59](https://user-images.githubusercontent.com/6951813/31083235-0efc2ace-a789-11e7-9b81-b5394cdf0247.png)

---
This change does not affect tests.
- [ ] Tests Pass
