### PR TITLE
PCHR-2878: TOIL validation for Leave in Hours

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -707,14 +707,11 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    * Whether the calculation unit for the Absence Type is in
    * Hours or not.
    *
-   * @param int $absenceTypeID
-   *
    * @return bool
    */
-  public static function isCalculationUnitInHours($absenceTypeID) {
-    $absenceType = self::findById($absenceTypeID);
+  public function isCalculationUnitInHours() {
     $calculationUnitOptions = array_flip(self::buildOptions('calculation_unit', 'validate'));
 
-    return $absenceType->calculation_unit == $calculationUnitOptions['hours'];
+    return $this->calculation_unit == $calculationUnitOptions['hours'];
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -286,8 +286,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     if($params['request_type'] !== self::REQUEST_TYPE_TOIL) {
       return;
     }
-
-    self::validateTOILToAccrueIsAValidOptionValue($params);
+    $isCalculationUnitInHours = AbsenceType::isCalculationUnitInHours($params['type_id']);
+    self::validateTOILToAccrueIsAValidOptionValue($params, $isCalculationUnitInHours);
     self::validateTOILPastDays($params, $absenceType);
     self::validateTOILToAccruedAmountIsValid($params, $absenceType, $absencePeriod);
   }
@@ -296,12 +296,20 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    * Validates if the value passed to the TOIL To Accrue field is one of the
    * options available on the hrleaveandabsences_toil_amounts option group and
    * is also a numeric value.
+   * If TOIL is requested in hours, this validation is not applicable since a
+   * user can request TOIL in hours based on a user imputed value.
    *
    * @param array $params
+   * @param bool $isCalculationUnitInHours
+   *   Whether the Absence type calculation unit is in hours or not.
    *
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
    */
-  private static function validateTOILToAccrueIsAValidOptionValue($params) {
+  private static function validateTOILToAccrueIsAValidOptionValue($params, $isCalculationUnitInHours) {
+    if($isCalculationUnitInHours) {
+      return;
+    }
+
     $toilAmountOptions = array_flip(self::buildOptions('toil_to_accrue', 'validate'));
     if(!in_array($params['toil_to_accrue'], $toilAmountOptions) || !is_numeric($params['toil_to_accrue'])) {
       throw new InvalidLeaveRequestException(

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -289,7 +289,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     $isCalculationUnitInHours = AbsenceType::isCalculationUnitInHours($params['type_id']);
     self::validateTOILToAccrueIsAValidOptionValue($params, $isCalculationUnitInHours);
     self::validateTOILPastDays($params, $absenceType);
-    self::validateTOILToAccruedAmountIsValid($params, $absenceType, $absencePeriod);
+    self::validateTOILToAccruedAmountIsValid($params, $absenceType, $absencePeriod, $isCalculationUnitInHours);
   }
 
   /**
@@ -353,10 +353,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    *   The params array received by the create method
    * @param AbsenceType $absenceType
    * @param AbsencePeriod $absencePeriod
+   * @param bool $isCalculationUnitInHours
+   *   Whether the Absence type calculation unit is in hours or not.
    *
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
    */
-  private static function validateTOILToAccruedAmountIsValid($params, $absenceType, $absencePeriod) {
+  private static function validateTOILToAccruedAmountIsValid($params, $absenceType, $absencePeriod, $isCalculationUnitInHours) {
     $unlimitedAccrual = empty($absenceType->max_leave_accrual) && $absenceType->max_leave_accrual !== 0;
     $oldToilRequest = '';
 
@@ -381,10 +383,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
       }
     }
 
+    $unit = $isCalculationUnitInHours ? 'hours' : 'days';
     $maxLeaveAccrual = $absenceType->max_leave_accrual;
     if ($totalProjectedToilForPeriod > $maxLeaveAccrual && !$unlimitedAccrual) {
       throw new InvalidLeaveRequestException(
-        'The maximum amount of leave that you can accrue is '. round($maxLeaveAccrual, 1) .' days. Please modify the dates of this request',
+        'The maximum amount of leave that you can accrue is '. round($maxLeaveAccrual, 1) .' '. $unit . '. Please modify the dates of this request',
         'leave_request_toil_amount_more_than_maximum_for_absence_type',
         'toil_to_accrue'
       );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/LeaveBalanceChangeCalculation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/LeaveBalanceChangeCalculation.php
@@ -17,7 +17,8 @@ class CRM_HRLeaveAndAbsences_Factory_LeaveBalanceChangeCalculation {
    * @return CRM_HRLeaveAndAbsences_Service_LeaveBalanceChangeCalculation
    */
   public static function create(LeaveRequest $leaveRequest) {
-    $isCalculationUnitInHours = AbsenceType::isCalculationUnitInHours($leaveRequest->type_id);
+    $absenceType = AbsenceType::findById($leaveRequest->type_id);
+    $isCalculationUnitInHours = $absenceType->isCalculationUnitInHours();
 
     if($isCalculationUnitInHours) {
       return new LeaveHoursBalanceChangeCalculation();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/LeaveDateAmountDeduction.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/LeaveDateAmountDeduction.php
@@ -15,7 +15,8 @@ class CRM_HRLeaveAndAbsences_Factory_LeaveDateAmountDeduction {
    * @return CRM_HRLeaveAndAbsences_Service_LeaveDateAmountDeduction
    */
   public static function createForAbsenceType($absenceTypeID) {
-    $isCalculationUnitInHours = AbsenceType::isCalculationUnitInHours($absenceTypeID);
+    $absenceType = AbsenceType::findById($absenceTypeID);
+    $isCalculationUnitInHours = $absenceType->isCalculationUnitInHours();
 
     if($isCalculationUnitInHours) {
       return new LeaveDateHoursAmountDeduction();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -280,7 +280,8 @@ function _civicrm_api3_leave_request_calculateBalanceChange_spec(&$spec) {
  * @throws CiviCRM_API3_Exception
  */
 function civicrm_api3_leave_request_calculateBalanceChange($params) {
-  $calculationUnitInHours = CRM_HRLeaveAndAbsences_BAO_AbsenceType::isCalculationUnitInHours($params['type_id']);
+  $absenceType = CRM_HRLeaveAndAbsences_BAO_AbsenceType::findById($params['type_id']);
+  $calculationUnitInHours = $absenceType->isCalculationUnitInHours();
 
   if(!$calculationUnitInHours) {
     if(empty($params['from_date_type']) || empty($params['to_date_type'])) {
@@ -794,7 +795,9 @@ function _civicrm_api3_leave_request_set_time_for_leave_dates(&$params) {
     return;
   }
 
-  if(CRM_HRLeaveAndAbsences_BAO_AbsenceType::isCalculationUnitInHours($params['type_id'])) {
+  $absenceType = CRM_HRLeaveAndAbsences_BAO_AbsenceType::findById($params['type_id']);
+
+  if($absenceType->isCalculationUnitInHours()) {
     return;
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -13,6 +13,14 @@ function _civicrm_api3_leave_request_create_spec(&$spec) {
     'type' => CRM_Utils_Type::T_BOOLEAN,
     'api.required' => 0,
   ];
+
+  $spec['toil_to_accrue'] = [
+    'name' => 'toil_to_accrue',
+    'title' => 'TOIL to accrue amount',
+    'description' => 'Amount of TOIL to accrue for the request',
+    'type' => CRM_Utils_Type::T_FLOAT,
+    'api.required' => 0,
+  ];
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -14,13 +14,10 @@ function _civicrm_api3_leave_request_create_spec(&$spec) {
     'api.required' => 0,
   ];
 
-  $spec['toil_to_accrue'] = [
-    'name' => 'toil_to_accrue',
-    'title' => 'TOIL to accrue amount',
-    'description' => 'Amount of TOIL to accrue for the request',
-    'type' => CRM_Utils_Type::T_FLOAT,
-    'api.required' => 0,
-  ];
+  //We need to unset this because we need to bypass civi validating
+  //this field against the toil amounts option group especially for
+  //TOIL in hours which can have values not part of the option group.
+  unset($spec['toil_to_accrue']['pseudoconstant']);
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -852,7 +852,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     ]);
 
 
-    $this->assertTrue(AbsenceType::isCalculationUnitInHours($absenceType->id));
+    $this->assertTrue($absenceType->isCalculationUnitInHours());
   }
 
   public function testIsCalculationUnitInHoursReturnsFalseWhenCalculationUnitIsNotInHours() {
@@ -861,6 +861,6 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     ]);
 
 
-    $this->assertFalse(AbsenceType::isCalculationUnitInHours($absenceType->id));
+    $this->assertFalse($absenceType->isCalculationUnitInHours());
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -2880,6 +2880,48 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertNotNull($toilRequest->id);
   }
 
+  public function testToilCanBeAccruedWhenTheToilRequestIsInHoursAndToilToAccrueValueIsNotAValidToilAmountOptionValue() {
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-1 day'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days'),
+    ]);
+
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'calculation_unit' => 2,
+      'allow_accruals_request' => true,
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceType->id,
+      'contact_id' => 1,
+      'period_id' => $period->id
+    ]);
+
+    $periodStartDate = date('2016-01-01');
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $periodEntitlement->contact_id],
+      ['period_start_date' => $periodStartDate]
+    );
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
+
+    $toilRequest = LeaveRequest::create([
+      'type_id' => $absenceType->id,
+      'contact_id' => $periodEntitlement->contact_id,
+      'status_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('today'),
+      'from_date_amount' => 0,
+      'to_date' => CRM_Utils_Date::processDate('tomorrow'),
+      'to_date_amount' => 0,
+      'toil_to_accrue' => 100,
+      'toil_duration' => 120,
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
+    ]);
+
+    $this->assertNotNull($toilRequest->id);
+  }
+
   public function testToilToAccrueAmountIsSavedCorrectlyWhenAmountToAccrueIsAFloatingNumber() {
     $toilToAccrueAmounts = [1.5, 1.8, 2.5];
     foreach ($toilToAccrueAmounts as $toilToAccrueAmount) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -2477,7 +2477,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     ]);
 
     $this->setExpectedException(
-      'CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException',
+      CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException::class,
       'The maximum amount of leave that you can accrue is '. $maxLeaveAccrual . ' hours. Please modify the dates of this request'
     );
     LeaveRequest::create([


### PR DESCRIPTION
## Overview
When creating a TOIL request, the amount to be accrued is validated against the values of the toil amounts option group. This was causing an a validation error when requesting TOIL in hours and the number of hours does not match the option values in the toil amounts option group because for TOIL in hours, the user can enter a custom amount in hours for TOIL to be accrued

## Before
Only TOIL in hours that match the values of the TOIL amount option group can be requested
![toilbefore](https://user-images.githubusercontent.com/6951813/32601685-c9336600-c543-11e7-941c-748c11269495.gif)


## After
The user can request TOIL for a custom amount in hours that is not part of the values of the TOIL amount option group.
![toilafter](https://user-images.githubusercontent.com/6951813/32601695-d50ed0fe-c543-11e7-82f5-509732ccbc3d.gif)


## Technical Details
- I had to add the specification for the `toil_to_accrue` param for the LeaveRequest.create API. The API field was bound to the toil_amount option group and any value passed in the parameter that is not part of the toil amount option group throws the error `CiviCRM_API3_Exception: 'value' is not a valid option for field toil_to_accrue`. The specification added allows any parameter that is float to be passed, since the BAO already validates the Toil amount to accrue for Leave in days