### PR TITLE
PCHR-2961: Set recruitment menu item icon also on install

### DIFF
--- a/hrrecruitment/hrrecruitment.php
+++ b/hrrecruitment/hrrecruitment.php
@@ -101,6 +101,7 @@ function hrrecruitment_civicrm_install() {
     'domain_id' => CRM_Core_Config::domainID(),
     'label' => ts('Recruitment'),
     'name' => 'Vacancies',
+    'icon' => 'crm-i fa-user-plus',
     'url' => null,
     'operator' => null,
     'weight' => $reportWeight-1,


### PR DESCRIPTION
_(nevermind the name of the branch with the wrong ticket number, the correct ticket was created after the branch was already created in other repos)_

The recruitment extension got its menu item's icon set for existing sites in the upgrader [here](https://github.com/civicrm/civihr/pull/2248), but the icon wasn't set when the extension was simply installed from scratch (as it happens for new sites). This PR fixes that.