### PR TITLE
PCHR-2906: Create Public Holiday Requests in the past when MTPHL is set to yes

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -566,7 +566,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    */
   private static function enqueuePublicHolidayLeaveRequestUpdateTask() {
     $task = new CRM_Queue_Task(
-      ['CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequests', 'run'],
+      ['CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllPublicHolidayLeaveRequestsExceptThoseAlreadyCreatedInThePast', 'run'],
       []
     );
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -566,7 +566,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    */
   private static function enqueuePublicHolidayLeaveRequestUpdateTask() {
     $task = new CRM_Queue_Task(
-      ['CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllPublicHolidayLeaveRequestsExceptThoseAlreadyCreatedInThePast', 'run'],
+      ['CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllPublicHolidayLeaveRequests', 'run'],
       []
     );
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/Task/UpdateAllPublicHolidayLeaveRequests.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/Task/UpdateAllPublicHolidayLeaveRequests.php
@@ -7,13 +7,13 @@ use CRM_HRLeaveAndAbsences_Factory_PublicHolidayLeaveRequestService as PublicHol
  * PublicHolidayLeaveRequestUpdates queue is processed.
  *
  * Basically, it uses the PublicHolidayLeaveRequest service to update all leave
- * requests for public holidays except those already created in the past.
+ * requests for public holidays.
  */
-class CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllPublicHolidayLeaveRequestsExceptThoseAlreadyCreatedInThePast {
+class CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllPublicHolidayLeaveRequests {
 
   public static function run(CRM_Queue_TaskContext $ctx) {
     $service = PublicHolidayLeaveRequestServiceFactory::create();
-    $service->updateAllExceptThoseAlreadyCreatedInThePast();
+    $service->updateAll();
   }
 
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/Task/UpdateAllPublicHolidayLeaveRequestsExceptThoseAlreadyCreatedInThePast.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/Task/UpdateAllPublicHolidayLeaveRequestsExceptThoseAlreadyCreatedInThePast.php
@@ -1,0 +1,19 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Factory_PublicHolidayLeaveRequestService as PublicHolidayLeaveRequestServiceFactory;
+
+/**
+ * This is the Queue Task which will be executed by the whenever the
+ * PublicHolidayLeaveRequestUpdates queue is processed.
+ *
+ * Basically, it uses the PublicHolidayLeaveRequest service to update all leave
+ * requests for public holidays except those already created in the past.
+ */
+class CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllPublicHolidayLeaveRequestsExceptThoseAlreadyCreatedInThePast {
+
+  public static function run(CRM_Queue_TaskContext $ctx) {
+    $service = PublicHolidayLeaveRequestServiceFactory::create();
+    $service->updateAllExceptThoseAlreadyCreatedInThePast();
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
@@ -34,7 +34,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest {
    */
   public function updateAllInTheFuture() {
     $this->deletionLogic->deleteAllInTheFuture();
-    $this->creationLogic->createForAllInTheFuture();
+    $this->creationLogic->createAllInTheFuture();
   }
 
   /**
@@ -54,9 +54,9 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest {
    * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion::deleteAllInTheFuture()
    * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation::createForAll()
    */
-  public function updateAllExceptThoseAlreadyCreatedInThePast() {
+  public function updateAll() {
     $this->deletionLogic->deleteAllInTheFuture();
-    $this->creationLogic->createForAll();
+    $this->creationLogic->createAll();
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
@@ -38,6 +38,28 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest {
   }
 
   /**
+   * Creates/Updates all the Leave Requests for Public Holidays in all absence periods.
+   * Those already created in the past are left untouched.
+   *
+   * In a situation where a public holiday was added in the past when there is no
+   * absence type with MTPHL = Yes, when the absence type's MTPHL is set to Yes,
+   * leave requests will be created for all public holidays including those in the
+   * past with no leave requests associated or those that does not have leave requests
+   * created for all qualified contacts.
+   *
+   * Basically, this uses the Deletion Logic to delete all the leave requests
+   * for public holidays in the future and then uses the Creation Logic to
+   * create leave requests for all public holidays.
+   *
+   * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion::deleteAllInTheFuture()
+   * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation::createForAll()
+   */
+  public function updateAllExceptThoseAlreadyCreatedInThePast() {
+    $this->deletionLogic->deleteAllInTheFuture();
+    $this->creationLogic->createForAll();
+  }
+
+  /**
    * Updates all the Leave Requests for Public Holidays between
    * the start and end dates of the given contract.
    *

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -92,7 +92,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
    * @param array $contactID
    *  If not empty, Public Holiday Leave Requests are created for only these contacts
    */
-  public function createForAllInTheFuture(array $contactID = []) {
+  public function createAllInTheFuture(array $contactID = []) {
     if(!$this->absenceType) {
       return;
     }
@@ -312,7 +312,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
       );
     }
 
-    $this->createForAllInTheFuture($contacts);
+    $this->createAllInTheFuture($contacts);
   }
 
   /**
@@ -370,7 +370,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
    * overlapping the public holiday date.
    *
    */
-  public function createForAll() {
+  public function createAll() {
     $absencePeriods = $this->getAllAbsencePeriods();
 
     if(!$absencePeriods || !$this->absenceType) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -360,6 +360,40 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
   }
 
   /**
+   * Creates Public Holiday Leave Requests for all Public Holidays in all
+   * absence periods for all contacts. It does not re-create a leave request
+   * that already exists.
+   *
+   * The Public Holiday leave request will not be created if a contact has no
+   * entitlement for the absence type with MTPHL in the absence period the
+   * public holiday date falls in or If the contact does not have a contract
+   * overlapping the public holiday date.
+   *
+   */
+  public function createForAll() {
+    $absencePeriods = $this->getAllAbsencePeriods();
+
+    if(!$absencePeriods || !$this->absenceType) {
+      return;
+    }
+
+    foreach($absencePeriods as $absencePeriod) {
+      $this->createAllForAbsencePeriod($absencePeriod);
+    }
+  }
+
+  private function getAllAbsencePeriods() {
+    $absencePeriod = new AbsencePeriod();
+    $absencePeriod->find();
+
+    $absencePeriods = [];
+    while($absencePeriod->fetch()) {
+      $absencePeriods[] = clone $absencePeriod;
+    }
+
+    return $absencePeriods;
+  }
+  /**
    * Checks if the contract's contact has entitlement for the given
    * absence type ID.
    *

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -467,7 +467,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
 
     $item = $queue->claimItem();
     $this->assertEquals(
-      'CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllPublicHolidayLeaveRequestsExceptThoseAlreadyCreatedInThePast',
+      'CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllPublicHolidayLeaveRequests',
       $item->data->callback[0]
     );
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -467,7 +467,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
 
     $item = $queue->claimItem();
     $this->assertEquals(
-      'CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequests',
+      'CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllPublicHolidayLeaveRequestsExceptThoseAlreadyCreatedInThePast',
       $item->data->callback[0]
     );
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -1286,10 +1286,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'date' =>  CRM_Utils_Date::processDate('+7 days')
     ]);
 
-    //create public holiday leave requests for public holiday 1 for contact1
-    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact1['id'], $publicHoliday1);
-    $publicHolidayRequestContact1 = LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday1);
-
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday1));
     $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday2));
     $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday3));
     $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday1));
@@ -1299,11 +1296,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     //Create public holiday requests for all contacts for all periods.
     $this->getCreationLogicWithEntitlementsMock([$contact1['id'], $contact2['id']])->createAll();
 
-    //We need to check that the public holiday1 created for contact1 earlier was not touched since it
-    //already exists.
-    $publicHolidayRequest = LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday1);
-    $this->assertEquals($publicHolidayRequestContact1->id, $publicHolidayRequest->id);
-
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday1));
     $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday2));
     $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday3));
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -153,7 +153,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'date' =>  CRM_Utils_Date::processDate('+5 days')
     ]);
 
-    $this->getCreationLogicWithEntitlementsMock([$contact['id']])->createForAllInTheFuture();
+    $this->getCreationLogicWithEntitlementsMock([$contact['id']])->createAllInTheFuture();
 
     // It's -2 instead of -3 because the first public holiday is in the past
     // and we should not create a leave request for it
@@ -179,11 +179,11 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'date' => $date->format('Ymd')
     ]);
 
-    $this->getCreationLogicWithEntitlementsMock([$contact['id']])->createForAllInTheFuture();
+    $this->getCreationLogicWithEntitlementsMock([$contact['id']])->createAllInTheFuture();
 
     $this->assertEquals(1, $this->countNumberOfLeaveRequests($contact['id'], $date->format('Ymd')));
 
-    $this->getCreationLogicWithEntitlementsMock([$contact['id']])->createForAllInTheFuture();
+    $this->getCreationLogicWithEntitlementsMock([$contact['id']])->createAllInTheFuture();
 
     $this->assertEquals(1, $this->countNumberOfLeaveRequests($contact['id'], $date->format('Ymd')));
   }
@@ -205,7 +205,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'date' =>  CRM_Utils_Date::processDate('tomorrow')
     ]);
 
-    $this->getCreationLogicWithEntitlementsMock([$contact['id']])->createForAllInTheFuture();
+    $this->getCreationLogicWithEntitlementsMock([$contact['id']])->createAllInTheFuture();
 
     // The Balance is still 0 because no Leave Request was created
     $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
@@ -503,7 +503,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'date' => $date->format('Ymd')
     ]);
 
-    $this->getCreationLogicWithEntitlementsMock([$contact['id']])->createForAllInTheFuture();
+    $this->getCreationLogicWithEntitlementsMock([$contact['id']])->createAllInTheFuture();
 
     $this->assertEquals(1, $this->countNumberOfLeaveRequests($contact['id'], $date->format('Ymd')));
     $this->assertEquals(0, $this->countNumberOfLeaveRequests($contact2['id'], $date->format('Ymd')));
@@ -1171,7 +1171,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'date' =>  CRM_Utils_Date::processDate('+9 days')
     ]);
 
-    $this->getCreationLogic([$contact['id']])->createForAllInTheFuture();
+    $this->getCreationLogic([$contact['id']])->createAllInTheFuture();
 
     //Only Public holiday leave request for the second public holiday is created because it falls
     //within the date where the contact has entitlement.
@@ -1297,7 +1297,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday3));
 
     //Create public holiday requests for all contacts for all periods.
-    $this->getCreationLogicWithEntitlementsMock([$contact1['id'], $contact2['id']])->createForAll();
+    $this->getCreationLogicWithEntitlementsMock([$contact1['id'], $contact2['id']])->createAll();
 
     //We need to check that the public holiday1 created for contact1 earlier was not touched since it
     //already exists.

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -1246,7 +1246,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement2));
   }
 
-  public function testCreateForAllWillCreatePublicHolidayLeaveRequestsForAllPublicHolidaysInAllPeriodsForAllContacts() {
+  public function testCreateAllWillCreatePublicHolidayLeaveRequestsForAllPublicHolidaysInAllPeriodsForAllContacts() {
     $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
@@ -51,11 +51,11 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseH
 
     $creationLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestCreation::class)
                               ->disableOriginalConstructor()
-                              ->setMethods(['createForAllInTheFuture'])
+                              ->setMethods(['createAllInTheFuture'])
                               ->getMock();
 
     $creationLogicMock->expects($this->once())
-                      ->method('createForAllInTheFuture');
+                      ->method('createAllInTheFuture');
 
     $service = new PublicHolidayLeaveRequestService($creationLogicMock, $deletionLogicMock);
     $service->updateAllInTheFuture();
@@ -83,7 +83,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseH
     $service->updateAllForAbsencePeriod($absencePeriod->id);
   }
 
-  public function testUpdateAllPublicHolidayLeaveRequestsExceptThoseAlreadyCreatedInThePast() {
+  public function testUpdateAllPublicHolidayLeaveRequests() {
     $deletionLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestDeletion::class)
       ->disableOriginalConstructor()
       ->setMethods(['deleteAllInTheFuture'])
@@ -94,14 +94,14 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseH
 
     $creationLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestCreation::class)
       ->disableOriginalConstructor()
-      ->setMethods(['createForAll'])
+      ->setMethods(['createAll'])
       ->getMock();
 
     $creationLogicMock->expects($this->once())
-      ->method('createForAll');
+      ->method('createAll');
 
     $service = new PublicHolidayLeaveRequestService($creationLogicMock, $deletionLogicMock);
-    $service->updateAllExceptThoseAlreadyCreatedInThePast();
+    $service->updateAll();
   }
 
   public function testUpdateAllLeaveRequestsInTheFutureForWorkPatternContacts() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
@@ -83,6 +83,27 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseH
     $service->updateAllForAbsencePeriod($absencePeriod->id);
   }
 
+  public function testUpdateAllPublicHolidayLeaveRequestsExceptThoseAlreadyCreatedInThePast() {
+    $deletionLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestDeletion::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['deleteAllInTheFuture'])
+      ->getMock();
+
+    $deletionLogicMock->expects($this->once())
+      ->method('deleteAllInTheFuture');
+
+    $creationLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestCreation::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['createForAll'])
+      ->getMock();
+
+    $creationLogicMock->expects($this->once())
+      ->method('createForAll');
+
+    $service = new PublicHolidayLeaveRequestService($creationLogicMock, $deletionLogicMock);
+    $service->updateAllExceptThoseAlreadyCreatedInThePast();
+  }
+
   public function testUpdateAllLeaveRequestsInTheFutureForWorkPatternContacts() {
     $workPatternID = 5;
     $deletionLogicMock = $this->getMockBuilder(PublicHolidayLeaveRequestDeletion::class)


### PR DESCRIPTION
## Overview
If a public holiday is added in the past or future when there is no absence type with MTPHL = Yes, public holiday leave requests will not be created for any of the the public holiday dates. However when MTPHL is now set = Yes for an absence type, only public holiday leave requests in the future get created. This PR modifies this logic when the MTPHL property of an absence type is toggled, in order to allow leave requests for past holiday dates to also be created.

## Before
Public Holiday leave requests for past public holiday dates(that does not have leave requests created for them for all qualified contacts) are not created when an Absence Type MTPHL is set to Yes.

## After
Public Holiday leave requests for past public holiday dates(that does not have leave requests created for them for all qualified contacts) are now created when an Absence Type MTPHL is set to Yes.

## Technical Details
- A new `createForAll` method was added in the `PublicHolidayLeaveRequestCreation` Service that creates leave requests for all public holidays in all absence periods for all contacts. It only creates for leave requests that does not already exist on that date for a contact.
- Added a new `updateAllExceptThoseAlreadyCreatedInThePast` method in the `PublicHoliday` Service that updates/creates public holiday leave requests in past and future but leaves past public holiday leave requests already created untouched.