### PR TITLE
PCHR-2616: Add ssp menu item on the fly

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -221,6 +221,20 @@ function hrcore_civicrm_pageRun($page) {
 }
 
 /**
+ * Implements hook_civicrm_navigationMenu().
+ *
+ * @param Array $params List of menu items
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_navigationMenu
+ */
+function hrcore_civicrm_navigationMenu(&$menu) {
+  _hrcore_civix_insert_navigation_menu($menu, '', [
+    'name' => ts('ssp'),
+    'label' => ts('Self Service Portal'),
+    'url' => 'dashboard',
+  ]);
+}
+
+/**
  * This function adds the session variable to CRM.vars object.
  */
 function _hrcore_add_js_session_vars() {


### PR DESCRIPTION
## Overview
This PR adds a "Self Service Portal" to the main menu in the CiviHR admin

## Before
<img width="450" alt="before" src="https://user-images.githubusercontent.com/6400898/31667550-0effd6c4-b350-11e7-8a4f-70c895a6246f.png">

## After
<img width="450" alt="after" src="https://user-images.githubusercontent.com/6400898/31667549-0eca0c42-b350-11e7-980b-7a54075536dc.png">

## Technical Details
Initially the menu item was meant to be added via an upgrader, but then quickly realized that no matter how high of a weight we assigned to the item, it would still appear before "Help" and "Developer" in the menu list.

This was due to [hrui](https://github.com/civicrm/civihr/blob/staging/hrui/hrui.php#L997) extension, which added those two items on the fly using the `hook_civicrm_navigationMenu` hook, practically bypassing the DB completely, and as such ignoring any weight assigned to the menu items.

So in the end the hook was used also here in hrcore.
