### PR TITLE
PCHR-3018: Re-add missing upgrader

### DIFF
--- a/hrui/CRM/HRUI/Upgrader.php
+++ b/hrui/CRM/HRUI/Upgrader.php
@@ -37,6 +37,7 @@ class CRM_HRUI_Upgrader extends CRM_HRUI_Upgrader_Base {
   use CRM_HRUI_Upgrader_Steps_4704;
   use CRM_HRUI_Upgrader_Steps_4705;
   use CRM_HRUI_Upgrader_Steps_4706;
+  use CRM_HRUI_Upgrader_Steps_4707;
 
   public function install() {
     $this->runAllUpgraders();


### PR DESCRIPTION
## Overview

After a merge conflict an upgrader was renamed, but it wasn't added to
the upgrader after renaming.

## Before

An upgrader trait that adds a new custom field was not added to the base upgrader class.

## After

The upgrader trait is added.

## Notes

- The conflict was fixed in [this commit](https://github.com/civicrm/civihr/commit/c21a632d8df1cc657c40bb80536217ab1c174cfa)
