### PR TITLE
PCHR-2931: Fix layout problems with Shortcut module

### DIFF
--- a/hrui/css/hrui.css
+++ b/hrui/css/hrui.css
@@ -1,11 +1,3 @@
-/**
- * Ensures that there is the same top padding regardless whether
- * the user can see the admin toolbar or not
- */
-body {
-  padding-top: 60px !important;
-}
-
 #civicrm-footer {
   height: 250px;
   background-color: #e8eef0 !important;


### PR DESCRIPTION
_(Related to https://github.com/compucorp/org.civicrm.shoreditch/pull/71/)_

The padding top of the body was enforced in hrui, but it should have been done in Shoreditch as it related to the new menu, which is defined in the theme extension