### PR TITLE
PCHR-2998: Add Upgrader to set Emergency Contact Required Fields

### DIFF
--- a/org.civicrm.hremergency/CRM/Hremergency/Upgrader.php
+++ b/org.civicrm.hremergency/CRM/Hremergency/Upgrader.php
@@ -8,6 +8,7 @@ class CRM_Hremergency_Upgrader extends CRM_Hremergency_Upgrader_Base {
   use CRM_Hremergency_Upgrader_Steps_1000;
   use CRM_Hremergency_Upgrader_Steps_1001;
   use CRM_Hremergency_Upgrader_Steps_1002;
+  use CRM_Hremergency_Upgrader_Steps_1003;
 
   /**
    * Change the custom_group ID to 99999 as we have this exported through Drupal webforms so the ID needs to be always the same

--- a/org.civicrm.hremergency/CRM/Hremergency/Upgrader/Steps/1003.php
+++ b/org.civicrm.hremergency/CRM/Hremergency/Upgrader/Steps/1003.php
@@ -4,6 +4,8 @@ trait CRM_Hremergency_Upgrader_Steps_1003 {
 
   /**
    * Makes some emergency contact fields required.
+   *
+   * @return TRUE
    */
   public function upgrade_1003() {
     $params = ['custom_group_id' => 'Emergency_Contacts'];
@@ -17,12 +19,10 @@ trait CRM_Hremergency_Upgrader_Steps_1003 {
     ];
 
     foreach ($customFields as $customField) {
-      if (!in_array($customField['name'], $shouldBeRequired)) {
-        continue;
+      if (in_array($customField['name'], $shouldBeRequired)) {
+        $customField['is_required'] = TRUE;
+        civicrm_api3('CustomField', 'create', $customField);
       }
-
-      $customField['is_required'] = TRUE;
-      civicrm_api3('CustomField', 'create', $customField);
     }
 
     return TRUE;

--- a/org.civicrm.hremergency/CRM/Hremergency/Upgrader/Steps/1003.php
+++ b/org.civicrm.hremergency/CRM/Hremergency/Upgrader/Steps/1003.php
@@ -1,0 +1,31 @@
+<?php
+
+trait CRM_Hremergency_Upgrader_Steps_1003 {
+
+  /**
+   * Makes some emergency contact fields required.
+   */
+  public function upgrade_1003() {
+    $params = ['custom_group_id' => 'Emergency_Contacts'];
+    $customFields = civicrm_api3('CustomField', 'get', $params)['values'];
+
+    $shouldBeRequired = [
+      'Name',
+      'Mobile_number',
+      'Relationship_with_Employee',
+      'Dependant_s_',
+    ];
+
+    foreach ($customFields as $customField) {
+      if (!in_array($customField['name'], $shouldBeRequired)) {
+        continue;
+      }
+
+      $customField['is_required'] = TRUE;
+      civicrm_api3('CustomField', 'create', $customField);
+    }
+
+    return TRUE;
+  }
+  
+}


### PR DESCRIPTION
## Overview

Emergency contacts have no required fields. With the new separation of "Emergency Contacts" and "Dependants" it is important that "Is a Dependant" is always set. In other places we require it (but hide the field) as well as name, mobile number and relationship. These should be required everywhere.

## Before

Emergency contact custom fields had no required fields.

## After

Emergency contacts have the following required fields:

- Name
- Mobile Number
- Relationship with Employee
- Is a Dependant?