### PR TITLE
PCHR-2957: Use option group names in Job Contract dropdowns links

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -512,7 +512,6 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     $this->upgrade_1030();
     $this->upgrade_1032();
     $this->upgrade_1033();
-    $this->upgrade_1034();
   }
 
   function upgrade_1001() {
@@ -1146,6 +1145,19 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
   }
 
   /**
+   * Removes menu link pointing to an nonexistent option group and update
+   * dropdown links to use option group names instead of IDs.
+   *
+   * @return bool
+   */
+  public function upgrade_1033() {
+    $this->deletePensionTypeDropdownMenu();
+    $this->updateDropdownMenuItemsLinkToUseOptionGroupName();
+
+    return TRUE;
+  }
+
+  /**
    * Removes the "Pension Type" item from the
    *  "Administer -> Customize Data and Screens -> Dropdowns" menu
    *
@@ -1154,16 +1166,14 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
    *
    * @return bool
    */
-  public function upgrade_1033() {
+  private function deletePensionTypeDropdownMenu() {
     civicrm_api3('Navigation', 'get', [
-      'sequential' => 1,
       'name' => 'hrjc_pension_type',
       'url' => ['LIKE' => 'civicrm/admin/options?gid%'],
       'api.Navigation.delete' => ['id' => '$value.id'],
     ]);
-    CRM_Core_BAO_Navigation::resetNavigation();
 
-    return TRUE;
+    CRM_Core_BAO_Navigation::resetNavigation();
   }
 
   /**
@@ -1173,7 +1183,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
    *
    * @return bool
    */
-  public function upgrade_1034() {
+  private function updateDropdownMenuItemsLinkToUseOptionGroupName() {
     $dropdownMenuItems = [
       'hrjc_contract_type',
       'hrjc_location',
@@ -1186,9 +1196,8 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
       'hrjc_contract_end_reason',
     ];
 
-    foreach($dropdownMenuItems as $menuItem) {
+    foreach ($dropdownMenuItems as $menuItem) {
       civicrm_api3('Navigation', 'get', [
-        'sequential' => 1,
         'name' => $menuItem,
         'url' => ['LIKE' => 'civicrm/admin/options?gid%'],
         'api.Navigation.create' => [
@@ -1199,8 +1208,6 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     }
 
     CRM_Core_BAO_Navigation::resetNavigation();
-
-    return TRUE;
   }
 
   /**

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -512,6 +512,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     $this->upgrade_1030();
     $this->upgrade_1032();
     $this->upgrade_1033();
+    $this->upgrade_1034();
   }
 
   function upgrade_1001() {
@@ -1160,6 +1161,43 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
       'url' => ['LIKE' => 'civicrm/admin/options?gid%'],
       'api.Navigation.delete' => ['id' => '$value.id'],
     ]);
+    CRM_Core_BAO_Navigation::resetNavigation();
+
+    return TRUE;
+  }
+
+  /**
+   * Update the URLs of all menu items pointing to Job Contracts options under
+   * the "Administer -> Customize Data and Screens -> Dropdowns" menu to have
+   * the option group name instead of its ID
+   *
+   * @return bool
+   */
+  public function upgrade_1034() {
+    $dropdownMenuItems = [
+      'hrjc_contract_type',
+      'hrjc_location',
+      'hrjc_pay_cycle',
+      'hrjc_benefit_name',
+      'hrjc_benefit_type',
+      'hrjc_deduction_name',
+      'hrjc_deduction_type',
+      'hrjc_revision_change_reason',
+      'hrjc_contract_end_reason',
+    ];
+
+    foreach($dropdownMenuItems as $menuItem) {
+      civicrm_api3('Navigation', 'get', [
+        'sequential' => 1,
+        'name' => $menuItem,
+        'url' => ['LIKE' => 'civicrm/admin/options?gid%'],
+        'api.Navigation.create' => [
+          'id' => '$value.id',
+          'url' => "civicrm/admin/options/{$menuItem}?reset=1"
+        ],
+      ]);
+    }
+
     CRM_Core_BAO_Navigation::resetNavigation();
 
     return TRUE;

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -511,6 +511,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     $this->upgrade_1029();
     $this->upgrade_1030();
     $this->upgrade_1032();
+    $this->upgrade_1033();
   }
 
   function upgrade_1001() {
@@ -1139,6 +1140,27 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
   public function upgrade_1032() {
     $query = "ALTER TABLE civicrm_hrpay_scale CHANGE periodicity pay_frequency VARCHAR(63)";
     CRM_Core_DAO::executeQuery($query);
+
+    return TRUE;
+  }
+
+  /**
+   * Removes the "Pension Type" item from the
+   *  "Administer -> Customize Data and Screens -> Dropdowns" menu
+   *
+   * The option group this menu item links to has been removed by PCHR-1820,
+   * but the menu item itself wasn't, so we're deleting it now.
+   *
+   * @return bool
+   */
+  public function upgrade_1033() {
+    civicrm_api3('Navigation', 'get', [
+      'sequential' => 1,
+      'name' => 'hrjc_pension_type',
+      'url' => ['LIKE' => 'civicrm/admin/options?gid%'],
+      'api.Navigation.delete' => ['id' => '$value.id'],
+    ]);
+    CRM_Core_BAO_Navigation::resetNavigation();
 
     return TRUE;
   }


### PR DESCRIPTION
## Overview
The Job Contracts extension adds some items to the Administer -> Customize Data and Screens -> Dropdowns menu, with links to pages where the users can add/update options to the extension's option groups. The URLs of these links contains the option group ID.

In some very unusual setups, the ID of the option group in the database might be different than the menu item link (especially when data is copied from one site to another), making it impossible for users to add or update the options.

## Before

The links to the Job Contract dropdowns followed this structure: `civicrm/admin/options?gid=<ID>` where ID was the option group ID

## After

The links to the Job Contract dropdowns now have the option group name instead of their ID. They now follow this structure: `civicrm/admin/options/<option_group_name>`

## Comments

As part of this PR, we're also deleting the menu item linking to the  "Pension type" option group. The reason is that this option group doesn't exist anymore. It was originally  deleted by https://github.com/civicrm/civihr/pull/1557, but the menu item was left behind.
