### PR TITLE
PCHR-2921: Add "Son/Daughter" Emergency Contact relationship option

### DIFF
--- a/org.civicrm.hremergency/CRM/Hremergency/Upgrader.php
+++ b/org.civicrm.hremergency/CRM/Hremergency/Upgrader.php
@@ -7,6 +7,7 @@ class CRM_Hremergency_Upgrader extends CRM_Hremergency_Upgrader_Base {
 
   use CRM_Hremergency_Upgrader_Steps_1000;
   use CRM_Hremergency_Upgrader_Steps_1001;
+  use CRM_Hremergency_Upgrader_Steps_1002;
 
   /**
    * Change the custom_group ID to 99999 as we have this exported through Drupal webforms so the ID needs to be always the same

--- a/org.civicrm.hremergency/CRM/Hremergency/Upgrader/Steps/1002.php
+++ b/org.civicrm.hremergency/CRM/Hremergency/Upgrader/Steps/1002.php
@@ -1,0 +1,36 @@
+<?php
+
+trait CRM_Hremergency_Upgrader_Steps_1002 {
+
+  /**
+   * Creates a new option value for emergency contact relationship.
+   */
+  public function upgrade_1002() {
+    $this->up1002_create_emergency_contact_relationship_option();
+
+    return TRUE;
+  }
+
+  /**
+   * Creates the new option value "Son/Daughter" for emergency contacts
+   * relationship with employee.
+   */
+  private function up1002_create_emergency_contact_relationship_option() {
+    $relationshipName = 'Son/Daughter';
+    $optionGroupName = 'relationship_with_employee_20150304120408';
+    $params = [
+      'name' => $relationshipName,
+      'option_group_id' => $optionGroupName,
+    ];
+    $result = civicrm_api3('OptionValue', 'get', $params);
+
+    if ($result['count'] != 0) {
+      return;
+    }
+
+    $params['label'] = $relationshipName;
+    $params['value'] = 'son_daughter';
+    civicrm_api3('OptionValue', 'create', $params);
+  }
+
+}


### PR DESCRIPTION
## Overview

This PR creates a new Emergency Contact relationship option, "Son/Daughter"

## Before

The "Son/Daughter" option did not exist.

## After

The "Son/Daughter" option exists.