### PR TITLE
PCHR-2789: Fix L&A tests in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,13 @@ pipeline {
           def buildBranch = params.CIVIHR_BRANCH != '' ? params.CIVIHR_BRANCH : env.CHANGE_TARGET != null ? env.CHANGE_TARGET : env.BRANCH_NAME != null ? env.BRANCH_NAME : 'staging'
 
           // Build site with CV Buildkit
-          sh "civibuild create ${params.CIVIHR_BUILDNAME} --type hr16 --civi-ver 4.7.22 --hr-ver ${buildBranch} --url $WEBURL --admin-pass $ADMIN_PASS"
+          sh "civibuild create ${params.CIVIHR_BUILDNAME} --type hr17 --civi-ver 4.7.22 --hr-ver ${buildBranch} --url $WEBURL --admin-pass $ADMIN_PASS"
+          sh """
+            cd $DRUPAL_MODULES_ROOT/civicrm
+            wget https://gist.githubusercontent.com/davialexandre/deafc6d4929fbf58b97105e54bfb300f/raw/2ec70492a8d5ce419337cc58097c1dfd3e2d4df6/attachments.patch
+            patch -p1 -i attachments.patch
+            rm attachments.patch
+          """
 
           // Change git remote of civihr ext to support dev version of Jenkins pipeline
           changeCivihrGitRemote()

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkDay.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkDay.php
@@ -7,7 +7,6 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDay extends CRM_HRLeaveAndAbsences_DAO_Work
   /**
    * @var array|null
    *   Caches the list of option values for the type field.
-   *   When it is null, it means the values were not loaded yet
    */
   private static $workDayTypes;
 
@@ -54,7 +53,7 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDay extends CRM_HRLeaveAndAbsences_DAO_Work
    * @return string
    */
   private static function getTypeValue($optionName) {
-    if(is_null(self::$workDayTypes)) {
+    if(empty(self::$workDayTypes)) {
       self::$workDayTypes = array_flip(self::buildOptions('type', 'validate'));
 
       // The option value values are stored as strings on the database, so we
@@ -204,6 +203,7 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDay extends CRM_HRLeaveAndAbsences_DAO_Work
     if(!in_array($type, $validTypes)) {
       throw new InvalidWorkDayException(
         'Invalid Work Day Type'
+        //'Invalid Work Day Type: ' . $type . 'The valid types are: '.implode(', ', $validTypes)
       );
     }
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkDay.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkDay.php
@@ -203,7 +203,6 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDay extends CRM_HRLeaveAndAbsences_DAO_Work
     if(!in_array($type, $validTypes)) {
       throw new InvalidWorkDayException(
         'Invalid Work Day Type'
-        //'Invalid Work Day Type: ' . $type . 'The valid types are: '.implode(', ', $validTypes)
       );
     }
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkDayTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkDayTest.php
@@ -12,6 +12,8 @@ use CRM_HRLeaveAndAbsences_Exception_InvalidWorkDayException as InvalidWorkDayEx
  */
 class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends BaseHeadlessTest {
 
+  use CRM_HRLeaveAndAbsences_WorkDayHelpersTrait;
+
   protected $workPattern = null;
   protected $workWeek = null;
 
@@ -313,11 +315,12 @@ class CRM_HRLeaveAndAbsences_BAO_WorkDayTest extends BaseHeadlessTest {
   }
 
   public function workDayTypeDataProvider() {
+    $workDayTypes = $this->getWorkDayTypes();
     return [
       [0, true],
-      [WorkDay::getWorkingDayTypeValue(), false],
-      [WorkDay::getNonWorkingDayTypeValue(), false],
-      [WorkDay::getWeekendTypeValue(), false],
+      [$workDayTypes['working_day']['value'], false],
+      [$workDayTypes['non_working_day']['value'], false],
+      [$workDayTypes['weekend']['value'], false],
       ['adasdsa', true],
       [rand(4, PHP_INT_MAX), true],
     ];

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
@@ -14,7 +14,6 @@ use CRM_HRLeaveAndAbsences_Factory_RequestNotificationTemplate as RequestNotific
  */
 class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
 
-  use CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait;
   use CRM_HRLeaveAndAbsences_LeaveManagerHelpersTrait;
   use CRM_HRLeaveAndAbsences_MailHelpersTrait;
 
@@ -29,9 +28,6 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
     $this->leaveContact = ContactFabricator::fabricateWithEmail([
       'first_name' => 'Staff1', 'last_name' => 'Staff1'], 'staffmember@dummysite.com'
     );
-
-    $this->leaveRequestStatuses = $this->getLeaveRequestStatuses();
-    $this->leaveRequestDayTypes = $this->getLeaveRequestDayTypes();
   }
 
   public function testGetRecipientEmailsReturnsCorrectlyWhenLeaveContactHasLeaveApprover() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/LeaveRequestNotificationTemplateTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/LeaveRequestNotificationTemplateTest.php
@@ -23,9 +23,6 @@ class CRM_HRLeaveAndAbsences_Mail_Template_LeaveRequestNotificationTemplateTest 
     CRM_Core_DAO::executeQuery('SET foreign_key_checks = 0;');
     $leaveRequestCommentService = new LeaveRequestCommentService();
     $this->leaveRequestNotificationTemplate = new LeaveRequestNotificationTemplate($leaveRequestCommentService);
-
-    $this->leaveRequestStatuses = $this->getLeaveRequestStatuses();
-    $this->leaveRequestDayTypes = $this->getLeaveRequestDayTypes();
   }
 
   public function testGetTemplateIDReturnsTheCorrectID() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/SicknessRequestNotificationTemplateTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/SicknessRequestNotificationTemplateTest.php
@@ -23,9 +23,6 @@ class CRM_HRLeaveAndAbsences_Mail_Template_SicknessRequestNotificationTemplateTe
     CRM_Core_DAO::executeQuery('SET foreign_key_checks = 0;');
     $leaveRequestCommentService = new LeaveRequestCommentService();
     $this->sicknessRequestNotificationTemplate = new SicknessRequestNotificationTemplate($leaveRequestCommentService);
-
-    $this->leaveRequestStatuses = $this->getLeaveRequestStatuses();
-    $this->leaveRequestDayTypes = $this->getLeaveRequestDayTypes();
   }
 
   public function testGetTemplateIDReturnsTheCorrectID() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/TOILRequestNotificationTemplateTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/Template/TOILRequestNotificationTemplateTest.php
@@ -23,9 +23,6 @@ class CRM_HRLeaveAndAbsences_Mail_Template_TOILRequestNotificationTemplateTest e
     CRM_Core_DAO::executeQuery('SET foreign_key_checks = 0;');
     $leaveRequestCommentService = new LeaveRequestCommentService();
     $this->toilRequestNotificationTemplate = new TOILRequestNotificationTemplate($leaveRequestCommentService);
-
-    $this->leaveRequestStatuses = $this->getLeaveRequestStatuses();
-    $this->leaveRequestDayTypes = $this->getLeaveRequestDayTypes();
   }
 
   public function testGetTemplateIDReturnsTheCorrectID() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -23,8 +23,6 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     $this->leaveContact = 1;
     $this->registerCurrentLoggedInContactInSession($this->leaveContact);
     CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
-
-    $this->leaveRequestStatuses = LeaveRequest::getStatuses();
   }
 
   public function testCanCreateAndUpdateForReturnsFalseWhenCurrentUserIsNotAnAdminOrLeaveManagerOrLeaveContact() {
@@ -170,38 +168,26 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     );
   }
 
-  public function testCanChangeAbsenceTypeForReturnsTrueWhenCurrentUserIsLeaveContactAndStatusPassedIsInAllowedStatuses() {
-    //When user is leave request contact and status is 'More information Required'
+  /**
+   * @dataProvider openLeaveRequestStatusesDataProvider
+   */
+  public function testCanChangeAbsenceTypeForReturnsTrueWhenCurrentUserIsLeaveContactAndTheLeaveRequestIsOpen($status) {
     $this->assertTrue(
       $this->getLeaveRightsService()->canChangeAbsenceTypeFor(
         $this->leaveContact,
-        $this->leaveRequestStatuses['more_information_required']
-      )
-    );
-
-    //When user is leave request contact and status is 'Awaiting Approval'
-    $this->assertTrue(
-      $this->getLeaveRightsService()->canChangeAbsenceTypeFor(
-        $this->leaveContact,
-        $this->leaveRequestStatuses['awaiting_approval']
+        $status
       )
     );
   }
 
-  public function testCanChangeAbsenceTypeForReturnsFalseWhenCurrentUserIsLeaveContactAndStatusPassedIsNotInAllowedStatuses() {
-    //When user is leave request contact and status is 'Approved'
+  /**
+   * @dataProvider approvedLeaveRequestStatusesDataProvider
+   */
+  public function testCanChangeAbsenceTypeForReturnsFalseWhenCurrentUserIsLeaveContactAndTheLeaveRequestIsApproved($status) {
     $this->assertFalse(
       $this->getLeaveRightsService()->canChangeAbsenceTypeFor(
         $this->leaveContact,
-        $this->leaveRequestStatuses['approved']
-      )
-    );
-
-    //When user is leave request contact and status is 'Admin Approved'
-    $this->assertFalse(
-      $this->getLeaveRightsService()->canChangeAbsenceTypeFor(
-        $this->leaveContact,
-        $this->leaveRequestStatuses['admin_approved']
+        $status
       )
     );
   }
@@ -251,12 +237,12 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     $leaveRequestStatuses =  $this->getLeaveRequestStatuses();
 
     return [
-      [$leaveRequestStatuses['more_information_required']['id']],
-      [$leaveRequestStatuses['awaiting_approval']['id']],
-      [$leaveRequestStatuses['cancelled']['id']],
-      [$leaveRequestStatuses['rejected']['id']],
-      [$leaveRequestStatuses['admin_approved']['id']],
-      [$leaveRequestStatuses['approved']['id']],
+      [$leaveRequestStatuses['more_information_required']],
+      [$leaveRequestStatuses['awaiting_approval']],
+      [$leaveRequestStatuses['cancelled']],
+      [$leaveRequestStatuses['rejected']],
+      [$leaveRequestStatuses['admin_approved']],
+      [$leaveRequestStatuses['approved']],
     ];
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -24,7 +24,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     $this->registerCurrentLoggedInContactInSession($this->leaveContact);
     CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
 
-    $this->leaveRequestStatuses = $this->getLeaveRequestStatuses();
+    $this->leaveRequestStatuses = LeaveRequest::getStatuses();
   }
 
   public function testCanCreateAndUpdateForReturnsFalseWhenCurrentUserIsNotAnAdminOrLeaveManagerOrLeaveContact() {
@@ -175,7 +175,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     $this->assertTrue(
       $this->getLeaveRightsService()->canChangeAbsenceTypeFor(
         $this->leaveContact,
-        $this->leaveRequestStatuses['more_information_required']['id']
+        $this->leaveRequestStatuses['more_information_required']
       )
     );
 
@@ -183,7 +183,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     $this->assertTrue(
       $this->getLeaveRightsService()->canChangeAbsenceTypeFor(
         $this->leaveContact,
-        $this->leaveRequestStatuses['awaiting_approval']['id']
+        $this->leaveRequestStatuses['awaiting_approval']
       )
     );
   }
@@ -193,7 +193,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     $this->assertFalse(
       $this->getLeaveRightsService()->canChangeAbsenceTypeFor(
         $this->leaveContact,
-        $this->leaveRequestStatuses['approved']['id']
+        $this->leaveRequestStatuses['approved']
       )
     );
 
@@ -201,7 +201,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     $this->assertFalse(
       $this->getLeaveRightsService()->canChangeAbsenceTypeFor(
         $this->leaveContact,
-        $this->leaveRequestStatuses['admin_approved']['id']
+        $this->leaveRequestStatuses['admin_approved']
       )
     );
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrixTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrixTest.php
@@ -170,7 +170,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrixTest extends BaseHe
   }
 
   public function allPossibleStatusTransitionForStaffDataProvider() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = $this->getLeaveRequestStatuses();
 
     return [
       [$leaveRequestStatuses['awaiting_approval'], $leaveRequestStatuses['awaiting_approval']],
@@ -183,7 +183,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrixTest extends BaseHe
   }
 
   public function allNonPossibleStatusTransitionForStaffDataProvider() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = $this->getLeaveRequestStatuses();
 
     return [
       [$leaveRequestStatuses['awaiting_approval'], $leaveRequestStatuses['more_information_required']],
@@ -214,7 +214,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrixTest extends BaseHe
   }
 
   public function allPossibleStatusTransitionForLeaveApprover() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = $this->getLeaveRequestStatuses();
 
     return [
       [$leaveRequestStatuses['awaiting_approval'], $leaveRequestStatuses['more_information_required']],
@@ -244,7 +244,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrixTest extends BaseHe
   }
 
   public function allNonPossibleStatusTransitionForLeaveApprover() {
-    $leaveRequestStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
+    $leaveRequestStatuses = $this->getLeaveRequestStatuses();
 
     return [
       [$leaveRequestStatuses['awaiting_approval'], $leaveRequestStatuses['awaiting_approval']],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -38,7 +38,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     $this->registerCurrentLoggedInContactInSession($this->leaveContact);
     CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
 
-    $this->leaveRequestStatuses = $this->getLeaveRequestStatuses();
+    $this->leaveRequestStatuses = LeaveRequest::getStatuses();
   }
 
   public function testCreateAlsoCreateTheLeaveRequestBalanceChanges() {
@@ -164,11 +164,11 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
 
     $this->setExpectedException(
       'RuntimeException', "You can't change the Leave Request status from ".
-      $this->getDefaultParams()['status_id']. " to {$this->leaveRequestStatuses['awaiting_approval']['id']}"
+      $this->getDefaultParams()['status_id']. " to {$this->leaveRequestStatuses['awaiting_approval']}"
     );
 
     $params['id'] = $leaveRequest->id;
-    $params['status_id'] = $this->leaveRequestStatuses['awaiting_approval']['id'];
+    $params['status_id'] = $this->leaveRequestStatuses['awaiting_approval'];
 
     $this->getLeaveRequestServiceWhenStatusTransitionIsNotAllowed()->create($params, false);
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -37,8 +37,6 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     $this->leaveContact = 1;
     $this->registerCurrentLoggedInContactInSession($this->leaveContact);
     CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
-
-    $this->leaveRequestStatuses = LeaveRequest::getStatuses();
   }
 
   public function testCreateAlsoCreateTheLeaveRequestBalanceChanges() {
@@ -161,14 +159,15 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
   public function testCreateThrowsAnExceptionWhenTransitionStatusIsNotValidWhenUpdatingLeaveRequestStatus() {
     $params = $this->getDefaultParams();
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $this->setExpectedException(
       'RuntimeException', "You can't change the Leave Request status from ".
-      $this->getDefaultParams()['status_id']. " to {$this->leaveRequestStatuses['awaiting_approval']}"
+      $this->getDefaultParams()['status_id']. " to {$leaveRequestStatuses['awaiting_approval']}"
     );
 
     $params['id'] = $leaveRequest->id;
-    $params['status_id'] = $this->leaveRequestStatuses['awaiting_approval'];
+    $params['status_id'] = $leaveRequestStatuses['awaiting_approval'];
 
     $this->getLeaveRequestServiceWhenStatusTransitionIsNotAllowed()->create($params, false);
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
@@ -1,5 +1,5 @@
 <?php
-
+define('CIVICRM_CONTAINER_CACHE', 'never');
 ini_set('memory_limit', '2G');
 ini_set('safe_mode', 0);
 eval(cv('php:boot --level=full -t', 'phpcode'));

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
@@ -1,11 +1,12 @@
 <?php
+
 define('CIVICRM_CONTAINER_CACHE', 'never');
+//This will redirect all mails to the database.
+define('CIVICRM_MAILER_SPOOL', 1);
+
 ini_set('memory_limit', '2G');
 ini_set('safe_mode', 0);
 eval(cv('php:boot --level=full -t', 'phpcode'));
-
-//This will redirect all mails to the database.
-define('CIVICRM_MAILER_SPOOL', 1);
 
 require_once 'BaseHeadlessTest.php';
 require_once 'helpers/OptionGroupHelpersTrait.php';

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
@@ -18,6 +18,7 @@ require_once 'helpers/SessionHelpersTrait.php';
 require_once 'helpers/LeaveRequestStatusMatrixHelpersTrait.php';
 require_once 'helpers/ApiHelpersTrait.php';
 require_once 'helpers/MailHelpersTrait.php';
+require_once 'helpers/WorkDayHelpersTest.php';
 
 /**
  * Call the "cv" command.

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
@@ -8,6 +8,7 @@ eval(cv('php:boot --level=full -t', 'phpcode'));
 define('CIVICRM_MAILER_SPOOL', 1);
 
 require_once 'BaseHeadlessTest.php';
+require_once 'helpers/OptionGroupHelpersTrait.php';
 require_once 'helpers/ContractHelpersTrait.php';
 require_once 'helpers/LeaveBalanceChangeHelpersTrait.php';
 require_once 'helpers/LeavePeriodEntitlementHelpersTrait.php';

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestHelpersTrait.php
@@ -31,10 +31,7 @@ trait CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait {
       foreach($leaveRequestStatusOptions  as $key => $label) {
         $name = CRM_Core_Pseudoconstant::getName(LeaveRequest::class, 'status_id', $key);
         $this->leaveRequestStatuses[$name] = [
-          'id' => $key,
-          'value' => $key,
-          'name' => $name,
-          'label' => $label
+          'id' => $key
         ];
       }
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestHelpersTrait.php
@@ -5,20 +5,17 @@ use CRM_HRLeaveAndAbsences_Service_LeaveRequestComment as LeaveRequestCommentSer
 
 trait CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait {
 
+  use CRM_HRLeaveAndAbsences_OptionGroupHelpersTrait;
+
   protected $leaveRequestDayTypes = [];
   protected $leaveRequestStatuses = [];
 
   protected function getLeaveRequestDayTypes() {
     if(empty($this->leaveRequestDayTypes)) {
-      $leaveRequestDayTypeOptions = LeaveRequest::buildOptions('from_date_type');
-      foreach($leaveRequestDayTypeOptions  as $key => $label) {
-        $name = CRM_Core_Pseudoconstant::getName(LeaveRequest::class, 'from_date_type', $key);
-        $this->leaveRequestDayTypes[$name] = [
-          'id' => $key,
-          'value' => $key,
-          'name' => $name,
-          'label' => $label
-        ];
+      $leaveRequestDayTypeOptions = $this->getLeaveDayTypesFromXML();
+      foreach($leaveRequestDayTypeOptions  as $option) {
+        $this->leaveRequestDayTypes[$option['name']] = $option;
+        $this->leaveRequestDayTypes[$option['name']]['id'] = $option['value'];
       }
     }
 
@@ -26,14 +23,14 @@ trait CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait {
   }
 
   protected function getLeaveRequestStatuses() {
-    return [
-      'approved' => 1,
-      'admin_approved' => 2,
-      'awaiting_approval' => 3,
-      'more_information_required' => 4,
-      'rejected' => 5,
-      'cancelled' => 6,
-    ];
+    if(empty($this->leaveRequestStatuses)) {
+      $leaveRequestStatusOptions = $this->getLeaveRequestStatusesFromXML();
+      foreach($leaveRequestStatusOptions  as $option) {
+        $this->leaveRequestStatuses[$option['name']] = $option['value'];
+      }
+    }
+
+    return $this->leaveRequestStatuses;
   }
 
   public function openLeaveRequestStatusesDataProvider() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestHelpersTrait.php
@@ -26,17 +26,14 @@ trait CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait {
   }
 
   protected function getLeaveRequestStatuses() {
-    if(empty($this->leaveRequestStatuses)) {
-      $leaveRequestStatusOptions = LeaveRequest::buildOptions('status_id');
-      foreach($leaveRequestStatusOptions  as $key => $label) {
-        $name = CRM_Core_Pseudoconstant::getName(LeaveRequest::class, 'status_id', $key);
-        $this->leaveRequestStatuses[$name] = [
-          'id' => $key
-        ];
-      }
-    }
-
-    return $this->leaveRequestStatuses;
+    return [
+      'approved' => ['id' => 1],
+      'admin_approved' => ['id' => 2],
+      'awaiting_approval' => ['id' => 3],
+      'more_information_required' => ['id' => 4],
+      'rejected' => ['id' => 5],
+      'cancelled' => ['id' => 6],
+    ];
   }
 
   public function openLeaveRequestStatusesDataProvider() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestHelpersTrait.php
@@ -53,6 +53,15 @@ trait CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait {
     ];
   }
 
+  public function approvedLeaveRequestStatusesDataProvider() {
+    $leaveRequestStatuses = $this->getLeaveRequestStatuses();
+
+    return [
+      [$leaveRequestStatuses['admin_approved']],
+      [$leaveRequestStatuses['approved']],
+    ];
+  }
+
   protected function createAttachmentForLeaveRequest($params) {
     $defaultParams = [
       'entity_table' => LeaveRequest::getTableName(),

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveRequestHelpersTrait.php
@@ -27,12 +27,12 @@ trait CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait {
 
   protected function getLeaveRequestStatuses() {
     return [
-      'approved' => ['id' => 1],
-      'admin_approved' => ['id' => 2],
-      'awaiting_approval' => ['id' => 3],
-      'more_information_required' => ['id' => 4],
-      'rejected' => ['id' => 5],
-      'cancelled' => ['id' => 6],
+      'approved' => 1,
+      'admin_approved' => 2,
+      'awaiting_approval' => 3,
+      'more_information_required' => 4,
+      'rejected' => 5,
+      'cancelled' => 6,
     ];
   }
 
@@ -40,8 +40,8 @@ trait CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait {
     $leaveRequestStatuses = $this->getLeaveRequestStatuses();
 
     return [
-      [$leaveRequestStatuses['more_information_required']['id']],
-      [$leaveRequestStatuses['awaiting_approval']['id']],
+      [$leaveRequestStatuses['more_information_required']],
+      [$leaveRequestStatuses['awaiting_approval']],
     ];
   }
 
@@ -49,10 +49,10 @@ trait CRM_HRLeaveAndAbsences_LeaveRequestHelpersTrait {
     $leaveRequestStatuses = $this->getLeaveRequestStatuses();
 
     return [
-      [$leaveRequestStatuses['cancelled']['id']],
-      [$leaveRequestStatuses['rejected']['id']],
-      [$leaveRequestStatuses['admin_approved']['id']],
-      [$leaveRequestStatuses['approved']['id']],
+      [$leaveRequestStatuses['cancelled']],
+      [$leaveRequestStatuses['rejected']],
+      [$leaveRequestStatuses['admin_approved']],
+      [$leaveRequestStatuses['approved']],
     ];
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/OptionGroupHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/OptionGroupHelpersTrait.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This is a helper that loads Option Values from XML files instead of the
+ * database.
+ *
+ * Why do we need this? Before running any actual code, PHPUnit reads all the
+ * test files looking for test methods and data providers available. For data
+ * providers, it also calls the method in order to cache the provided data. At
+ * the moment this happens, Civi hasn't been initialized yet, and Option Groups
+ * created during the extension's installation won't be available in the
+ * database, effectively meaning that data providers cannot use such Option
+ * Groups. To work around this problem, the helper methods in this trait can
+ * be used to load the option values directly from the XML files used during
+ * the installation.
+ */
+trait CRM_HRLeaveAndAbsences_OptionGroupHelpersTrait {
+
+  public function getLeaveRequestStatusesFromXML() {
+    return $this->getOptionValuesFromXML('leave_request_status_install.xml');
+  }
+
+  public function getLeaveDayTypesFromXML() {
+    return $this->getOptionValuesFromXML('leave_request_day_type_install.xml');
+  }
+
+  public function getWorkDayTypesFromXML() {
+    return $this->getOptionValuesFromXML('work_day_type_install.xml');
+  }
+
+  /**
+   * This methods parses the given Option Group XML and returns a list of
+   * Option Values contained in it.
+   *
+   * Important note: It assumes that the XML represents a single Option Group,
+   * and that all the Option Values in belong to the same Group.
+   *
+   * @param $xml
+   *   The name of a file inside the xml/option_groups folder
+   *
+   * @return array
+   *   An array following the same OptionValues structure of the given XML
+   */
+  public function getOptionValuesFromXML($xml) {
+    $mapper = CRM_Extension_System::singleton()->getManager()->mapper;
+    $extPath = $mapper->keyToBasePath('uk.co.compucorp.civicrm.hrleaveandabsences');
+    $xmlFullPath = "{$extPath}/xml/option_groups/{$xml}";
+
+    $optionValues = [];
+
+    $xml = new DOMDocument();
+    $xml->load($xmlFullPath);
+    $xmlOptionValues = $xml->getElementsByTagName('OptionValue');
+    foreach($xmlOptionValues as $xmlOptionValue) {
+      $optionValue = [];
+
+      foreach($xmlOptionValue->childNodes as $node) {
+        if($node->nodeType == XML_ELEMENT_NODE) {
+          $optionValue[$node->nodeName] = $node->nodeValue;
+        }
+      }
+
+      if(!empty($optionValue)) {
+        $optionValues[] = $optionValue;
+      }
+    }
+
+    return $optionValues;
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/OptionGroupHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/OptionGroupHelpersTrait.php
@@ -35,7 +35,7 @@ trait CRM_HRLeaveAndAbsences_OptionGroupHelpersTrait {
    * Important note: It assumes that the XML represents a single Option Group,
    * and that all the Option Values in belong to the same Group.
    *
-   * @param $xml
+   * @param string $xml
    *   The name of a file inside the xml/option_groups folder
    *
    * @return array

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/WorkDayHelpersTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/WorkDayHelpersTest.php
@@ -1,0 +1,17 @@
+<?php
+
+trait CRM_HRLeaveAndAbsences_WorkDayHelpersTrait {
+
+  use CRM_HRLeaveAndAbsences_OptionGroupHelpersTrait;
+
+  protected function getWorkDayTypes() {
+    $optionValues = $this->getWorkDayTypesFromXML();
+    $workDayTypes = [];
+    foreach($optionValues as $optionValue) {
+      $workDayTypes[$optionValue['name']] = $optionValue;
+    }
+
+    return $workDayTypes;
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR fixes several errors while running the L&A tests with Jenkins. There were different types of errors, but almost all of them happened only the first time the tests were executed on a brand new site (which is exactly what Jenkins does). The only exception was with a set of tests around Leave Request attachments, that failed because the test site didn't have the attachments patch applied.

## Before
This is the situation before the fixes:

![captura de tela de 2017-10-23 09-38-53](https://user-images.githubusercontent.com/388373/31887200-34c09ca6-b7d6-11e7-8e27-96f7ab5b7ddf.png)

## After

All the tests are passing:

![captura de tela de 2017-10-23 10-17-42](https://user-images.githubusercontent.com/388373/31888567-7266637e-b7db-11e7-95fb-a6f42c43ab57.png)

Please check the next section for details on the problems and the solutions that were applied.

## Technical Details

As previously mentioned, there were different types of errors. Here is a list of them, and the solutions that were applied:

#### Attachments tests

There are a number of tests in this extension that requires changes in CiviCRM core related to attachments. I've sent PRs to core for these, but they've not been merged yet, as they still require some work. In the meantime, we've been using a patch to apply those changes in our sites. The site created by Jenkins didn't have this patch and the tests were failing. 

**Solution**: Update the Jenkins file with commands to apply the patch. With this change, now that staging is CiviHR 1.7, I've also updated it to use the hr17 build type, rather than hr16.

#### Tests failing because of data providers using option groups

The `LeaveRequestHelpers` trait, provided some methods to quickly get a list of option values for Leave Request statuses. Some tests were using these methods as PHPUnit data providers. Unfortunately, in order to cache things, PHPUnit calls the dataProviders way before actually running the tests, at a point where the CiviCRM environment isn't properly set and the Option Groups haven't been stored in the database yet. This resulted in Data Providers returning invalid values (`null`) that made the tests fail.

Note: This only happens when we run the extension the first time. On a second run, since the environment is the same (that is, the environment set by the `setUpHeadless()` method), civi won't reset the database and the Option Values will be there, making the data providers work just fine.

**Solution**: I've updated the trait methods to load data from the Option Group XMLs instead of the database. I've also checked all the tests that were using those methods to make sure if they're really necessary. Where it wasn't, I replace the helper methods calls to a call for `LeaveRequest::getStatuses()` instead.

#### Tests failing because of a missing `hrleaveandabsences.settings_manager` service

The extension defines a service that encapsulates some logic to return a different Settings Manager during the tests (an in-memory one, to speed things up). This service was exposed using the CiviCRM container, which is normally heavily cached. The problem happened because, when we run the tests, Civi loads the cached container created during the tests execution of the previous extension, which didn't include the necessary service and the tests would fail.

Note: This also only happens the first time we run the extension tests. The next time, the container cache would have been updated (when the L&A extension is installed during the `setupHeadless()` call) and the tests will pass.

**Solution**: The `CIVICRM_CONTAINER_CACHE` constant was defined to `never` when runnint the L&A tests. This way, we always force it to start from a clean state.