### PR TITLE
PCHR-2630: Remove user guide menu from user menu dropdown

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/UserMenuMarkup.tpl
+++ b/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/UserMenuMarkup.tpl
@@ -16,11 +16,6 @@
         </a>
       </li>
       <li>
-        <a href="http://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/" target="_blank">
-          <i class="fa fa-book"></i>{ts}User guide{/ts}
-        </a>
-      </li>
-      <li>
         <a href="{$logoutLink}">
           <i class="fa fa-sign-out"></i>{ts}Log Out{/ts}
         </a>


### PR DESCRIPTION
## Overview
The user menu, which is now the same component used both in the SSP and in the admin, contained an item called "User Guide" pointing [here](http://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/)

Given that now the SSP will have a separate "Help" menu item (see [here](https://github.com/compucorp/civihr-employee-portal/pull/375)), the "User Guide" item can be safely removed

## Before
_(The screenshot is from the admin, but it's the same also in the SSP)_
<img width="250" alt="before" src="https://user-images.githubusercontent.com/6400898/32009546-b73e2376-b9af-11e7-8563-07ed2c669b17.png">

## After
<img width="250" alt="after" src="https://user-images.githubusercontent.com/6400898/32009545-b6f55cfe-b9af-11e7-9711-9718b9b8ecff.png">