### PR TITLE
PCHR-2427: Fix failing PHP unit tests

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/HrJobRoles.php
@@ -81,7 +81,7 @@ class CRM_Hrjobroles_BAO_HrJobRoles extends CRM_Hrjobroles_DAO_HrJobRoles {
               WHERE hrjr.job_contract_id = %1
                 AND hrjr.start_date <= '{$today}'
                 AND (
-                  hrjr.end_date = 0
+                  hrjr.end_date IS NULL
                   OR hrjr.end_date >= '{$today}'
                 )
                 AND cog.name = 'hrjc_department'";

--- a/com.civicrm.hrjobroles/tests/phpunit/CRM/Hrjobroles/BAO/HrJobRolesTest.php
+++ b/com.civicrm.hrjobroles/tests/phpunit/CRM/Hrjobroles/BAO/HrJobRolesTest.php
@@ -155,8 +155,13 @@ class CRM_Hrjobroles_BAO_HrJobRolesTest extends \PHPUnit_Framework_TestCase impl
 
     $department = $this->createDepartment('special_investigation', 'Special Investigation')['value'];
 
-    $this->createJobRole(array('job_contract_id' => $contract->id, 'department' => $department));
-    $this->createJobRole(array('job_contract_id' => $contract->id, 'department' => $department));
+    $params = [
+      'job_contract_id' => $contract->id,
+      'department' => $department,
+      'start_date' => date('Ymd')
+    ];
+    $this->createJobRole($params);
+    $this->createJobRole($params);
 
     $departmentsList = CRM_Hrjobroles_BAO_HrJobRoles::getCurrentDepartmentsList($contract->id);
 

--- a/hrvisa/CRM/HRVisa/Activity.php
+++ b/hrvisa/CRM/HRVisa/Activity.php
@@ -54,7 +54,7 @@ class CRM_HRVisa_Activity {
     // activity processing if immigration data found
     if ($immigrationDateInfo['count']) {
       // get 'Visa Expiration' activity for this contact
-      $activityTypeId = CRM_Core_OptionGroup::getValue('activity_type', 'Visa Expiration', 'name');
+      $activityTypeId = self::getActivityTypeID('Visa Expiration');
       $activityStatuses = CRM_Core_OptionGroup::values('activity_status', FALSE, FALSE, FALSE, NULL, 'name');
 
       // to check if visa expiration activity exists for the input target_contact_id
@@ -103,5 +103,21 @@ class CRM_HRVisa_Activity {
         }
       }
     } // end of if for immgration info check
+  }
+
+  public static function getActivityTypeID($activityType) {
+    return self::getActivityFieldOptionID('activity_type_id', $activityType);
+  }
+
+  public static function getActivityStatusID($activityStatus) {
+    return self::getActivityFieldOptionID('status_id', $activityStatus);
+  }
+
+  private static function getActivityFieldOptionID($field, $option) {
+    return CRM_Core_PseudoConstant::getKey(
+      CRM_Activity_BAO_Activity::class,
+      $field,
+      $option
+    );
   }
 }

--- a/hrvisa/tests/phpunit/CRM/HRVisa/ActivityTest.php
+++ b/hrvisa/tests/phpunit/CRM/HRVisa/ActivityTest.php
@@ -113,7 +113,7 @@ class CRM_HRVisa_ActivityTest extends PHPUnit_Framework_TestCase implements Head
       date('YmdHis', strtotime($activity['values'][$activity['id']]['activity_date_time'])),
       "Activity date time not set to latest Immigration visa end date for 'Visa Expiration' activity (in line " . __LINE__ . ")");
 
-    $this->assertEquals(CRM_Core_OptionGroup::getValue('activity_status', 'Scheduled', 'name'), $activity['values'][$activity['id']]['status_id'], 'in line ' . __LINE__ . ' Status of \'Visa Expiration\' activity should be \'Scheduled\' but wrongly is ' . $activity['values'][$activity['id']]['status_id']);
+    $this->assertEquals(CRM_HRVisa_Activity::getActivityStatusID('Scheduled'), $activity['values'][$activity['id']]['status_id'], 'in line ' . __LINE__ . ' Status of \'Visa Expiration\' activity should be \'Scheduled\' but wrongly is ' . $activity['values'][$activity['id']]['status_id']);
 
     // now mark the field visa required to false
     $params = array(
@@ -128,11 +128,11 @@ class CRM_HRVisa_ActivityTest extends PHPUnit_Framework_TestCase implements Head
     $activityGetParams = array('id' => $activityId);
     $activity = civicrm_api3('activity', 'get', $activityGetParams);
 
-    $this->assertEquals(CRM_Core_OptionGroup::getValue('activity_status', 'Cancelled', 'name'), $activity['values'][$activity['id']]['status_id'], 'in line ' . __LINE__ . ' Status of \'Visa Expiration\' activity should be \'Cancelled\' but wrongly is ' . $activity['values'][$activity['id']]['status_id']);
+    $this->assertEquals(CRM_HRVisa_Activity::getActivityStatusID('Cancelled'), $activity['values'][$activity['id']]['status_id'], 'in line ' . __LINE__ . ' Status of \'Visa Expiration\' activity should be \'Cancelled\' but wrongly is ' . $activity['values'][$activity['id']]['status_id']);
   }
 
   private function getTargetContactActivity($contactId) {
-    $activityTypeId = CRM_Core_OptionGroup::getValue('activity_type', 'Visa Expiration', 'name');
+    $activityTypeId = CRM_HRVisa_Activity::getActivityTypeID('Visa Expiration');
     // to check if visa expiration activity exists for the input target_contact_id
     $activityGetParams = array(
       'contact_id' => $contactId,


### PR DESCRIPTION
## Overview
Some of the PHP unit tests have been failing for a while. It's hard to know the exact reason, but this is probably because either:
- Changes were made to the extension but the tests were not ran
- The tests started failing after a CiviCRM upgrade and we didn't cache

This PR fixes these tests

## Before

There were 4 failing tests. 2 in hrvisa and 2 in job roles:

![captura de tela de 2017-10-09 07-50-21](https://user-images.githubusercontent.com/388373/31334890-9000f158-acc6-11e7-9c70-41c19b3aaead.png)


## After

All the tests are passing:

![captura de tela de 2017-10-09 07-51-47](https://user-images.githubusercontent.com/388373/31334929-bca9c23e-acc6-11e7-9593-ee1c77a86101.png)


## Technical Details
- The HRVisa tests were failing because they were using a deprecated CiviCRM function. Civi now throws an exception when this function is used and this was causing the tests to fail. The fix was basically to replace the deprecated function with the new one suggested by Civi.
- There were 2 tests failing in Job Roles, each one for a different reason:
  - One of the tests was failing because the query in `getCurrentDepartmentsList` was using a `end_date = 0` to get Job Roles without an end date, but such records actually have this field set to `NULL` when no date is available. This was fixed by changing the condition to `end_date IS NULL`
  - The second method was failing because the test fixtures didn't have a start_date set, but the `getCurrentDepartmentsList` only return Job Roles with a start date

## Comments

- As it is possible to see by this PR's status, the Jenkins build is still failing. The reason is that we still have some issues with the JS tests. This will be fixed on a separate PR.
- The two extensions touched by this PR deserve a lot of refactoring and cleanup, but this is not the scope of this PR. We want to have the Jenkins build fixed as soon as possible, so, right now, we're only focusing on fixing the failing tests.
