### PR TITLE
PCHR-2747: Fix menu items order and Vacancies label

### DIFF
--- a/hrrecruitment/CRM/HRRecruitment/Upgrader.php
+++ b/hrrecruitment/CRM/HRRecruitment/Upgrader.php
@@ -16,4 +16,21 @@ class CRM_HRRecruitment_Upgrader extends CRM_HRRecruitment_Upgrader_Base {
     return TRUE;
   }
 
+  /**
+   * Renames the main menu item "Vacancies" to "Recruitment"
+   *
+   * @return bool
+   */
+  public function upgrade_1401() {
+    $default = [];
+    $params = ['name' => 'Vacancies', 'url' => null];
+
+    $menuItem = CRM_Core_BAO_Navigation::retrieve($params, $default);
+    $menuItem->label = 'Recruitment';
+    $menuItem->save();
+
+    CRM_Core_BAO_Navigation::resetNavigation();
+
+    return TRUE;
+  }
 }

--- a/hrrecruitment/hrrecruitment.php
+++ b/hrrecruitment/hrrecruitment.php
@@ -99,7 +99,7 @@ function hrrecruitment_civicrm_install() {
   $vacancyNavigation = new CRM_Core_DAO_Navigation();
   $params = array (
     'domain_id' => CRM_Core_Config::domainID(),
-    'label' => ts('Vacancies'),
+    'label' => ts('Recruitment'),
     'name' => 'Vacancies',
     'url' => null,
     'operator' => null,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
@@ -11,6 +11,7 @@ class CRM_HRLeaveAndAbsences_Upgrader extends CRM_HRLeaveAndAbsences_Upgrader_Ba
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1003;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1004;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1005;
+  use CRM_HRLeaveAndAbsences_Upgrader_Step_1006;
 
   /**
    * A list of directories to be scanned for XML installation files

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1006.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1006.php
@@ -1,0 +1,28 @@
+<?php
+
+use CRM_Core_BAO_SchemaHandler as SchemaHandler;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
+
+trait CRM_HRLeaveAndAbsences_Upgrader_Step_1006 {
+
+  /**
+   * Renames the two "Leave and Absences" menu items to just "Absences"
+   *
+   * @return bool
+   */
+  public function upgrade_1006() {
+    $default = [];
+
+    $vacanciesParams = ['name' => 'Vacancies', 'url' => null];
+    $vacanciesMenuItem = CRM_Core_BAO_Navigation::retrieve($vacanciesParams, $default);
+
+    $leaveParams = ['name' => 'leave_and_absences_dashboard', 'url' => 'civicrm/leaveandabsences/dashboard'];
+    $leaveMenuItem = CRM_Core_BAO_Navigation::retrieve($leaveParams, $default);
+    $leaveMenuItem->weight = $vacanciesMenuItem->weight - 1;
+    $leaveMenuItem->save();
+
+    CRM_Core_BAO_Navigation::resetNavigation();
+
+    return TRUE;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1006.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1006.php
@@ -6,7 +6,7 @@ use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
 trait CRM_HRLeaveAndAbsences_Upgrader_Step_1006 {
 
   /**
-   * Renames the two "Leave and Absences" menu items to just "Absences"
+   * Moves the "leave_and_absences_dashboard" menu item before the "Vacancies" one
    *
    * @return bool
    */


### PR DESCRIPTION
## Overview
This PR fixes a couple of bugs

1. The "Vacancies" menu item hadn't been renamed in #2189 as expected
2. The position of "Vacancies" and "Leave" was wrong

## Before
1. We had a "Vacancies" menu item
2. The "Leave" menu item was after "Vacancies"

## After
1. We have a "Recruitment" menu item
2. The "Leave" menu item is before "Vacancies"

## Technical Details
The changes were done with Upgraders
