### PR TITLE
PCHR-2830: Replacing fa class for menu item icons with crm-i

### DIFF
--- a/hrrecruitment/CRM/HRRecruitment/Upgrader.php
+++ b/hrrecruitment/CRM/HRRecruitment/Upgrader.php
@@ -42,7 +42,7 @@ class CRM_HRRecruitment_Upgrader extends CRM_HRRecruitment_Upgrader_Base {
   public function upgrade_1402() {
     $params = [
       'name' => 'Vacancies',
-      'api.Navigation.create' => ['id' => '$value.id', 'icon' => 'fa fa-user-plus'],
+      'api.Navigation.create' => ['id' => '$value.id', 'icon' => 'crm-i fa-user-plus'],
       'parent_id' => ['IS NULL' => true],
     ];
     civicrm_api3('Navigation', 'get', $params);

--- a/hrui/CRM/HRUI/Upgrader/Steps/4706.php
+++ b/hrui/CRM/HRUI/Upgrader/Steps/4706.php
@@ -9,9 +9,9 @@ trait CRM_HRUI_Upgrader_Steps_4706 {
    */
   public function upgrade_4706() {
     $menuToIcons = [
-      'Search...' => 'fa fa-search',
-      'Contacts'=> 'fa fa-users',
-      'Administer' => 'fa fa-cog',
+      'Search...' => 'crm-i fa-search',
+      'Contacts'=> 'crm-i fa-users',
+      'Administer' => 'crm-i fa-cog',
     ];
 
     foreach ($menuToIcons as $menuName => $menuIcon) {

--- a/hrui/hrui.php
+++ b/hrui/hrui.php
@@ -1058,8 +1058,8 @@ function _hrui_createDeveloperMenu(&$menu) {
  */
 function _hui_setDynamicMenuIcons(&$menu) {
   $menuToIcons = [
-    'Help' => 'fa fa-question-circle',
-    'Developer'=> 'fa fa-code',
+    'Help' => 'crm-i fa-question-circle',
+    'Developer'=> 'crm-i fa-code',
   ];
 
   foreach ($menu as $key => $item) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1008.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1008.php
@@ -10,7 +10,7 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1008 {
   public function upgrade_4706() {
     $params = [
       'name' => 'leave_and_absences_dashboard',
-      'api.Navigation.create' => ['id' => '$value.id', 'icon' => 'fa fa-briefcase'],
+      'api.Navigation.create' => ['id' => '$value.id', 'icon' => 'crm-i fa-briefcase'],
       'parent_id' => ['IS NULL' => true],
     ];
     civicrm_api3('Navigation', 'get', $params);


### PR DESCRIPTION
## Overview
Menu item class that get inserted when updating the menu item icon from the form is changed from fa to **crm-i** in this PR https://github.com/civicrm/civicrm-core/pull/11025  but the upgrader I wrote still use the **fa** class.

## Before
Default icons use **fa** class.

## After
Default icons use **crm-i** class.

## Technical Details
Since this is not merged to staging, I just updated the existing upgraders directly.

