### PR TITLE
PCHR-2610: Update L&A menu items labels

### DIFF
--- a/hrabsence/CRM/HRAbsence/Upgrader.php
+++ b/hrabsence/CRM/HRAbsence/Upgrader.php
@@ -634,4 +634,20 @@ class CRM_HRAbsence_Upgrader extends CRM_HRAbsence_Upgrader_Base {
 
     return TRUE;
   }
+
+  /**
+   * Rename "Absences" menu item to "Leave"
+   */
+  public function upgrade_1405() {
+    $default = [];
+    $paramsDashboard = ['name' => 'Absences'];
+
+    $menuItem = CRM_Core_BAO_Navigation::retrieve($paramsDashboard, $default);
+    $menuItem->label = 'Leave';
+    $menuItem->save();
+
+    CRM_Core_BAO_Navigation::resetNavigation();
+
+    return true;
+  }
 }

--- a/hrabsence/CRM/HRAbsence/Upgrader.php
+++ b/hrabsence/CRM/HRAbsence/Upgrader.php
@@ -648,6 +648,6 @@ class CRM_HRAbsence_Upgrader extends CRM_HRAbsence_Upgrader_Base {
 
     CRM_Core_BAO_Navigation::resetNavigation();
 
-    return true;
+    return TRUE;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
@@ -10,6 +10,7 @@ class CRM_HRLeaveAndAbsences_Upgrader extends CRM_HRLeaveAndAbsences_Upgrader_Ba
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1002;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1003;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1004;
+  use CRM_HRLeaveAndAbsences_Upgrader_Step_1005;
 
   /**
    * A list of directories to be scanned for XML installation files

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1005.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1005.php
@@ -1,0 +1,32 @@
+<?php
+
+use CRM_Core_BAO_SchemaHandler as SchemaHandler;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
+
+trait CRM_HRLeaveAndAbsences_Upgrader_Step_1005 {
+
+  /**
+   * Renames the two "Leave and Absences" menu items to just "Absences"
+   *
+   * @return bool
+   */
+  public function upgrade_1005() {
+    $default = [];
+    $paramsDashboard = ['name' => 'leave_and_absences_dashboard', 'url' => 'civicrm/leaveandabsences/dashboard'];
+    $paramsAdmin = ['name' => 'leave_and_absences', 'url' => null];
+
+    $menuItems = [
+      'dashboard' => CRM_Core_BAO_Navigation::retrieve($paramsDashboard, $default),
+      'admin' => CRM_Core_BAO_Navigation::retrieve($paramsAdmin, $default)
+    ];
+    
+    foreach ($menuItems as $menuItem) {
+      $menuItem->label = 'Absences';
+      $menuItem->save();
+    }
+
+    CRM_Core_BAO_Navigation::resetNavigation();
+
+    return true;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1005.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1005.php
@@ -27,6 +27,6 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1005 {
 
     CRM_Core_BAO_Navigation::resetNavigation();
 
-    return true;
+    return TRUE;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -442,7 +442,7 @@ function _hrleaveandabsences_create_administer_menu() {
   $maxWeightOfAdminMenuItems = _hrleaveandabsences_get_max_child_weight_for_menu($administerMenuId);
 
   $params = [
-    'label'      => ts('Leave and Absences'),
+    'label'      => ts('Absences'),
     'name'       => 'leave_and_absences',
     'url'        => null,
     'operator'   => null,
@@ -531,7 +531,7 @@ function _hrleavesandabsences_create_main_menu() {
   $vacanciesWeight = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Vacancies', 'weight', 'name');
 
   $params = [
-    'label'      => ts('Leave and Absences'),
+    'label'      => ts('Absences'),
     'name'       => 'leave_and_absences',
     'url'        => 'civicrm/leaveandabsences/dashboard',
     'operator'   => null,


### PR DESCRIPTION
## Overview
This PR updates the label of the main menu items of the old and new L&A extensions

## Before
### Old extension
The item was labeled "Absences"

### New extension
The items were labeled
1. Leave and Absences
2. Administer / Leave and Absences

## After
### Old extension
The item is now labeled "Leave"

### New extension
The items are now labeled
1. Leave
2. Administer / Leave
