### PR TITLE
PCHR-2427: Add the Jenkinsfile

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,3 @@ _If the PR introduces noteworthy technical changes, please describe them here. P
 
 ## Comments
 _Anything else you would like the reviewer to note_
-
----
-
-- [ ] Tests Pass

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,9 @@ pipeline {
       steps {
         script {
           for (extension in listCivihrExtensions()) {
-            testPHPUnit(extension)
+            if (extension.hasPHPTests) {
+              testPHPUnit(extension)
+            }
           }
         }
       }
@@ -122,7 +124,11 @@ pipeline {
 
           // Install NPM jobs
           for (extension in listCivihrExtensions()) {
-            extensionTestings[extension] = {
+            if(!extension.hasJSTests) {
+              continue;
+            }
+
+            extensionTestings[extension.shortName] = {
               installNPM(extension)
             }
           }
@@ -137,7 +143,9 @@ pipeline {
         script {
           // Testing JS in sequent
           for (extension in listCivihrExtensions) {
-            testJS(extension)
+            if(extension.hasJSTests) {
+              testJS(extension)
+            }
           }
         }
       }
@@ -229,41 +237,37 @@ def mergeEnvBranchInAllRepos(String envBranch) {
 
 /*
  * Execute PHPUnit testing
- * params: extensionName
+ * params: extension
  */
-def testPHPUnit(String extensionName) {
-  def extensionShortName = extensionName.tokenize('.')[-1]
-
-  echo "PHPUnit testing: ${extensionShortName}"
+def testPHPUnit(java.util.LinkedHashMap extension) {
+  echo "PHPUnit testing: ${extension.name}"
 
   sh """
-    cd $CIVICRM_EXT_ROOT/civihr/${extensionName}
-    phpunit4 \
-      --log-junit $WORKSPACE/reports/phpunit/result-phpunit_${extensionShortName}.xml \
-      || true
+    cd $CIVICRM_EXT_ROOT/civihr/${extension.folder}
+    phpunit4 --log-junit $WORKSPACE/reports/phpunit/result-phpunit_${extension.shortName}.xml || true
   """
 }
 
 /*
  * Installk JS Testing
- * params: extensionName
+ * params: extension
  */
-def installNPM(String extensionName) {
+def installNPM(java.util.LinkedHashMap extension) {
   sh """
-    cd $CIVICRM_EXT_ROOT/civihr/${extensionName}
+    cd $CIVICRM_EXT_ROOT/civihr/${extension.folder}
     npm install || true
   """
 }
 
 /*
  * Execute JS Testing
- * params: extensionName
+ * params: extension
  */
-def testJS(String extensionName) {
-  echo "JS Testing ${extensionName.tokenize('.')[-1]}"
+def testJS(java.util.LinkedHashMap extension) {
+  echo "JS Testing ${extension.name}"
 
   sh """
-    cd $CIVICRM_EXT_ROOT/civihr/${extensionName}
+    cd $CIVICRM_EXT_ROOT/civihr/${extension.folder}
     gulp test || true
   """
 }
@@ -288,7 +292,75 @@ def listCivihrGitRepoPath() {
  */
 def listCivihrExtensions() {
   return [
-    'uk.co.compucorp.civicrm.hrcore',
-    'com.civicrm.hrjobroles',
+    [
+      name: 'Job Roles',
+      shortName: 'hrjobroles',
+      folder: 'com.civicrm.hrjobroles',
+      hasJSTests: false,
+      hasPHPTests: true
+    ],
+    [
+      name: 'Contacts Access Rights',
+      shortName: 'contactaccessrights',
+      folder: 'contactaccessrights',
+      hasJSTests: false,
+      hasPHPTests: true
+    ],
+    [
+      name: 'Job Contracts',
+      shortName: 'hrjobcontract',
+      folder: 'hrjobcontract',
+      hasJSTests: false,
+      hasPHPTests: true
+    ],
+    [
+      name: 'Recruitment',
+      shortName: 'hrrecruitment',
+      folder: 'hrrecruitment',
+      hasJSTests: false,
+      hasPHPTests: true
+    ],
+    [
+      name: 'Reports',
+      shortName: 'hrreport',
+      folder: 'hrreport',
+      hasJSTests: false,
+      hasPHPTests: true
+    ],
+    [
+      name: 'HR UI',
+      shortName: 'hrui',
+      folder: 'hrui',
+      hasJSTests: false,
+      hasPHPTests: true
+    ],
+    [
+      name: 'HR Visa',
+      shortName: 'hrvisa',
+      folder: 'hrvisa',
+      hasJSTests: false,
+      hasPHPTests: true
+    ],
+    [
+      name: 'HRCore',
+      shortName: 'hrcore',
+      folder: 'uk.co.compucorp.civicrm.hrcore',
+      hasJSTests: false,
+      hasPHPTests: true
+    ],
+    [
+      name: 'Leave and Absences',
+      shortName: 'hrleaveandabsences',
+      folder: 'uk.co.compucorp.civicrm.hrleaveandabsences',
+      hasJSTests: false,
+      hasPHPTests: true
+    ],
+    [
+      name: 'Sample Data',
+      shortName: 'hrsampledata',
+      folder: 'uk.co.compucorp.civicrm.hrsampledata',
+      hasJSTests: false,
+      hasPHPTests: true
+    ]
   ]
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,8 +89,8 @@ pipeline {
             thresholds: [
               [
                 $class: 'FailedThreshold',
-                failureNewThreshold: '5',
-                failureThreshold: '5',
+                failureNewThreshold: '1',
+                failureThreshold: '1',
                 unstableNewThreshold: '1',
                 unstableThreshold: '1'
               ],
@@ -148,8 +148,8 @@ pipeline {
             thresholds: [
               [
                 $class: 'FailedThreshold',
-                failureNewThreshold: '5',
-                failureThreshold: '5',
+                failureNewThreshold: '1',
+                failureThreshold: '1',
                 unstableNewThreshold: '1',
                 unstableThreshold: '1'
               ],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
               drush features-revert civihr_employee_portal_features -y
               drush features-revert civihr_default_permissions -y
               drush updatedb -y
-              drush cvapi extenion.upgrade -y
+              drush cvapi extension.upgrade -y
               drush cc all
               drush cc civicrm
             """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,205 +1,204 @@
 #!groovy
 
 pipeline {
-	agent any
+  agent any
 
-	parameters {
-		string(name: 'CVHR_BRANCH', defaultValue: '', description: 'Default build branch of CiviHR to build site using CiviCRM-Buildkit')
-		string(name: 'CVHR_BUILDNAME', defaultValue: "hr17-dev_$BRANCH_NAME", description: 'CiviHR site name')
-		booleanParam(name: 'DESTORY_SITE', defaultValue: true, description: 'Destroy built site after build finish')
-	}
+  parameters {
+    string(name: 'CVHR_BRANCH', defaultValue: '', description: 'Default build branch of CiviHR to build site using CiviCRM-Buildkit')
+    string(name: 'CVHR_BUILDNAME', defaultValue: "hr17-dev_$BRANCH_NAME", description: 'CiviHR site name')
+    booleanParam(name: 'DESTORY_SITE', defaultValue: true, description: 'Destroy built site after build finish')
+  }
 
-	environment {
-		WEBROOT = "/opt/buildkit/build/${params.CVHR_BUILDNAME}"
+  environment {
+    WEBROOT = "/opt/buildkit/build/${params.CVHR_BUILDNAME}"
     DRUPAL_SITES_ALL = "$WEBROOT/sites/all"
     DR_MODU_ROOT = "$DRUPAL_SITES_ALL/modules"
     DR_THEME_ROOT = "$DRUPAL_SITES_ALL/themes"
-		CVCRM_EXT_ROOT = "$DR_MODU_ROOT/civicrm/tools/extensions"
-		WEBURL = "http://jenkins.compucorp.co.uk:8900"
-		ADMIN_PASS = credentials('CVHR_ADMIN_PASS')
-	}
+    CVCRM_EXT_ROOT = "$DR_MODU_ROOT/civicrm/tools/extensions"
+    WEBURL = "http://jenkins.compucorp.co.uk:8900"
+    ADMIN_PASS = credentials('CVHR_ADMIN_PASS')
+  }
 
-  	stages {
-	    stage('Pre-tasks execution') {
-	      steps {
-				// Print all Environment variables
-				sh 'printenv | sort'
+  stages {
+    stage('Pre-tasks execution') {
+      steps {
+        // Print all Environment variables
+        sh 'printenv | sort'
 
-				// Destroy existing site
-				sh "civibuild destroy ${params.CVHR_BUILDNAME} || true"
+        // Destroy existing site
+        sh "civibuild destroy ${params.CVHR_BUILDNAME} || true"
 
-				// Test build tools
-				sh 'amp test'
-			}
-	    }
+        // Test build tools
+        sh 'amp test'
+      }
+    }
 
-	    stage('Build site') {
-			steps {
-				script {
-					// Setup Building branch with
-					// CVHR_BRANCH parameter from manually build with parameter
-					// or PR target branch (CHANGE_TARGET) from building pull request
-					// or branch (BRANCH_NAME) from building individual branch
-					def buildBranch = params.CVHR_BRANCH != '' ? params.CVHR_BRANCH : env.CHANGE_TARGET != null ? env.CHANGE_TARGET : env.BRANCH_NAME != null ? env.BRANCH_NAME : 'staging'
+    stage('Build site') {
+      steps {
+        script {
+          // Setup Building branch with
+          // CVHR_BRANCH parameter from manually build with parameter
+          // or PR target branch (CHANGE_TARGET) from building pull request
+          // or branch (BRANCH_NAME) from building individual branch
+          def buildBranch = params.CVHR_BRANCH != '' ? params.CVHR_BRANCH : env.CHANGE_TARGET != null ? env.CHANGE_TARGET : env.BRANCH_NAME != null ? env.BRANCH_NAME : 'staging'
 
-					echo "Build branch: ${buildBranch}"
+          // Build site with CV Buildkit
+          sh "civibuild create ${params.CVHR_BUILDNAME} --type hr16 --civi-ver 4.7.22 --hr-ver ${buildBranch} --url $WEBURL --admin-pass $ADMIN_PASS"
 
-					// Build site with CV Buildkit
-					echo 'Build site with CV Buildkit'
-					sh "civibuild create ${params.CVHR_BUILDNAME} --type hr16 --civi-ver 4.7.22 --hr-ver ${buildBranch} --url $WEBURL --admin-pass $ADMIN_PASS"
+          // Change git remote of civihr ext to support dev version of Jenkins pipeline
+          changeCivihrGitRemote()
 
-					// Change git remote of civihr ext to support dev version of Jenkins pipeline
-					changeCivihrGitRemote()
-
-					// Get repos & branch name
-					def prBranch = env.CHANGE_BRANCH
-					def envBranch = env.CHANGE_TARGET
-					if (prBranch != null && prBranch.startsWith("hotfix-")) {
-						envBranch = 'master'
-					}
+          // Get repos & branch name
+          def prBranch = env.CHANGE_BRANCH
+          def envBranch = env.CHANGE_TARGET
+          if (prBranch != null && prBranch.startsWith("hotfix-")) {
+            envBranch = 'master'
+          }
 
           if (prBranch) {
             checkoutPrBranchInCiviHRRepos(prBranch)
             mergeEnvBranchInAllRepos(envBranch)
           }
 
-					// Upgrade Drupal & CiviCRM extensions
-					echo 'Upgrade Drupal & CV extensions'
-					sh """
-						cd $WEBROOT
-						drush features-revert civihr_employee_portal_features -y
-	    				drush features-revert civihr_default_permissions -y
-	    				drush updatedb -y
-	    				drush cvapi extenion.upgrade -y
-	    				drush cc all
-	    				drush cc civicrm
-    				"""
-				}
-			}
-	    }
-
-	    /* Testing PHP */
-	    stage('Test PHP') {
-			steps {
-				script {
-					// Get civihr extensions list
-					def extensions = listCivihrExtensions()
-
-					// Execute PHP test
-					for (int i = 0; i<extensions.size(); i++) {
-						testPHPUnit(extensions[i])
-					}
-				}
-			}
-			post {
-                always {
-                	// XUnit
-					step([
-	                    $class: 'XUnitBuilder',
-                    	thresholds: [
-	                    	[$class: 'FailedThreshold',
-	                          failureNewThreshold: '5',
-	                          failureThreshold: '5',
-	                          unstableNewThreshold: '1',
-	                          unstableThreshold: '1'],
-	                        [$class: 'SkippedThreshold',
-	                          failureNewThreshold: '0',
-	                          failureThreshold: '0',
-	                          unstableNewThreshold: '0',
-	                          unstableThreshold: '0']
-                    	],
-	                    tools: [[$class: 'JUnitType', pattern: 'reports/phpunit/*.xml']]
-	                ])
-            	}
-            }
-	    }
-
-		/* Testing JS */
-		// TODO: Execute test and Generate report without stop on fail
-	    stage('Testing JS: Install NPM in parallel') {
-			steps {
-				script {
-					// Get civihr extensions list
-					def extensions = listCivihrExtensions()
-					def extensionTestings = [:]
-
-					// Install NPM jobs
-					for (int i = 0; i<extensions.size(); i++) {
-						def index = i
-						extensionTestings[extensions[index]] = {
-						  echo 'Installing NPM: ' + extensions[index]
-						  installNPM(extensions[index])
-						}
-					}
-					// Running install NPM jobs in parallel
-					parallel extensionTestings
-				}
-			}
-	    }
-	    stage('Testing JS: Test JS in sequent') {
-			steps {
-				script {
-					// Get civihr extensions list
-					def extensions = listCivihrExtensions()
-					def extensionTestings = [:]
-
-					// Testing JS in sequent
-					for (int j = 0; j<extensions.size(); j++) {
-						def index = j
-						echo 'Testing with Gulp: ' + extensions[index]
-						testJS(extensions[index])
-					}
-				}
-			}
-			post {
-                always {
-                	// XUnit
-					step([
-	                    $class: 'XUnitBuilder',
-                    	thresholds: [
-	                    	[$class: 'FailedThreshold',
-	                          failureNewThreshold: '5',
-	                          failureThreshold: '5',
-	                          unstableNewThreshold: '1',
-	                          unstableThreshold: '1'],
-	                        [$class: 'SkippedThreshold',
-	                          failureNewThreshold: '0',
-	                          failureThreshold: '0',
-	                          unstableNewThreshold: '0',
-	                          unstableThreshold: '0']
-                    	],
-	                    tools: [[$class: 'JUnitType', pattern: 'reports/js-karma/*.xml']]
-	                ])
-            	}
-            }
-	    }
-  	}
-
-    post {
-    	always {
-    		// Destroy built site
-    		script {
-				if (params.DESTORY_SITE == true) {
-					echo 'Destroying built site...'
-					sh "civibuild destroy ${params.CVHR_BUILDNAME} || true"
-				}
-    		}
-    	}
+          sh """
+              cd $WEBROOT
+              drush features-revert civihr_employee_portal_features -y
+              drush features-revert civihr_default_permissions -y
+              drush updatedb -y
+              drush cvapi extenion.upgrade -y
+              drush cc all
+              drush cc civicrm
+            """
+        }
+      }
     }
+
+    /* Testing PHP */
+    stage('Test PHP') {
+      steps {
+        script {
+          for (extension in listCivihrExtensions()) {
+            testPHPUnit(extension)
+          }
+        }
+      }
+      post {
+        always {
+          step([
+            $class: 'XUnitBuilder',
+            thresholds: [
+              [
+                $class: 'FailedThreshold',
+                failureNewThreshold: '5',
+                failureThreshold: '5',
+                unstableNewThreshold: '1',
+                unstableThreshold: '1'
+              ],
+              [
+                $class: 'SkippedThreshold',
+                failureNewThreshold: '0',
+                failureThreshold: '0',
+                unstableNewThreshold: '0',
+                unstableThreshold: '0'
+              ]
+            ],
+            tools: [
+              [
+                $class: 'JUnitType',
+                pattern: 'reports/phpunit/*.xml'
+              ]
+            ]
+          ])
+        }
+      }
+    }
+
+  /* Testing JS */
+  // TODO: Execute test and Generate report without stop on fail
+    stage('Testing JS: Install NPM in parallel') {
+      steps {
+        script {
+          def extensionTestings = [:]
+
+          // Install NPM jobs
+          for (extension in listCivihrExtensions()) {
+            extensionTestings[extension] = {
+              installNPM(extension)
+            }
+          }
+          // Running install NPM jobs in parallel
+          parallel extensionTestings
+        }
+      }
+    }
+
+    stage('Testing JS: Test JS in sequent') {
+      steps {
+        script {
+          // Testing JS in sequent
+          for (extension in listCivihrExtensions) {
+            testJS(extension)
+          }
+        }
+      }
+      post {
+        always {
+          step([
+            $class: 'XUnitBuilder',
+            thresholds: [
+              [
+                $class: 'FailedThreshold',
+                failureNewThreshold: '5',
+                failureThreshold: '5',
+                unstableNewThreshold: '1',
+                unstableThreshold: '1'
+              ],
+              [
+                $class: 'SkippedThreshold',
+                failureNewThreshold: '0',
+                failureThreshold: '0',
+                unstableNewThreshold: '0',
+                unstableThreshold: '0'
+              ]
+            ],
+            tools: [
+              [
+                $class: 'JUnitType',
+                pattern: 'reports/js-karma/*.xml'
+              ]
+            ]
+          ])
+        }
+      }
+    }
+  }
+
+  post {
+    always {
+      // Destroy built site
+      script {
+        if (params.DESTORY_SITE == true) {
+          echo 'Destroying built site...'
+          sh "civibuild destroy ${params.CVHR_BUILDNAME} || true"
+        }
+      }
+    }
+  }
 }
+
 /*
- *	Change URL Git remote of civihr main repositry to the URL where configured by Jenkins project
+ *  Change URL Git remote of civihr main repositry to the URL where configured by Jenkins project
  */
 def changeCivihrGitRemote() {
-	def pulledCvhrRepo = sh(returnStdout: true, script: "cd $WORKSPACE; git remote -v | grep fetch | awk '{print \$2}'").trim()
+  def pulledCvhrRepo = sh(returnStdout: true, script: "cd $WORKSPACE; git remote -v | grep fetch | awk '{print \$2}'").trim()
 
-	echo 'Changing Civihr git URL..'
+  echo 'Changing Civihr git URL..'
 
-	sh """
-		cd $CVCRM_EXT_ROOT/civihr
-		git remote set-url origin ${pulledCvhrRepo}
-		git fetch --all
-	"""
+  sh """
+    cd $CVCRM_EXT_ROOT/civihr
+    git remote set-url origin ${pulledCvhrRepo}
+    git fetch --all
+  """
 }
 
 def checkoutPrBranchInCiviHRRepos(String branch) {
@@ -207,7 +206,7 @@ def checkoutPrBranchInCiviHRRepos(String branch) {
 
   for (repo in listCivihrGitRepoPath()) {
     try {
-				sh """
+        sh """
           cd ${repo}
           git checkout ${branch}
         """
@@ -220,7 +219,7 @@ def mergeEnvBranchInAllRepos(String envBranch) {
 
   for (repo in listCivihrGitRepoPath()) {
     try {
-				sh """
+        sh """
           cd ${repo}
           git merge origin/${envBranch} --no-edit
         """
@@ -232,66 +231,64 @@ def mergeEnvBranchInAllRepos(String envBranch) {
  * Execute PHPUnit testing
  * params: extensionName
  */
-def testPHPUnit(String extensionName){
-	def extensionShortName = extensionName.tokenize('.')[-1]
+def testPHPUnit(String extensionName) {
+  def extensionShortName = extensionName.tokenize('.')[-1]
 
-	echo "PHPUnit testing: ${extensionShortName}"
+  echo "PHPUnit testing: ${extensionShortName}"
 
-	sh """
-		cd $CVCRM_EXT_ROOT/civihr/${extensionName}
-		phpunit4 \
-			--log-junit $WORKSPACE/reports/phpunit/result-phpunit_${extensionShortName}.xml \
-			|| true
-	"""
+  sh """
+    cd $CVCRM_EXT_ROOT/civihr/${extensionName}
+    phpunit4 \
+      --log-junit $WORKSPACE/reports/phpunit/result-phpunit_${extensionShortName}.xml \
+      || true
+  """
 }
+
 /*
  * Installk JS Testing
  * params: extensionName
  */
-def installNPM(String extensionName){
-	sh """
-		cd $CVCRM_EXT_ROOT/civihr/${extensionName}
-		npm install || true
-	"""
+def installNPM(String extensionName) {
+  sh """
+    cd $CVCRM_EXT_ROOT/civihr/${extensionName}
+    npm install || true
+  """
 }
+
 /*
  * Execute JS Testing
  * params: extensionName
  */
-def testJS(String extensionName){
-	echo "JS Testing ${extensionName.tokenize('.')[-1]}"
+def testJS(String extensionName) {
+  echo "JS Testing ${extensionName.tokenize('.')[-1]}"
 
-	sh """
-		cd $CVCRM_EXT_ROOT/civihr/${extensionName}
-		gulp test || true
-	"""
+  sh """
+    cd $CVCRM_EXT_ROOT/civihr/${extensionName}
+    gulp test || true
+  """
 }
+
 /*
  * Get a list of CiviHR repository
  * https://compucorp.atlassian.net/wiki/spaces/PCHR/pages/68714502/GitHub+repositories
  */
 def listCivihrGitRepoPath() {
-	return [
-		"$CVCRM_EXT_ROOT/civihr",
-		"$CVCRM_EXT_ROOT/civihr_tasks",
-		"$CVCRM_EXT_ROOT/org.civicrm.shoreditch",
-		"$CVCRM_EXT_ROOT/org.civicrm.styleguide",
-		"$DR_MODU_ROOT/civihr-custom",
+  return [
+    "$CVCRM_EXT_ROOT/civihr",
+    "$CVCRM_EXT_ROOT/civihr_tasks",
+    "$CVCRM_EXT_ROOT/org.civicrm.shoreditch",
+    "$CVCRM_EXT_ROOT/org.civicrm.styleguide",
+    "$DR_MODU_ROOT/civihr-custom",
     "$DR_THEME_ROOT/civihr_employee_portal_theme"
-	]
+  ]
 }
+
 /*
  * Get a list of enabled CiviHR extensions
  */
-def listCivihrExtensions(){
-	// All enabled cvhr extensions
-	// return sh(returnStdout: true, script: "cd /opt/buildkit/build/hr17/sites/; drush cvapi extension.get statusLabel=Enabled return=path | grep '/civihr/' | awk -F '[//]' '{print \$NF}' | sort").split("\n")
-
- 	// Manually select cvhr extensions
- 	return [
- 		'uk.co.compucorp.civicrm.hrcore',
- 		'uk.co.compucorp.civicrm.hrleaveandabsences',
- 		'com.civicrm.hrjobroles',
- 	]
+def listCivihrExtensions() {
+  return [
+    'uk.co.compucorp.civicrm.hrcore',
+    'com.civicrm.hrjobroles',
+  ]
 }
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,6 +170,27 @@ pipeline {
 					}
 				}
 			}
+			post {
+                always {
+                	// XUnit
+					step([
+	                    $class: 'XUnitBuilder',
+                    	thresholds: [
+	                    	[$class: 'FailedThreshold',
+	                          failureNewThreshold: '5',
+	                          failureThreshold: '5',
+	                          unstableNewThreshold: '1',
+	                          unstableThreshold: '1'],
+	                        [$class: 'SkippedThreshold',
+	                          failureNewThreshold: '0',
+	                          failureThreshold: '0',
+	                          unstableNewThreshold: '0',
+	                          unstableThreshold: '0']
+                    	],
+	                    tools: [[$class: 'JUnitType', pattern: 'reports/js-karma/*.xml']]
+	                ])
+            	}
+            }
 	    }
   	}
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
 
 					// Build site with CV Buildkit
 					echo 'Build site with CV Buildkit'
-					sh "civibuild create ${params.CVHR_BUILDNAME} --type hr16 --civi-ver 4.7.18 --hr-ver ${buildBranch} --url $WEBURL --admin-pass $ADMIN_PASS"
+					sh "civibuild create ${params.CVHR_BUILDNAME} --type hr16 --civi-ver 4.7.22 --hr-ver ${buildBranch} --url $WEBURL --admin-pass $ADMIN_PASS"
 
 					// Change git remote of civihr ext to support dev version of Jenkins pipeline
 					changeCivihrGitRemote()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -241,7 +241,6 @@ def testPHPUnit(String extensionName){
 		cd $CVCRM_EXT_ROOT/civihr/${extensionName}
 		phpunit4 \
 			--log-junit $WORKSPACE/reports/phpunit/result-phpunit_${extensionShortName}.xml \
-			--coverage-html $WORKSPACE/reports/phpunit/resultPHPUnitHtml_${extensionShortName} \
 			|| true
 	"""
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,272 @@
+#!groovy
+
+pipeline {
+	agent any
+
+	parameters {
+		string(name: 'CVHR_BRANCH', defaultValue: '', description: 'Default build branch of CiviHR to build site using CiviCRM-Buildkit')
+		string(name: 'CVHR_BUILDNAME', defaultValue: "hr17-dev_$BRANCH_NAME", description: 'CiviHR site name')
+		booleanParam(name: 'DESTORY_SITE', defaultValue: true, description: 'Destroy built site after build finish')
+	}
+
+	environment {
+		WEBROOT = "/opt/buildkit/build/${params.CVHR_BUILDNAME}"
+		CVCRM_EXT_ROOT = "$WEBROOT/sites/all/modules/civicrm/tools/extensions"
+		DR_MODU_ROOT = "$WEBROOT/sites/all/modules"
+		WEBURL = "http://jenkins.compucorp.co.uk:8900"
+		ADMIN_PASS = credentials('CVHR_ADMIN_PASS')
+	}
+
+  	stages {
+	    stage('Pre-tasks execution') {
+	      steps {
+				// Print all Environment variables
+				sh 'printenv | sort'
+
+				// Destroy existing site
+				sh "civibuild destroy ${params.CVHR_BUILDNAME} || true"
+
+				// Test build tools
+				sh 'amp test'
+			}
+	    }
+
+	    stage('Build site') {
+			steps {
+				script {
+					// Setup Building branch with 
+					// CVHR_BRANCH parameter from manually build with parameter
+					// or PR target branch (CHANGE_TARGET) from building pull request 
+					// or branch (BRANCH_NAME) from building individual branch
+					def buildBranch = params.CVHR_BRANCH != '' ? params.CVHR_BRANCH : env.CHANGE_TARGET != null ? env.CHANGE_TARGET : env.BRANCH_NAME != null ? env.BRANCH_NAME : 'staging'
+					
+					echo "Build branch: ${buildBranch}"
+
+					// Build site with CV Buildkit
+					echo 'Build site with CV Buildkit'
+					sh "civibuild create ${params.CVHR_BUILDNAME} --type hr16 --civi-ver 4.7.18 --hr-ver ${buildBranch} --url $WEBURL --admin-pass $ADMIN_PASS"
+
+					// Change git remote of civihr ext to support dev version of Jenkins pipeline
+					changeCivihrGitRemote()
+
+					// Get repos & branch name
+					def prBranch = env.CHANGE_BRANCH
+					def envBranch = env.CHANGE_TARGET
+					if (prBranch != null && prBranch.startsWith("hotfix-")) {
+						envBranch = 'master'
+					}
+					
+					// DEBUG
+					// echo "envBranch: ${envBranch} prBranch: ${prBranch}"
+
+					// Checkout PR Branch in CiviHR repos
+					echo 'Checking out CiviHR repos..'
+					sh """
+						cd $CVCRM_EXT_ROOT
+						git-scan foreach -c \"git checkout -b testing-${prBranch} --track remotes/origin/${prBranch}\" || true
+					"""
+
+					// Merge PR Branch in CiviHR repos
+					def cvhrRepos = listCivihrGitRepoPath()
+					for (int i=0; i<cvhrRepos.size(); i++) {
+						tokens = cvhrRepos[i].tokenize('/');
+						echo 'Merging ' + tokens[tokens.size()-1]
+						try {
+							sh """
+								cd ${cvhrRepos[i]}
+								git merge origin/${envBranch} --no-edit
+							"""	
+						} catch (err) {
+							echo "Something failed at Check out PR Branch in CiviHR extension: ${cvhrRepos[i]}"
+							echo "Failed: ${err}"
+						}
+					}
+
+					// Upgrade Drupal & CiviCRM extensions
+					echo 'Upgrade Drupal & CV extensions'
+					sh """
+						cd $WEBROOT
+						drush features-revert civihr_employee_portal_features -y
+	    				drush features-revert civihr_default_permissions -y
+	    				drush updatedb -y
+	    				drush cvapi extenion.upgrade -y
+	    				drush cc all
+	    				drush cc civicrm
+    				"""
+				}
+			}
+	    }
+
+	    /* Testing PHP */
+	    stage('Test PHP') {
+			steps {
+				script {
+					// Get civihr extensions list
+					def extensions = listCivihrExtensions()
+					
+					// Execute PHP test
+					for (int i = 0; i<extensions.size(); i++) {
+						testPHPUnit(extensions[i])
+					}
+				}
+			}
+			post {
+                always {
+                	// XUnit
+					step([
+	                    $class: 'XUnitBuilder',
+                    	thresholds: [
+	                    	[$class: 'FailedThreshold',
+	                          failureNewThreshold: '5',
+	                          failureThreshold: '5',
+	                          unstableNewThreshold: '1',
+	                          unstableThreshold: '1'],
+	                        [$class: 'SkippedThreshold',
+	                          failureNewThreshold: '0',
+	                          failureThreshold: '0',
+	                          unstableNewThreshold: '0',
+	                          unstableThreshold: '0']
+                    	],
+	                    tools: [[$class: 'JUnitType', pattern: 'reports/phpunit/*.xml']]
+	                ])
+            	}
+            }
+	    }
+		
+		/* Testing JS */
+		// TODO: Execute test and Generate report without stop on fail
+	    stage('Testing JS: Install NPM in parallel') {
+			steps {
+				script {
+					// Get civihr extensions list
+					def extensions = listCivihrExtensions()
+					def extensionTestings = [:]
+
+					// Install NPM jobs
+					for (int i = 0; i<extensions.size(); i++) {
+						def index = i
+						extensionTestings[extensions[index]] = {
+						  echo 'Installing NPM: ' + extensions[index]
+						  installNPM(extensions[index])
+						}
+					}
+					// Running install NPM jobs in parallel
+					parallel extensionTestings
+				}
+			}
+	    }
+	    stage('Testing JS: Test JS in sequent') {
+			steps {
+				script {
+					// Get civihr extensions list
+					def extensions = listCivihrExtensions()
+					def extensionTestings = [:]
+
+					// Testing JS in sequent
+					for (int j = 0; j<extensions.size(); j++) {
+						def index = j
+						echo 'Testing with Gulp: ' + extensions[index]
+						testJS(extensions[index])  
+					}
+				}
+			}
+	    }
+  	}
+
+    post {
+    	always {
+    		// Destroy built site
+    		script {
+				if (params.DESTORY_SITE == true) {
+					echo 'Destroying built site...'
+					sh "civibuild destroy ${params.CVHR_BUILDNAME} || true"
+				}
+    		}
+    	}
+    }
+}
+/*
+ *	Change URL Git remote of civihr main repositry to the URL where configured by Jenkins project
+ */
+def changeCivihrGitRemote() {
+	def pulledCvhrRepo = sh(returnStdout: true, script: "cd $WORKSPACE; git remote -v | grep fetch | awk '{print \$2}'").trim()
+
+	echo 'Changing Civihr git URL..'
+
+	sh """
+		cd $CVCRM_EXT_ROOT/civihr
+		git remote set-url origin ${pulledCvhrRepo}
+		git fetch --all
+	"""
+}
+/* 
+ * Execute PHPUnit testing
+ * params: extensionName
+ */
+def testPHPUnit(String extensionName){
+	def extensionShortName = extensionName.tokenize('.')[-1]
+
+	echo "PHPUnit testing: ${extensionShortName}" 
+
+	sh """
+		cd $CVCRM_EXT_ROOT/civihr/${extensionName}
+		phpunit4 \
+			--log-junit $WORKSPACE/reports/phpunit/result-phpunit_${extensionShortName}.xml \
+			--coverage-html $WORKSPACE/reports/phpunit/resultPHPUnitHtml_${extensionShortName} \
+			|| true
+	"""
+}
+/* 
+ * Installk JS Testing
+ * params: extensionName
+ */
+def installNPM(String extensionName){
+	sh """
+		cd $CVCRM_EXT_ROOT/civihr/${extensionName}
+		npm install || true
+	"""
+}
+/* 
+ * Execute JS Testing
+ * params: extensionName
+ */
+def testJS(String extensionName){
+	echo "JS Testing ${extensionName.tokenize('.')[-1]}"
+
+	sh """
+		cd $CVCRM_EXT_ROOT/civihr/${extensionName}
+		gulp test || true
+	"""
+}
+/* 
+ * Get a list of CiviHR repository
+ * https://compucorp.atlassian.net/wiki/spaces/PCHR/pages/68714502/GitHub+repositories
+ */
+def listCivihrGitRepoPath(){
+	// Get list of CiviHR Git repository paths using git-scan
+	return sh(returnStdout: true, script: "cd $WEBROOT; git-scan foreach -c 'pwd' | grep civihr").split("\n")
+
+	// Manually set the list
+	// return [
+	// 	"$CVCRM_EXT_ROOT/civihr",
+	// 	"$CVCRM_EXT_ROOT/civihr_tasks",
+	// 	"$CVCRM_EXT_ROOT/org.civicrm.shoreditch",
+	// 	"$CVCRM_EXT_ROOT/org.civicrm.styleguide",
+	// 	"$DR_MODU_ROOT/civihr-custom/civihr_employee_portal",
+	// ]
+}
+/* 
+ * Get a list of enabled CiviHR extensions
+ */
+def listCivihrExtensions(){
+	// All enabled cvhr extensions
+	// return sh(returnStdout: true, script: "cd /opt/buildkit/build/hr17/sites/; drush cvapi extension.get statusLabel=Enabled return=path | grep '/civihr/' | awk -F '[//]' '{print \$NF}' | sort").split("\n")
+
+ 	// Manually select cvhr extensions
+ 	return [
+ 		'uk.co.compucorp.civicrm.hrcore',
+ 		'uk.co.compucorp.civicrm.hrleaveandabsences',
+ 		'com.civicrm.hrjobroles',
+ 	]
+}
+


### PR DESCRIPTION
## Overview
After a long wait and multiple requests from developers, we'll finally start using Jenkins to automatically run the tests for our Pull Requests. 

This PR adds the initial version of the Jenkinsfile with the very minimum required to start. We're not covering all the tests yet. At this moment, Jenkins will only run the PHP Unit tests. 

Soon enough other types of tests will be covered (Like JS Tests, Web Tests and Backstop JS), as well as Code Style checks and no failure will pass unnoticed.

## Before
Developers had to run the tests manually. Reviewers had to trust the developer to run the rights tests.

## After
When a PR has the "Ready for Testing" label assigned to it, Jenkins will pull it, run the PHP Unit tests automatically (for all the extensions) and update the PR status with the test results.

Jenkins will do the same when new commits are added to a staging branch (`staging` and `1.7-wip` as of the time of this PR), but it will report the test results by updating the commit status instead.