### PR TITLE
PCHR-2960: Fix L&A upgraders

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1005.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1005.php
@@ -3,7 +3,7 @@
 trait CRM_HRLeaveAndAbsences_Upgrader_Step_1005 {
 
   /**
-   * Renames the two "Leave and Absences" menu items to just "Absences"
+   * Renames the two "Leave and Absences" menu items to just "Leave"
    *
    * @return bool
    */

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1005.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1005.php
@@ -1,8 +1,5 @@
 <?php
 
-use CRM_Core_BAO_SchemaHandler as SchemaHandler;
-use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
-
 trait CRM_HRLeaveAndAbsences_Upgrader_Step_1005 {
 
   /**
@@ -19,7 +16,7 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1005 {
       'dashboard' => CRM_Core_BAO_Navigation::retrieve($paramsDashboard, $default),
       'admin' => CRM_Core_BAO_Navigation::retrieve($paramsAdmin, $default)
     ];
-    
+
     foreach ($menuItems as $menuItem) {
       $menuItem->label = 'Leave';
       $menuItem->save();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1006.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1006.php
@@ -1,8 +1,5 @@
 <?php
 
-use CRM_Core_BAO_SchemaHandler as SchemaHandler;
-use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
-
 trait CRM_HRLeaveAndAbsences_Upgrader_Step_1006 {
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1006.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1006.php
@@ -3,23 +3,33 @@
 trait CRM_HRLeaveAndAbsences_Upgrader_Step_1006 {
 
   /**
-   * Moves the "leave_and_absences_dashboard" menu item before the "Vacancies" one
+   * Moves the "leave_and_absences_dashboard" menu item either after "Tasks"
+   *  or after "Contacts", as a fallback in case T&A is not enabled
    *
    * @return bool
    */
   public function upgrade_1006() {
     $default = [];
 
-    $vacanciesParams = ['name' => 'Vacancies', 'url' => null];
-    $vacanciesMenuItem = CRM_Core_BAO_Navigation::retrieve($vacanciesParams, $default);
+    if ($this->up1006_isExtensionEnabled('uk.co.compucorp.civicrm.tasksassignments')) {
+      $prevParams = ['name' => 'tasksassignments'];
+    } else {
+      $prevParams = ['name' => 'Contacts'];
+    }
 
-    $leaveParams = ['name' => 'leave_and_absences_dashboard', 'url' => 'civicrm/leaveandabsences/dashboard'];
+    $prevMenuItem = CRM_Core_BAO_Navigation::retrieve($prevParams, $default);
+
+    $leaveParams = ['name' => 'leave_and_absences_dashboard', 'url' => null];
     $leaveMenuItem = CRM_Core_BAO_Navigation::retrieve($leaveParams, $default);
-    $leaveMenuItem->weight = $vacanciesMenuItem->weight - 1;
+    $leaveMenuItem->weight = $prevMenuItem->weight + 1;
     $leaveMenuItem->save();
 
     CRM_Core_BAO_Navigation::resetNavigation();
 
     return TRUE;
+  }
+
+  private function up1006_isExtensionEnabled($extension) {
+    return CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Extension', $extension, 'is_active', 'full_name');
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1007.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1007.php
@@ -1,8 +1,5 @@
 <?php
 
-use CRM_Core_BAO_SchemaHandler as SchemaHandler;
-use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
-
 trait CRM_HRLeaveAndAbsences_Upgrader_Step_1007 {
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1008.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1008.php
@@ -7,7 +7,7 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1008 {
    *
    * @return bool
    */
-  public function upgrade_4706() {
+  public function upgrade_1008() {
     $params = [
       'name' => 'leave_and_absences_dashboard',
       'api.Navigation.create' => ['id' => '$value.id', 'icon' => 'crm-i fa-briefcase'],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -442,7 +442,7 @@ function _hrleaveandabsences_create_administer_menu() {
   $maxWeightOfAdminMenuItems = _hrleaveandabsences_get_max_child_weight_for_menu($administerMenuId);
 
   $params = [
-    'label'      => ts('Absences'),
+    'label'      => ts('Leave'),
     'name'       => 'leave_and_absences',
     'url'        => null,
     'operator'   => null,
@@ -531,7 +531,7 @@ function _hrleavesandabsences_create_main_menu() {
   $vacanciesWeight = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Vacancies', 'weight', 'name');
 
   $params = [
-    'label'      => ts('Absences'),
+    'label'      => ts('Leave'),
     'name'       => 'leave_and_absences',
     'url'        => 'civicrm/leaveandabsences/dashboard',
     'operator'   => null,


### PR DESCRIPTION
_(nevermind the name of the branch with the wrong ticket number, the correct ticket was created after the PR)_

## Overview
This PR introduces several fix to some of the L&A upgraders, see the Technical Details section

## Technical Details
* The `CRM_HRLeaveAndAbsences_Upgrader_Step_1008` trait was using a upgrader function numbered `4706`, fixed it
* This
    ```php
    use CRM_Core_BAO_SchemaHandler as SchemaHandler;
    use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
    ```
    was unnecessarily added to all the new upgraders, removed it
* In #2189 i wrote
    > Finally, in #2186 I made a mistake and renamed "Leaves and Absences" into "Absences" instead of "Leave", this PR takes care of that
    
    but didn't fix the wrong name everywhere, now it's fixed
* The `1006` upgrader moved the "leave" menu item before the "Vacancies" (renames later to "Recruitment"), but that didn't work in new sites, because L&A is installed *before* the recruitment extension. As a result this
    ```js
    $leaveMenuItem->weight = $vacanciesMenuItem->weight - 1;
    ```
    was equal to `-1` which placed the "leave" menu item right after the home link.

    A better approach is then to use T&A as a reference, given that it is installed before L&A. If for whatever reason T&A would not be yet installed, then the fallback is to use the "Contacts" menu item, which is granted to be present