### PR TITLE
PCHR-2626: Add 'Access CiviCRM developer menu and tools' permission

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -236,6 +236,17 @@ function hrcore_civicrm_navigationMenu(&$params) {
 }
 
 /**
+ * Implements hook_civicrm_permission().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/
+ */
+function hrcore_civicrm_permission(&$permissions) {
+  $permissions += [
+    'access CiviCRM developer menu and tools' => ts('Access CiviCRM developer menu and tools')
+  ];
+}
+
+/**
  * Renames a menu with the given new label
  *
  * @param array $params


### PR DESCRIPTION
This PR adds the "Access CiviCRM developer menu and tools" permission to the set of available permissions in CiviHR, which will then be later used to decide whether to allow the user to see developer-related pages