### PR TITLE
PCHR-2696: Changes to the Absence Type Form for Leave in Hours Requirements

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -304,7 +304,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
 
       if($absenceTypeHasBeenUsed) {
         throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException(
-          'The Calculation unit cannot be change because the Absence Type is In Use!'
+          'The Calculation unit cannot be changed because the Absence Type is In Use!'
         );
       }
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -252,6 +252,8 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    * There can be only one AbsenceType where this field is true. So this
    * method checks if one such type already exists and throws an error if that
    * is the case.
+   * It also checks to ensure that public holiday cannot be added to entitlement
+   * if the absence type leave is to be calculated in hours.
    *
    * @param array $params
    *  The params array received by the create method
@@ -262,6 +264,14 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
     if(!self::fieldIsUnique('add_public_holiday_to_entitlement', 1, $params)) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException(
         'There is already one Absence Type where public holidays should be added to it'
+      );
+    }
+
+    $calculationUnitOptions = array_flip(self::buildOptions('calculation_unit', 'validate'));
+    $calculationUnitIsInHours = $params['calculation_unit'] == $calculationUnitOptions['hours'];
+    if($params['add_public_holiday_to_entitlement'] == 1 && $calculationUnitIsInHours) {
+      throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException(
+        'You cannot add public holiday to entitlement when Absence Type calculation unit is in Hours'
       );
     }
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
@@ -207,7 +207,7 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form {
     $this->add(
       'checkbox',
       'allow_accruals_request',
-      ts('Allow staff to request to accrue additional days leave of this type during the period')
+      ts('Allow staff to request to accrue additional leave of this type during the period')
     );
     $this->add(
       'text',
@@ -243,7 +243,7 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form {
     $this->add(
       'text',
       'max_number_of_days_to_carry_forward',
-      ts('Maximum number of days that can be carried forward to a new period? (Leave blank for unlimited)'),
+      ts('Maximum amount of leave that can be carried forward to a new period? (Leave blank for unlimited)'),
       $this->getDAOFieldAttributes('max_number_of_days_to_carry_forward')
     );
     $this->add(

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
@@ -148,7 +148,7 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form {
       [
         'options' => $this->getCalculationUnitOptions(),
         'option_url' => NULL,
-        'label' => 'Calculate Leave in'
+        'label' => ts('Calculate Leave in')
       ],
       TRUE
     );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
@@ -143,17 +143,13 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form {
         ['disabled' => 'disabled']
       );
     }
-    $calculationUnitFieldOptions =  [
-      'options' => $this->getCalculationUnitOptions(),
-      'option_url' => NULL,
-      'label' => 'Calculate Leave in'
-    ];
-    if($this->absenceTypeHasEverBeenUsed()) {
-      $calculationUnitFieldOptions['disabled'] = 'disabled';
-    }
     $this->addSelect(
       'calculation_unit',
-      $calculationUnitFieldOptions,
+      [
+        'options' => $this->getCalculationUnitOptions(),
+        'option_url' => NULL,
+        'label' => 'Calculate Leave in'
+      ],
       TRUE
     );
     $this->addYesNo(
@@ -423,13 +419,26 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form {
   /**
    * Get the option values for the calculation_unit
    * select field.
+   * When the Absence Type has been used, the only option
+   * returned is the current value of the calculation unit for the
+   * absence type.
    *
    * @return array
    */
   private function getCalculationUnitOptions() {
     $options = AbsenceType::buildOptions('calculation_unit');
     $selectOptions = [];
+    $absenceTypeHasBeenUsed = $this->absenceTypeHasEverBeenUsed();
+    $calculationUnitValue = false;
+
+    if($absenceTypeHasBeenUsed) {
+      $calculationUnitValue = AbsenceType::getFieldValue(AbsenceType::class, $this->_id, 'calculation_unit');
+    }
+
     foreach($options as $value => $label) {
+      if($calculationUnitValue && $value != $calculationUnitValue) {
+        continue;
+      }
       $selectOptions[$value] = ts($label);
     }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
@@ -54,6 +54,7 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form {
     $this->assign('canDeleteType', $this->canDelete());
     $this->assign('deleteUrl', $this->getDeleteUrl());
     $this->assign('availableColors', json_encode(CRM_HRLeaveAndAbsences_BAO_AbsenceType::getAvailableColors()));
+    $this->assign('hoursUnitValue', $this->getHoursCalculationUnitValue());
 
     CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/leaveandabsence.css');
     CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/spectrum.css');
@@ -445,6 +446,17 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form {
     $calculationUnitOptions = array_flip(AbsenceType::buildOptions('calculation_unit', 'validate'));
 
     return $calculationUnitOptions['days'];
+  }
+
+  /**
+   * Gets the value for the hours calculation_unit
+   *
+   * @return mixed
+   */
+  private function getHoursCalculationUnitValue() {
+    $calculationUnitOptions = array_flip(AbsenceType::buildOptions('calculation_unit', 'validate'));
+
+    return $calculationUnitOptions['hours'];
   }
 
   /** Checks if the Absence Type record has ever been used.

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
@@ -87,6 +87,10 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form {
         $params['notification_receivers_ids'] = explode(',', $params['notification_receivers_ids']);
       }
 
+      if(!array_key_exists('add_public_holiday_to_entitlement', $params)) {
+        $params['add_public_holiday_to_entitlement'] = 0;
+      }
+
       $actionDescription = ($this->_action & CRM_Core_Action::UPDATE) ? 'updated' : 'created';
       try {
         $absenceType = CRM_HRLeaveAndAbsences_BAO_AbsenceType::create($params);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/AbsenceType.php
@@ -6,10 +6,11 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType extends
   CRM_HRLeaveAndAbsences_Test_Fabricator_SequentialTitle {
 
   private static $defaultParams = [
-    'color'                     => '#000000',
-    'default_entitlement'       => 20,
+    'color' => '#000000',
+    'default_entitlement' => 20,
     'allow_request_cancelation' => 1,
-    'allow_carry_forward'       => 1,
+    'allow_carry_forward' => 1,
+    'calculation_unit' => 1
   ];
 
   public static function fabricate($params = []) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
@@ -27,6 +27,10 @@
               <div class="col-sm-6">{$form.is_reserved.label}</div>
               <div class="col-sm-6">{$form.is_reserved.html}</div>
             </div>
+            <div class="form-group row">
+              <div class="col-sm-6">{$form.calculation_unit.label}</div>
+              <div class="col-sm-6">{$form.calculation_unit.html}</div>
+            </div>
           </div>
           <div class="col-sm-8">
             <div class="form-group row">

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
@@ -275,18 +275,19 @@
                 }
 
                 function initCalculationUnitControls() {
-                  calculationUnitRelatedControls();
+                  toggleCalculationUnitRelatedControls();
 
                   $('.absence-calculation-unit select').on('change', function(e) {
-                    calculationUnitRelatedControls();
+                    toggleCalculationUnitRelatedControls();
                   });
                 }
 
-                function calculationUnitRelatedControls() {
+                function toggleCalculationUnitRelatedControls() {
                   publicHolidayToggle();
                   setEntitlementLabelText();
                   toggleEntitlementHelpIcon();
                 }
+
                 function setEntitlementLabelText() {
                   $('.entitlement-label').text($('.absence-calculation-unit select option:selected').text());
                 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
@@ -27,7 +27,7 @@
               <div class="col-sm-6">{$form.is_reserved.label}</div>
               <div class="col-sm-6">{$form.is_reserved.html}</div>
             </div>
-            <div class="form-group row">
+            <div class="form-group row absence-calculation-unit">
               <div class="col-sm-6">{$form.calculation_unit.label}</div>
               <div class="col-sm-6">{$form.calculation_unit.html}</div>
             </div>
@@ -35,7 +35,7 @@
           <div class="col-sm-8">
             <div class="form-group row">
               <div class="col-sm-6">{$form.default_entitlement.label}</div>
-              <div class="col-sm-6">{$form.default_entitlement.html}</div>
+              <div class="col-sm-6">{$form.default_entitlement.html} <span class="entitlement-label"></span></div>
             </div>
             <div class="form-group row">
               <div class="col-sm-6">{$form.add_public_holiday_to_entitlement.label}</div>
@@ -56,7 +56,7 @@
             <h3>{ts}Requesting Leave/Absence{/ts}</h3>
             <div class="form-group row">
               <div class="col-sm-6">{$form.max_consecutive_leave_days.label}</div>
-              <div class="col-sm-6">{$form.max_consecutive_leave_days.html}</div>
+              <div class="col-sm-6">{$form.max_consecutive_leave_days.html} <span class="entitlement-label"></span></div>
             </div>
             <div class="form-group row">
               <div class="col-sm-6">{$form.allow_request_cancelation.label}</div>
@@ -75,7 +75,7 @@
             </div>
             <div class="form-group row toil-option">
               <div class="col-sm-6">{$form.max_leave_accrual.label}</div>
-              <div class="col-sm-6">{$form.max_leave_accrual.html}</div>
+              <div class="col-sm-6">{$form.max_leave_accrual.html} <span class="entitlement-label"></span></div>
             </div>
             <div class="form-group row toil-option">
               <div class="col-sm-6">{$form.allow_accrue_in_the_past.label}</div>
@@ -111,7 +111,7 @@
             </div>
             <div class="form-group row carry-forward-option">
               <div class="col-sm-6">{$form.max_number_of_days_to_carry_forward.label}</div>
-              <div class="col-sm-6">{$form.max_number_of_days_to_carry_forward.html}</div>
+              <div class="col-sm-6">{$form.max_number_of_days_to_carry_forward.html} <span class="entitlement-label"></span></div>
             </div>
             <div class="form-group row carry-forward-option">
               <div class="col-sm-6">{ts}Carry forward leave expiry{/ts}</div>
@@ -274,11 +274,23 @@
                       {literal}
                   }
 
+                function initEntitlementLabelSwitch() {
+                  setEntitlementLabelText();
+                  $('.absence-calculation-unit select').on('change', function(e) {
+                    setEntitlementLabelText();
+                  });
+                }
+
+                function setEntitlementLabelText() {
+                  $('.entitlement-label').text($('.absence-calculation-unit select option:selected').text());
+                }
+
                   $(document).ready(function() {
                       initToilControls();
                       initCarryForwardControls();
                       initColorPicker();
                       initDeleteButton();
+                      initEntitlementLabelSwitch()
                   });
 
               });

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
@@ -132,147 +132,147 @@
       {literal}
           <script type="text/javascript">
               CRM.$(function($) {
-                  function initToilControls() {
-                      var allow_accruals_request = $('#allow_accruals_request');
-                      var accrual_never_expire = $('#accrual_never_expire');
+                function initToilControls() {
+                  var allow_accruals_request = $('#allow_accruals_request');
+                  var accrual_never_expire = $('#accrual_never_expire');
 
-                      if(allow_accruals_request.is(':checked')) {
-                          $('.toil-option').show();
-                      }
-
-                      if(!accrual_never_expire.is(':checked')) {
-                          $('.toil-expiration').show();
-                      }
-
-                      allow_accruals_request.on('click', function() {
-                          if(this.checked) {
-                              $('.toil-option').show();
-                          } else {
-                              hideToilOptions();
-                          }
-                      });
-
-                      accrual_never_expire.on('click', function() {
-                          if(this.checked) {
-                              hideToilExpiration();
-                          } else {
-                              $('.toil-expiration').show();
-                          }
-                      });
+                  if(allow_accruals_request.is(':checked')) {
+                    $('.toil-option').show();
                   }
 
-                  function hideToilOptions() {
-                      document.getElementById('max_leave_accrual').value = '';
-                      var allow_accrue_in_the_past_radios = document.getElementsByName('allow_accrue_in_the_past')
-                      for(i = 0; i < allow_accrue_in_the_past_radios.length; i++) {
-                          allow_accrue_in_the_past_radios.item(i).checked = false;
-                      }
-                      document.getElementById('accrual_never_expire').checked = true;
+                  if(!accrual_never_expire.is(':checked')) {
+                    $('.toil-expiration').show();
+                  }
+
+                  allow_accruals_request.on('click', function() {
+                    if(this.checked) {
+                      $('.toil-option').show();
+                    } else {
+                      hideToilOptions();
+                    }
+                  });
+
+                  accrual_never_expire.on('click', function() {
+                    if(this.checked) {
                       hideToilExpiration();
-                      $('.toil-option').hide();
+                    } else {
+                      $('.toil-expiration').show();
+                    }
+                  });
+                }
+
+                function hideToilOptions() {
+                  document.getElementById('max_leave_accrual').value = '';
+                  var allow_accrue_in_the_past_radios = document.getElementsByName('allow_accrue_in_the_past')
+                  for(i = 0; i < allow_accrue_in_the_past_radios.length; i++) {
+                    allow_accrue_in_the_past_radios.item(i).checked = false;
+                  }
+                  document.getElementById('accrual_never_expire').checked = true;
+                  hideToilExpiration();
+                  $('.toil-option').hide();
+                }
+
+                function hideToilExpiration() {
+                  document.getElementById('accrual_expiration_duration').value = '';
+                  $('#accrual_expiration_unit').select2('val', '');
+                  $('.toil-expiration').hide();
+                }
+
+                function initCarryForwardControls() {
+                  var allow_carry_forward = $('#allow_carry_forward');
+                  var carry_forward_never_expire = $('#carry_forward_never_expire');
+                  var carry_forward_expire_after_duration = $('#carry_forward_expire_after_duration');
+
+                  if(allow_carry_forward.is(':checked')) {
+                    $('.carry-forward-option').show();
                   }
 
-                  function hideToilExpiration() {
-                      document.getElementById('accrual_expiration_duration').value = '';
-                      $('#accrual_expiration_unit').select2('val', '');
-                      $('.toil-expiration').hide();
+                  if(!carry_forward_never_expire.is(':checked')) {
+                    $('.carry-forward-expiration-duration').show();
                   }
 
-                  function initCarryForwardControls() {
-                      var allow_carry_forward = $('#allow_carry_forward');
-                      var carry_forward_never_expire = $('#carry_forward_never_expire');
-                      var carry_forward_expire_after_duration = $('#carry_forward_expire_after_duration');
+                  allow_carry_forward.on('click', function() {
+                    if(this.checked) {
+                      $('.carry-forward-option').show();
+                    } else {
+                      hideCarryForwardOptions();
+                    }
+                  });
 
-                      if(allow_carry_forward.is(':checked')) {
-                          $('.carry-forward-option').show();
-                      }
-
-                      if(!carry_forward_never_expire.is(':checked')) {
-                          $('.carry-forward-expiration-duration').show();
-                      }
-
-                      allow_carry_forward.on('click', function() {
-                          if(this.checked) {
-                              $('.carry-forward-option').show();
-                          } else {
-                              hideCarryForwardOptions();
-                          }
-                      });
-
-                      carry_forward_never_expire.on('click', function() {
-                          if(this.checked) {
-                              hideCarryForwardExpirationDuration();
-                          }
-                      });
-
-                      carry_forward_expire_after_duration.on('click', function() {
-                          if(this.checked) {
-                              $('.carry-forward-expiration-duration').show();
-                          }
-                      });
-                  }
-
-                  function hideCarryForwardOptions() {
-                      var carry_forward_expiration_radios = document.getElementsByName('carry_forward_expiration');
-                      document.getElementById('max_number_of_days_to_carry_forward').value = '';
-                      for(i = 0; i < carry_forward_expiration_radios.length; i++) {
-                          carry_forward_expiration_radios.item(i).checked = false;
-                      }
-                      carry_forward_expiration_radios.item(0).checked = true;
+                  carry_forward_never_expire.on('click', function() {
+                    if(this.checked) {
                       hideCarryForwardExpirationDuration();
-                      $('.carry-forward-option').hide();
-                  }
+                    }
+                  });
 
-                  function hideCarryForwardExpirationDuration() {
-                      document.getElementById('carry_forward_expiration_duration').value = '';
-                      $('#carry_forward_expiration_unit').select2('val', '');
-                      $('.carry-forward-expiration-duration').hide();
-                  }
+                  carry_forward_expire_after_duration.on('click', function() {
+                    if(this.checked) {
+                      $('.carry-forward-expiration-duration').show();
+                    }
+                  });
+                }
 
-                  function initColorPicker() {
-                      $('#color').spectrum({
-                          preferredFormat: "hex3",
-                          allowEmpty:true,
-                          showPaletteOnly: true,
-                          showPalette:true,
-                          {/literal}
-                          palette: {$availableColors}
-                          {literal}
-                      });
+                function hideCarryForwardOptions() {
+                  var carry_forward_expiration_radios = document.getElementsByName('carry_forward_expiration');
+                  document.getElementById('max_number_of_days_to_carry_forward').value = '';
+                  for(i = 0; i < carry_forward_expiration_radios.length; i++) {
+                    carry_forward_expiration_radios.item(i).checked = false;
                   }
+                  carry_forward_expiration_radios.item(0).checked = true;
+                  hideCarryForwardExpirationDuration();
+                  $('.carry-forward-option').hide();
+                }
 
-                  function initDeleteButton() {
-                      $('.crm-button-type-delete').on('click', function(e) {
-                        e.preventDefault();
-                        {/literal}
-                        {if $canDeleteType}
-                        {literal}
-                            CRM.confirm({
-                              title: ts('Delete Leave/Absence type'),
-                              message: ts('Are you sure you want to delete this leave/absence type?'),
-                              options: {
-                                yes: ts('Yes'),
-                                no: ts('No')
-                              }
-                            })
-                            .on('crmConfirm:yes', deleteCallback);
-                        {/literal}
-                        {else}
-                        {literal}
-                            CRM.alert("This leave/absence type is in use and cannot be deleted. Please disable it instead.",
-                                      'Delete Leave/Absence type', 'error');
-                        {/literal}
-                        {/if}
-                        {literal}
+                function hideCarryForwardExpirationDuration() {
+                  document.getElementById('carry_forward_expiration_duration').value = '';
+                  $('#carry_forward_expiration_unit').select2('val', '');
+                  $('.carry-forward-expiration-duration').hide();
+                }
 
-                      });
-                  }
+                function initColorPicker() {
+                  $('#color').spectrum({
+                    preferredFormat: "hex3",
+                    allowEmpty:true,
+                    showPaletteOnly: true,
+                    showPalette:true,
+                    {/literal}
+                    palette: {$availableColors}
+                    {literal}
+                  });
+                }
 
-                  function deleteCallback() {
-                      {/literal}
-                      window.location = "{$deleteUrl}";
-                      {literal}
-                  }
+                function initDeleteButton() {
+                  $('.crm-button-type-delete').on('click', function(e) {
+                    e.preventDefault();
+                    {/literal}
+                    {if $canDeleteType}
+                    {literal}
+                    CRM.confirm({
+                      title: ts('Delete Leave/Absence type'),
+                      message: ts('Are you sure you want to delete this leave/absence type?'),
+                      options: {
+                        yes: ts('Yes'),
+                        no: ts('No')
+                      }
+                    })
+                      .on('crmConfirm:yes', deleteCallback);
+                    {/literal}
+                    {else}
+                    {literal}
+                    CRM.alert("This leave/absence type is in use and cannot be deleted. Please disable it instead.",
+                      'Delete Leave/Absence type', 'error');
+                    {/literal}
+                    {/if}
+                    {literal}
+
+                  });
+                }
+
+                function deleteCallback() {
+                  {/literal}
+                  window.location = "{$deleteUrl}";
+                  {literal}
+                }
 
                 function initCalculationUnitControls() {
                   setEntitlementLabelText();
@@ -284,7 +284,7 @@
                       $('.absence-calculation-unit select').select2('val', prev_calculation_unit_val);
                       showPublicHolidayEntitlementErrorAlert();
                     }
-                    else{
+                    else {
                       prev_calculation_unit_val = $('.absence-calculation-unit select option:selected').val();
                     }
                     setEntitlementLabelText();
@@ -319,14 +319,14 @@
                   return hours_unit_value;
                 }
 
-                  $(document).ready(function() {
-                      initToilControls();
-                      initCarryForwardControls();
-                      initColorPicker();
-                      initDeleteButton();
-                      initCalculationUnitControls()
-                      initPublicHolidayControls()
-                  });
+                $(document).ready(function() {
+                  initToilControls();
+                  initCarryForwardControls();
+                  initColorPicker();
+                  initDeleteButton();
+                  initCalculationUnitControls()
+                  initPublicHolidayControls()
+                });
 
               });
           </script>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
@@ -37,7 +37,7 @@
               <div class="col-sm-6">{$form.default_entitlement.label}</div>
               <div class="col-sm-6">{$form.default_entitlement.html} <span class="entitlement-label"></span></div>
             </div>
-            <div class="form-group row">
+            <div class="form-group row public-holiday-option">
               <div class="col-sm-6">{$form.add_public_holiday_to_entitlement.label}</div>
               <div class="col-sm-6">{$form.add_public_holiday_to_entitlement.html}</div>
             </div>
@@ -274,9 +274,19 @@
                       {literal}
                   }
 
-                function initEntitlementLabelSwitch() {
+                function initCalculationUnitControls() {
                   setEntitlementLabelText();
+                  var prev_calculation_unit_val = $('.absence-calculation-unit select option:selected').val();
                   $('.absence-calculation-unit select').on('change', function(e) {
+                    var add_public_holiday_entitlement = $('.public-holiday-option input[type=radio]:checked').val();
+                    var hours_unit_value = getHoursUnitValue();
+                    if(this.value == hours_unit_value && add_public_holiday_entitlement == 1) {
+                      $('.absence-calculation-unit select').select2('val', prev_calculation_unit_val);
+                      showPublicHolidayEntitlementErrorAlert();
+                    }
+                    else{
+                      prev_calculation_unit_val = $('.absence-calculation-unit select option:selected').val();
+                    }
                     setEntitlementLabelText();
                   });
                 }
@@ -285,12 +295,37 @@
                   $('.entitlement-label').text($('.absence-calculation-unit select option:selected').text());
                 }
 
+                function initPublicHolidayControls() {
+                  $('.public-holiday-option input[type=radio]').on('click', function(e) {
+                    var calculation_unit = $('.absence-calculation-unit select option:selected').val();
+                    var hours_unit_value = getHoursUnitValue();
+                    if (this.value == 1 && calculation_unit == hours_unit_value) {
+                      showPublicHolidayEntitlementErrorAlert();
+                      e.preventDefault();
+                    }
+                  });
+                }
+
+                function showPublicHolidayEntitlementErrorAlert() {
+                  CRM.alert("You cannot add public holiday to entitlement when calculation unit is in Hours",
+                    'Modify Absence Type', 'error');
+                }
+
+                function getHoursUnitValue() {
+                  {/literal}
+                  var hours_unit_value = {$hoursUnitValue};
+                  {literal}
+
+                  return hours_unit_value;
+                }
+
                   $(document).ready(function() {
                       initToilControls();
                       initCarryForwardControls();
                       initColorPicker();
                       initDeleteButton();
-                      initEntitlementLabelSwitch()
+                      initCalculationUnitControls()
+                      initPublicHolidayControls()
                   });
 
               });

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
@@ -39,7 +39,7 @@
             </div>
             <div class="form-group row public-holiday-option">
               <div class="col-sm-6">{$form.add_public_holiday_to_entitlement.label}</div>
-              <div class="col-sm-6">{$form.add_public_holiday_to_entitlement.html}</div>
+              <div class="col-sm-6">{$form.add_public_holiday_to_entitlement.html}<span class="entitlement-help-text">{help id="id-entitlement-error"}</span></div>
             </div>
             <div class="form-group row">
               <div class="col-sm-6">{$form.notification_receivers_ids.label}</div>
@@ -275,40 +275,40 @@
                 }
 
                 function initCalculationUnitControls() {
-                  setEntitlementLabelText();
-                  var prev_calculation_unit_val = $('.absence-calculation-unit select option:selected').val();
+                  calculationUnitRelatedControls();
+
                   $('.absence-calculation-unit select').on('change', function(e) {
-                    var add_public_holiday_entitlement = $('.public-holiday-option input[type=radio]:checked').val();
-                    var hours_unit_value = getHoursUnitValue();
-                    if(this.value == hours_unit_value && add_public_holiday_entitlement == 1) {
-                      $('.absence-calculation-unit select').select2('val', prev_calculation_unit_val);
-                      showPublicHolidayEntitlementErrorAlert();
-                    }
-                    else {
-                      prev_calculation_unit_val = $('.absence-calculation-unit select option:selected').val();
-                    }
-                    setEntitlementLabelText();
+                    calculationUnitRelatedControls();
                   });
                 }
 
+                function calculationUnitRelatedControls() {
+                  publicHolidayToggle();
+                  setEntitlementLabelText();
+                  toggleEntitlementHelpIcon();
+                }
                 function setEntitlementLabelText() {
                   $('.entitlement-label').text($('.absence-calculation-unit select option:selected').text());
                 }
 
-                function initPublicHolidayControls() {
-                  $('.public-holiday-option input[type=radio]').on('click', function(e) {
-                    var calculation_unit = $('.absence-calculation-unit select option:selected').val();
-                    var hours_unit_value = getHoursUnitValue();
-                    if (this.value == 1 && calculation_unit == hours_unit_value) {
-                      showPublicHolidayEntitlementErrorAlert();
-                      e.preventDefault();
-                    }
-                  });
+                function toggleEntitlementHelpIcon() {
+                  if($('.public-holiday-option input[type=radio]').attr('disabled')) {
+                    $('.entitlement-help-text').show();
+                  }
+                  else {
+                    $('.entitlement-help-text').hide();
+                  }
                 }
 
-                function showPublicHolidayEntitlementErrorAlert() {
-                  CRM.alert("You cannot add public holiday to entitlement when calculation unit is in Hours",
-                    'Modify Absence Type', 'error');
+                function publicHolidayToggle() {
+                  var calculation_unit = $('.absence-calculation-unit select option:selected').val();
+                  var hours_unit_value = getHoursUnitValue();
+                  if(calculation_unit == hours_unit_value) {
+                    $('.public-holiday-option input[type=radio]').val([0]).attr('disabled', true);
+                  }
+                  else {
+                    $('.public-holiday-option input[type=radio]').attr('disabled', false);
+                  }
                 }
 
                 function getHoursUnitValue() {
@@ -325,7 +325,6 @@
                   initColorPicker();
                   initDeleteButton();
                   initCalculationUnitControls()
-                  initPublicHolidayControls()
                 });
 
               });

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsenceType.hlp
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsenceType.hlp
@@ -1,0 +1,6 @@
+{htxt id="id-entitlement-error-title"}
+  {ts}Modify Absence Type{/ts}
+{/htxt}
+{htxt id="id-entitlement-error"}
+  {ts}You cannot add public holiday to entitlement when calculation unit is in Hours.{/ts}
+{/htxt}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -26,11 +26,14 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
       '#151D2C', '#B32E2E', '#BF561D', '#377A31', '#803D5E', '#47275C', '#056780'
   ];
 
+  private $calculationUnitOptions;
+
   public function setUp() {
     // We delete everything two avoid problems with the default absence types
     // created during the extension installation
     $tableName = AbsenceType::getTableName();
     CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+    $this->calculationUnitOptions = array_flip(AbsenceType::buildOptions('calculation_unit', 'validate'));
   }
 
   public function testTypeTitlesShouldBeUnique() {
@@ -583,6 +586,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
       'default_entitlement' => 21,
       'allow_request_cancelation' => 1,
       'is_active' => 1,
+      'calculation_unit' => $this->calculationUnitOptions['days']
     ]);
     $this->assertEquals(0, $absenceType->is_sick);
   }
@@ -594,7 +598,8 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
       'default_entitlement' => 21,
       'allow_request_cancelation' => 1,
       'is_active' => 1,
-      'is_sick' => 1
+      'is_sick' => 1,
+      'calculation_unit' => $this->calculationUnitOptions['days']
     ]);
     $this->assertEquals(1, $absenceType->is_sick);
   }
@@ -792,5 +797,16 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     );
 
     AbsenceTypeFabricator::fabricate($params);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
+   * @expectedExceptionMessage You cannot add public holiday to entitlement when Absence Type calculation unit is in Hours
+   */
+  public function testPublicHolidayEntitlementCannotBeAddedWhenLeaveIsCalculatedInHours() {
+    AbsenceTypeFabricator::fabricate([
+      'add_public_holiday_to_entitlement' => true,
+      'calculation_unit' => $this->calculationUnitOptions['hours']
+    ]);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -809,4 +809,39 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
       'calculation_unit' => $this->calculationUnitOptions['hours']
     ]);
   }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
+   * @expectedExceptionMessage The Calculation unit cannot be change because the Absence Type is In Use!
+   */
+  public function testCalculationUnitCannotBeChangedWhenAbsenceTypeIsInUse() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'calculation_unit' => $this->calculationUnitOptions['hours']
+    ]);
+
+    LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $absenceType->id,
+      'contact_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-02'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-02'),
+    ]);
+
+    AbsenceTypeFabricator::fabricate([
+      'id' => $absenceType->id,
+      'calculation_unit' => $this->calculationUnitOptions['days']
+    ]);
+  }
+
+  public function testCalculationUnitCanBeChangedWhenAbsenceTypeIsInNotInUse() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'calculation_unit' => $this->calculationUnitOptions['hours']
+    ]);
+
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'id' => $absenceType->id,
+      'calculation_unit' => $this->calculationUnitOptions['days']
+    ]);
+
+    $this->assertEquals($absenceType->calculation_unit, $this->calculationUnitOptions['days']);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -810,10 +810,6 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     ]);
   }
 
-  /**
-   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
-   * @expectedExceptionMessage The Calculation unit cannot be change because the Absence Type is In Use!
-   */
   public function testCalculationUnitCannotBeChangedWhenAbsenceTypeIsInUse() {
     $absenceType = AbsenceTypeFabricator::fabricate([
       'calculation_unit' => $this->calculationUnitOptions['hours']
@@ -825,6 +821,11 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
       'from_date' => CRM_Utils_Date::processDate('2016-01-02'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-02'),
     ]);
+
+    $this->setExpectedException(
+      'CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException',
+      'The Calculation unit cannot be changed because the Absence Type is In Use!'
+    );
 
     AbsenceTypeFabricator::fabricate([
       'id' => $absenceType->id,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
@@ -359,7 +359,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
 
   public function testCanSaveALeavePeriodEntitlementFromAnEntitlementCalculation() {
 
-    $type = $this->createAbsenceType();
+    $type = AbsenceTypeFabricator::fabricate();
     $period = $this->createAbsencePeriod('2016-01-01', '2016-12-31');
     $this->setContractDates('2016-01-01', '2016-12-31');
 
@@ -429,7 +429,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
   }
 
   public function testSaveFromCalculationWillReplaceExistingLeavePeriodEntitlement() {
-    $type = $this->createAbsenceType();
+    $type = AbsenceTypeFabricator::fabricate();
     $period = $this->createAbsencePeriod('2016-01-01', '2016-12-31');
     $this->setContractDates('2016-01-01', '2016-12-31');
 
@@ -579,7 +579,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
   public function testGetStartAndEndDatesShouldReturnAbsencePeriodDateIfContractStartDateIsLessThanThePeriodStartDate() {
     $this->setContractDates('2015-12-31', null);
     $absencePeriod = $this->createAbsencePeriod('2016-01-01', '2016-12-31');
-    $absenceType = $this->createAbsenceType();
+    $absenceType = AbsenceTypeFabricator::fabricate();
 
     $periodEntitlement = LeavePeriodEntitlement::create([
       'contact_id' => $this->contract['contact_id'],
@@ -595,7 +595,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
   public function testGetStartAndEndDatesShouldReturnContractDateIfContractStartDateIsGreaterThanThePeriodStartDate() {
     $this->setContractDates('2016-03-17', null);
     $absencePeriod = $this->createAbsencePeriod('2016-01-01', '2016-12-31');
-    $absenceType = $this->createAbsenceType();
+    $absenceType = AbsenceTypeFabricator::fabricate();
 
     $periodEntitlement = LeavePeriodEntitlement::create([
       'contact_id' => $this->contract['contact_id'],
@@ -611,7 +611,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
   public function testGetStartAndEndDatesShouldReturnAbsencePeriodDateIfContractEndDateIsGreaterThanThePeriodEndDate() {
     $this->setContractDates('2015-03-17', '2017-01-01');
     $absencePeriod = $this->createAbsencePeriod('2016-01-01', '2016-12-31');
-    $absenceType = $this->createAbsenceType();
+    $absenceType = AbsenceTypeFabricator::fabricate();
 
     $periodEntitlement = LeavePeriodEntitlement::create([
       'contact_id' => $this->contract['contact_id'],
@@ -627,7 +627,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
   public function testGetStartAndEndDatesShouldReturnContractDateIfContractEndDateIsLessThanThePeriodEndDate() {
     $this->setContractDates('2016-03-17', '2016-05-23');
     $absencePeriod = $this->createAbsencePeriod('2016-01-01', '2016-12-31');
-    $absenceType = $this->createAbsenceType();
+    $absenceType = AbsenceTypeFabricator::fabricate();
 
     $periodEntitlement = LeavePeriodEntitlement::create([
       'contact_id' => $this->contract['contact_id'],
@@ -646,10 +646,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
       'start_date' => date('YmdHis', strtotime($startDate)),
       'end_date' => date('YmdHis', strtotime($endDate)),
     ]);
-  }
-
-  private function createAbsenceType() {
-    return AbsenceTypeFabricator::fabricate();
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
@@ -11,6 +11,7 @@ use CRM_HRLeaveAndAbsences_Test_Fabricator_LeavePeriodEntitlement as LeavePeriod
 use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod as AbsencePeriodFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
 use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
 
 /**
  * Class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest
@@ -648,15 +649,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
   }
 
   private function createAbsenceType() {
-    $calculationUnitOptions = array_flip(AbsenceType::buildOptions('calculation_unit', 'validate'));
-
-    return AbsenceType::create([
-      'title' => 'Type ' . microtime(),
-      'color' => '#000000',
-      'default_entitlement' => 20,
-      'allow_request_cancelation' => 1,
-      'calculation_unit' => $calculationUnitOptions['days']
-    ]);
+    return AbsenceTypeFabricator::fabricate();
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
@@ -648,11 +648,14 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
   }
 
   private function createAbsenceType() {
+    $calculationUnitOptions = array_flip(AbsenceType::buildOptions('calculation_unit', 'validate'));
+
     return AbsenceType::create([
       'title' => 'Type ' . microtime(),
       'color' => '#000000',
       'default_entitlement' => 20,
       'allow_request_cancelation' => 1,
+      'calculation_unit' => $calculationUnitOptions['days']
     ]);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/NotificationReceiverTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/NotificationReceiverTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
 
 /**
  * Class CRM_HRLeaveAndAbsences_BAO_NotificationReceiverTest
@@ -41,14 +41,7 @@ class CRM_HRLeaveAndAbsences_BAO_NotificationReceiverTest extends BaseHeadlessTe
 
   private function instantiateAbsenceType()
   {
-    $calculationUnitOptions = array_flip(AbsenceType::buildOptions('calculation_unit', 'validate'));
-    $this->absenceType = AbsenceType::create([
-        'title' => 'Type ' . microtime(),
-        'color' => '#000000',
-        'default_entitlement' => 20,
-        'allow_request_cancelation' => 1,
-        'calculation_unit' => $calculationUnitOptions['days']
-    ]);
+    $this->absenceType = AbsenceTypeFabricator::fabricate();
   }
 
   private function getContactsIds($limit = 5)

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/NotificationReceiverTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/NotificationReceiverTest.php
@@ -41,11 +41,13 @@ class CRM_HRLeaveAndAbsences_BAO_NotificationReceiverTest extends BaseHeadlessTe
 
   private function instantiateAbsenceType()
   {
+    $calculationUnitOptions = array_flip(AbsenceType::buildOptions('calculation_unit', 'validate'));
     $this->absenceType = AbsenceType::create([
         'title' => 'Type ' . microtime(),
         'color' => '#000000',
         'default_entitlement' => 20,
         'allow_request_cancelation' => 1,
+        'calculation_unit' => $calculationUnitOptions['days']
     ]);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/NotificationReceiverTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/NotificationReceiverTest.php
@@ -14,7 +14,7 @@ class CRM_HRLeaveAndAbsences_BAO_NotificationReceiverTest extends BaseHeadlessTe
   public function setUp()
   {
     parent::setUp();
-    $this->instantiateAbsenceType();
+    $this->absenceType = AbsenceTypeFabricator::fabricate();
   }
 
   public function tearDown()
@@ -37,11 +37,6 @@ class CRM_HRLeaveAndAbsences_BAO_NotificationReceiverTest extends BaseHeadlessTe
         $this->absenceType->id
     );
     $this->assertEmpty($receiversIds);
-  }
-
-  private function instantiateAbsenceType()
-  {
-    $this->absenceType = AbsenceTypeFabricator::fabricate();
   }
 
   private function getContactsIds($limit = 5)

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/EntitlementCalculatorTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/EntitlementCalculatorTest.php
@@ -51,11 +51,13 @@ class CRM_HRLeaveAndAbsences_Service_EntitlementCalculatorTest extends BaseHeadl
   }
 
   private function createBasicType($params = array()) {
+    $calculationUnitOptions = array_flip(AbsenceType::buildOptions('calculation_unit', 'validate'));
     $basicRequiredFields = [
       'title' => 'Type ' . microtime(),
       'color' => '#000000',
       'default_entitlement' => 20,
       'allow_request_cancelation' => 1,
+      'calculation_unit' => $calculationUnitOptions['days']
     ];
 
     $params = array_merge($basicRequiredFields, $params);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/EntitlementCalculatorTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/EntitlementCalculatorTest.php
@@ -51,6 +51,6 @@ class CRM_HRLeaveAndAbsences_Service_EntitlementCalculatorTest extends BaseHeadl
   }
 
   private function createBasicType($params = array()) {
-    return AbsenceTypeFabricator::fabricate();
+    return AbsenceTypeFabricator::fabricate($params);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/EntitlementCalculatorTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/EntitlementCalculatorTest.php
@@ -14,7 +14,7 @@ class CRM_HRLeaveAndAbsences_Service_EntitlementCalculatorTest extends BaseHeadl
 
   public function testCanReturnCalculationsForMultipleAbsenceTypes()
   {
-    $this->createBasicType();
+    AbsenceTypeFabricator::fabricate();
     $period = new AbsencePeriod();
 
     // mock the array returned by an API call
@@ -34,7 +34,7 @@ class CRM_HRLeaveAndAbsences_Service_EntitlementCalculatorTest extends BaseHeadl
 
   public function testCanOnlyReturnCalculationsForEnabledAbsenceTypes()
   {
-    $this->createBasicType(['is_active' => false]);
+    AbsenceTypeFabricator::fabricate(['is_active' => false]);
     $period = new AbsencePeriod();
 
     // mock the array returned by an API call
@@ -48,9 +48,5 @@ class CRM_HRLeaveAndAbsences_Service_EntitlementCalculatorTest extends BaseHeadl
     // new disabled AbsenceType, so we should get only 3 calculations, since
     // the new one is disabled and should not be included in the calculation
     $this->assertCount(3, $calculations);
-  }
-
-  private function createBasicType($params = array()) {
-    return AbsenceTypeFabricator::fabricate($params);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/EntitlementCalculatorTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/EntitlementCalculatorTest.php
@@ -3,7 +3,7 @@
 use CRM_HRLeaveAndAbsences_Service_EntitlementCalculator as EntitlementCalculator;
 use CRM_HRLeaveAndAbsences_Service_EntitlementCalculation as EntitlementCalculation;
 use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
-use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
 
 /**
  * Class CRM_HRLeaveAndAbsences_Service_EntitlementCalculatorTest
@@ -51,16 +51,6 @@ class CRM_HRLeaveAndAbsences_Service_EntitlementCalculatorTest extends BaseHeadl
   }
 
   private function createBasicType($params = array()) {
-    $calculationUnitOptions = array_flip(AbsenceType::buildOptions('calculation_unit', 'validate'));
-    $basicRequiredFields = [
-      'title' => 'Type ' . microtime(),
-      'color' => '#000000',
-      'default_entitlement' => 20,
-      'allow_request_cancelation' => 1,
-      'calculation_unit' => $calculationUnitOptions['days']
-    ];
-
-    $params = array_merge($basicRequiredFields, $params);
-    return AbsenceType::create($params);
+    return AbsenceTypeFabricator::fabricate();
   }
 }


### PR DESCRIPTION
## Overview
This PR makes some changes to the Absence Type Form by adding the `Calculate Leave in field` which allows the user to select if Leave for the Absence Type is to be calculated in Hours or Days. It also implements some Form logic for the new changes.

## Before
- The `Calculate Leave in` field was not present in the Absence Type form

## After
- The `Calculate Leave in field` was added to the Absence Type form. This field is a select field that uses the option values in the `absence_type_calculation_unit` option group as its select options.
- For an Absence Type that is linked to an existing leave request, the `Calculate Leave in` field cannot be changed.
- If Leave is in hours, Public Holiday cannot be added to the entitlement.
- References to days in the form labels were removed


![absencetypeform2](https://user-images.githubusercontent.com/6951813/31391166-b210dd28-adcd-11e7-9d75-1a8e0382b8a2.gif)

