### PR TITLE
PCHR-2883: Improve Absence Types calculation unit selector

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
@@ -149,11 +149,7 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form {
     }
     $this->addSelect(
       'calculation_unit',
-      [
-        'options' => $this->getCalculationUnitOptions(),
-        'option_url' => NULL,
-        'label' => ts('Calculate Leave in')
-      ],
+      $this->getCalculationUnitSelectorParams(),
       TRUE
     );
     $this->addYesNo(
@@ -272,6 +268,25 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form {
   private function getDAOFieldAttributes($field) {
     $dao = 'CRM_HRLeaveAndAbsences_DAO_AbsenceType';
     return CRM_Core_DAO::getAttribute($dao, $field);
+  }
+
+  /**
+   * Returns parameters needed for the calculation unit selector
+   *
+   * @return array
+   */
+  private function getCalculationUnitSelectorParams () {
+    $calculationUnitSelectorParams = [
+      'options' => $this->getCalculationUnitOptions(),
+      'option_url' => NULL,
+      'label' => ts('Calculate Leave in')
+    ];
+
+    if ($this->absenceTypeHasEverBeenUsed()) {
+      $calculationUnitSelectorParams['disabled'] = 'disabled';
+    }
+
+    return $calculationUnitSelectorParams;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
@@ -277,7 +277,6 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form {
    */
   private function getCalculationUnitSelectorParams () {
     $calculationUnitSelectorParams = [
-      'options' => $this->getCalculationUnitOptions(),
       'option_url' => NULL,
       'label' => ts('Calculate Leave in')
     ];
@@ -433,35 +432,6 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form {
   private function canDelete() {
     $absenceTypeService = new AbsenceTypeService();
     return !$absenceTypeService->absenceTypeHasEverBeenUsed($this->_id);
-  }
-
-  /**
-   * Get the option values for the calculation_unit
-   * select field.
-   * When the Absence Type has been used, the only option
-   * returned is the current value of the calculation unit for the
-   * absence type.
-   *
-   * @return array
-   */
-  private function getCalculationUnitOptions() {
-    $options = AbsenceType::buildOptions('calculation_unit');
-    $selectOptions = [];
-    $absenceTypeHasBeenUsed = $this->absenceTypeHasEverBeenUsed();
-    $calculationUnitValue = false;
-
-    if($absenceTypeHasBeenUsed) {
-      $calculationUnitValue = AbsenceType::getFieldValue(AbsenceType::class, $this->_id, 'calculation_unit');
-    }
-
-    foreach($options as $value => $label) {
-      if($calculationUnitValue && $value != $calculationUnitValue) {
-        continue;
-      }
-      $selectOptions[$value] = ts($label);
-    }
-
-    return $selectOptions;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
@@ -132,6 +132,15 @@
       {literal}
           <script type="text/javascript">
               CRM.$(function($) {
+                $(document).ready(function() {
+                  initToilControls();
+                  initCarryForwardControls();
+                  initColorPicker();
+                  initDeleteButton();
+                  initCalculationUnitControls();
+                  supportValueSubmissionOfAllSelectorsIfDisabled();
+                });
+
                 function initToilControls() {
                   var allow_accruals_request = $('#allow_accruals_request');
                   var accrual_never_expire = $('#accrual_never_expire');
@@ -349,15 +358,6 @@
                     $inputHidden.val($select.val());
                   });
                 }
-
-                $(document).ready(function() {
-                  initToilControls();
-                  initCarryForwardControls();
-                  initColorPicker();
-                  initDeleteButton();
-                  initCalculationUnitControls();
-                  supportValueSubmissionOfAllSelectorsIfDisabled();
-                });
               });
           </script>
         {/literal}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
@@ -320,14 +320,44 @@
                   return hours_unit_value;
                 }
 
+                /**
+                 * Supports value submission of all CRM selectors
+                 * when such selectors are disabled
+                 */
+                function supportValueSubmissionOfAllSelectorsIfDisabled () {
+                  var $selectors = $('select.crm-select2');
+
+                  $.each($selectors, function (index, select) {
+                    supportValueSubmissionOfSelectorIfDisabled($(select));
+                  });
+                }
+
+                /**
+                 * Adds <input type="hidden"> before disabled <select>
+                 * with the same, watches <select> value and sets to the <input>
+                 *
+                 * @param {jQueryElement} $select - the selector to be amended
+                 */
+                function supportValueSubmissionOfSelectorIfDisabled ($select) {
+                  var $inputHidden = $('<input type="hidden" name="' +
+                    $select.attr('name') + '" value="' +
+                    $select.val() + '" />');
+
+                  $select.before($inputHidden);
+                  $select.removeAttr('name');
+                  $select.on('change', function () {
+                    $inputHidden.val($select.val());
+                  });
+                }
+
                 $(document).ready(function() {
                   initToilControls();
                   initCarryForwardControls();
                   initColorPicker();
                   initDeleteButton();
-                  initCalculationUnitControls()
+                  initCalculationUnitControls();
+                  supportValueSubmissionOfAllSelectorsIfDisabled();
                 });
-
               });
           </script>
         {/literal}


### PR DESCRIPTION
## Overview

This PR disables the Absence Type calculation unit selector if it cannot be changed (for example, when such an absence type has already been used in leave requests).

## Before

![1](https://user-images.githubusercontent.com/3973243/32890284-fc4809a6-cac5-11e7-831e-f9a549855b48.gif)

## After

![2](https://user-images.githubusercontent.com/3973243/32890158-83ff8e38-cac5-11e7-89f4-a793ca0179d1.gif)

## Technical Details

In PHP form builder the `disabled` attribute is now conditionally set:

```php
$this->addSelect(
  'calculation_unit',
  $this->getCalculationUnitSelectorParams(),
  TRUE
);
// ...
private function getCalculationUnitSelectorParams () {
  $calculationUnitSelectorParams = [
    'options' => $this->getCalculationUnitOptions(),
    // ...
  ];

  if ($this->absenceTypeHasEverBeenUsed()) {
    $calculationUnitSelectorParams['disabled'] = 'disabled';
  }

  return $calculationUnitSelectorParams;
}
```

However, this is not enough since the disabled selector would not provide a value on form submit which makes such an Absence Type updating impossible due to the failing backend validation. 

Removing `disabled` attribute from the `<select>` would not work since the CRM selector watches the original `<select>` and unsets `disabled` attribute for itself as well. Same happens if you then apply `disabled` attribute to the CRM selector - the original `<select>` would set `disabled` attribute to itself.

So another method needs to be performed on the front-end: adding `<input type hidden>` just before the `<select>`, watch `<select>` value and set it to the hidden input.

```js
function supportValueSubmissionOfAllSelectorsIfDisabled () {
  var $selectors = $('select.crm-select2');

  $.each($selectors, function (index, select) {
    supportValueSubmissionOfSelectorIfDisabled($(select));
  });
}

function supportValueSubmissionOfSelectorIfDisabled ($select) {
  var $inputHidden = $('<input type="hidden" name="' +
    $select.attr('name') + '" value="' +
    $select.val() + '" />');

  $select.before($inputHidden);
  $select.removeAttr('name');
  $select.on('change', function () {
    $inputHidden.val($select.val());
  });
}

$(document).ready(function() {
  // ...
  supportValueSubmissionOfAllSelectorsIfDisabled();
});
```

## Comments

Changing a selector to a label instead would not work since flickering will happen.

-----

✅ Manual Tests - passed
✅ PHP Unit Tests - passed
⏹ CSS distributive files - not needed
⏹ Jasmine Tests - n/a
⏹ JS distributive files - not needed
⏹ Backstop Tests - omitted
