### PR TITLE
PCHR-2863: Change Default From Address For L&A Email Notifications

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Exception/InvalidLeaveRequestMailNotificationSenderException.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Exception/InvalidLeaveRequestMailNotificationSenderException.php
@@ -1,0 +1,2 @@
+<?php
+class CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestMailNotificationSenderException extends Exception {}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Message.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Message.php
@@ -232,7 +232,12 @@ class CRM_HRLeaveAndAbsences_Mail_Message {
    * @return string|null
    */
   private function getFirstFromEmailAddress($params = []) {
-    $params = array_merge(['option_group_id' => 'from_email_address'], $params);
+    $params = array_merge([
+      'option_group_id' => 'from_email_address',
+      'options' => ['limit' => 1, 'sort' => 'weight ASC'],
+      'return' => ['label']
+    ], $params);
+
     $result = civicrm_api3('OptionValue', 'get', $params);
 
     $result = array_shift($result['values']);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Message.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Message.php
@@ -30,12 +30,6 @@ class CRM_HRLeaveAndAbsences_Mail_Message {
   private $requestTemplateFactory;
 
   /**
-   * @var String
-   *   The From email configured on the site for sending out emails.
-   */
-  private $fromEmail;
-
-  /**
    * CRM_HRLeaveAndAbsences_Mail_Message constructor.
    *
    * @param \CRM_HRLeaveAndAbsences_BAO_LeaveRequest $leaveRequest
@@ -50,29 +44,23 @@ class CRM_HRLeaveAndAbsences_Mail_Message {
   }
 
   /**
-   * Gets the From Email address configured on the site
-   * Currently It gets the from email address and name of the contact linked to the
-   * default domain in civicrm_domain table.
+   * Gets the default From Email address configured on the site
+   * at civicrm/admin/options/from_email_address?reset=1.
+   * from the from_email_address civi option group.
    *
-   * @TODO This logic will be changed later to fetch from L&A general settings
+   * If there is no default from email address, the first from
+   * email address is returned.
    *
-   * @return string
+   * @return string|null
    */
   public function getFromEmail() {
-    if (is_null($this->fromEmail)) {
-      $domainValues = [];
-      $domain = CRM_Core_BAO_Domain::getDomain();
-      $tokens = [
-        'domain' => ['name', 'email'],
-      ];
+    $fromEmail = $this->getDefaultFromEmailAddress();
 
-      foreach ($tokens['domain'] as $token) {
-        $domainValues[$token] = CRM_Utils_Token::getDomainTokenReplacement($token, $domain);
-      }
-
-      $this->fromEmail = $domainValues['name'] . ' <' . $domainValues['email'] . '>';
+    if($fromEmail) {
+      return $fromEmail;
     }
-    return $this->fromEmail;
+
+    return $this->getFirstFromEmailAddress();
   }
 
   /**
@@ -233,5 +221,32 @@ class CRM_HRLeaveAndAbsences_Mail_Message {
    */
   private function isValidTemplate() {
     return $this->getTemplate() instanceof BaseRequestNotificationTemplate;
+  }
+
+  /**
+   * Returns the first email address from the
+   * from_email_address option group.
+   *
+   * @param array $params
+   *
+   * @return string|null
+   */
+  private function getFirstFromEmailAddress($params = []) {
+    $params = array_merge(['option_group_id' => 'from_email_address'], $params);
+    $result = civicrm_api3('OptionValue', 'get', $params);
+
+    $result = array_shift($result['values']);
+
+    return $result ? $result['label'] : null;
+  }
+
+  /**
+   * Returns the default from email address from the
+   * from_email_address option group.
+   *
+   * @return string|null
+   */
+  private function getDefaultFromEmailAddress() {
+    return $this->getFirstFromEmailAddress(['is_default' => 1]);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestMailNotificationSender.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestMailNotificationSender.php
@@ -2,6 +2,7 @@
 
 use CRM_HRLeaveAndAbsences_Mail_Message as Message;
 use CRM_Core_BAO_MessageTemplate as MessageTemplate;
+use CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestMailNotificationSenderException as InvalidLeaveRequestMailNotificationSenderException;
 
 class CRM_HRLeaveAndAbsences_Service_LeaveRequestMailNotificationSender {
 
@@ -13,14 +14,21 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestMailNotificationSender {
    * @return array
    *  an array containing the status of the mail sent for each recipient
    *  ['test@example.com' => true, 'tester@example.com' => true]
+   *
+   * @throws InvalidLeaveRequestMailNotificationSenderException
    */
   public function send(Message $message) {
-
     $recipientEmails = $message->getRecipientEmails();
     $templateID = $message->getTemplateID();
     $contactID = $message->getLeaveContactID();
     $fromEmail = $message->getFromEmail();
     $status = [];
+
+    if(is_null($fromEmail)) {
+      throw new InvalidLeaveRequestMailNotificationSenderException(
+        'From Email Address need to be configured in order to allow Email notifications'
+      );
+    }
 
     foreach($recipientEmails as $recipient) {
       $recipientID = $recipient['api.Contact.get']['values'][0]['id'];

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -41,7 +41,19 @@ function civicrm_api3_leave_request_create($params) {
   $values = [];
   _civicrm_api3_object_to_array($leaveRequest, $values[$leaveRequest->id]);
 
-  return civicrm_api3_create_success($values, $params, null, 'create', $leaveRequest);
+  $extraParams = ['from_email_configured' => true];
+  if(!civicrm_api3_leave_request_get_from_email_for_notifications($leaveRequest)) {
+    $extraParams['from_email_configured'] = false;
+  }
+
+  return civicrm_api3_create_success($values, $params, null, 'create', $leaveRequest, $extraParams);
+}
+
+function civicrm_api3_leave_request_get_from_email_for_notifications($leaveRequest) {
+  $leaveRequestTemplateFactory = new CRM_HRLeaveAndAbsences_Factory_RequestNotificationTemplate();
+  $message = new CRM_HRLeaveAndAbsences_Mail_Message($leaveRequest, $leaveRequestTemplateFactory);
+
+  return $message->getFromEmail();
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -2468,6 +2468,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testEmailGetsSentWhenLeaveRequestIsCreatedAndUpdated() {
+    $defaultEmailAddress = "Default Email <default_email@testdomain.com>";
+    $this->createDefaultFromEmail($defaultEmailAddress);
     $manager1 = ContactFabricator::fabricateWithEmail([
       'first_name' => 'Manager1', 'last_name' => 'Manager1'], 'manager1@dummysite.com'
     );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
@@ -190,10 +190,8 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
       'From Email 3 <from_email3@testdomain.com>',
     ];
 
-    $value = 1;
     foreach ($fromEmailAddress as $fromAddress) {;
       $this->createFromEmail($fromAddress);
-      $value++;
     }
     $leaveRequest = new LeaveRequest();
     $message = new Message($leaveRequest, $this->leaveRequestTemplateFactory);
@@ -209,10 +207,8 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
       'From Email 3 <from_email3@testdomain.com>',
     ];
 
-    $value = 1;
     foreach ($fromEmailAddress as $fromAddress) {
       $this->createFromEmail($fromAddress);
-      $value++;
     }
 
     $defaultEmailAddress = 'Default Email <default_email@testdomain.com>';

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
@@ -185,9 +185,9 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
 
   public function testGetFromEmailReturnsTheFirstOptionFromTheFromEmailAddressOptionGroupWhenThereIsNoDefaultAddress() {
     $fromEmailAddress = [
-      "From Email 1 <from_email1@testdomain.com>",
-      "From Email 2 <from_email2@testdomain.com>",
-      "From Email 3 <from_email3@testdomain.com>",
+      'From Email 1 <from_email1@testdomain.com>',
+      'From Email 2 <from_email2@testdomain.com>',
+      'From Email 3 <from_email3@testdomain.com>',
     ];
 
     $value = 1;
@@ -204,9 +204,9 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
 
   public function testGetFromEmailReturnsTheDefaultEmailAddressFromTheFromEmailAddressOption() {
     $fromEmailAddress = [
-      "From Email 1 <from_email1@testdomain.com>",
-      "From Email 2 <from_email2@testdomain.com>",
-      "From Email 3 <from_email3@testdomain.com>",
+      'From Email 1 <from_email1@testdomain.com>',
+      'From Email 2 <from_email2@testdomain.com>',
+      'From Email 3 <from_email3@testdomain.com>',
     ];
 
     $value = 1;
@@ -215,7 +215,7 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
       $value++;
     }
 
-    $defaultEmailAddress = "Default Email <default_email@testdomain.com>";
+    $defaultEmailAddress = 'Default Email <default_email@testdomain.com>';
     $this->createDefaultFromEmail($defaultEmailAddress, $value + 1);
 
     $leaveRequest = new LeaveRequest();
@@ -225,7 +225,7 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
     $this->assertEquals($defaultEmailAddress, $fromEmail);
   }
 
-  public function testGetFromEmailReturnsNullWhenThereIsNoOptionForTheFromEmailAddressOption() {
+  public function testGetFromEmailReturnsNullWhenThereIsNoOptionForTheFromEmailAddressOptionGroup() {
     $leaveRequest = new LeaveRequest();
     $message = new Message($leaveRequest, $this->leaveRequestTemplateFactory);
     $fromEmail = $message->getFromEmail();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
@@ -192,7 +192,7 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
 
     $value = 1;
     foreach ($fromEmailAddress as $fromAddress) {;
-      $this->createFromEmail($fromAddress, $value);
+      $this->createFromEmail($fromAddress);
       $value++;
     }
     $leaveRequest = new LeaveRequest();
@@ -210,13 +210,13 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
     ];
 
     $value = 1;
-    foreach ($fromEmailAddress as $fromAddress) {;
-      $this->createFromEmail($fromAddress, $value);
+    foreach ($fromEmailAddress as $fromAddress) {
+      $this->createFromEmail($fromAddress);
       $value++;
     }
 
     $defaultEmailAddress = 'Default Email <default_email@testdomain.com>';
-    $this->createDefaultFromEmail($defaultEmailAddress, $value + 1);
+    $this->createDefaultFromEmail($defaultEmailAddress);
 
     $leaveRequest = new LeaveRequest();
     $message = new Message($leaveRequest, $this->leaveRequestTemplateFactory);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
@@ -258,21 +258,4 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
     $message = new Message($leaveRequest, $this->leaveRequestTemplateFactory);
     $this->assertNull($message->getTemplateID());
   }
-
-  private function createFromEmail($label, $value, $isDefault = false) {
-    $params = [
-      'option_group_id' => 'from_email_address',
-      'label' => $label,
-      'value' => $value,
-    ];
-
-    if($isDefault) {
-      $params['is_default'] = 1;
-    }
-    civicrm_api3('OptionValue', 'create', $params);
-  }
-
-  private function createDefaultFromEmail($label, $value) {
-    $this->createFromEmail($label, $value, true);
-  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestMailNotificationSenderTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestMailNotificationSenderTest.php
@@ -34,7 +34,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestMailNotificationSenderTest exte
     );
 
     $defaultEmailAddress = "Default Email <default_email@testdomain.com>";
-    $this->createDefaultFromEmail($defaultEmailAddress, 1);
+    $this->createDefaultFromEmail($defaultEmailAddress);
 
     // Set manager1 to be leave aprovers for the leave contact
     $this->setContactAsLeaveApproverOf($manager1, $this->leaveContact);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestMailNotificationSenderTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestMailNotificationSenderTest.php
@@ -84,7 +84,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestMailNotificationSenderTest exte
   public function testSendThrowsExceptionWhenFromEmailIsNotConfigured() {
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => 1,
-      'contact_id' =>$this->leaveContact['id'],
+      'contact_id' => $this->leaveContact['id'],
       'from_date' => CRM_Utils_Date::processDate('tomorrow'),
       'to_date' => CRM_Utils_Date::processDate('tomorrow'),
     ], false);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestMailNotificationSenderTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestMailNotificationSenderTest.php
@@ -33,6 +33,9 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestMailNotificationSenderTest exte
       'first_name' => 'Manager1', 'last_name' => 'Manager1'], 'manager1@dummysite.com'
     );
 
+    $defaultEmailAddress = "Default Email <default_email@testdomain.com>";
+    $this->createDefaultFromEmail($defaultEmailAddress, 1);
+
     // Set manager1 to be leave aprovers for the leave contact
     $this->setContactAsLeaveApproverOf($manager1, $this->leaveContact);
 
@@ -76,5 +79,26 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestMailNotificationSenderTest exte
       $this->assertNotEmpty($email['body']);
       $this->assertNotEmpty($email['headers']);
     }
+  }
+
+  public function testSendThrowsExceptionWhenFromEmailIsNotConfigured() {
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => 1,
+      'contact_id' =>$this->leaveContact['id'],
+      'from_date' => CRM_Utils_Date::processDate('tomorrow'),
+      'to_date' => CRM_Utils_Date::processDate('tomorrow'),
+    ], false);
+
+    $leaveRequestTemplateFactory = new RequestNotificationTemplateFactory();
+    $message = new Message($leaveRequest, $leaveRequestTemplateFactory);
+
+    $leaveMailSenderService = new LeaveRequestMailNotificationSenderService();
+
+    $this->setExpectedException(
+      CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestMailNotificationSenderException::class,
+      'From Email Address need to be configured in order to allow Email notifications'
+    );
+
+    $leaveMailSenderService->send($message);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -3997,7 +3997,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $startDate = new DateTime();
     $endDate = new DateTime('+5 days');
 
-    $defaultEmailAddress = "Default Email <default_email@testdomain.com>";
+    $defaultEmailAddress = 'Default Email <default_email@testdomain.com>';
     $this->createDefaultFromEmail($defaultEmailAddress);
 
     $period = AbsencePeriodFabricator::fabricate([

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/MailHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/MailHelpersTrait.php
@@ -67,7 +67,7 @@ trait CRM_HRLeaveAndAbsences_MailHelpersTrait {
     civicrm_api3('OptionValue', 'create', $params);
   }
 
-  private function createDefaultFromEmail($label, $value) {
+  private function createDefaultFromEmail($label, $value = 1) {
     $this->createFromEmail($label, $value, true);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/MailHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/MailHelpersTrait.php
@@ -54,11 +54,11 @@ trait CRM_HRLeaveAndAbsences_MailHelpersTrait {
     return isset($result['values'][0]) ? $result['values'][0] : '';
   }
 
-  private function createFromEmail($label, $value, $isDefault = false) {
+  private function createFromEmail($label, $isDefault = false) {
     $params = [
       'option_group_id' => 'from_email_address',
       'label' => $label,
-      'value' => $value,
+      'value' => $label,
     ];
 
     if($isDefault) {
@@ -67,7 +67,7 @@ trait CRM_HRLeaveAndAbsences_MailHelpersTrait {
     civicrm_api3('OptionValue', 'create', $params);
   }
 
-  private function createDefaultFromEmail($label, $value = 1) {
-    $this->createFromEmail($label, $value, true);
+  private function createDefaultFromEmail($label) {
+    $this->createFromEmail($label, true);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/MailHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/MailHelpersTrait.php
@@ -53,4 +53,21 @@ trait CRM_HRLeaveAndAbsences_MailHelpersTrait {
 
     return isset($result['values'][0]) ? $result['values'][0] : '';
   }
+
+  private function createFromEmail($label, $value, $isDefault = false) {
+    $params = [
+      'option_group_id' => 'from_email_address',
+      'label' => $label,
+      'value' => $value,
+    ];
+
+    if($isDefault) {
+      $params['is_default'] = 1;
+    }
+    civicrm_api3('OptionValue', 'create', $params);
+  }
+
+  private function createDefaultFromEmail($label, $value) {
+    $this->createFromEmail($label, $value, true);
+  }
 }


### PR DESCRIPTION
## Overview
Currently Email field from "Organization contact information" from` /civicrm/admin/domain?action=update&reset=1` is used as the From email address for L&A emails. We need the from email to be picked from `/civicrm/admin/options/from_email_address?reset=1`, When there is no default from address, the first from address is picked.
 
## Before
Email field from "Organization contact information" from` /civicrm/admin/domain?action=update&reset=1` is used as the From email address for L&A emails.
![organization address and contact info - staging17 2017-11-21 15-14-02](https://user-images.githubusercontent.com/6951813/33076965-ae631750-cece-11e7-96c3-2d7a6c95b613.png)


## After
The default From email address at `/civicrm/admin/options/from_email_address?reset=1` is used as the From email address for L&A emails. When there is no default, the first email address is used.
![from email address options - staging17 2017-11-21 15-16-54](https://user-images.githubusercontent.com/6951813/33077132-347d0aa8-cecf-11e7-8341-c5d84f759c87.png)


## Technical Details
- The From email addresses listed at `/civicrm/admin/options/from_email_address?reset=1` are actually option values of the Civi `from_email_address` option group. So the `CRM_HRLeaveAndAbsences_Mail_Message` checks these option group to get the default option value or the first option value in the case where there is no default.
- The Leave Request create API now returns an additional field which gives information about whether the from_email_address is configured or not.
- When the From email address is not configured, emails are not sent for L&A leave request notifications.

## Comments
- There will be a follow up FE ticket/PR to this PR since the A/C states that the front end should display a popup error when the from email address is not configured.
