### PR TITLE
PCHR-2949: Fix namespace exclusion patterns

### DIFF
--- a/org.civicrm.bootstrapcivihr/gulpfile.js
+++ b/org.civicrm.bootstrapcivihr/gulpfile.js
@@ -22,10 +22,7 @@ gulp.task('sass', ['sass:sync'], function () {
     .pipe(postcss([postcssPrefix({
       prefix: bootstrapNamespace + ' ',
       exclude: [
-        /^html/, /^body/, /page-civi/,
-        '.crm-container .blockUI.blockOverlay', // class to display spinner on overlay
-        '.crm-container .dataTables_processing', // class to display spinner datatable load
-        outsideNamespaceRegExp
+        /^html/, /^body/, /page-civi/, /crm-container/, outsideNamespaceRegExp
       ]
     })]))
     .pipe(transformSelectors(namespaceRootElements, { splitOnCommas: true }))


### PR DESCRIPTION
## Overview
As part of [this PR](https://github.com/civicrm/civihr/pull/2290) some overly-specific exclusion patterns were added to the gulpfile of the `org.civicrm.bootstrapcivihr` theme extension.

This PR makes them more generic

## Before
```js
.pipe(postcss([postcssPrefix({
  prefix: bootstrapNamespace + ' ',
  exclude: [
    /^html/, /^body/, /page-civi/,
    '.crm-container .blockUI.blockOverlay', // class to display spinner on overlay
    '.crm-container .dataTables_processing', // class to display spinner datatable load
    outsideNamespaceRegExp
  ]
})]))
```

## After
```js
.pipe(postcss([postcssPrefix({
  prefix: bootstrapNamespace + ' ',
  exclude: [
    /^html/, /^body/, /page-civi/, /crm-container/, outsideNamespaceRegExp
  ]
})]))
```