### PR TITLE
PCHR-2611: Update core menu items

### DIFF
--- a/org.civicrm.bootstrapcivihr/bootstrapcivihr.php
+++ b/org.civicrm.bootstrapcivihr/bootstrapcivihr.php
@@ -109,11 +109,12 @@ _bootstrapcivihr_civix_civicrm_angularModules($angularModules);
 function bootstrapcivihr_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   _bootstrapcivihr_civix_civicrm_alterSettingsFolders($metaDataFolders);
 }
+
 /**
- * Implementation of hook_civicrm_pageRun
+ * Implements hook_civicrm_coreResourceList().
  */
-function bootstrapcivihr_civicrm_pageRun($page) {
-  if (!(isset($_GET['snippet']) && $_GET['snippet'] == 'json')) {
-    CRM_Core_Resources::singleton()->addStyleFile('org.civicrm.bootstrapcivihr', 'css/civihr.css');
+function bootstrapcivihr_civicrm_coreResourceList(&$items, $region) {
+  if ($region == 'html-header') {
+    CRM_Core_Resources::singleton()->addStyleFile('org.civicrm.bootstrapcivihr', 'css/civihr.css', 100, 'html-header');
   }
 }

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -172,11 +172,20 @@ function hrcore_civicrm_pageRun($page) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu/
  */
 function hrcore_civicrm_navigationMenu(&$params) {
-  $menuItemID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Contacts', 'id', 'name');
-  $params[$menuItemID]['attributes']['label'] = 'Staff'; 
+  _hrcore_renameMenuLabel($params, 'Contacts', 'Staff');
+  _hrcore_renameMenuLabel($params, 'Administer', 'Configure');
+}
 
-  $menuItemID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Administer', 'id', 'name');
-  $params[$menuItemID]['attributes']['label'] = 'Configure'; 
+/**
+ * Renames a menu with the given new label
+ *
+ * @param array $params
+ * @param string $menuName
+ * @param string $newLabel
+ */
+function _hrcore_renameMenuLabel(&$params, $menuName, $newLabel) {
+  $menuItemID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', $menuName, 'id', 'name');
+  $params[$menuItemID]['attributes']['label'] = $newLabel; 
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -167,6 +167,19 @@ function hrcore_civicrm_pageRun($page) {
 }
 
 /**
+ * Implements hook_civicrm_navigationMenu().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu/
+ */
+function hrcore_civicrm_navigationMenu(&$params) {
+  $menuItemID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Contacts', 'id', 'name');
+  $params[$menuItemID]['attributes']['label'] = 'Staff'; 
+
+  $menuItemID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Administer', 'id', 'name');
+  $params[$menuItemID]['attributes']['label'] = 'Configure'; 
+}
+
+/**
  * This function adds the session variable to CRM.vars object.
  */
 function _hrcore_add_js_session_vars() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1005.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1005.php
@@ -21,7 +21,7 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1005 {
     ];
     
     foreach ($menuItems as $menuItem) {
-      $menuItem->label = 'Absences';
+      $menuItem->label = 'Leave';
       $menuItem->save();
     }
 


### PR DESCRIPTION
## Overview
This PR renames the labels of two core menu items: "Contacts" and "Administer".
It also contains changes that make sure that the css file of the `org.civicrm.bootstrapcivihr` extension (`civihr.css`) is included in every page of civicrm

Finally, in #2186 I made a mistake and renamed "Leaves and Absences" into "Absences" instead of "Leave", this PR takes care of that

## Before
The two menu items are called "Contacts" and "Administer".
The `civihr.css` is not included in pages that CiviCRM treats as "forms" (like the "Advanced Search" page)

## After
The two menu items are now called "Staff" and "Configure".
The `civihr.css` is included in every page