### PR TITLE
PCHR-2962: Show time unit for overridden values in the CSV exported from the Manage Entitlements page

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
@@ -370,7 +370,10 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
       ];
 
       if(!empty($formValues['overridden_entitlement'][$contactID][$absenceTypeID])) {
-        $row['proposed_entitlement'] = $formValues['overridden_entitlement'][$contactID][$absenceTypeID];
+        $row['proposed_entitlement'] = TimeUnitApplier::apply(
+          $formValues['overridden_entitlement'][$contactID][$absenceTypeID],
+          $calculationUnit
+        );
         $row['overridden'] = 1;
       }
 


### PR DESCRIPTION
## Problem
When exporting a CSV from the Manage Entitlements page, the time unit wasn't applied to overridden entitlements

![captura de tela de 2017-11-22 07-58-02](https://user-images.githubusercontent.com/388373/33121131-0b84cfa0-cf5b-11e7-91ee-c03bc67622ad.png)

## Solution

There's a special condition that checks for overridden values when exporting the CSV. Now we use the `TimeUnitApplier` to apply the unit there as well.

The overridden values now have time units in the exported CSV:

![captura de tela de 2017-11-22 08-00-41](https://user-images.githubusercontent.com/388373/33121209-428f3f1c-cf5b-11e7-9e22-a49d323c934a.png)

---
[x] Tests pass