### PR TITLE
PCHR-3025: Add API Endpoint

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/api/v3/Job/CheckCivihrVersion.php
+++ b/uk.co.compucorp.civicrm.hrcore/api/v3/Job/CheckCivihrVersion.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * Job.send_civihr_stats API
+ *
+ * @return array API result
+ */
+function civicrm_api3_job_check_civihr_version() {
+  return civicrm_api3_create_success();
+}


### PR DESCRIPTION
## Overview

This PR adds the API endpoint to send statistics. The endpoint is still empty right now.

## Before

There was no `Job.check_civihr_version` endpoint`

## After

There is a `Job.check_civihr_version` endpoint` and it is only accessible to those with "Access AJAX API" permission (by default)