### PR TITLE
PCHR-2834: Create LeaveRequest.getWorkDayForDate API

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -516,18 +516,21 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
    *  The LeaveRequest which the $date belongs to
    * @param \DateTime $date
    * @param CRM_HRLeaveAndAbsences_Service_LeaveDateAmountDeduction $dateDeduction
+   * @param CRM_HRLeaveAndAbsences_Service_ContactWorkPattern $contactWorkPatternService
    *
    * @return float
    */
-  public static function calculateAmountForDate(LeaveRequest $leaveRequest, DateTime $date, LeaveDateAmountDeduction $dateDeduction) {
-    $workPattern = ContactWorkPattern::getWorkPattern($leaveRequest->contact_id, $date);
-    $startDate = ContactWorkPattern::getStartDate($leaveRequest->contact_id, $date);
+  public static function calculateAmountForDate
+  (LeaveRequest $leaveRequest,
+   DateTime $date,
+   LeaveDateAmountDeduction $dateDeduction,
+   $contactWorkPatternService
+  ) {
+    $workDay = $contactWorkPatternService->getContactWorkDayForDate($leaveRequest->contact_id, $date);
 
-    if(!$workPattern || !$startDate) {
+    if(is_null($workDay)) {
       return 0.0;
     }
-
-    $workDay = $workPattern->getWorkDayForDate($date, $startDate);
 
     return $dateDeduction->calculate($date, $workDay, $leaveRequest) * -1;
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -520,11 +520,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
    *
    * @return float
    */
-  public static function calculateAmountForDate
-  (LeaveRequest $leaveRequest,
-   DateTime $date,
-   LeaveDateAmountDeduction $dateDeduction,
-   $contactWorkPatternService
+  public static function calculateAmountForDate(
+    LeaveRequest $leaveRequest,
+    DateTime $date,
+    LeaveDateAmountDeduction $dateDeduction,
+    $contactWorkPatternService
   ) {
     $workDay = $contactWorkPatternService->getContactWorkDayForDate($leaveRequest->contact_id, $date);
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -13,6 +13,7 @@ use CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException as InvalidLeav
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_Hrjobcontract_BAO_HRJobContract as JobContract;
 use CRM_HRLeaveAndAbsences_Factory_LeaveDateAmountDeduction as LeaveDateAmountDeductionFactory;
+use CRM_HRLeaveAndAbsences_Service_ContactWorkPattern as ContactWorkPatternService;
 
 class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO_LeaveRequest {
 
@@ -971,6 +972,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
 
     $isCalculationUnitInHours = AbsenceType::isCalculationUnitInHours($leaveRequest->type_id);
     $dateDeductionService = LeaveDateAmountDeductionFactory::createForAbsenceType($leaveRequest->type_id);
+    $contactWorkPatternService = new ContactWorkPatternService();
 
     foreach ($datePeriod as $date) {
       if($excludeStartAndEndDates) {
@@ -988,7 +990,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
       if(!$publicHolidayLeaveRequestExists){
         $type = ContactWorkPattern::getWorkDayType($contactId, $date);
         $dayType = self::getLeaveRequestDayTypeFromWorkDayType($type);
-        $amount = LeaveBalanceChange::calculateAmountForDate($leaveRequest, $date, $dateDeductionService);
+        $amount = LeaveBalanceChange::calculateAmountForDate(
+          $leaveRequest,
+          $date,
+          $dateDeductionService,
+          $contactWorkPatternService
+        );
 
         if(!$isCalculationUnitInHours) {
           if($amount == -0.5) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/ContactWorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/ContactWorkPattern.php
@@ -1,0 +1,35 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern as ContactWorkPattern;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Service_ContactWorkPattern
+ */
+class CRM_HRLeaveAndAbsences_Service_ContactWorkPattern {
+
+
+  /**
+   * Returns the WorkDay information for a given date for the
+   * contact based on the Contact's Work pattern.
+   *
+   * Returns null when no work day can be found for the contact,
+   * either due to the absence of a default work pattern or a
+   * custom work pattern for the contact or even due to the fact
+   * that the contact has no contract.
+   *
+   * @param int $contactID
+   * @param \DateTime $date
+   *
+   * @return array|null
+   */
+  public function getContactWorkDayForDate($contactID, DateTime $date) {
+    $workPattern = ContactWorkPattern::getWorkPattern($contactID, $date);
+    $startDate = ContactWorkPattern::getStartDate($contactID, $date);
+
+    if(!$workPattern->id || !$startDate) {
+      return null;
+    }
+
+    return $workPattern->getWorkDayForDate($date, $startDate);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChange.php
@@ -122,6 +122,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange {
       $leaveRequest,
       $date,
       $dateDeductionFactory,
-      $contactWorkPatternService);
+      $contactWorkPatternService
+    );
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveBalanceChange.php
@@ -3,6 +3,7 @@
 use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_Factory_LeaveDateAmountDeduction as LeaveDateAmountDeductionFactory;
+use CRM_HRLeaveAndAbsences_Service_ContactWorkPattern as ContactWorkPatternService;
 
 class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange {
 
@@ -116,6 +117,11 @@ class CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange {
    */
   public function calculateAmountToBeDeductedForDate(LeaveRequest $leaveRequest, DateTime $date) {
     $dateDeductionFactory = LeaveDateAmountDeductionFactory::createForAbsenceType($leaveRequest->type_id);
-    return LeaveBalanceChange::calculateAmountForDate($leaveRequest, $date, $dateDeductionFactory);
+    $contactWorkPatternService = new ContactWorkPatternService();
+    return LeaveBalanceChange::calculateAmountForDate(
+      $leaveRequest,
+      $date,
+      $dateDeductionFactory,
+      $contactWorkPatternService);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
@@ -7,6 +7,7 @@ use CRM_HRLeaveAndAbsences_Service_JobContract as JobContractService;
 use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
 use CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern as ContactWorkPattern;
 use CRM_HRLeaveAndAbsences_Factory_LeaveDateAmountDeduction as LeaveDateAmountDeductionFactory;
+use CRM_HRLeaveAndAbsences_Service_ContactWorkPattern as ContactWorkPatternService;
 
 class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion {
 
@@ -121,12 +122,14 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion {
   private function recalculateDeductionForOverlappingLeaveRequestDate(LeaveRequest $leaveRequest, DateTime $date) {
     $leaveBalanceChange = LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $date);
     $dateDeductionFactory = LeaveDateAmountDeductionFactory::createForAbsenceType($leaveRequest->type_id);
+    $contactWorkPatternService = new ContactWorkPatternService();
 
     if($leaveBalanceChange) {
       $deduction = LeaveBalanceChange::calculateAmountForDate(
         $leaveRequest,
         $date,
-        $dateDeductionFactory
+        $dateDeductionFactory,
+        $contactWorkPatternService
       );
 
       LeaveBalanceChange::create([

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/WorkPattern.php
@@ -19,6 +19,15 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
     return WorkPattern::create($params);
   }
 
+  public static function getWeekFor40HourWorkWeek() {
+    $workWeek = self::get40HoursWeekParams();
+    return array_shift($workWeek);
+  }
+
+  public static function getWeekForTwoWeeksAnd31AndHalfHours() {
+    return self::getTwoWeeksWith31AndHalfHoursParams();
+  }
+
   public static function fabricateWithTwoWeeksAnd31AndHalfHours($params = []) {
     $params = array_merge(self::getDefaultParams(), $params);
     $params['weeks'] = self::getTwoWeeksWith31AndHalfHoursParams();
@@ -44,7 +53,7 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
       'days' => [
         [
           'type' => WorkDay::getWorkingDayTypeValue(),
-          'day_of_week' => 1,
+          'day_of_the_week' => 1,
           'time_from' => '09:00',
           'time_to' => '18:00',
           'break' => 1,
@@ -53,7 +62,7 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
         ],
         [
           'type' => WorkDay::getWorkingDayTypeValue(),
-          'day_of_week' => 2,
+          'day_of_the_week' => 2,
           'time_from' => '09:00',
           'time_to' => '18:00',
           'break' => 1,
@@ -62,7 +71,7 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
         ],
         [
           'type' => WorkDay::getWorkingDayTypeValue(),
-          'day_of_week' => 3,
+          'day_of_the_week' => 3,
           'time_from' => '09:00',
           'time_to' => '18:00',
           'break' => 1,
@@ -71,7 +80,7 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
         ],
         [
           'type' => WorkDay::getWorkingDayTypeValue(),
-          'day_of_week' => 4,
+          'day_of_the_week' => 4,
           'time_from' => '09:00',
           'time_to' => '18:00',
           'break' => 1,
@@ -80,7 +89,7 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
         ],
         [
           'type' => WorkDay::getWorkingDayTypeValue(),
-          'day_of_week' => 5,
+          'day_of_the_week' => 5,
           'time_from' => '09:00',
           'time_to' => '18:00',
           'break' => 1,
@@ -89,13 +98,15 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern extends SequentialTitle
         ],
         [
           'type' => WorkDay::getWeekendTypeValue(),
-          'day_of_week' => 6,
+          'day_of_the_week' => 6,
           'leave_days' => 0,
+          'number_of_hours' => 0
         ],
         [
           'type' => WorkDay::getWeekendTypeValue(),
-          'day_of_week' => 7,
-          'leave_days' => 0
+          'day_of_the_week' => 7,
+          'leave_days' => 0,
+          'number_of_hours' => 0
         ],
       ]
     ]];

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -3629,22 +3629,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
   }
 
   public function testCalculateAmountForDateReturnsCorrectly() {
-    $periodStartDate = new DateTime('2016-01-01');
-
-    AbsencePeriodFabricator::fabricate([
-      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
-      'end_date' => CRM_Utils_Date::processDate('2016-12-31')
-    ]);
-
-    $contract = HRJobContractFabricator::fabricate(
-      [ 'contact_id' => 1 ],
-      [ 'period_start_date' => $periodStartDate->format('Y-m-d') ]
-    );
-
-    $pattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
-
-    $leaveRequest = new LeaveRequest();
-    $leaveRequest->contact_id = $contract['contact_id'];
     $leaveRequest = new LeaveRequest();
     $leaveRequest->contact_id = 1;
 
@@ -3675,6 +3659,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
   private function calculateAmountForDate(LeaveRequest $leaveRequest, DateTime $date, $amount) {
     $dayAmountDeductionService = $this->createLeaveDateAmountDeductionServiceMock($amount);
-    return LeaveBalanceChange::calculateAmountForDate($leaveRequest, $date, $dayAmountDeductionService);
+    $contactWorkPatternService = $this->createContractWorkPatternServiceMock();
+    return LeaveBalanceChange::calculateAmountForDate($leaveRequest, $date, $dayAmountDeductionService, $contactWorkPatternService);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -3628,25 +3628,22 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $this->assertNotNull($balanceChanges[$dates[0]->id]);
   }
 
-  public function testCalculateAmountForDateReturnsCorrectly() {
+  public function testCalculateAmountForDateReturnsCorrectAmountWhenContactWorkDayIsNotNull() {
     $leaveRequest = new LeaveRequest();
     $leaveRequest->contact_id = 1;
 
     $amountToReturn = -2;
     $amount = $this->calculateAmountForDate($leaveRequest, new DateTime('2016-07-28'), $amountToReturn);
     $this->assertEquals($amountToReturn, $amount);
+  }
 
-    $amountToReturn = -1;
-    $amount = $this->calculateAmountForDate($leaveRequest, new DateTime('2016-07-29'), $amountToReturn);
-    $this->assertEquals($amountToReturn, $amount);
+  public function testCalculateAmountForDateReturnsZeroWhenContactWorkDayIsNull() {
+    $leaveRequest = new LeaveRequest();
+    $leaveRequest->contact_id = 1;
 
-    $amountToReturn = -8;
-    $amount = $this->calculateAmountForDate($leaveRequest, new DateTime('2016-07-29 14:00'), $amountToReturn);
-    $this->assertEquals($amountToReturn, $amount);
-
-    $amountToReturn = -4.5;
-    $amount = $this->calculateAmountForDate($leaveRequest, new DateTime('2016-07-29 13:00'), $amountToReturn);
-    $this->assertEquals($amountToReturn, $amount);
+    $amountToReturn = -2;
+    $amount = $this->calculateAmountForDateWhenWorkDayIsNull($leaveRequest, new DateTime('2016-07-28'), $amountToReturn);
+    $this->assertEquals(0, $amount);
   }
 
   private function getBalanceChangesForPeriodEntitlement($leavePeriodEntitlement) {
@@ -3657,9 +3654,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     return $record;
   }
 
-  private function calculateAmountForDate(LeaveRequest $leaveRequest, DateTime $date, $amount) {
+  private function calculateAmountForDate(LeaveRequest $leaveRequest, DateTime $date, $amount, $workDayReturnValue = []) {
     $dayAmountDeductionService = $this->createLeaveDateAmountDeductionServiceMock($amount);
-    $contactWorkPatternService = $this->createContractWorkPatternServiceMock();
+    $contactWorkPatternService = $this->createContractWorkPatternServiceMock($workDayReturnValue);
     return LeaveBalanceChange::calculateAmountForDate($leaveRequest, $date, $dayAmountDeductionService, $contactWorkPatternService);
+  }
+
+  private function calculateAmountForDateWhenWorkDayIsNull(LeaveRequest $leaveRequest, DateTime $date, $amount) {
+    $this->calculateAmountForDate($leaveRequest, $date, $amount, null);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/ContactWorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/ContactWorkPatternTest.php
@@ -1,0 +1,200 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod as AbsencePeriodFabricator;
+use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern as WorkPatternFabricator;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_ContactWorkPattern as ContactWorkPatternFabricator;
+use CRM_HRLeaveAndAbsences_Service_ContactWorkPattern as ContactWorkPatternService;
+
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Service_ContactWorkPatternTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_Service_ContactWorkPatternTest extends BaseHeadlessTest {
+
+  private $contactWorkPatternService;
+
+  public function setUp() {
+    CRM_Core_DAO::executeQuery('SET foreign_key_checks = 0;');
+    $tableName = WorkPattern::getTableName();
+    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+    $this->contactWorkPatternService = new contactWorkPatternService();
+  }
+
+  public function tearDown() {
+    CRM_Core_DAO::executeQuery('SET foreign_key_checks = 1;');
+  }
+
+
+  public function testGetContactWorkDayForDateReturnsCorrectlyForAContactUsingTheDefaultWorkPattern() {
+    $periodStartDate = new DateTime('2017-01-01');
+
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2017-12-31')
+    ]);
+
+    $contract = HRJobContractFabricator::fabricate(
+      [ 'contact_id' => 1 ],
+      [ 'period_start_date' => $periodStartDate->format('Y-m-d') ]
+    );
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
+    $workWeeks = WorkPatternFabricator::getWeekFor40HourWorkWeek();
+
+    //2017-01-02 is a monday and a working day
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-02'));
+    $expectedWorkDay =  $this->getExpectedWorkDayArray($workWeeks['days'][0]);
+    $this->assertEquals($expectedWorkDay, $workDay);
+
+    //2017-01-06 is a friday and a working day
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-06'));
+    $expectedWorkDay =  $this->getExpectedWorkDayArray($workWeeks['days'][4]);
+    $this->assertEquals($expectedWorkDay, $workDay);
+
+    //2017-01-07 is a saturday and a weekend
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-07'));
+    $expectedWorkDay =  $this->getExpectedWorkDayArray($workWeeks['days'][5]);
+    $this->assertEquals($expectedWorkDay, $workDay);
+  }
+
+  public function testGetContactWorkDayForDateReturnsCorrectlyForAContactWithWorkPatternHavingOneWeek() {
+    $periodStartDate = new DateTime('2017-01-01');
+
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2017-12-31')
+    ]);
+
+    $contract = HRJobContractFabricator::fabricate(
+      [ 'contact_id' => 1 ],
+      [ 'period_start_date' => $periodStartDate->format('Y-m-d') ]
+    );
+
+    $pattern = WorkPatternFabricator::fabricateWithA40HourWorkWeek();
+
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $contract['contact_id'],
+      'pattern_id' => $pattern->id,
+      'effective_date' => $periodStartDate->format('YmdHis')
+    ]);
+
+    $workWeeks = WorkPatternFabricator::getWeekFor40HourWorkWeek();
+
+    //2017-01-02 is a monday and a working day
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-02'));
+    $expectedWorkDay =  $this->getExpectedWorkDayArray($workWeeks['days'][0]);
+    $this->assertEquals($expectedWorkDay, $workDay);
+
+    //2017-01-06 is a friday and a working day
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-06'));
+    $expectedWorkDay =  $this->getExpectedWorkDayArray($workWeeks['days'][4]);
+    $this->assertEquals($expectedWorkDay, $workDay);
+
+    //2017-01-07 is a saturday and a weekend
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-07'));
+    $expectedWorkDay =  $this->getExpectedWorkDayArray($workWeeks['days'][5]);
+    $this->assertEquals($expectedWorkDay, $workDay);
+  }
+
+  public function testGetContactWorkDayForDateReturnsCorrectlyForAContactWithWorkPatternHavingMoreThanOneWeek() {
+    $periodStartDate = new DateTime('2017-01-02');
+
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2017-01-02'),
+      'end_date' => CRM_Utils_Date::processDate('2017-12-31')
+    ]);
+
+    $contract = HRJobContractFabricator::fabricate(
+      [ 'contact_id' => 1 ],
+      [ 'period_start_date' => $periodStartDate->format('Y-m-d') ]
+    );
+
+    $pattern = WorkPatternFabricator::fabricateWithTwoWeeksAnd31AndHalfHours();
+
+    ContactWorkPatternFabricator::fabricate([
+      'contact_id' => $contract['contact_id'],
+      'pattern_id' => $pattern->id,
+      'effective_date' => $periodStartDate->format('YmdHis')
+    ]);
+
+    $workWeeks = WorkPatternFabricator::getWeekForTwoWeeksAnd31AndHalfHours();
+
+    //2017-01-06 is a friday on first week and a working day
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-06'));
+    $expectedWorkDay =  $this->getExpectedWorkDayArray($workWeeks[0]['days'][4]);
+    $this->assertEquals($expectedWorkDay, $workDay);
+
+    //2017-01-08 is a sunday on first week and non-working day
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-08'));
+    $expectedWorkDay =  $this->getExpectedWorkDayArray($workWeeks[0]['days'][6]);
+    $this->assertEquals($expectedWorkDay, $workDay);
+
+    //2017-01-09 is a monday on second week and not a working day
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-09'));
+    $expectedWorkDay =  $this->getExpectedWorkDayArray($workWeeks[1]['days'][0]);
+    $this->assertEquals($expectedWorkDay, $workDay);
+
+    //2017-01-10 is a tuesday on second week and a working day
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-10'));
+    $expectedWorkDay =  $this->getExpectedWorkDayArray($workWeeks[1]['days'][1]);
+    $this->assertEquals($expectedWorkDay, $workDay);
+  }
+
+  public function testGetContactWorkDayForDateReturnsNullWhenContactHasNoWorkPatternAndThereIsNoDefaultWorkPattern() {
+    $periodStartDate = new DateTime('2017-01-01');
+
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2017-12-31')
+    ]);
+
+    $contract = HRJobContractFabricator::fabricate(
+      [ 'contact_id' => 1 ],
+      [ 'period_start_date' => $periodStartDate->format('Y-m-d') ]
+    );
+
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-02'));
+    $this->assertNull($workDay);
+
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-06'));
+    $this->assertNull($workDay);
+
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-07'));
+    $this->assertNull($workDay);
+  }
+
+  public function testGetContactWorkDayForDateReturnsNullWhenContactHasNoContractAndThereIsDefaultWorkPattern() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2017-12-31')
+    ]);
+
+    $contactID = 1;
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
+
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contactID, new DateTime('2017-01-02'));
+    $this->assertNull($workDay);
+
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contactID, new DateTime('2017-01-06'));
+    $this->assertNull($workDay);
+
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contactID, new DateTime('2017-01-07'));
+    $this->assertNull($workDay);
+  }
+
+  private function getExpectedWorkDayArray($workDay) {
+    return [
+      'day_of_the_week' => $workDay['day_of_the_week'],
+      'type' => $workDay['type'],
+      'time_from' => CRM_Utils_Array::value('time_from', $workDay, '') ,
+      'time_to' => CRM_Utils_Array::value('time_to', $workDay, ''),
+      'break' => CRM_Utils_Array::value('break', $workDay, ''),
+      'leave_days' => !empty($workDay['leave_days']) ? $workDay['leave_days'] : '',
+      'number_of_hours' =>  !empty($workDay['number_of_hours']) ? $workDay['number_of_hours'] : ''
+    ];
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/ContactWorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/ContactWorkPatternTest.php
@@ -21,7 +21,7 @@ class CRM_HRLeaveAndAbsences_Service_ContactWorkPatternTest extends BaseHeadless
     CRM_Core_DAO::executeQuery('SET foreign_key_checks = 0;');
     $tableName = WorkPattern::getTableName();
     CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
-    $this->contactWorkPatternService = new contactWorkPatternService();
+    $this->contactWorkPatternService = new ContactWorkPatternService();
   }
 
   public function tearDown() {
@@ -62,11 +62,11 @@ class CRM_HRLeaveAndAbsences_Service_ContactWorkPatternTest extends BaseHeadless
   }
 
   public function testGetContactWorkDayForDateReturnsCorrectlyForAContactWithWorkPatternHavingOneWeek() {
-    $periodStartDate = new DateTime('2017-01-01');
+    $periodStartDate = new DateTime('2016-07-01');
 
     AbsencePeriodFabricator::fabricate([
-      'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
-      'end_date' => CRM_Utils_Date::processDate('2017-12-31')
+      'start_date' => CRM_Utils_Date::processDate('2016-07-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31')
     ]);
 
     $contract = HRJobContractFabricator::fabricate(
@@ -84,27 +84,27 @@ class CRM_HRLeaveAndAbsences_Service_ContactWorkPatternTest extends BaseHeadless
 
     $workWeeks = WorkPatternFabricator::getWeekFor40HourWorkWeek();
 
-    //2017-01-02 is a monday and a working day
-    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-02'));
+    //2016-07-04 is a monday and a working day
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2016-07-04'));
     $expectedWorkDay =  $this->getExpectedWorkDayArray($workWeeks['days'][0]);
     $this->assertEquals($expectedWorkDay, $workDay);
 
-    //2017-01-06 is a friday and a working day
-    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-06'));
+    //2016-07-08 is a friday and a working day
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2016-07-08'));
     $expectedWorkDay =  $this->getExpectedWorkDayArray($workWeeks['days'][4]);
     $this->assertEquals($expectedWorkDay, $workDay);
 
-    //2017-01-07 is a saturday and a weekend
-    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-07'));
+    //2016-07-09 is a saturday and a weekend
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2016-07-09'));
     $expectedWorkDay =  $this->getExpectedWorkDayArray($workWeeks['days'][5]);
     $this->assertEquals($expectedWorkDay, $workDay);
   }
 
   public function testGetContactWorkDayForDateReturnsCorrectlyForAContactWithWorkPatternHavingMoreThanOneWeek() {
-    $periodStartDate = new DateTime('2017-01-02');
+    $periodStartDate = new DateTime('2017-07-31');
 
     AbsencePeriodFabricator::fabricate([
-      'start_date' => CRM_Utils_Date::processDate('2017-01-02'),
+      'start_date' => CRM_Utils_Date::processDate('2017-07-31'),
       'end_date' => CRM_Utils_Date::processDate('2017-12-31')
     ]);
 
@@ -123,23 +123,23 @@ class CRM_HRLeaveAndAbsences_Service_ContactWorkPatternTest extends BaseHeadless
 
     $workWeeks = WorkPatternFabricator::getWeekForTwoWeeksAnd31AndHalfHours();
 
-    //2017-01-06 is a friday on first week and a working day
-    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-06'));
+    //2017-08-04 is a friday on first week and a working day
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-08-04'));
     $expectedWorkDay =  $this->getExpectedWorkDayArray($workWeeks[0]['days'][4]);
     $this->assertEquals($expectedWorkDay, $workDay);
 
-    //2017-01-08 is a sunday on first week and non-working day
-    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-08'));
+    //2017-08-06 is a sunday on first week and non-working day
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-08-06'));
     $expectedWorkDay =  $this->getExpectedWorkDayArray($workWeeks[0]['days'][6]);
     $this->assertEquals($expectedWorkDay, $workDay);
 
-    //2017-01-09 is a monday on second week and not a working day
-    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-09'));
+    //2017-08-07 is a monday on second week and not a working day
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-08-07'));
     $expectedWorkDay =  $this->getExpectedWorkDayArray($workWeeks[1]['days'][0]);
     $this->assertEquals($expectedWorkDay, $workDay);
 
-    //2017-01-10 is a tuesday on second week and a working day
-    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-10'));
+    //2017-08-08 is a tuesday on second week and a working day
+    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-08-08'));
     $expectedWorkDay =  $this->getExpectedWorkDayArray($workWeeks[1]['days'][1]);
     $this->assertEquals($expectedWorkDay, $workDay);
   }
@@ -159,12 +159,6 @@ class CRM_HRLeaveAndAbsences_Service_ContactWorkPatternTest extends BaseHeadless
 
     $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-02'));
     $this->assertNull($workDay);
-
-    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-06'));
-    $this->assertNull($workDay);
-
-    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contract['contact_id'], new DateTime('2017-01-07'));
-    $this->assertNull($workDay);
   }
 
   public function testGetContactWorkDayForDateReturnsNullWhenContactHasNoContractAndThereIsDefaultWorkPattern() {
@@ -177,12 +171,6 @@ class CRM_HRLeaveAndAbsences_Service_ContactWorkPatternTest extends BaseHeadless
     WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
 
     $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contactID, new DateTime('2017-01-02'));
-    $this->assertNull($workDay);
-
-    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contactID, new DateTime('2017-01-06'));
-    $this->assertNull($workDay);
-
-    $workDay = $this->contactWorkPatternService->getContactWorkDayForDate($contactID, new DateTime('2017-01-07'));
     $this->assertNull($workDay);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -4320,7 +4320,6 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'time_from' => CRM_Utils_Array::value('time_from', $workDay, '') ,
       'time_to' => CRM_Utils_Array::value('time_to', $workDay, ''),
       'number_of_hours' =>  !empty($workDay['number_of_hours']) ? $workDay['number_of_hours'] : ''
-
     ];
 
     //2017-01-02 is a monday and a working day

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
@@ -269,4 +269,16 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
 
     return $dateAmountDeductionService;
   }
+
+  public function createContractWorkPatternServiceMock() {
+    $contractWorkPatternService = $this->getMockBuilder(CRM_HRLeaveAndAbsences_Service_ContactWorkPattern::class)
+      ->setMethods(['getContactWorkDayForDate'])
+      ->getMock();
+
+    $contractWorkPatternService->expects($this->once())
+      ->method('getContactWorkDayForDate')
+      ->will($this->returnValue(true));
+
+    return $contractWorkPatternService;
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
@@ -263,21 +263,21 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
       ->setMethods(['calculate'])
       ->getMock();
 
-    $dateAmountDeductionService->expects($this->once())
+    $dateAmountDeductionService->expects($this->any())
       ->method('calculate')
       ->will($this->returnValue($amount * -1));
 
     return $dateAmountDeductionService;
   }
 
-  public function createContractWorkPatternServiceMock() {
+  public function createContractWorkPatternServiceMock($returnValue) {
     $contractWorkPatternService = $this->getMockBuilder(CRM_HRLeaveAndAbsences_Service_ContactWorkPattern::class)
       ->setMethods(['getContactWorkDayForDate'])
       ->getMock();
 
     $contractWorkPatternService->expects($this->once())
       ->method('getContactWorkDayForDate')
-      ->will($this->returnValue(true));
+      ->will($this->returnValue($returnValue));
 
     return $contractWorkPatternService;
   }


### PR DESCRIPTION
## Overview
This API is needed for a user to successfully request a leave in hours. The number of hours to be deducted for the Leave Request Start and End dates is set by the user on the Leave Request modal. The Front End needs the WorkDay information for a particular leave date in order to be able to present available options to the user for the start and end dates of the Leave request.


## After
```php
civicrm_api3('LeaveRequest', 'getWorkDayForDate', array(
  'leave_date' => '2016-06-01',
  'contact_id' => 204,
));

Response:
{
    "is_error": 0,
    "version": 3,
    "count": 3,
    "values": {
        "time_from": "09:00",
        "time_to": "17:30",
        "number_of_hours": "7.50"
    }
}
```

## Technical Details
- This PR adds a new `ContactWorkPatternService` class with a `getContactWorkDayForDate` which encapsulates the logic to retrieve the workday for a given date as per the Work pattern for the Contact.
- The `LeaveBalanceChange::calculateAmountForDate` now uses the contactWorkPatternService to get the Work Day information.
