### PR TITLE
PCHR-2770: Support time output in email templtes

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Template/BaseRequestNotification.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Template/BaseRequestNotification.php
@@ -2,6 +2,7 @@
 
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestComment as LeaveRequestCommentService;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 
 abstract class CRM_HRLeaveAndAbsences_Mail_Template_BaseRequestNotification {
 
@@ -56,7 +57,8 @@ abstract class CRM_HRLeaveAndAbsences_Mail_Template_BaseRequestNotification {
       'leaveStatus' => $this->getLeaveRequestStatusLabel($leaveRequest->status_id),
       'leaveRequest' => $leaveRequest,
       'absenceTypeName' => $this->getAbsenceTypeName($leaveRequest),
-      'currentDateTime' => new DateTime()
+      'currentDateTime' => new DateTime(),
+      'calculationUnitName' => $this->getAbsenceTypeCalculationUnitName($leaveRequest)
     ];
 
     return $templateParameters;
@@ -140,5 +142,22 @@ abstract class CRM_HRLeaveAndAbsences_Mail_Template_BaseRequestNotification {
     $absenceType->find(true);
 
     return $absenceType->title;
+  }
+
+  /**
+   * Gets the Name of the Absence Type Calculation Unit for a LeaveRequest
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_LeaveRequest $leaveRequest
+   *
+   * @return string
+   */
+  private function getAbsenceTypeCalculationUnitName(LeaveRequest $leaveRequest) {
+    $absenceType = new CRM_HRLeaveAndAbsences_BAO_AbsenceType();
+    $absenceType->id = $leaveRequest->type_id;
+    $absenceType->find(true);
+    $calculationUnitId = $absenceType->calculation_unit;
+    $calculationUnitOptions = AbsenceType::buildOptions('calculation_unit', 'validate');
+
+    return $calculationUnitOptions[$calculationUnitId];
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/managed_entities/EmailTemplate.mgd.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/managed_entities/EmailTemplate.mgd.php
@@ -12,6 +12,30 @@ return [
       'msg_html' => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
+{* Store all date (and optionally time) labels and captions for later re-use *}
+{if $calculationUnitName === \'days\'}
+  {assign var="dateLabel" value="Date"}
+{/if}
+{if $calculationUnitName === \'hours\'}
+  {assign var="dateLabel" value="Date/Time"}
+{/if}
+{capture name=\'fromDate\'}
+  {if $calculationUnitName === \'days\'}
+    <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+  {/if}
+  {if $calculationUnitName === \'hours\'}
+    <span>{$fromDate|truncate:16:\'\'|crmDate}</span>
+  {/if}
+{/capture}
+{capture name=\'toDate\'}
+  {if $calculationUnitName === \'days\'}
+    <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
+  {/if}
+  {if $calculationUnitName === \'hours\'}
+    <span>{$toDate|truncate:16:\'\'|crmDate}</span>
+  {/if}
+{/capture}
+
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
   <head>
 
@@ -149,15 +173,15 @@ return [
                       </tr></tbody></table>
 
 
-                      {if $leaveRequest->from_date eq $leaveRequest->to_date}
+                      {if $fromDate eq $toDate}
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                             <span style="color: #4D5663; font-weight: 600;">
-                              {ts}Date:{/ts}
+                              {ts}{$dateLabel}:{/ts}
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                            {$smarty.capture.fromDate}
                           </th></tr></table></th>
                         </tr></tbody></table>
 
@@ -165,22 +189,22 @@ return [
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                             <span style="color: #4D5663; font-weight: 600;">
-                              {ts}From Date:{/ts}
+                              {ts}From {$dateLabel}:{/ts}
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                            {$smarty.capture.fromDate}
                           </th></tr></table></th>
                         </tr></tbody></table>
 
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 0 !important; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                             <span style="color: #4D5663; font-weight: 600;">
-                              {ts}To Date:{/ts}
+                              {ts}To {$dateLabel}:{/ts}
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 0 !important; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
+                            {$smarty.capture.toDate}
                           </th></tr></table></th>
                         </tr></tbody></table>
 
@@ -417,11 +441,11 @@ return [
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                             <span style="color: #4D5663; font-weight: 600;">
-                              {ts}Date:{/ts}
+                              {ts}{$dateLabel}:{/ts}
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                            {$smarty.capture.fromDate}
                           </th></tr></table></th>
                         </tr></tbody></table>
 
@@ -429,22 +453,22 @@ return [
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                             <span style="color: #4D5663; font-weight: 600;">
-                              {ts}From Date:{/ts}
+                              {ts}From {$dateLabel}:{/ts}
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                            {$smarty.capture.fromDate}
                           </th></tr></table></th>
                         </tr></tbody></table>
 
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                             <span style="color: #4D5663; font-weight: 600;">
-                              {ts}To Date:{/ts}
+                              {ts}To {$dateLabel}:{/ts}
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
+                            {$smarty.capture.toDate}
                           </th></tr></table></th>
                         </tr></tbody></table>
 
@@ -692,11 +716,11 @@ return [
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                             <span style="color: #4D5663; font-weight: 600;">
-                              {ts}Date:{/ts}
+                              {ts}{$dateLabel}:{/ts}
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                            {$smarty.capture.fromDate}
                           </th></tr></table></th>
                         </tr></tbody></table>
 
@@ -704,22 +728,27 @@ return [
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                             <span style="color: #4D5663; font-weight: 600;">
-                              {ts}From Date:{/ts}
+                              {ts}From {$dateLabel}:{/ts}
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                            {$smarty.capture.fromDate}
                           </th></tr></table></th>
                         </tr></tbody></table>
 
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                             <span style="color: #4D5663; font-weight: 600;">
-                              {ts}To Date:{/ts}
+                              {ts}To {$dateLabel}:{/ts}
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
+                            {if $calculationUnitName === \'days\'}
+                              <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
+                            {/if}
+                            {if $calculationUnitName === \'hours\'}
+                              <span>{$toDate|truncate:16:\'\'|crmDate}</span>
+                            {/if}
                           </th></tr></table></th>
                         </tr></tbody></table>
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/LeaveRequestNotificationTemplateTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/LeaveRequestNotificationTemplateTest.php
@@ -4,6 +4,7 @@ use CRM_HRLeaveAndAbsences_Mail_Template_LeaveRequestNotification as LeaveReques
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestComment as LeaveRequestCommentService;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
 
 /**
@@ -70,6 +71,7 @@ class CRM_HRLeaveAndAbsences_Mail_Template_LeaveRequestNotificationTemplateTest 
     $leaveRequestDayTypes = LeaveRequest::buildOptions('from_date_type');
     $leaveRequestStatuses = LeaveRequest::buildOptions('status_id');
     $dateTimeNow = new DateTime('now');
+    $calculationUnitNames = AbsenceType::buildOptions('calculation_unit', 'validate');
 
     //validate template parameters
     $this->assertEquals($tplParams['toDate'], $leaveRequest->to_date);
@@ -80,6 +82,7 @@ class CRM_HRLeaveAndAbsences_Mail_Template_LeaveRequestNotificationTemplateTest 
     $this->assertEquals($tplParams['leaveStatus'], $leaveRequestStatuses[$leaveRequest->status_id]);
     $this->assertEquals($tplParams['currentDateTime'], $dateTimeNow, '', 10);
     $this->assertEquals($tplParams['absenceTypeName'], $absenceType->title);
+    $this->assertEquals($tplParams['calculationUnitName'], $calculationUnitNames[$absenceType->calculation_unit]);
 
     //There are two attachments for the leave request
     $this->assertCount(2, $tplParams['leaveFiles']);


### PR DESCRIPTION
## Overview

Currently emails managers and staff receive emails when a leave request is created or the leave request status is changed. These emails contain only dates now since only "days" Absence Type calculation unit is currently supported now.

Since now "hours" Absence Type calculation unit is supported in Leave in Hours, this PR adds support of time output to the emails mentioned above.

## Before

![image](https://user-images.githubusercontent.com/3973243/31663477-28436e54-b33a-11e7-8f09-abc6194edb57.png)

## After

![image](https://user-images.githubusercontent.com/3973243/31663551-6ae4a534-b33a-11e7-81de-4c3d1c87ebca.png)

## Technical Details

In `CRM/HRLeaveAndAbsences/Mail/Template/BaseRequestNotification.php`:

```php
// New function added that returns calculation unit name (required to decide which format to show)
private function getAbsenceTypeCalculationUnitName(LeaveRequest $leaveRequest) {
  $absenceType = new CRM_HRLeaveAndAbsences_BAO_AbsenceType();
  $absenceType->id = $leaveRequest->type_id;
  $absenceType->find(true);
  $calculationUnitId = $absenceType->calculation_unit;
  $calculationUnitOptions = AbsenceType::buildOptions('calculation_unit', 'validate');

  return $calculationUnitOptions[$calculationUnitId];
}

// Simply pass a new parameter to the email template
public function getTemplateParameters(LeaveRequest $leaveRequest) {
  $templateParameters =  [
    // ... params
    'calculationUnitName' => $this->getAbsenceTypeCalculationUnitName($leaveRequest) // <--
  ];

  return $templateParameters;
}
```

In `managed_entities/EmailTemplate.mgd.php`:

```html
<!-- To avoid repetition vars and html blocks for dates/times captions and labels were created -->
{* Store all date (and optionally time) labels and captions for later re-use *}
{if $calculationUnitName === \'days\'}
  {assign var="dateLabel" value="Date"}
{/if}
{if $calculationUnitName === \'hours\'}
  {assign var="dateLabel" value="Date/Time"}
{/if}
{capture name=\'fromDate\'}
  {if $calculationUnitName === \'days\'}
    <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
  {/if}
  {if $calculationUnitName === \'hours\'}
    <span>{$fromDate|truncate:16:\'\'|crmDate}</span>
  {/if}
{/capture}
{capture name=\'toDate\'}
  {if $calculationUnitName === \'days\'}
    <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
  {/if}
  {if $calculationUnitName === \'hours\'}
    <span>{$toDate|truncate:16:\'\'|crmDate}</span>
  {/if}
{/capture}

<!-- And then simply used in the template -->
{ts}{$dateLabel}:{/ts}
{$smarty.capture.fromDate}
<!-- etc... -->
```

## Comments

This PR also fixes plain text output which is currently broken.

### Before

![image](https://user-images.githubusercontent.com/3973243/31663864-42b598e2-b33b-11e7-8718-359600867c3c.png)

### After 

**Leave Request**
![image](https://user-images.githubusercontent.com/3973243/31672921-af8ccffc-b355-11e7-90e7-6cd56571dd66.png)

**Sickness**
![image](https://user-images.githubusercontent.com/3973243/31672950-d31086da-b355-11e7-8ef6-1b6b9d5dc9ec.png)

**TOIL**
![image](https://user-images.githubusercontent.com/3973243/31673400-02ef0218-b357-11e7-89ce-eb9ecfe6ddca.png)

----
✅ Manual Tests - passed
✅ PHP Unit Tests - passed
⏹ Jasmine Tests - n/a
⏹ JS distributive files - n/a
⏹ Backstop Tests - n/a
⏹ CSS distributive files - n/a

