### PR TITLE
PCHR-2616: Add ssp menu item on the fly

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -228,6 +228,11 @@ function hrcore_civicrm_pageRun($page) {
 function hrcore_civicrm_navigationMenu(&$params) {
   _hrcore_renameMenuLabel($params, 'Contacts', 'Staff');
   _hrcore_renameMenuLabel($params, 'Administer', 'Configure');
+  _hrcore_civix_insert_navigation_menu($params, '', [
+    'name' => ts('ssp'),
+    'label' => ts('Self Service Portal'),
+    'url' => 'dashboard',
+  ]);
 }
 
 /**
@@ -239,7 +244,7 @@ function hrcore_civicrm_navigationMenu(&$params) {
  */
 function _hrcore_renameMenuLabel(&$params, $menuName, $newLabel) {
   $menuItemID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', $menuName, 'id', 'name');
-  $params[$menuItemID]['attributes']['label'] = $newLabel; 
+  $params[$menuItemID]['attributes']['label'] = $newLabel;
 }
 
 /**


### PR DESCRIPTION
## Overview
This PR adds a "Self Service Portal" to the main menu in the CiviHR admin

## Before
<img width="450" alt="before" src="https://user-images.githubusercontent.com/6400898/31667550-0effd6c4-b350-11e7-8a4f-70c895a6246f.png">

## After
<img width="450" alt="after" src="https://user-images.githubusercontent.com/6400898/31667549-0eca0c42-b350-11e7-980b-7a54075536dc.png">

## Technical Details
Initially the menu item was meant to be added via an upgrader, but then quickly realized that no matter how high of a weight we assigned to the item, it would still appear before "Help" and "Developer" in the menu list.

This was due to [hrui](https://github.com/civicrm/civihr/blob/staging/hrui/hrui.php#L997) extension, which added those two items on the fly using the `hook_civicrm_navigationMenu` hook, practically bypassing the DB completely, and as such ignoring any weight assigned to the menu items.

So in the end the hook was used also here in hrcore.
