### PR TITLE
PCHR-2627: Use developer permission on developer menu and paths

### DIFF
--- a/hrui/hrui.php
+++ b/hrui/hrui.php
@@ -590,6 +590,17 @@ function hrui_civicrm_managed(&$entities) {
 }
 
 /**
+ * Implements hook_civicrm_alterMenu().
+ *
+ * @param Array $items List of http routes
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterMenu
+ */
+function hrui_civicrm_alterMenu(&$items) {
+  $items['civicrm/api']['access_arguments'] =[['access CiviCRM', 'access CiviCRM developer menu and tools'], "and"];
+  $items['civicrm/styleguide']['access_arguments'] =[['access CiviCRM', 'access CiviCRM developer menu and tools'], "and"];
+}
+
+/**
  * Implements hook_civicrm_navigationMenu().
  *
  * @param Array $params List of menu items

--- a/hrui/hrui.php
+++ b/hrui/hrui.php
@@ -997,28 +997,32 @@ function _hrui_createHelpMenu(&$menu) {
 function _hrui_createDeveloperMenu(&$menu) {
   _hrui_civix_insert_navigation_menu($menu, '', [
     'name' => ts('Developer'),
-    'permission' => 'access CiviCRM'
+    'permission' => 'access CiviCRM,access CiviCRM developer menu and tools',
+    'operator' => 'AND'
   ]);
 
   _hrui_civix_insert_navigation_menu($menu, 'Developer', [
     'name' => ts('API Explorer'),
     'url' => 'civicrm/api',
     'target' => '_blank',
-    'permission' => 'access CiviCRM'
+    'permission' => 'access CiviCRM,access CiviCRM developer menu and tools',
+    'operator' => 'AND'
   ]);
 
   _hrui_civix_insert_navigation_menu($menu, 'Developer', [
     'name' => ts('Developer Docs'),
     'target' => '_blank',
     'url' => 'https://civihr.atlassian.net/wiki/spaces/CIV/pages',
-    'permission' => 'access CiviCRM'
+    'permission' => 'access CiviCRM,access CiviCRM developer menu and tools',
+    'operator' => 'AND'
   ]);
 
   _hrui_civix_insert_navigation_menu($menu, 'Developer', [
     'name' => ts('Style Guide'),
     'target' => '_blank',
     'url' => 'https://www.civihr.org/support',
-    'permission' => 'access CiviCRM'
+    'permission' => 'access CiviCRM,access CiviCRM developer menu and tools',
+    'operator' => 'AND'
   ]);
 
   // Adds sub menu under Style Guide menu
@@ -1027,7 +1031,8 @@ function _hrui_createDeveloperMenu(&$menu) {
       'label' => $styleGuide['label'],
       'name' => $styleGuide['name'],
       'url' => 'civicrm/styleguide/' . $styleGuide['name'],
-      'permission' => 'access CiviCRM',
+      'permission' => 'access CiviCRM,access CiviCRM developer menu and tools',
+      'operator' => 'AND'
     ]);
   }
 }


### PR DESCRIPTION
This PR adds a new permission checks on the Developer's menu items and paths. Those can now be accessed only by users with the "access CiviCRM" and "access CiviCRM developer menu and tools" permissions
