### PR TITLE
PCHR-2929: Fix leave calendar

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-calendar-day.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-calendar-day.html
@@ -64,9 +64,13 @@
 <script type="text/ng-template" id="accrued-toil-tooltip">
   <div>
     <strong>{{day.contactData.leaveRequest['type_id.title']}}</strong>
-    <p ng-if="day.calculationUnit.name === 'days'">
-      {{day.supportData.toilAmounts[day.contactData.leaveRequest.toil_to_accrue].label}}</p>
-    <p ng-if="day.calculationUnit.name === 'hours'">
-      {{day.contactData.leaveRequest.toil_to_accrue | timeUnitApplier : 'hours' }}</p>
+    <p ng-switch="day.calculationUnit.name">
+      <span ng-switch-when="days">
+        {{day.supportData.toilAmounts[day.contactData.leaveRequest.toil_to_accrue].label}}
+      </span>
+      <span ng-switch-when="hours">
+        {{day.contactData.leaveRequest.toil_to_accrue | timeUnitApplier : 'hours' }}
+      </span>
+    </p>
   </div>
 </script>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-calendar-day.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-calendar-day.html
@@ -64,6 +64,9 @@
 <script type="text/ng-template" id="accrued-toil-tooltip">
   <div>
     <strong>{{day.contactData.leaveRequest['type_id.title']}}</strong>
-    <p>{{day.supportData.toilAmounts[day.contactData.leaveRequest.toil_to_accrue].label}}</p>
+    <p ng-if="day.calculationUnit.name === 'days'">
+      {{day.supportData.toilAmounts[day.contactData.leaveRequest.toil_to_accrue].label}}</p>
+    <p ng-if="day.calculationUnit.name === 'hours'">
+      {{day.contactData.leaveRequest.toil_to_accrue | timeUnitApplier : 'hours' }}</p>
   </div>
 </script>


### PR DESCRIPTION
## Overview

This PR fixes several issues in Leave Calendar:
- Legend for hours absence type (by syncing via https://github.com/compucorp/civihr-employee-portal-theme/pull/276)
- Tooltip caption for TOIL in hours

## Before

### Legend font size in SSP

<img width="1173" alt="screen shot 2017-11-15 at 13 08 46" src="https://user-images.githubusercontent.com/3973243/32837640-31e8b1b6-ca06-11e7-819c-f811cf2bab7a.png">

### Tooltip for TOIL

![1](https://user-images.githubusercontent.com/3973243/32837605-1628bd72-ca06-11e7-83f4-af30f4912b15.gif)

## After

### Legend font size in SSP

<img width="1176" alt="screen shot 2017-11-15 at 13 04 14" src="https://user-images.githubusercontent.com/3973243/32837465-94046d6e-ca05-11e7-8e17-8e64b2f7087b.png">

### Tooltip for TOIL

![2](https://user-images.githubusercontent.com/3973243/32837505-b9e049a4-ca05-11e7-8880-c955e5074100.gif)

## Technical Details

The captions need to be logically separated depending on the calculation unit because they show the data from different sources. For requests in **days** the value is taken from an option group, while for requests in **hours** the value is taken from the request itself and should be formatted accordingly.

```html
<p ng-if="day.calculationUnit.name === 'days'">
  {{day.supportData.toilAmounts[day.contactData.leaveRequest.toil_to_accrue].label}}</p>
<p ng-if="day.calculationUnit.name === 'hours'">
  {{day.contactData.leaveRequest.toil_to_accrue | timeUnitApplier : 'hours' }}</p>
```


---

✅ Manual Tests - passed
⏹ CSS distributive files - not needed
⏹ Jasmine Tests - omitted
⏹ JS distributive files - not needed
⏹ Backstop Tests - omitted
⏹ PHP Unit Tests - omitted
