### PR TITLE
PCHR-2770: Support time output in email templates

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Template/BaseRequestNotification.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Template/BaseRequestNotification.php
@@ -2,6 +2,7 @@
 
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestComment as LeaveRequestCommentService;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 
 abstract class CRM_HRLeaveAndAbsences_Mail_Template_BaseRequestNotification {
 
@@ -56,7 +57,8 @@ abstract class CRM_HRLeaveAndAbsences_Mail_Template_BaseRequestNotification {
       'leaveStatus' => $this->getLeaveRequestStatusLabel($leaveRequest->status_id),
       'leaveRequest' => $leaveRequest,
       'absenceTypeName' => $this->getAbsenceTypeName($leaveRequest),
-      'currentDateTime' => new DateTime()
+      'currentDateTime' => new DateTime(),
+      'calculationUnitName' => $this->getAbsenceTypeCalculationUnitName($leaveRequest)
     ];
 
     return $templateParameters;
@@ -140,5 +142,22 @@ abstract class CRM_HRLeaveAndAbsences_Mail_Template_BaseRequestNotification {
     $absenceType->find(true);
 
     return $absenceType->title;
+  }
+
+  /**
+   * Gets the Name of the Absence Type Calculation Unit for a LeaveRequest
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_LeaveRequest $leaveRequest
+   *
+   * @return string
+   */
+  private function getAbsenceTypeCalculationUnitName(LeaveRequest $leaveRequest) {
+    $absenceType = new CRM_HRLeaveAndAbsences_BAO_AbsenceType();
+    $absenceType->id = $leaveRequest->type_id;
+    $absenceType->find(true);
+    $calculationUnitId = $absenceType->calculation_unit;
+    $calculationUnitOptions = AbsenceType::buildOptions('calculation_unit', 'validate');
+
+    return $calculationUnitOptions[$calculationUnitId];
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/managed_entities/EmailTemplate.mgd.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/managed_entities/EmailTemplate.mgd.php
@@ -1,5 +1,18 @@
 <?php
 
+$br = "\r\n";
+$dateLabel = '{if $calculationUnitName === \'days\'}Date{/if}{if $calculationUnitName === \'hours\'}Date/Time{/if}';
+$fromDateCaption = '{if $calculationUnitName === \'days\'}{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}{/if}{if $calculationUnitName === \'hours\'}{$fromDate|truncate:16:\'\'|crmDate}{/if}';
+$toDateCaption = '{if $calculationUnitName === \'days\'}{$toDate|truncate:10:\'\'|crmDate} {$toDateType}{/if}{if $calculationUnitName === \'hours\'}{$toDate|truncate:16:\'\'|crmDate}{/if}';
+$header =
+  '{ts}Status:{/ts} {$leaveStatus}' . $br .
+  '{ts}Staff Member:{/ts} {contact.display_name}' . $br .
+  '{if $leaveRequest->from_date eq $leaveRequest->to_date}{ts}' . $dateLabel . ':{/ts} ' . $fromDateCaption . '{else}{ts}From ' . $dateLabel . ':{/ts} ' . $fromDateCaption . $br . $br . '{ts}To ' . $dateLabel . ':{/ts} ' . $toDateCaption . '{/if}';
+$footer = $br .
+  'View This Request: {$leaveRequestLink}' .
+  '{if $leaveComments}' . $br . $br . 'Request Comments{foreach from=$leaveComments item=value key=label}' . $br . $br . '{$value.commenter}:' . $br . '{$value.created_at|crmDate}' . $br . '{$value.text}{/foreach}{/if}'.
+  '{if $leaveFiles}' . $br . $br . 'Other files recorded on this request{foreach from=$leaveFiles item=value key=label}' . $br . $br . '{$value.name}: Added on {$value.upload_date|crmDate}{/foreach}{/if}';
+
 return [
   [
     'name' => 'Email Template: Leave Request',
@@ -8,7 +21,11 @@ return [
       'version' => 3,
       'msg_title' => 'CiviHR Leave Request Notification',
       'msg_subject' => 'Leave Request',
-      'msg_text' => 'CiviHR Leave RequestLeave Request Type{ts}Status:{/ts}{$leaveStatus}{ts}Staff Member:{/ts}{contact.display_name}{if $leaveRequest->from_date eq $leaveRequest->to_date}{ts}Date:{/ts}{$fromDate|truncate:10:\'\'|crmDate}{$fromDateType}{else}{ts}From Date:{/ts}{$fromDate|truncate:10:\'\'|crmDate}{$fromDateType}{ts}To Date:{/ts}{$toDate|truncate:10:\'\'|crmDate}{$toDateType}{/if}View This Request{if $leaveComments}Request Comments{foreach from=$leaveComments item=value key=label}{$value.commenter}:{$value.created_at|crmDate}{$value.text}{/foreach}{/if}{if $leaveFiles}Other files recorded on this request{foreach from=$leaveFiles item=value key=label}{$value.name}: Added on{$value.upload_date|crmDate}{/foreach}{/if}',
+      'msg_text' =>
+        'CiviHR Leave Request' . $br .
+        'Leave Request Type' . $br .
+        $header . $br . $br .
+        $footer,
       'msg_html' => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
@@ -149,15 +166,15 @@ return [
                       </tr></tbody></table>
 
 
-                      {if $leaveRequest->from_date eq $leaveRequest->to_date}
+                      {if $fromDate eq $toDate}
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                             <span style="color: #4D5663; font-weight: 600;">
-                              {ts}Date:{/ts}
+                              {ts}' . $dateLabel . ':{/ts}
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                            ' . $fromDateCaption . '
                           </th></tr></table></th>
                         </tr></tbody></table>
 
@@ -165,22 +182,22 @@ return [
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                             <span style="color: #4D5663; font-weight: 600;">
-                              {ts}From Date:{/ts}
+                              {ts}From ' . $dateLabel . ':{/ts}
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                            ' . $fromDateCaption . '
                           </th></tr></table></th>
                         </tr></tbody></table>
 
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 0 !important; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                             <span style="color: #4D5663; font-weight: 600;">
-                              {ts}To Date:{/ts}
+                              {ts}To ' . $dateLabel . ':{/ts}
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 0 !important; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
+                            ' . $toDateCaption . '
                           </th></tr></table></th>
                         </tr></tbody></table>
 
@@ -272,7 +289,12 @@ return [
       'version' => 3,
       'msg_title' => 'CiviHR TOIL Request Notification',
       'msg_subject' => 'TOIL Request',
-      'msg_text' => 'CiviHR TOIL RequestLeave Request Type{ts}Status:{/ts}{$leaveStatus}{ts}Staff Member:{/ts}{contact.display_name}{if $leaveRequest->from_date eq $leaveRequest->to_date}{ts}Date:{/ts}{$fromDate|truncate:10:\'\'|crmDate}{else}{ts}From Date:{/ts}{$fromDate|truncate:10:\'\'|crmDate}{ts}To Date:{/ts}{$toDate|truncate:10:\'\'|crmDate}{/if}{ts}No. TOIL Days Requested{/ts}{$leaveRequest->toil_to_accrue}{if $leaveRequest->toil_to_accrue > 1}days{else}day{/if}View This Request{if $leaveComments}Request Comments{foreach from=$leaveComments item=value key=label}{$value.commenter}:{$value.created_at|crmDate}{$value.text}{/foreach}{/if}{if $leaveFiles}Other files recorded on this request{foreach from=$leaveFiles item=value key=label}{$value.name}: Added on{$value.upload_date|crmDate}{/foreach}{/if}',
+      'msg_text' =>
+        'CiviHR TOIL Request' . $br .
+        'Leave Request Type' . $br .
+        $header . $br . $br .
+        '{ts}No. TOIL Days Requested{/ts} {$leaveRequest->toil_to_accrue} {if $leaveRequest->toil_to_accrue > 1}days{else}day{/if}' . $br . $br .
+        $footer,
       'msg_html' => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
@@ -417,11 +439,11 @@ return [
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                             <span style="color: #4D5663; font-weight: 600;">
-                              {ts}Date:{/ts}
+                              {ts}' . $dateLabel . ':{/ts}
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                            ' . $fromDateCaption . '
                           </th></tr></table></th>
                         </tr></tbody></table>
 
@@ -429,22 +451,22 @@ return [
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                             <span style="color: #4D5663; font-weight: 600;">
-                              {ts}From Date:{/ts}
+                              {ts}From ' . $dateLabel . ':{/ts}
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                            ' . $fromDateCaption . '
                           </th></tr></table></th>
                         </tr></tbody></table>
 
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-4 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 33.33333%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                             <span style="color: #4D5663; font-weight: 600;">
-                              {ts}To Date:{/ts}
+                              {ts}To ' . $dateLabel . ':{/ts}
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
+                            ' . $toDateCaption . '
                           </th></tr></table></th>
                         </tr></tbody></table>
 
@@ -692,11 +714,11 @@ return [
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                             <span style="color: #4D5663; font-weight: 600;">
-                              {ts}Date:{/ts}
+                              {ts}' . $dateLabel . ':{/ts}
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                            ' . $fromDateCaption . '
                           </th></tr></table></th>
                         </tr></tbody></table>
 
@@ -704,22 +726,22 @@ return [
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                             <span style="color: #4D5663; font-weight: 600;">
-                              {ts}From Date:{/ts}
+                              {ts}From ' . $dateLabel . ':{/ts}
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$fromDate|truncate:10:\'\'|crmDate} {$fromDateType}</span>
+                            ' . $fromDateCaption . '
                           </th></tr></table></th>
                         </tr></tbody></table>
 
                         <table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
                           <th class="request-data-key small-12 large-3 columns first" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 25%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
                             <span style="color: #4D5663; font-weight: 600;">
-                              {ts}To Date:{/ts}
+                              {ts}To ' . $dateLabel . ':{/ts}
                             </span>
                           </th></tr></table></th>
                           <th class="request-data-value small-12 large-6 columns last" style="Margin: 0 auto; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 0 !important; padding-right: 0 !important; text-align: left; width: 50%;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #727E8A; font-family: \'Open Sans\', \'Helvetica Neue\', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; padding: 0; text-align: left;">
-                            <span>{$toDate|truncate:10:\'\'|crmDate} {$toDateType}</span>
+                            ' . $toDateCaption . '
                           </th></tr></table></th>
                         </tr></tbody></table>
 
@@ -840,7 +862,13 @@ return [
    <div style="display:none; white-space:nowrap; font:15px courier; line-height:0;"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </div>
   </body>
 </html>',
-      'msg_text' => 'CiviHR Sickness RecordSickness Request Type Name{ts}Status:{/ts}{$leaveStatus}{ts}Staff Member:{/ts}{contact.display_name}{if $leaveRequest->from_date eq $leaveRequest->to_date}{ts}Date:{/ts}{$fromDate|truncate:10:\'\'|crmDate}{$fromDateType}{else}{ts}From Date:{/ts}{$fromDate|truncate:10:\'\'|crmDate}{$fromDateType}{ts}To Date:{/ts}{$toDate|truncate:10:\'\'|crmDate}{$toDateType}{/if}Additional Details:The Reason{foreach from=$sicknessReasons item=value key=id}{if $id eq $leaveRequest->sickness_reason}{$value}{/if}{/foreach}{if $leaveRequiredDocuments}{foreach from=$sicknessRequiredDocuments item=value key=id}{if in_array($id, $leaveRequiredDocuments)}{$value}{/if}{/foreach}{/if}{if $leaveComments}Request Comments{foreach from=$leaveComments item=value key=label}{$value.commenter}:{$value.created_at|crmDate}{$value.text}{/foreach}{/if}{if $leaveFiles}Other files recorded on this request{foreach from=$leaveFiles item=value key=label}{$value.name}: Added on{$value.upload_date|crmDate}{/foreach}{/if}',
+      'msg_text' =>
+        'CiviHR Sickness Record' . $br .
+        'Sickness Request Type' . $br .
+        $header . $br . $br .
+        'Additional Details:' . $br .
+        'The Reason: {$sicknessReason}' . $br . $br .
+        $footer,
       'is_reserved' => 1
     ],
   ]

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -2478,8 +2478,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     $this->setContactAsLeaveApproverOf($manager1, $leaveContact);
 
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'calculation_unit' => '1'
+    ]);
+
     $params = [
-      'type_id' => 1,
+      'type_id' => $absenceType->id,
       'contact_id' => $leaveContact['id'],
       'status_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('tomorrow'),

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -2478,9 +2478,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     $this->setContactAsLeaveApproverOf($manager1, $leaveContact);
 
-    $absenceType = AbsenceTypeFabricator::fabricate([
-      'calculation_unit' => '1'
-    ]);
+    $absenceType = AbsenceTypeFabricator::fabricate();
 
     $params = [
       'type_id' => $absenceType->id,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/LeaveRequestNotificationTemplateTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/LeaveRequestNotificationTemplateTest.php
@@ -4,6 +4,7 @@ use CRM_HRLeaveAndAbsences_Mail_Template_LeaveRequestNotification as LeaveReques
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestComment as LeaveRequestCommentService;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
 
 /**
@@ -70,6 +71,7 @@ class CRM_HRLeaveAndAbsences_Mail_Template_LeaveRequestNotificationTemplateTest 
     $leaveRequestDayTypes = LeaveRequest::buildOptions('from_date_type');
     $leaveRequestStatuses = LeaveRequest::buildOptions('status_id');
     $dateTimeNow = new DateTime('now');
+    $calculationUnitNames = AbsenceType::buildOptions('calculation_unit', 'validate');
 
     //validate template parameters
     $this->assertEquals($tplParams['toDate'], $leaveRequest->to_date);
@@ -80,6 +82,7 @@ class CRM_HRLeaveAndAbsences_Mail_Template_LeaveRequestNotificationTemplateTest 
     $this->assertEquals($tplParams['leaveStatus'], $leaveRequestStatuses[$leaveRequest->status_id]);
     $this->assertEquals($tplParams['currentDateTime'], $dateTimeNow, '', 10);
     $this->assertEquals($tplParams['absenceTypeName'], $absenceType->title);
+    $this->assertEquals($tplParams['calculationUnitName'], $calculationUnitNames[$absenceType->calculation_unit]);
 
     //There are two attachments for the leave request
     $this->assertCount(2, $tplParams['leaveFiles']);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/SicknessRequestNotificationTemplateTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/SicknessRequestNotificationTemplateTest.php
@@ -4,6 +4,7 @@ use CRM_HRLeaveAndAbsences_Mail_Template_SicknessRequestNotification as Sickness
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestComment as LeaveRequestCommentService;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
 
 /**
@@ -74,6 +75,7 @@ class CRM_HRLeaveAndAbsences_Mail_Template_SicknessRequestNotificationTemplateTe
     $leaveRequestStatuses = LeaveRequest::buildOptions('status_id');
     $sicknessReasons = LeaveRequest::buildOptions('sickness_reason');
     $dateTimeNow = new DateTime('now');
+    $calculationUnitNames = AbsenceType::buildOptions('calculation_unit', 'validate');
 
     //validate template parameters
     $this->assertEquals($tplParams['toDate'], $leaveRequest->to_date);
@@ -84,6 +86,7 @@ class CRM_HRLeaveAndAbsences_Mail_Template_SicknessRequestNotificationTemplateTe
     $this->assertEquals($tplParams['leaveStatus'], $leaveRequestStatuses[$leaveRequest->status_id]);
     $this->assertEquals($tplParams['currentDateTime'], $dateTimeNow, '', 10);
     $this->assertEquals($tplParams['absenceTypeName'], $absenceType->title);
+    $this->assertEquals($tplParams['calculationUnitName'], $calculationUnitNames[$absenceType->calculation_unit]);
 
     //There are two attachments for the Sickness request
     $this->assertCount(2, $tplParams['leaveFiles']);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/TOILRequestNotificationTemplateTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/TOILRequestNotificationTemplateTest.php
@@ -4,6 +4,7 @@ use CRM_HRLeaveAndAbsences_Mail_Template_TOILRequestNotification as TOILRequestN
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestComment as LeaveRequestCommentService;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
 
 /**
@@ -72,6 +73,7 @@ class CRM_HRLeaveAndAbsences_Mail_Template_TOILRequestNotificationTemplateTest e
     $leaveRequestDayTypes = LeaveRequest::buildOptions('from_date_type');
     $leaveRequestStatuses = LeaveRequest::buildOptions('status_id');
     $dateTimeNow = new DateTime('now');
+    $calculationUnitNames = AbsenceType::buildOptions('calculation_unit', 'validate');
 
     //validate template parameters
     $this->assertEquals($tplParams['toDate'], $leaveRequest->to_date);
@@ -82,6 +84,7 @@ class CRM_HRLeaveAndAbsences_Mail_Template_TOILRequestNotificationTemplateTest e
     $this->assertEquals($tplParams['leaveStatus'], $leaveRequestStatuses[$leaveRequest->status_id]);
     $this->assertEquals($tplParams['currentDateTime'], $dateTimeNow, '', 10);
     $this->assertEquals($tplParams['absenceTypeName'], $absenceType->title);
+    $this->assertEquals($tplParams['calculationUnitName'], $calculationUnitNames[$absenceType->calculation_unit]);
 
     //There are two attachments for the TOIL request
     $this->assertCount(2, $tplParams['leaveFiles']);


### PR DESCRIPTION
## Overview

Currently emails managers and staff receive emails when a leave request is created or the leave request status is changed. These emails contain only dates now since only "days" Absence Type calculation unit is currently supported now.

Since now "hours" Absence Type calculation unit is supported in Leave in Hours, this PR adds support of time output to the emails mentioned above.

## Before

![image](https://user-images.githubusercontent.com/3973243/31663477-28436e54-b33a-11e7-8f09-abc6194edb57.png)

## After

![image](https://user-images.githubusercontent.com/3973243/31663551-6ae4a534-b33a-11e7-81de-4c3d1c87ebca.png)

## Technical Details

In `CRM/HRLeaveAndAbsences/Mail/Template/BaseRequestNotification.php`:

```php
// New function added that returns calculation unit name (required to decide which format to show)
private function getAbsenceTypeCalculationUnitName(LeaveRequest $leaveRequest) {
  $absenceType = new CRM_HRLeaveAndAbsences_BAO_AbsenceType();
  $absenceType->id = $leaveRequest->type_id;
  $absenceType->find(true);
  $calculationUnitId = $absenceType->calculation_unit;
  $calculationUnitOptions = AbsenceType::buildOptions('calculation_unit', 'validate');

  return $calculationUnitOptions[$calculationUnitId];
}

// Simply pass a new parameter to the email template
public function getTemplateParameters(LeaveRequest $leaveRequest) {
  $templateParameters =  [
    // ... params
    'calculationUnitName' => $this->getAbsenceTypeCalculationUnitName($leaveRequest) // <--
  ];

  return $templateParameters;
}
```

In `managed_entities/EmailTemplate.mgd.php`:

```php
// Create vars to re-use (note, some parts in the email templates are different/custom)
// The snippet below is just to show that some vars re-use already assigned above
$br = "\r\n";
$dateLabel = /* ... */;
$fromDateCaption = /* ... */;
$toDateCaption = /* ... */;
$header = /* ... */ . $fromDateCaption . $dateLabel . $toDateCaption . /* ... */;
$footer = $br . /* ... */ . $leaveRequestLink;

<!-- And then simply used in the template -->
{ts}' . $dateLabel . ':{/ts}
<!-- etc... -->
```
_Note: at first it seemed like a good idea to use Smarty Captures, but it turned to be the implementation is much more compact in PHP_

## Comments

This PR also fixes plain text output which is currently broken.

### Before

![image](https://user-images.githubusercontent.com/3973243/31663864-42b598e2-b33b-11e7-8718-359600867c3c.png)

### After 

**Leave Request**
![image](https://user-images.githubusercontent.com/3973243/31672921-af8ccffc-b355-11e7-90e7-6cd56571dd66.png)

**Sickness**
![image](https://user-images.githubusercontent.com/3973243/31672950-d31086da-b355-11e7-8ef6-1b6b9d5dc9ec.png)

**TOIL**
![image](https://user-images.githubusercontent.com/3973243/31673400-02ef0218-b357-11e7-89ce-eb9ecfe6ddca.png)

----
✅ Manual Tests - passed
✅ PHP Unit Tests - passed
⏹ Jasmine Tests - n/a
⏹ JS distributive files - n/a
⏹ Backstop Tests - n/a
⏹ CSS distributive files - n/a