### PR TITLE
PCHR-2856: Modify Conditions To Create Public Holiday Leave Requests.

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
@@ -583,7 +583,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
   }
 
   /**
-   * Returns the absence periods overlapping the given start and
+   * Returns the absence periods between the given start and
    * end dates ordered by the weight in ascending order. When
    * the end date is not present, it returns only the absence
    * periods with end dates >= to the start date.
@@ -594,7 +594,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    * @return CRM_HRLeaveAndAbsences_BAO_AbsencePeriod[]
    *   An empty array is returned when there are no absence periods
    */
-  public static function getPeriodsOverlappingDates(DateTime $fromDate, DateTime $toDate = null) {
+  public static function getPeriodsBetweenDates(DateTime $fromDate, DateTime $toDate = null) {
     $tableName = self::getTableName();
 
     $query = "SELECT * FROM {$tableName} WHERE end_date >= %1";

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
@@ -581,4 +581,41 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
     }
     return null;
   }
+
+  /**
+   * Returns the absence periods overlapping the given start and
+   * end dates ordered by the weight in ascending order. When
+   * the end date is not present, it returns only the absence
+   * periods with end dates >= to the start date.
+   *
+   * @param \DateTime $fromDate
+   * @param \DateTime|null $toDate
+   *
+   * @return CRM_HRLeaveAndAbsences_BAO_AbsencePeriod[]
+   *   An empty array is returned when there are no absence periods
+   */
+  public static function getPeriodsOverlappingDates(DateTime $fromDate, DateTime $toDate = null) {
+    $tableName = self::getTableName();
+
+    $query = "SELECT * FROM {$tableName} WHERE end_date >= %1";
+    $queryParams = [
+      1 => [$fromDate->format('Y-m-d'), 'String'],
+    ];
+
+    if($toDate){
+      $query .= ' AND start_date <= %2';
+      $queryParams[2] = [$toDate->format('Y-m-d'), 'String'];
+    }
+
+    $query .= ' ORDER BY weight ASC';
+
+    $absencePeriod = CRM_Core_DAO::executeQuery($query, $queryParams, true, self::class);
+
+    $absencePeriods = [];
+    while($absencePeriod->fetch()) {
+      $absencePeriods[] = clone $absencePeriod;
+    }
+
+    return $absencePeriods;
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/PublicHolidayLeaveRequestService.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Factory/PublicHolidayLeaveRequestService.php
@@ -3,6 +3,7 @@
 use CRM_HRLeaveAndAbsences_Service_JobContract as JobContractService;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest as PublicHolidayLeaveRequestService;
 use CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange as LeaveBalanceChangeService;
+use CRM_HRLeaveAndAbsences_Service_LeavePeriodEntitlement as LeavePeriodEntitlementService;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation as PublicHolidayLeaveRequestCreation;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion as PublicHolidayLeaveRequestDeletion;
 
@@ -21,10 +22,14 @@ class CRM_HRLeaveAndAbsences_Factory_PublicHolidayLeaveRequestService {
   public static function create() {
     $jobContractService = new JobContractService();
     $leaveBalanceChangeService = new LeaveBalanceChangeService();
-    $creationLogic = new PublicHolidayLeaveRequestCreation($jobContractService, $leaveBalanceChangeService);
+    $leavePeriodEntitlementService = new LeavePeriodEntitlementService();
+    $creationLogic = new PublicHolidayLeaveRequestCreation(
+      $jobContractService,
+      $leaveBalanceChangeService,
+      $leavePeriodEntitlementService
+    );
     $deletionLogic = new PublicHolidayLeaveRequestDeletion($jobContractService);
 
     return new PublicHolidayLeaveRequestService($creationLogic, $deletionLogic);
   }
-
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/Task/UpdatePublicHolidayLeaveRequestsForAbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/Task/UpdatePublicHolidayLeaveRequestsForAbsencePeriod.php
@@ -1,0 +1,25 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Factory_PublicHolidayLeaveRequestService as PublicHolidayLeaveRequestServiceFactory;
+
+/**
+ * This is the Queue Task which will be executed by the whenever the
+ * PublicHolidayLeaveRequestUpdates queue is processed.
+ *
+ * Basically, it uses the PublicHolidayLeaveRequest service to update all leave
+ * requests for public holidays in the absence period for contacts having contracts
+ * within the period.
+ * If contactID is not empty, the update is performed for these contacts only.
+ */
+class CRM_HRLeaveAndAbsences_Queue_Task_UpdatePublicHolidayLeaveRequestsForAbsencePeriod {
+
+  /**
+   * @param \CRM_Queue_TaskContext $ctx
+   * @param int $absencePeriodID
+   * @param array $contactID
+   */
+  public static function run(CRM_Queue_TaskContext $ctx, $absencePeriodID, array $contactID = []) {
+    $service = PublicHolidayLeaveRequestServiceFactory::create();
+    $service->updateAllForAbsencePeriod($absencePeriodID, $contactID);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeavePeriodEntitlement.php
@@ -1,0 +1,22 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement as LeavePeriodEntitlement;
+
+class CRM_HRLeaveAndAbsences_Service_LeavePeriodEntitlement {
+
+  /**
+   * This method uses getEntitlementsForContacts method of the
+   * LeavePeriodEntitlement BAO to return a list of entitlements
+   * for the given Contacts during the given during the given
+   * Absence Period for the given Absence Type
+   *
+   * @param array $contactIDs
+   * @param int $absencePeriodID
+   * @param int $absenceTypeID
+   *
+   * @return array
+   */
+  public function getEntitlementsForContacts($contactIDs, $absencePeriodID, $absenceTypeID) {
+    return LeavePeriodEntitlement::getEntitlementsForContacts($contactIDs, $absencePeriodID, $absenceTypeID);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
@@ -3,6 +3,7 @@
 use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation as CreationLogic;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion as DeletionLogic;
+use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
 
 class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest {
 
@@ -99,7 +100,8 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest {
    * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation::createForAllinAbsencePeriod()
    */
   public function updateAllForAbsencePeriod($absencePeriodID, array $contactID = []) {
-    $this->deletionLogic->deleteAllForAbsencePeriod($absencePeriodID, $contactID);
-    $this->creationLogic->createForAllinAbsencePeriod($absencePeriodID, $contactID);
+    $absencePeriod = AbsencePeriod::findById($absencePeriodID);
+    $this->deletionLogic->deleteAllForAbsencePeriod($absencePeriod, $contactID);
+    $this->creationLogic->createAllForAbsencePeriod($absencePeriod, $contactID);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
@@ -85,4 +85,17 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest {
     $this->creationLogic->createAllInFutureForWorkPatternContacts($workPatternID);
   }
 
+  /**
+   * Updates all the leave requests for Public Holidays for the absence
+   * period for the contacts with contracts during the period.
+   *
+   * @param int $absencePeriodID
+   *
+   * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion::deleteAllForAbsencePeriod()
+   * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation::createForAllinAbsencePeriod()
+   */
+  public function updateAllForAbsencePeriod($absencePeriodID) {
+    $this->deletionLogic->deleteAllForAbsencePeriod($absencePeriodID);
+    $this->creationLogic->createForAllinAbsencePeriod($absencePeriodID);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
@@ -89,13 +89,17 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest {
    * Updates all the leave requests for Public Holidays for the absence
    * period for the contacts with contracts during the period.
    *
+   * If contactID is present, it will update only for the contacts in the
+   * array.
+   *
    * @param int $absencePeriodID
+   * @param array $contactID
    *
    * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion::deleteAllForAbsencePeriod()
    * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation::createForAllinAbsencePeriod()
    */
-  public function updateAllForAbsencePeriod($absencePeriodID) {
-    $this->deletionLogic->deleteAllForAbsencePeriod($absencePeriodID);
-    $this->creationLogic->createForAllinAbsencePeriod($absencePeriodID);
+  public function updateAllForAbsencePeriod($absencePeriodID, array $contactID = []) {
+    $this->deletionLogic->deleteAllForAbsencePeriod($absencePeriodID, $contactID);
+    $this->creationLogic->createForAllinAbsencePeriod($absencePeriodID, $contactID);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -73,7 +73,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
 
     foreach($contracts as $contract) {
       if($this->contactHasEntitlement($entitlements, $contract['contact_id'])) {
-        $this->create($contract['contact_id'], $publicHoliday);
+        $this->createForContact($contract['contact_id'], $publicHoliday);
       }
     }
   }
@@ -187,20 +187,6 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
       return;
     }
 
-    $this->create($contactID, $publicHoliday);
-  }
-
-  /**
-   * Creates a Public Holiday Leave Request for the given $contactID, Absence
-   * Type and Public Holiday.
-   *
-   * The Leave Request will only be created if there's no existing Public Holiday
-   * Leave Request for the given $contactID and $publicHoliday.
-   *
-   * @param int $contactID
-   * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
-   */
-  private function create($contactID, PublicHoliday $publicHoliday) {
     $existingLeaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
     if($existingLeaveRequest) {
       return;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -106,7 +106,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
 
     $this->adjustPeriodDates($absencePeriods, $today);
     foreach($absencePeriods as $absencePeriod) {
-      $this->createForAbsencePeriod($absencePeriod, $contactID);
+      $this->createAllForAbsencePeriod($absencePeriod, $contactID);
     }
   }
 
@@ -332,7 +332,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
 
   /**
    * Creates Public Holiday Leave Requests for all public Holidays
-   * within the given Absence Period ID for contacts with contracts and
+   * within the given Absence Period for contacts with contracts and
    * entitlements for the absence type with MTPHL within this period.
    * If the contactID is present will create only for the contacts in the
    * contactID array
@@ -341,28 +341,10 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
    * entitlement for the absence type with MTPHL in the absence period the
    * public holiday date falls in.
    *
-   * @param int $absencePeriodID
-   * @param array $contactID
-   */
-  public function createForAllinAbsencePeriod($absencePeriodID, array $contactID = []) {
-    $absencePeriod = AbsencePeriod::findById($absencePeriodID);
-    $this->createForAbsencePeriod($absencePeriod, $contactID);
-  }
-
-  /**
-   * Creates Public Holiday Leave Requests for all public Holidays
-   * within the given Absence Period for contacts with contracts and
-   * entitlements for the absence type with MTPHL within this period.
-   *
-   * The Public Holiday leave request will not be created if contact has no
-   * entitlement for the absence type with MTPHL in the absence period the
-   * public holiday date falls in.
-   *
    * @param AbsencePeriod $absencePeriod
    * @param array $contactID
-   *  If not empty, Public Holiday Leave Requests are created for only these contacts
    */
-  private function createForAbsencePeriod($absencePeriod, array $contactID = []) {
+  public function createAllForAbsencePeriod($absencePeriod, array $contactID = []) {
     if(!$this->absenceType) {
       return;
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -359,7 +359,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
       $contactID
     );
 
-    $contactIDs = array_column($contracts, 'contact_id');
+    $contactIDs = array_unique(array_column($contracts, 'contact_id'));
     $entitlements = $this->getEntitlementsForContacts($contactIDs, $absencePeriod);
 
     foreach($contracts as $contract) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -9,6 +9,8 @@ use CRM_HRLeaveAndAbsences_Service_JobContract as JobContractService;
 use CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange as LeaveBalanceChangeService;
 use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
 use CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern as ContactWorkPattern;
+use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
+use CRM_HRLeaveAndAbsences_Service_LeavePeriodEntitlement as LeavePeriodEntitlementService;
 
 class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
 
@@ -22,21 +24,42 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
    */
   private $leaveBalanceChangeService;
 
-  public function __construct(JobContractService $jobContractService, LeaveBalanceChangeService $leaveBalanceChangeService) {
+  /**
+   * @var \CRM_HRLeaveAndAbsences_Service_LeavePeriodEntitlement
+   */
+  private $leavePeriodEntitlementService;
+
+  /**
+   * @var \CRM_HRLeaveAndAbsences_BAO_AbsenceType|null
+   *   An absence Type with MTPHL set to true
+   */
+  private $absenceType;
+
+  public function __construct(
+    JobContractService $jobContractService,
+    LeaveBalanceChangeService $leaveBalanceChangeService,
+    LeavePeriodEntitlementService $leavePeriodEntitlementService)
+  {
     $this->jobContractService = $jobContractService;
     $this->leaveBalanceChangeService = $leaveBalanceChangeService;
+    $this->leavePeriodEntitlementService = $leavePeriodEntitlementService;
+    $this->absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
   }
 
   /**
    * Creates Public Holiday Leave Requests for all the contacts with contracts
-   * overlapping the date of the given Public Holiday
+   * overlapping the date of the given Public Holiday.
+   *
+   * The Public Holiday leave request will not be created if contact has no
+   * entitlement for the absence type with MTPHL in the absence period the
+   * public holiday date falls in.
    *
    * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
    */
   public function createForAllContacts(PublicHoliday $publicHoliday) {
-    $absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
+    $absencePeriod = AbsencePeriod::getPeriodOverlappingDate(new DateTime($publicHoliday->date));
 
-    if(!$absenceType) {
+    if(!$absencePeriod || !$this->absenceType) {
       return;
     }
 
@@ -45,8 +68,13 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
       new DateTime($publicHoliday->date)
     );
 
+    $contactIDs = array_column($contracts, 'contact_id');
+    $entitlements = $this->getEntitlementsForContacts($contactIDs, $absencePeriod);
+
     foreach($contracts as $contract) {
-      $this->create($contract['contact_id'], $absenceType, $publicHoliday);
+      if($this->contactHasEntitlement($entitlements, $contract['contact_id'], $this->absenceType->id)) {
+        $this->create($contract['contact_id'], $this->absenceType, $publicHoliday);
+      }
     }
   }
 
@@ -57,30 +85,52 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
    * For each contract overlapping one Public Holiday, a Leave Request will be
    * created for the contract's contact and the public holiday date.
    *
+   * The Public Holiday leave request will not be created if contact has no
+   * entitlement for the absence type with MTPHL in the absence period the
+   * public holiday date falls in.
+   *
    * @param array $contactID
    *  If not empty, Public Holiday Leave Requests are created for only these contacts
    */
   public function createForAllInTheFuture(array $contactID = []) {
-    $absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
-
-    if(!$absenceType) {
+    if(!$this->absenceType) {
       return;
     }
 
-    $futurePublicHolidays = PublicHoliday::getAllInFuture();
-    $lastPublicHoliday = end($futurePublicHolidays);
+    $today = new DateTime();
+    $absencePeriods = AbsencePeriod::getPeriodsOverlappingDates($today);
 
-    $contracts = $this->jobContractService->getContractsForPeriod(
-      new DateTime(),
-      new DateTime($lastPublicHoliday->date),
-      $contactID
-    );
+    if(!$absencePeriods) {
+      return;
+    }
 
-    foreach($contracts as $contract) {
-      foreach($futurePublicHolidays as $publicHoliday) {
-        if($this->publicHolidayOverlapsContract($contract, $publicHoliday)) {
-          $this->create($contract['contact_id'], $absenceType, $publicHoliday);
-        }
+    $this->adjustPeriodDates($absencePeriods, $today);
+    foreach($absencePeriods as $absencePeriod) {
+      $this->createForAbsencePeriod($absencePeriod, $contactID);
+    }
+  }
+
+  /**
+   * Adjusts the absence periods array to conform to the start and end
+   * date interval. It does this by setting the from date of the first
+   * absence period to the startDate and the end date of the last absence
+   * period to the endDate if present.
+   *
+   * @param array $absencePeriods
+   * @param DateTime $startDate
+   * @param DateTime|null $endDate
+   */
+  private function adjustPeriodDates($absencePeriods, DateTime $startDate, DateTime $endDate = null){
+    $firstPeriod = reset($absencePeriods);
+
+    if(new DateTime($firstPeriod->start_date) < $startDate) {
+      $firstPeriod->start_date = $startDate->format('Y-m-d');
+    }
+
+    if($endDate) {
+      $lastPeriod = end($absencePeriods);
+      if(new DateTime($lastPeriod->end_date) > $endDate) {
+        $lastPeriod->end_date = $endDate->format('Y-m-d');
       }
     }
   }
@@ -88,23 +138,40 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
   /**
    * Creates Public Holiday Leave Requests for all Public Holidays
    * overlapping the start and end dates of the given contract
+   * The Public Holiday leave request will not be created if contact has no
+   * entitlement for the absence type with MTPHL in the absence period the
+   * public holiday date falls in.
    *
    * @param int $contractID
    */
   public function createAllForContract($contractID) {
     $contract = $this->jobContractService->getContractByID($contractID);
 
-    if (!$contract) {
+    if (!$contract || !$this->absenceType) {
       return;
     }
 
-    $publicHolidays = PublicHoliday::getAllForPeriod(
-      $contract['period_start_date'],
-      $contract['period_end_date']
-    );
+    $contractStartDate = new DateTime($contract['period_start_date']);
+    $contractEndDate = $contract['period_end_date'] ? new DateTime($contract['period_end_date']) : null;
+    $absencePeriods = AbsencePeriod::getPeriodsOverlappingDates($contractStartDate, $contractEndDate);
 
-    foreach($publicHolidays as $publicHoliday) {
-      $this->createForContact($contract['contact_id'], $publicHoliday);
+    if(!$absencePeriods) {
+      return;
+    }
+
+    $this->adjustPeriodDates($absencePeriods, $contractStartDate, $contractEndDate);
+    foreach($absencePeriods as $absencePeriod) {
+      $publicHolidays = PublicHoliday::getAllForPeriod(
+        $absencePeriod->start_date,
+        $absencePeriod->end_date
+      );
+
+      $entitlements = $this->getEntitlementsForContacts([$contract['contact_id']], $absencePeriod);
+      foreach($publicHolidays as $publicHoliday) {
+        if($this->contactHasEntitlement($entitlements, $contract['contact_id'], $this->absenceType->id)) {
+          $this->create($contract['contact_id'], $this->absenceType, $publicHoliday);
+        }
+      }
     }
   }
 
@@ -116,13 +183,11 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
    * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
    */
   public function createForContact($contactID, PublicHoliday $publicHoliday) {
-    $absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
-
-    if (!$absenceType) {
+    if (!$this->absenceType) {
       return;
     }
 
-    $this->create($contactID, $absenceType, $publicHoliday);
+    $this->create($contactID, $this->absenceType, $publicHoliday);
   }
 
   /**
@@ -263,6 +328,96 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
     }
 
     $this->createForAllInTheFuture($contacts);
+  }
+
+  /**
+   * Creates Public Holiday Leave Requests for all public Holidays
+   * within the given Absence Period ID for contacts with contracts and
+   * entitlements for the absence type with MTPHL within this period.
+   *
+   * The Public Holiday leave request will not be created if contact has no
+   * entitlement for the absence type with MTPHL in the absence period the
+   * public holiday date falls in.
+   *
+   * @param int $absencePeriodID
+   */
+  public function createForAllinAbsencePeriod($absencePeriodID) {
+    $absencePeriod = AbsencePeriod::findById($absencePeriodID);
+    $this->createForAbsencePeriod($absencePeriod);
+  }
+
+  /**
+   * Creates Public Holiday Leave Requests for all public Holidays
+   * within the given Absence Period for contacts with contracts and
+   * entitlements for the absence type with MTPHL within this period.
+   *
+   * The Public Holiday leave request will not be created if contact has no
+   * entitlement for the absence type with MTPHL in the absence period the
+   * public holiday date falls in.
+   *
+   * @param AbsencePeriod $absencePeriod
+   * @param array $contactID
+   *  If not empty, Public Holiday Leave Requests are created for only these contacts
+   */
+  private function createForAbsencePeriod($absencePeriod, array $contactID = []) {
+    if(!$this->absenceType) {
+      return;
+    }
+
+    $publicHolidays = PublicHoliday::getAllForPeriod(
+      $absencePeriod->start_date,
+      $absencePeriod->end_date
+    );
+
+    $contracts = $this->jobContractService->getContractsForPeriod(
+      new DateTime($absencePeriod->start_date),
+      new DateTime($absencePeriod->end_date),
+      $contactID
+    );
+
+    $contactIDs = array_column($contracts, 'contact_id');
+    $entitlements = $this->getEntitlementsForContacts($contactIDs, $absencePeriod);
+
+    foreach($contracts as $contract) {
+      foreach($publicHolidays as $publicHoliday) {
+        if($this->publicHolidayOverlapsContract($contract, $publicHoliday)) {
+          if($this->contactHasEntitlement($entitlements, $contract['contact_id'], $this->absenceType->id)) {
+            $this->create($contract['contact_id'], $this->absenceType, $publicHoliday);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Checks if the contract's contact has entitlement for the given
+   * absence type ID.
+   *
+   * @param array $entitlements
+   * @param int $contactID
+   * @param int $absenceTypeID
+   *
+   * @return bool
+   */
+  private function contactHasEntitlement($entitlements, $contactID, $absenceTypeID) {
+    return !empty($entitlements[$contactID][$absenceTypeID]) && $entitlements[$contactID][$absenceTypeID] != 0;
+  }
+
+  /**
+   * Returns the entitlements for the given contact(s) during the absence
+   * period for the absence type with MTPHL.
+   *
+   * @param array $contactIDs
+   * @param AbsencePeriod $absencePeriod
+   *
+   * @return array
+   */
+  private function getEntitlementsForContacts($contactIDs, AbsencePeriod $absencePeriod) {
+    return $this->leavePeriodEntitlementService->getEntitlementsForContacts(
+      $contactIDs,
+      $absencePeriod->id,
+      $this->absenceType->id
+    );
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -98,7 +98,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
     }
 
     $today = new DateTime();
-    $absencePeriods = AbsencePeriod::getPeriodsOverlappingDates($today);
+    $absencePeriods = AbsencePeriod::getPeriodsBetweenDates($today);
 
     if(!$absencePeriods) {
       return;
@@ -153,7 +153,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
 
     $contractStartDate = new DateTime($contract['period_start_date']);
     $contractEndDate = $contract['period_end_date'] ? new DateTime($contract['period_end_date']) : null;
-    $absencePeriods = AbsencePeriod::getPeriodsOverlappingDates($contractStartDate, $contractEndDate);
+    $absencePeriods = AbsencePeriod::getPeriodsBetweenDates($contractStartDate, $contractEndDate);
 
     if(!$absencePeriods) {
       return;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -334,16 +334,19 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
    * Creates Public Holiday Leave Requests for all public Holidays
    * within the given Absence Period ID for contacts with contracts and
    * entitlements for the absence type with MTPHL within this period.
+   * If the contactID is present will create only for the contacts in the
+   * contactID array
    *
    * The Public Holiday leave request will not be created if contact has no
    * entitlement for the absence type with MTPHL in the absence period the
    * public holiday date falls in.
    *
    * @param int $absencePeriodID
+   * @param array $contactID
    */
-  public function createForAllinAbsencePeriod($absencePeriodID) {
+  public function createForAllinAbsencePeriod($absencePeriodID, array $contactID = []) {
     $absencePeriod = AbsencePeriod::findById($absencePeriodID);
-    $this->createForAbsencePeriod($absencePeriod);
+    $this->createForAbsencePeriod($absencePeriod, $contactID);
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
@@ -103,9 +103,11 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion {
       $contactID
     );
 
-    foreach($contracts as $contract) {
+    $contactIDs = array_unique(array_column($contracts, 'contact_id'));
+
+    foreach($contactIDs as $contactID) {
       foreach($futurePublicHolidays as $publicHoliday) {
-        $this->deleteForContact($contract['contact_id'], $publicHoliday);
+        $this->deleteForContact($contactID, $publicHoliday);
       }
     }
   }
@@ -184,9 +186,11 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion {
       $contactID
     );
 
-    foreach($contracts as $contract) {
+    $contactIDs = array_unique(array_column($contracts, 'contact_id'));
+
+    foreach($contactIDs as $contactID) {
       foreach($publicHolidays as $publicHoliday) {
-        $this->deleteForContact($contract['contact_id'], $publicHoliday);
+        $this->deleteForContact($contactID, $publicHoliday);
       }
     }
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
@@ -169,12 +169,10 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion {
    * If contactID is present, will only delete for the contacts in the
    * array.
    *
-   * @param int $absencePeriodID
+   * @param AbsencePeriod $absencePeriod
    * @param array $contactID
    */
-  public function deleteAllForAbsencePeriod($absencePeriodID, array $contactID = []) {
-    $absencePeriod = AbsencePeriod::findById($absencePeriodID);
-
+  public function deleteAllForAbsencePeriod($absencePeriod, array $contactID = []) {
     $publicHolidays = PublicHoliday::getAllForPeriod(
       $absencePeriod->start_date,
       $absencePeriod->end_date

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
@@ -166,9 +166,13 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion {
    * within the given Absence Period for all contacts with contracts
    * within the period.
    *
+   * If contactID is present, will only delete for the contacts in the
+   * array.
+   *
    * @param int $absencePeriodID
+   * @param array $contactID
    */
-  public function deleteAllForAbsencePeriod($absencePeriodID) {
+  public function deleteAllForAbsencePeriod($absencePeriodID, array $contactID = []) {
     $absencePeriod = AbsencePeriod::findById($absencePeriodID);
 
     $publicHolidays = PublicHoliday::getAllForPeriod(
@@ -178,7 +182,8 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion {
 
     $contracts = $this->jobContractService->getContractsForPeriod(
       new DateTime($absencePeriod->start_date),
-      new DateTime($absencePeriod->end_date)
+      new DateTime($absencePeriod->end_date),
+      $contactID
     );
 
     foreach($contracts as $contract) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/PublicHolidayLeaveRequest.php
@@ -4,6 +4,7 @@ use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
 use CRM_HRLeaveAndAbsences_Service_JobContract as JobContractService;
 use CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange as LeaveBalanceChangeService;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation as PublicHolidayLeaveRequestCreation;
+use CRM_HRLeaveAndAbsences_Service_LeavePeriodEntitlement as LeavePeriodEntitlementService;
 
 class CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest {
 
@@ -26,7 +27,12 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest {
     if ($mockBalanceChangeService) {
       $leaveBalanceChangeService = $mockBalanceChangeService;
     }
-    $creationLogic = new PublicHolidayLeaveRequestCreation(new JobContractService(), $leaveBalanceChangeService);
+    $leavePeriodEntitlementService = new LeavePeriodEntitlementService();
+    $creationLogic = new PublicHolidayLeaveRequestCreation(
+      new JobContractService(),
+      $leaveBalanceChangeService,
+      $leavePeriodEntitlementService
+    );
     $creationLogic->createForContact($contactID, $publicHoliday);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
@@ -804,7 +804,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseHeadlessTest {
     $this->assertNull($absencePeriod);
   }
 
-  public function testGetPeriodsOverlappingDatesReturnsPeriodsOverlappingTheFromAndToDates() {
+  public function testGetPeriodsBetweenDatesReturnsPeriodsOverlappingTheFromAndToDates() {
     $period5 = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-11-05'),
       'end_date' => CRM_Utils_Date::processDate('2016-12-31'),
@@ -840,7 +840,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseHeadlessTest {
     //ascending order.
     $fromDate = new DateTime('2016-04-20');
     $toDate = new DateTime('2016-10-25');
-    $absencePeriods = AbsencePeriod::getPeriodsOverlappingDates($fromDate, $toDate);
+    $absencePeriods = AbsencePeriod::getPeriodsBetweenDates($fromDate, $toDate);
     $this->assertCount(3, $absencePeriods);
 
     //Since the periods should be arranged in ascending order by weight
@@ -853,7 +853,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseHeadlessTest {
     //So overlapping periods should be period 4, 5
     $fromDate = new DateTime('2016-09-05');
     $toDate = new DateTime('2016-12-31');
-    $absencePeriods = AbsencePeriod::getPeriodsOverlappingDates($fromDate, $toDate);
+    $absencePeriods = AbsencePeriod::getPeriodsBetweenDates($fromDate, $toDate);
     $this->assertCount(2, $absencePeriods);
 
     //Since the periods should be arranged in ascending order by weight
@@ -861,7 +861,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseHeadlessTest {
     $this->assertEquals($period5->id, $absencePeriods[1]->id);
   }
 
-  public function testGetPeriodsOverlappingDatesReturnsPeriodsWithEndDateGreaterThanOrEqualToTheStartDateWhenEndDateIsNull() {
+  public function testGetPeriodsBetweenDatesReturnsPeriodsWithEndDateGreaterThanOrEqualToTheStartDateWhenEndDateIsNull() {
     $period5 = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-11-05'),
       'end_date' => CRM_Utils_Date::processDate('2016-12-31'),
@@ -895,7 +895,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseHeadlessTest {
     //From Date is exactly the start date of period 2
     //Overlapping periods should be period 2,3,4,5
     $fromDate = new DateTime('2016-04-10');
-    $absencePeriods = AbsencePeriod::getPeriodsOverlappingDates($fromDate, null);
+    $absencePeriods = AbsencePeriod::getPeriodsBetweenDates($fromDate, null);
     $this->assertCount(4, $absencePeriods);
 
     //Since the periods should be arranged in ascending order by weight
@@ -905,7 +905,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseHeadlessTest {
     $this->assertEquals($period5->id, $absencePeriods[3]->id);
   }
 
-  public function testGetPeriodsOverlappingDatesReturnsEmptyWhenNoOverlappingPeriodsAreFound() {
+  public function testGetPeriodsBetweenDatesReturnsEmptyWhenNoOverlappingPeriodsAreFound() {
     $period2 = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-04-10'),
       'end_date' => CRM_Utils_Date::processDate('2016-05-20'),
@@ -920,7 +920,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseHeadlessTest {
 
     $fromDate = new DateTime('2016-09-05');
     $toDate = new DateTime('2016-12-31');
-    $absencePeriods = AbsencePeriod::getPeriodsOverlappingDates($fromDate, $toDate);
+    $absencePeriods = AbsencePeriod::getPeriodsBetweenDates($fromDate, $toDate);
     $this->assertEmpty($absencePeriods);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
@@ -803,4 +803,124 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseHeadlessTest {
     $absencePeriod = AbsencePeriod::getPeriodContainingDates($fromDate, $toDate);
     $this->assertNull($absencePeriod);
   }
+
+  public function testGetPeriodsOverlappingDatesReturnsPeriodsOverlappingTheFromAndToDates() {
+    $period5 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-11-05'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31'),
+      'weight' => 5
+    ]);
+
+    $period4 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-09-05'),
+      'end_date' => CRM_Utils_Date::processDate('2016-10-28'),
+      'weight' => 4
+    ]);
+
+    $period3 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-06-11'),
+      'end_date' => CRM_Utils_Date::processDate('2016-08-30'),
+      'weight' => 3
+    ]);
+
+    $period2 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-04-10'),
+      'end_date' => CRM_Utils_Date::processDate('2016-05-20'),
+      'weight' => 2
+    ]);
+
+    $period1 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-03-30'),
+      'weight' => 1
+    ]);
+
+    //From date is after start date of period2 and to date is before the end date
+    //of period 4. So overlapping periods should be period 2,3,4 and arranged in
+    //ascending order.
+    $fromDate = new DateTime('2016-04-20');
+    $toDate = new DateTime('2016-10-25');
+    $absencePeriods = AbsencePeriod::getPeriodsOverlappingDates($fromDate, $toDate);
+    $this->assertCount(3, $absencePeriods);
+
+    //Since the periods should be arranged in ascending order by weight
+    $this->assertEquals($period2->id, $absencePeriods[0]->id);
+    $this->assertEquals($period3->id, $absencePeriods[1]->id);
+    $this->assertEquals($period4->id, $absencePeriods[2]->id);
+
+    //From date is exactly the start date of period 4 and to date is the end date
+    //of period 5
+    //So overlapping periods should be period 4, 5
+    $fromDate = new DateTime('2016-09-05');
+    $toDate = new DateTime('2016-12-31');
+    $absencePeriods = AbsencePeriod::getPeriodsOverlappingDates($fromDate, $toDate);
+    $this->assertCount(2, $absencePeriods);
+
+    //Since the periods should be arranged in ascending order by weight
+    $this->assertEquals($period4->id, $absencePeriods[0]->id);
+    $this->assertEquals($period5->id, $absencePeriods[1]->id);
+  }
+
+  public function testGetPeriodsOverlappingDatesReturnsPeriodsWithEndDateGreaterThanOrEqualToTheStartDateWhenEndDateIsNull() {
+    $period5 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-11-05'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31'),
+      'weight' => 5
+    ]);
+
+    $period4 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-09-05'),
+      'end_date' => CRM_Utils_Date::processDate('2016-10-28'),
+      'weight' => 4
+    ]);
+
+    $period3 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-06-11'),
+      'end_date' => CRM_Utils_Date::processDate('2016-08-30'),
+      'weight' => 3
+    ]);
+
+    $period2 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-04-10'),
+      'end_date' => CRM_Utils_Date::processDate('2016-05-20'),
+      'weight' => 2
+    ]);
+
+    $period1 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-03-30'),
+      'weight' => 1
+    ]);
+
+    //From Date is exactly the start date of period 2
+    //Overlapping periods should be period 2,3,4,5
+    $fromDate = new DateTime('2016-04-10');
+    $absencePeriods = AbsencePeriod::getPeriodsOverlappingDates($fromDate, null);
+    $this->assertCount(4, $absencePeriods);
+
+    //Since the periods should be arranged in ascending order by weight
+    $this->assertEquals($period2->id, $absencePeriods[0]->id);
+    $this->assertEquals($period3->id, $absencePeriods[1]->id);
+    $this->assertEquals($period4->id, $absencePeriods[2]->id);
+    $this->assertEquals($period5->id, $absencePeriods[3]->id);
+  }
+
+  public function testGetPeriodsOverlappingDatesReturnsEmptyWhenNoOverlappingPeriodsAreFound() {
+    $period2 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-04-10'),
+      'end_date' => CRM_Utils_Date::processDate('2016-05-20'),
+      'weight' => 2
+    ]);
+
+    $period1 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-03-30'),
+      'weight' => 1
+    ]);
+
+    $fromDate = new DateTime('2016-09-05');
+    $toDate = new DateTime('2016-12-31');
+    $absencePeriods = AbsencePeriod::getPeriodsOverlappingDates($fromDate, $toDate);
+    $this->assertEmpty($absencePeriods);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
@@ -793,7 +793,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
                 ->method('getProRata')
                 ->will($this->returnValue($proRata));
 
-    $calculation->expects($this->once())
+    $calculation->expects($this->any())
                 ->method('getBroughtForwardExpirationDate')
                 ->will($this->returnValue('2016-01-01'));
 
@@ -1714,6 +1714,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
 
     //Contact has initial entitlement of 5
     $this->createLeaveBalanceChange($periodEntitlement->id, 5);
+
 
     $calculation = $this->getEntitlementCalculationMock(
       $period,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -854,7 +854,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'date' =>  CRM_Utils_Date::processDate('2017-02-01')
     ]);
 
-    $this->getCreationLogic()->createForAllInAbsencePeriod($period->id);
+    $this->getCreationLogic()->createAllForAbsencePeriod($period);
 
     //The first public holiday is before the absence period and the last public holiday is
     //after the absence period. So the balance will be -2 for both contacts
@@ -910,7 +910,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'date' =>  CRM_Utils_Date::processDate('2016-09-01')
     ]);
 
-    $this->getCreationLogic()->createForAllInAbsencePeriod($period->id, [$contact['id']]);
+    $this->getCreationLogic()->createAllForAbsencePeriod($period, [$contact['id']]);
 
     //Public holiday leave requests will only be created for the first contact.
     $this->assertEquals(-2, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
@@ -976,7 +976,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'date' =>  CRM_Utils_Date::processDate('2016-10-01')
     ]);
 
-    $this->getCreationLogic()->createForAllInAbsencePeriod($period->id);
+    $this->getCreationLogic()->createAllForAbsencePeriod($period);
 
     //So the balance will be -3 for the first contact
     //the second contact has no entitlement for the period so no public holiday

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -803,6 +803,395 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));
   }
 
+  public function testCanCreatePublicHolidayLeaveRequestsForAllPublicHolidaysInAbsencePeriod() {
+    $contact = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'period_id' => $period->id,
+      'type_id' => $this->absenceType->id,
+    ]);
+
+    $periodEntitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact2['id'],
+      'period_id' => $period->id,
+      'type_id' => $this->absenceType->id,
+    ]);
+
+    //Add entitlements for the contacts
+    $this->createLeaveBalanceChange($periodEntitlement->id, 1);
+    $this->createLeaveBalanceChange($periodEntitlement2->id, 1);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact['id']],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('2015-12-31')
+    ]);
+
+    $publicHoliday2 = PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('2016-01-01')
+    ]);
+
+    $publicHoliday3 = PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('2016-09-01')
+    ]);
+
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('2017-02-01')
+    ]);
+
+    $this->getCreationLogic()->createForAllInAbsencePeriod($period->id);
+
+
+    //The first public holiday is before the absence period and the last public holiday is
+    //after the absence period. So the balance will be -2 for both contacts
+    $this->assertEquals(-2, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday3));
+
+    $this->assertEquals(-2, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement2));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday3));
+  }
+
+  public function testPublicHolidayLeaveRequestsAreNotCreatedWhenContactHasZeroEntitlementForPeriod() {
+    $contact = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'period_id' => $period->id,
+      'type_id' => $this->absenceType->id,
+    ]);
+
+    $periodEntitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact2['id'],
+      'period_id' => $period->id,
+      'type_id' => $this->absenceType->id,
+    ]);
+
+    //Add entitlements for the contacts
+    $this->createLeaveBalanceChange($periodEntitlement->id, 1);
+    $this->createLeaveBalanceChange($periodEntitlement2->id, 0);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact['id']],
+      ['period_start_date' => '2016-03-01']
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    //This public holiday is within the absence  period but
+    //the first contact does not have a contract during this
+    //public holiday date, so it will not be included.
+    $publicHoliday1 = PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('2016-01-01')
+    ]);
+
+    $publicHoliday2 = PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('2016-03-01')
+    ]);
+
+    $publicHoliday3 = PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('2016-09-01')
+    ]);
+
+    $publicHoliday4 = PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('2016-10-01')
+    ]);
+
+    $this->getCreationLogic()->createForAllInAbsencePeriod($period->id);
+
+    //So the balance will be -3 for the first contact
+    //the second contact has no entitlement for the period so no public holiday
+    //leave request will be created.
+    $this->assertEquals(-3, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday3));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday4));
+
+    $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement2));
+  }
+
+  public function testCreateAllForContractDoesNotCreateForPeriodWhereContactHasNoEntitlement() {
+    $contact = ContactFabricator::fabricate();
+
+    $contract = HRJobContractFabricator::fabricate([
+      'contact_id' => $contact['id']], [
+      'period_start_date' =>  CRM_Utils_Date::processDate('2016-01-10'),
+      'period_end_date' =>   CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    $period1 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-04-30')
+    ]);
+
+    $period2 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-07-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-30')
+    ]);
+
+    $periodEntitlement1 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'period_id' => $period1->id,
+      'type_id' => $this->absenceType->id,
+    ]);
+
+    $periodEntitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'period_id' => $period2->id,
+      'type_id' => $this->absenceType->id,
+    ]);
+
+    $this->createLeaveBalanceChange($periodEntitlement1->id, 1);
+    $this->createLeaveBalanceChange($periodEntitlement2->id, 0);
+
+    //Public holiday is within the first absence period where contact has entitlement
+    //but does not overlap the contract date.
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('2016-01-01')
+    ]);
+
+    //Public holiday is within the first absence period
+    //and contact has entitlement for this period
+    $publicHoliday2 = PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('2016-03-30')
+    ]);
+
+    //Public holiday is within the lapse between absence period 1 and 2
+    //i.e its not within any absence period
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('2016-06-06')
+    ]);
+
+    //Public holiday is within the second absence period but contact
+    //has no entitlement for this period.
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('2016-07-06')
+    ]);
+
+    $this->getCreationLogic()->createAllForContract($contract['id']);
+
+    //Only Public holiday leave request for '2016-03-30' is created within period 1. none for period 2
+    //for which contact has no entitlement.
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2));
+    $this->assertEquals(-1, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement1));
+
+    $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement2));
+  }
+
+  public function testCreateForAllContactsDoesNotCreateForPeriodWhereContactHasNoEntitlement() {
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+    $contact3 = ContactFabricator::fabricate();
+
+    $period = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2016-02-01'),
+    ]);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      ['period_start_date' => CRM_Utils_Date::processDate('2016-01-01')]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => CRM_Utils_Date::processDate('2016-01-01')]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact3['id']],
+      ['period_start_date' => CRM_Utils_Date::processDate('2016-01-01')]
+    );
+
+    $periodEntitlement1 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact1['id'],
+      'period_id' => $period->id,
+      'type_id' => $this->absenceType->id,
+    ]);
+
+    $periodEntitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact2['id'],
+      'period_id' => $period->id,
+      'type_id' => $this->absenceType->id,
+    ]);
+
+    $this->createLeaveBalanceChange($periodEntitlement1->id, 1);
+    $this->createLeaveBalanceChange($periodEntitlement2->id, 0);
+
+    $publicHoliday = new PublicHoliday();
+    $publicHoliday->date = '2016-01-20';
+
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));
+
+    $this->getCreationLogic()->createForAllContacts($publicHoliday);
+
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday));
+
+    //Contact2 has zero entitlement for the period therefore the public holiday leave request will not be
+    //created fot it.
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));
+
+    //Contact3 has no entitlement for the period therefore the public holiday leave request will not be
+    //created fot it.
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact3['id'], $publicHoliday));
+  }
+
+  public function testWillNotCreatePublicHolidayLeaveRequestsInTheFutureForWhereContactHasNoEntitlement() {
+    $contact = ContactFabricator::fabricate();
+
+    $period1 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('today'),
+      'end_date'   => CRM_Utils_Date::processDate('+5 days'),
+    ]);
+
+    $period2 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('+9 days'),
+      'end_date'   => CRM_Utils_Date::processDate('+15 days'),
+    ]);
+
+    $periodEntitlement1 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'period_id' => $period1->id,
+      'type_id' => $this->absenceType->id,
+    ]);
+
+    $periodEntitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'period_id' => $period2->id,
+      'type_id' => $this->absenceType->id,
+    ]);
+
+    $this->createLeaveBalanceChange($periodEntitlement1->id, 1);
+    $this->createLeaveBalanceChange($periodEntitlement2->id, 0);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact['id']],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    //This public holiday is in the past
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('2016-01-01')
+    ]);
+
+    //This public holiday is within the first absence period and contact
+    //has entitlement for this period.
+    $publicHoliday2 = PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('tomorrow')
+    ]);
+
+    //This public holiday is between the lapse between the two periods
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('+6 days')
+    ]);
+
+    //This public holiday is in the second absence period for
+    //which the contact has no entitlement
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('+9 days')
+    ]);
+
+    $this->getCreationLogic([$contact['id']])->createForAllInTheFuture();
+
+    //Only Public holiday leave request for the second public holiday is created because it falls
+    //within the date where the contact has entitlement.
+    $this->assertEquals(-1, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement1));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2));
+
+    $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement2));
+  }
+
+  public function testWillNotCreatePublicHolidayLeaveRequestsInTheFutureForWorkPatternContactHavingNoEntitlementForThePeriod() {
+    $contact = ContactFabricator::fabricate();
+
+    $period1 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('today'),
+      'end_date'   => CRM_Utils_Date::processDate('+5 days'),
+    ]);
+
+    $period2 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('+9 days'),
+      'end_date'   => CRM_Utils_Date::processDate('+15 days'),
+    ]);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact['id']],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    $periodEntitlement1 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'period_id' => $period1->id,
+      'type_id' => $this->absenceType->id,
+    ]);
+
+    $periodEntitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'period_id' => $period2->id,
+      'type_id' => $this->absenceType->id,
+    ]);
+
+    $this->createLeaveBalanceChange($periodEntitlement1->id, 1);
+    $this->createLeaveBalanceChange($periodEntitlement2->id, 0);
+
+    $workPattern = WorkPatternFabricator::fabricate(['is_default' => 1]);
+
+    //This public holiday is in the past
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('2016-01-01')
+    ]);
+
+    //This public holiday is within the first absence period
+    $publicHoliday2 = PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('tomorrow')
+    ]);
+
+    //This public holiday is between the lapse between the two periods
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('+6 days')
+    ]);
+
+    //This public holiday is in the second absence period for
+    PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('+9 days')
+    ]);
+
+    $this->getCreationLogic()->createAllInFutureForWorkPatternContacts($workPattern->id);
+
+    //Only Public holiday leave request for the second public holiday is created because it falls
+    //within the date where the contact has entitlement.
+    $this->assertEquals(-1, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement1));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2));
+
+    $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement2));
+  }
+
   private function getCreationLogicWithEntitlementsMock($contactIDs) {
     return $this->getCreationLogic($contactIDs, true);
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
@@ -527,4 +527,63 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
     $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement2));
   }
+
+  public function testCanDeleteAllPublicHolidayLeaveRequestsForAbsencePeriod() {
+    $contact = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    $period1 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2015-09-01'),
+      'end_date' => CRM_Utils_Date::processDate('2015-12-31'),
+    ]);
+
+    $period2 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2016-12-31'),
+    ]);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact['id']],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    //Public holiday is within the first absence period
+    $publicHoliday1 = PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('2015-12-31')
+    ]);
+
+    //pubic holiday is within the second absence period
+    $publicHoliday2 = PublicHolidayFabricator::fabricateWithoutValidation([
+      'date' =>  CRM_Utils_Date::processDate('2016-01-01')
+    ]);
+
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact['id'], $publicHoliday1);
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact2['id'], $publicHoliday1);
+
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact['id'], $publicHoliday2);
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact2['id'], $publicHoliday2);
+
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday1));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2));
+
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday1));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday2));
+
+    //Delete all Public holiday leave requests for absence period 2.
+    $deletionLogic = new PublicHolidayLeaveRequestDeletion(new JobContractService());
+    $deletionLogic->deleteAllForAbsencePeriod($period2->id);
+
+    //Leave Request for PublicHoliday2 which falls within the absence period will be deleted for both contacts
+    //While that of Public Holiday1 will not be deleted.
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday1));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2));
+
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday1));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday2));
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
@@ -576,7 +576,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     //Delete all Public holiday leave requests for absence period 2.
     $deletionLogic = new PublicHolidayLeaveRequestDeletion(new JobContractService());
-    $deletionLogic->deleteAllForAbsencePeriod($period2->id);
+    $deletionLogic->deleteAllForAbsencePeriod($period2);
 
     //Leave Request for PublicHoliday2 which falls within the absence period will be deleted for both contacts
     //While that of Public Holiday1 will not be deleted.
@@ -619,7 +619,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     //Delete all Public holiday leave requests for absence period for first contact only
     $deletionLogic = new PublicHolidayLeaveRequestDeletion(new JobContractService());
-    $deletionLogic->deleteAllForAbsencePeriod($period->id, [$contact['id']]);
+    $deletionLogic->deleteAllForAbsencePeriod($period, [$contact['id']]);
 
     //Leave Request for PublicHoliday will be deleted for contact1 only
     $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday));

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
@@ -72,15 +72,15 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseH
 
     $creationLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestCreation::class)
       ->disableOriginalConstructor()
-      ->setMethods(['createForAllinAbsencePeriod'])
+      ->setMethods(['createAllForAbsencePeriod'])
       ->getMock();
 
     $creationLogicMock->expects($this->once())
-      ->method('createForAllinAbsencePeriod');
+      ->method('createAllForAbsencePeriod');
 
     $service = new PublicHolidayLeaveRequestService($creationLogicMock, $deletionLogicMock);
-    $absencePeriodID = 1;
-    $service->updateAllForAbsencePeriod($absencePeriodID);
+    $absencePeriod = AbsencePeriodFabricator::fabricate();
+    $service->updateAllForAbsencePeriod($absencePeriod->id);
   }
 
   public function testUpdateAllLeaveRequestsInTheFutureForWorkPatternContacts() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
@@ -61,6 +61,28 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseH
     $service->updateAllInTheFuture();
   }
 
+  public function testUpdateAllPublicHolidayLeaveRequestsInAbsencePeriod() {
+    $deletionLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestDeletion::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['deleteAllForAbsencePeriod'])
+      ->getMock();
+
+    $deletionLogicMock->expects($this->once())
+      ->method('deleteAllForAbsencePeriod');
+
+    $creationLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestCreation::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['createForAllinAbsencePeriod'])
+      ->getMock();
+
+    $creationLogicMock->expects($this->once())
+      ->method('createForAllinAbsencePeriod');
+
+    $service = new PublicHolidayLeaveRequestService($creationLogicMock, $deletionLogicMock);
+    $absencePeriodID = 1;
+    $service->updateAllForAbsencePeriod($absencePeriodID);
+  }
+
   public function testUpdateAllLeaveRequestsInTheFutureForWorkPatternContacts() {
     $workPatternID = 5;
     $deletionLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestDeletion::class)

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeavePeriodEntitlementHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeavePeriodEntitlementHelpersTrait.php
@@ -42,4 +42,16 @@ trait CRM_HRLeaveAndAbsences_LeavePeriodEntitlementHelpersTrait {
 
     return $periodEntitlement;
   }
+
+  public function createLeavePeriodEntitlementServiceForPublicHolidayLeaveRequestMock($entitlements) {
+    $leavePeriodEntitlementService = $this->getMockBuilder(CRM_HRLeaveAndAbsences_Service_LeavePeriodEntitlement::class)
+      ->setMethods(['getEntitlementsForContacts'])
+      ->getMock();
+
+    $leavePeriodEntitlementService->expects($this->any())
+      ->method('getEntitlementsForContacts')
+      ->will($this->returnValue($entitlements));
+
+    return $leavePeriodEntitlementService;
+  }
 }


### PR DESCRIPTION
## Overview
Currently if there is at least one absence type with MTPHL = Yes, the scheduled job will create public holidays for contacts having contracts in the system if a job is put on the queue. Since this is just a setting on the absence type Level, This PR makes changes such that only contacts that have entitlement of that absence type should have public holiday requests created (in addition to the existing conditions for a public holiday leave request to be created).

Also since public holiday leave requests will now only be created when the contact has entitlement for the absence type with MTPHL = Yes in addition with other conditions that need to be satisfied to create the Public Holiday leave request. It is possible for public holiday leave request not to be created at some particular point for a public holiday date due to contact having no entitlement for the period the date falls in and then entitlements added later for the period. For this kind of scenario the public holiday leave request creation job needs to be ran to update  public holiday leave requests for that period for the contact.

## Before
- Once there is an absence type with MTPHL = Yes, Even if the contact has no entitlement for that absence type, a public holiday leave request can be created for the contact having satisfied other conditions needed to create a public holiday leave request.
- No job is put on the public holiday queue when entitlements are updated for contacts for an absence period.

## After
- Once there is an absence type with MTPHL = Yes, If the contact has no entitlement for that absence type or the contact has entitlement of Zero, public holiday leave request is not created for the contact even if other conditions needed to create a public holiday leave request are satisfied .
- A job is now put on the public holiday queue to update public holiday leave requests for the absence period for a contact that previously has no entitlement and now has entitlement(or vice versa) when entitlements are updated for the contact for the absence period.

## Technical Details
- A new method method `createForAllinAbsencePeriod` is added in the `PublicHolidayLeaveRequestCreation` class that creates/updates public holiday leave requests for public holidays for contacts having entitlements for the absence type with MTPHL = Yes for that period having satisfied other conditions to create the public holiday requests.
- The `createForAllInTheFuture`, `createAllForContract`, `createAllInFutureForWorkPatternContacts`, `createForAllInTheFuture` of the PublicHolidayLeaveRequestCreation` class were modified to not create public holiday leave requests except the contact has entitlement for the period the public holiday date falls in.
- A job to update to update public holiday leave requests for a contact for an absence period when entitlements are updated for the contact is added in the `LeavePeriodEntitlement` class right after entitlements are created/updated for the absence period for the contact.

