### PR TITLE
PCHR-2625: Add sub menu to Leave menu item

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
@@ -12,6 +12,7 @@ class CRM_HRLeaveAndAbsences_Upgrader extends CRM_HRLeaveAndAbsences_Upgrader_Ba
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1004;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1005;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1006;
+  use CRM_HRLeaveAndAbsences_Upgrader_Step_1007;
 
   /**
    * A list of directories to be scanned for XML installation files

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1007.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1007.php
@@ -1,0 +1,68 @@
+<?php
+
+use CRM_Core_BAO_SchemaHandler as SchemaHandler;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
+
+trait CRM_HRLeaveAndAbsences_Upgrader_Step_1007 {
+
+  /**
+   * Removes the url of the "Leave" menu item and adds a sub menu to it
+   *
+   * @return bool
+   */
+  public function upgrade_1007() {
+    $default = [];
+    $menuItemParams = ['name' => 'leave_and_absences_dashboard'];
+    $menuItem = CRM_Core_BAO_Navigation::retrieve($menuItemParams, $default);
+
+    $this->up1007_clearMenuItemUrl($menuItem);
+    $this->up1007_addSubMenuToMenuItem($menuItem);
+
+    CRM_Core_BAO_Navigation::resetNavigation();
+
+    return TRUE;
+  }
+
+  /**
+   * Removes the url of the given menu item
+   *
+   * @param CRM_Core_BAO_Navigation $menuItem
+   */
+  private function up1007_clearMenuItemUrl(&$menuItem) {
+    $menuItem->url = 'NULL';
+    $menuItem->save();
+  }
+
+  /**
+   * Adds the leave sub menu items to the given menu item
+   *
+   * @param CRM_Core_BAO_Navigation $menuItem
+   */
+  private function up1007_addSubMenuToMenuItem($menuItem) {
+    $subMenu = [
+      [
+        'label' => ts('Leave Requests'),
+        'name' => 'leave_and_absences_leave_requests',
+        'url' => 'civicrm/leaveandabsences/dashboard#/requests',
+      ],
+      [
+        'label' => ts('Leave Calendar'),
+        'name' => 'leave_and_absences_leave_calendar',
+        'url' => 'civicrm/leaveandabsences/dashboard#/calendar',
+      ],
+      [
+        'label' => ts('Leave Balances'),
+        'name' => 'leave_and_absences_leave_balances',
+        'url' => 'civicrm/leaveandabsences/dashboard#/balance-report',
+      ]
+    ];
+
+    foreach ($subMenu as $key => $subMenuItem) {
+      $subMenuItem['parent_id'] = $menuItem->id;
+      $subMenuItem['weight'] = $key;
+      $subMenuItem['is_active'] = 1;
+
+      CRM_Core_BAO_Navigation::add($subMenuItem);
+    }
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1007.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1007.php
@@ -58,11 +58,29 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1007 {
     ];
 
     foreach ($subMenu as $key => $subMenuItem) {
+      if ($this->up1007_doesMenuItemExist($subMenuItem['name'])) {
+        continue;
+      }
+
       $subMenuItem['parent_id'] = $menuItem->id;
       $subMenuItem['weight'] = $key;
       $subMenuItem['is_active'] = 1;
 
       CRM_Core_BAO_Navigation::add($subMenuItem);
     }
+  }
+
+  /**
+   * Checks if the menu item with the given name already exists
+   *
+   * @param string $subMenuItem
+   *
+   * @return bool
+   */
+  private function up1007_doesMenuItemExist($subMenuItemName) {
+    $default = [];
+    $subMenuItemParams = ['name' => $subMenuItemName];
+
+    return CRM_Core_BAO_Navigation::retrieve($subMenuItemParams, $default) != NULL;
   }
 }


### PR DESCRIPTION
## Overview
This PR adds an upgrader to the L&A extension in order to remove the direct link of the "Leave" menu item in the admin, and to add instead a sub menu to it

## Before
The "Leave" menu item is a simple directly link to /civicrm/leaveandabsences/dashboard

## After
The "Leave" menu item is now a toggle for a sub menu, containing items pointing to the individual sections of the L&A admin

<img width="200" alt="after" src="https://user-images.githubusercontent.com/6400898/31959879-4ad13f98-b8f6-11e7-85e0-1d313a2a0955.png">