### PR TITLE
PCHR-2765:  Fix issues with creating entitlements

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
@@ -800,8 +800,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
    * @param CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement $leavePeriodEntitlement
    */
   private static function logChanges(LeavePeriodEntitlement $leavePeriodEntitlement) {
-    $editorId = !empty($leavePeriodEntitlement->editor_id) ?: CRM_Core_Session::getLoggedInContactID();
-    $createdDate = !empty($leavePeriodEntitlement->created_date) ?: date('YmdHis');
+    $editorId = $leavePeriodEntitlement->editor_id ?: CRM_Core_Session::getLoggedInContactID();
+    $createdDate = $leavePeriodEntitlement->created_date ?: date('YmdHis');
 
     LeavePeriodEntitlementLog::create([
       'entitlement_id' => $leavePeriodEntitlement->id,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_uninstall.sql
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/sql/auto_uninstall.sql
@@ -2,6 +2,7 @@ DROP TABLE IF EXISTS `civicrm_hrleaveandabsences_contact_work_pattern`;
 DROP TABLE IF EXISTS `civicrm_hrleaveandabsences_leave_request_date`;
 DROP TABLE IF EXISTS `civicrm_hrleaveandabsences_leave_request`;
 DROP TABLE IF EXISTS `civicrm_hrleaveandabsences_leave_balance_change`;
+DROP TABLE IF EXISTS `civicrm_hrleaveandabsences_leave_period_entitlement_log`;
 DROP TABLE IF EXISTS `civicrm_hrleaveandabsences_leave_period_entitlement`;
 DROP TABLE IF EXISTS `civicrm_hrleaveandabsences_notification_receiver`;
 DROP TABLE IF EXISTS `civicrm_hrleaveandabsences_absence_type`;


### PR DESCRIPTION
## Overview
This PR fixes an issue encountered when saving a Leave Period Entitlement. When the changes for the entitlement is to be logged in the Entitlement Log table an error is thrown on the screen.

## Before
The db error thrown is as a result of wrong values being inserted for the created_date column of the Leave Period Entitlement Log table.
The following lines of code was causing the `$editor` and `$createdDate` to evaluate to `1` whenever $leavePeriodEntitlement->editor_id and $leavePeriodEntitlement->created_date is not empty.
```php
    $editorId = !empty($leavePeriodEntitlement->editor_id) ?: CRM_Core_Session::getLoggedInContactID();
    $createdDate = !empty($leavePeriodEntitlement->created_date) ?: date('YmdHis');
```
The value of `1` being inserted into the `created_date` column which is a DATETIME type is what was causing the errors thrown.
## After
The code was fixed with the `empty` function removed since the `?:` already checks for empty.

## Comments
- This PR also adds the `civicrm_hrleaveandabsences_leave_period_entitlement_log` as one of the tables to be removed when L&A extension is uninstalled.
