### PR TITLE
PCHR-2618: Remove ssp link in civihr logo submenu

### DIFF
--- a/hrui/CRM/Core/BAO/Navigation.php
+++ b/hrui/CRM/Core/BAO/Navigation.php
@@ -679,7 +679,6 @@ ORDER BY parent_id, weight";
         <li class='menumain crm-link-home'>$homeIcon
           <ul id='civicrm-home'>
             <li><a href='$homeURL'>$homeLabel</a></li>
-            <li><a href='/dashboard'>$hideLabel</a></li>
             <li><a href='$logoutURL' class='crm-logout-link'>". ts('Logout') ."</a></li>
           </ul>";
       // <li> tag doesn't need to be closed


### PR DESCRIPTION
## Overview
This PR removes the old "Self Service Portal" link in the CiviHR logo submenu, given that now we have a standalone button that redirects (see #2220 )

## Before
<img width="200" alt="before" src="https://user-images.githubusercontent.com/6400898/31674351-e8be1f9a-b361-11e7-8904-870c787d85cc.png">

## After
<img width="200" alt="after" src="https://user-images.githubusercontent.com/6400898/31674350-e89d1782-b361-11e7-9d15-7e1a98b6fbf2.png">

