### PR TITLE
PCHR-3011: Update Public Holiday Leave Requests For Contact When Contact is Assigned A Custom Work Pattern

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/ContactWorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/ContactWorkPattern.php
@@ -1,8 +1,10 @@
 <?php
 
 use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
+use CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern as ContactWorkPattern;
 use CRM_HRLeaveAndAbsences_BAO_WorkDay as WorkDay;
 use CRM_HRLeaveAndAbsences_Exception_InvalidContactWorkPatternException as InvalidContactWorkPatternException;
+use CRM_HRLeaveAndAbsences_Queue_PublicHolidayLeaveRequestUpdates as PublicHolidayLeaveRequestUpdatesQueue;
 
 class CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern extends CRM_HRLeaveAndAbsences_DAO_ContactWorkPattern {
 
@@ -31,6 +33,10 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern extends CRM_HRLeaveAndAbsenc
       self::endEmployeePreviousWorkPattern($params);
       $instance->save();
       $transaction->commit();
+
+      if (self::shouldEnqueuePublicHolidayLeaveRequestTask($instance)) {
+        self::enqueuePublicHolidayLeaveRequestUpdateTaskForContact($instance->contact_id);
+      }
 
     } catch (Exception $e) {
       $transaction->rollback();
@@ -316,5 +322,43 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern extends CRM_HRLeaveAndAbsenc
     }
 
     return $contacts;
+  }
+
+  /**
+   * Enqueues a public holiday leave request update task for the given
+   * contact ID.
+   *
+   * @param int $contactID
+   */
+  private static function enqueuePublicHolidayLeaveRequestUpdateTaskForContact($contactID) {
+    $task = new CRM_Queue_Task(
+      ['CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequests', 'run'],
+      [[$contactID]]
+    );
+
+    PublicHolidayLeaveRequestUpdatesQueue::createItem($task);
+  }
+
+  /**
+   * Checks whether the public holiday leave request task should be enqueued.
+   * The function will return true if the contact work pattern's effective end
+   * date is NULL or greater than today.
+   *
+   * @param \CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern $contactWorkPattern
+   *
+   * @return bool
+   */
+  private static function shouldEnqueuePublicHolidayLeaveRequestTask(contactWorkPattern $contactWorkPattern) {
+    if(!$contactWorkPattern->effective_end_date) {
+      return true;
+    }
+
+    $today = new DateTime('today');
+
+    if(new DateTime($contactWorkPattern->effective_end_date) >= $today) {
+      return true;
+    }
+
+    return false;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/ContactWorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/ContactWorkPattern.php
@@ -332,7 +332,7 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern extends CRM_HRLeaveAndAbsenc
    */
   private static function enqueuePublicHolidayLeaveRequestUpdateTaskForContact($contactID) {
     $task = new CRM_Queue_Task(
-      ['CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequests', 'run'],
+      [CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequests::class, 'run'],
       [[$contactID]]
     );
 
@@ -348,7 +348,7 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern extends CRM_HRLeaveAndAbsenc
    *
    * @return bool
    */
-  private static function shouldEnqueuePublicHolidayLeaveRequestTask(contactWorkPattern $contactWorkPattern) {
+  private static function shouldEnqueuePublicHolidayLeaveRequestTask(ContactWorkPattern $contactWorkPattern) {
     if(!$contactWorkPattern->effective_end_date) {
       return true;
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/Task/UpdateAllFuturePublicHolidayLeaveRequests.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Queue/Task/UpdateAllFuturePublicHolidayLeaveRequests.php
@@ -8,12 +8,14 @@ use CRM_HRLeaveAndAbsences_Factory_PublicHolidayLeaveRequestService as PublicHol
  *
  * Basically, it uses the PublicHolidayLeaveRequest service to update all leave
  * requests for public holidays in the future
+ *
+ * @param array $contactID
  */
 class CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequests {
 
-  public static function run(CRM_Queue_TaskContext $ctx) {
+  public static function run(CRM_Queue_TaskContext $ctx, array $contactID = []) {
     $service = PublicHolidayLeaveRequestServiceFactory::create();
-    $service->updateAllInTheFuture();
+    $service->updateAllInTheFuture($contactID);
   }
 
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequest.php
@@ -29,12 +29,14 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequest {
    * for public holidays in the future and, then, uses the Creation Logic to
    * create leave requests to public holidays in the future.
    *
+   * @param array $contactID
+   *
    * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion::deleteAllInTheFuture()
    * @see CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation::createForAllInTheFuture()
    */
-  public function updateAllInTheFuture() {
-    $this->deletionLogic->deleteAllInTheFuture();
-    $this->creationLogic->createForAllInTheFuture();
+  public function updateAllInTheFuture(array $contactID = []) {
+    $this->deletionLogic->deleteAllInTheFuture($contactID);
+    $this->creationLogic->createForAllInTheFuture($contactID);
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/ContactWorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/ContactWorkPatternTest.php
@@ -584,7 +584,7 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest extends BaseHeadlessTest
     $this->assertEquals(0, $queue->numberOfItems());
   }
 
-  public function testTaskIsEnqueuedToUpdatePublicHolidayRequestsWhenEffectiveEndDateGreaterThanOrEqualToThanCurrentDate() {
+  public function testTaskIsEnqueuedToUpdatePublicHolidayRequestsWhenEffectiveEndDateGreaterThanOrEqualToTheCurrentDate() {
     $contactID = 2;
     //When the effective end date is today
     ContactWorkPattern::create([
@@ -599,7 +599,7 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest extends BaseHeadlessTest
 
     $item = $queue->claimItem();
     $this->assertEquals(
-      'CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequests',
+      CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequests::class,
       $item->data->callback[0]
     );
     $this->assertEquals([$contactID], $item->data->arguments[0]);
@@ -618,7 +618,7 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest extends BaseHeadlessTest
 
     $item = $queue->claimItem();
     $this->assertEquals(
-      'CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequests',
+      CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequests::class,
       $item->data->callback[0]
     );
     $this->assertEquals([$contactID], $item->data->arguments[0]);
@@ -638,7 +638,7 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest extends BaseHeadlessTest
 
     $item = $queue->claimItem();
     $this->assertEquals(
-      'CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequests',
+      CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequests::class,
       $item->data->callback[0]
     );
     $this->assertEquals([$contactID], $item->data->arguments[0]);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/ContactWorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/ContactWorkPatternTest.php
@@ -7,6 +7,7 @@ use CRM_HRLeaveAndAbsences_BAO_WorkDay as WorkDay;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_ContactWorkPattern as ContactWorkPatternFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_WorkPattern as WorkPatternFabricator;
 use CRM_HRLeaveAndAbsences_Exception_InvalidContactWorkPatternException as InvalidContactWorkPatternException;
+use CRM_HRLeaveAndAbsences_Queue_PublicHolidayLeaveRequestUpdates as PublicHolidayLeaveRequestUpdatesQueue;
 
 /**
  * Class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest
@@ -569,5 +570,78 @@ class CRM_HRLeaveAndAbsences_BAO_ContactWorkPatternTest extends BaseHeadlessTest
     $this->assertCount(2, $contacts);
     sort($contacts);
     $this->assertEquals($contacts, [$contactID1, $contactID2]);
+  }
+
+  public function testTaskNotEnqueuedToUpdatePublicHolidayRequestsWhenEffectiveEndDateIsLessThanCurrentDate() {
+    ContactWorkPattern::create([
+      'contact_id' => 2,
+      'pattern_id' => 1,
+      'effective_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'effective_end_date' => CRM_Utils_Date::processDate('yesterday'),
+    ]);
+
+    $queue = PublicHolidayLeaveRequestUpdatesQueue::getQueue();
+    $this->assertEquals(0, $queue->numberOfItems());
+  }
+
+  public function testTaskIsEnqueuedToUpdatePublicHolidayRequestsWhenEffectiveEndDateGreaterThanOrEqualToThanCurrentDate() {
+    $contactID = 2;
+    //When the effective end date is today
+    ContactWorkPattern::create([
+      'contact_id' => $contactID,
+      'pattern_id' => 1,
+      'effective_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'effective_end_date' => CRM_Utils_Date::processDate('today'),
+    ]);
+
+    $queue = PublicHolidayLeaveRequestUpdatesQueue::getQueue();
+    $this->assertEquals(1, $queue->numberOfItems());
+
+    $item = $queue->claimItem();
+    $this->assertEquals(
+      'CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequests',
+      $item->data->callback[0]
+    );
+    $this->assertEquals([$contactID], $item->data->arguments[0]);
+    $queue->deleteItem($item);
+
+    //When the effective end date is greater than today
+    ContactWorkPattern::create([
+      'contact_id' => $contactID,
+      'pattern_id' => 1,
+      'effective_date' => CRM_Utils_Date::processDate('2016-06-01'),
+      'effective_end_date' => CRM_Utils_Date::processDate('tomorrow'),
+    ]);
+
+    $queue = PublicHolidayLeaveRequestUpdatesQueue::getQueue();
+    $this->assertEquals(1, $queue->numberOfItems());
+
+    $item = $queue->claimItem();
+    $this->assertEquals(
+      'CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequests',
+      $item->data->callback[0]
+    );
+    $this->assertEquals([$contactID], $item->data->arguments[0]);
+    $queue->deleteItem($item);
+  }
+
+  public function testTaskIsEnqueuedToUpdatePublicHolidayRequestsForContactWhenEffectiveEndDateIsNull() {
+    $contactID = 2;
+    ContactWorkPattern::create([
+      'contact_id' => $contactID,
+      'pattern_id' => 1,
+      'effective_date' => CRM_Utils_Date::processDate('2016-01-01'),
+    ]);
+
+    $queue = PublicHolidayLeaveRequestUpdatesQueue::getQueue();
+    $this->assertEquals(1, $queue->numberOfItems());
+
+    $item = $queue->claimItem();
+    $this->assertEquals(
+      'CRM_HRLeaveAndAbsences_Queue_Task_UpdateAllFuturePublicHolidayLeaveRequests',
+      $item->data->callback[0]
+    );
+    $this->assertEquals([$contactID], $item->data->arguments[0]);
+    $queue->deleteItem($item);
   }
 }


### PR DESCRIPTION
## Overview
Currently, when changes are made to a Work Pattern, public holiday leave requests in the future are updated for all contacts using the work pattern If the work pattern has effective end date is greater than or equal to the current date for a work pattern that is not the default.
However for the case when a contact is newly assigned a custom Work Pattern, we don't currently update future public holiday leave requests for the contact. This PR makes changes such that when a custom work pattern whose effective end date is greater than or equal to the current date is newly assigned to a contact, public holiday leave requests in the future are updated for the contact.

## Before
- Public holiday leave requests in the future are not updated for a contact that is newly assigned a custom work pattern.

## After
- Public holiday leave requests in the future are updated for a contact that is newly assigned a custom work pattern whose effective end date is greater than or equal to the current date.

## Technical Details
- The `updateAllInTheFuture` method in the Public Holiday request service is modified to accept an optional contact ID array parameter that allows public holiday leave requests to be updated only for the contacts passed in.