### PR TITLE
PCHR-3026: Classes to Represent Pingback Statistics

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Model/CiviHRStatistics.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Model/CiviHRStatistics.php
@@ -1,0 +1,221 @@
+<?php
+
+use CRM_HRCore_Model_ReportConfiguration as ReportConfig;
+use CRM_HRCore_Model_ReportConfigurationAgeGroup as ReportAgeGroup;
+
+/**
+ * This is the parent class that contains all scalar values that will be sent
+ * as part of the statistics request. It contains links to other more complex
+ * data structures, such as Report configurations.
+ */
+class CRM_HRCore_Model_CiviHRStatistics {
+
+  /**
+   * @var string
+   *   The URL of the site
+   */
+  protected $siteUrl;
+
+  /**
+   * @var string
+   *   The name of the site, found in the Drupal settings.php
+   */
+  protected $siteName;
+
+  /**
+   * @var \DateTime
+   *   The date these statistics were generated
+   */
+  protected $generationDate;
+
+  /**
+   * @var \DateTime[]
+   *   Array of most recent login dates, indexed by role name
+   */
+  protected $mostRecentLogins = [];
+
+  /**
+   * @var int[]
+   *   Each entity count, indexed by entity type
+   */
+  protected $entityCounts = [];
+
+  /**
+   * @var int[]
+   *   Each contact subtype count, indexed by subtype name
+   */
+  protected $contactSubtypeCount = [];
+
+  /**
+   * @var ReportConfig[]
+   */
+  protected $reportConfigurations = [];
+
+  /**
+   * @var ReportAgeGroup[]
+   */
+  protected $reportConfigurationAgeGroups = [];
+
+  /**
+   * @return string
+   */
+  public function getSiteUrl() {
+    return $this->siteUrl;
+  }
+
+  /**
+   * @param string $siteUrl
+   *
+   * @return $this
+   */
+  public function setSiteUrl($siteUrl) {
+    $this->siteUrl = $siteUrl;
+
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getSiteName() {
+    return $this->siteName;
+  }
+
+  /**
+   * @param string $siteName
+   *
+   * @return $this
+   */
+  public function setSiteName($siteName) {
+    $this->siteName = $siteName;
+
+    return $this;
+  }
+
+  /**
+   * @return DateTime
+   */
+  public function getGenerationDate() {
+    return $this->generationDate;
+  }
+
+  /**
+   * @param DateTime $generationDate
+   *
+   * @return $this
+   */
+  public function setGenerationDate($generationDate) {
+    $this->generationDate = $generationDate;
+
+    return $this;
+  }
+
+  /**
+   * @param $roleName
+   * @param DateTime $time
+   *
+   * @return $this
+   */
+  public function setMostRecentLoginForRole($roleName, \DateTime $time) {
+    $this->mostRecentLogins[$roleName] = $time;
+
+    return $this;
+  }
+
+  /**
+   * @return DateTime[]
+   */
+  public function getMostRecentLogins() {
+    return $this->mostRecentLogins;
+  }
+
+  /**
+   * @param $role
+   * @return null|\DateTime
+   */
+  public function getMostRecentLoginByRole($role) {
+    return CRM_Utils_Array::value($role, $this->mostRecentLogins);
+  }
+
+  /**
+   * @param string $entity
+   * @param int $count
+   *
+   * @return $this
+   */
+  public function setEntityCount($entity, $count) {
+    $this->entityCounts[$entity] = $count;
+
+    return $this;
+  }
+
+  /**
+   * @param string $entity
+   * @return int
+   */
+  public function getEntityCount($entity) {
+    return CRM_Utils_Array::value($entity, $this->entityCounts, 0);
+  }
+
+  /**
+   * @return int[]
+   */
+  public function getEntityCounts() {
+    return $this->entityCounts;
+  }
+
+  /**
+   * @param string $subtypeName
+   * @param int $count
+   *
+   * @return $this
+   */
+  public function setContactSubtypeCount($subtypeName, $count) {
+    $this->contactSubtypeCount[$subtypeName] = $count;
+
+    return $this;
+  }
+
+  /**
+   * @return array
+   */
+  public function getContactSubtypeCounts() {
+    return $this->contactSubtypeCount;
+  }
+
+  /**
+   * @param ReportConfig $configuration
+   *
+   * @return $this
+   */
+  public function addReportConfiguration(ReportConfig $configuration) {
+    $this->reportConfigurations[] = $configuration;
+
+    return $this;
+  }
+
+  /**
+   * @return ReportConfig[]
+   */
+  public function getReportConfigurations() {
+    return $this->reportConfigurations;
+  }
+
+  /**
+   * @param ReportAgeGroup $ageGroup
+   *
+   * @return $this
+   */
+  public function addReportConfigurationAgeGroup(ReportAgeGroup $ageGroup) {
+    $this->reportConfigurationAgeGroups[] = $ageGroup;
+
+    return $this;
+  }
+
+  /**
+   * @return ReportAgeGroup[]
+   */
+  public function getReportConfigurationAgeGroups() {
+    return $this->reportConfigurationAgeGroups;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Model/ReportConfiguration.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Model/ReportConfiguration.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * Contains properties to represent a report configuration.
+ */
+class CRM_HRCore_Model_ReportConfiguration {
+
+  /**
+   * @var int
+   *   The report configuration ID on the host machine
+   */
+  protected $id;
+
+  /**
+   * @var string
+   *   The type of name of the report, e.g. "People" or "Leave and Absence"
+   */
+  protected $name;
+
+  /**
+   * @var string
+   *   The label to identify the report
+   */
+  protected $label;
+
+  /**
+   * @var string
+   *   A JSON string containing all configuration for the report
+   */
+  protected $jsonConfig;
+
+  /**
+   * @return int
+   */
+  public function getId() {
+    return $this->id;
+  }
+
+  /**
+   * @param int $id
+   *
+   * @return $this
+   */
+  public function setId($id) {
+    $this->id = $id;
+
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getName() {
+    return $this->name;
+  }
+
+  /**
+   * @param string $name
+   *
+   * @return $this
+   */
+  public function setName($name) {
+    $this->name = $name;
+
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getLabel() {
+    return $this->label;
+  }
+
+  /**
+   * @param string $label
+   *
+   * @return $this
+   */
+  public function setLabel($label) {
+    $this->label = $label;
+
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getJsonConfig() {
+    return $this->jsonConfig;
+  }
+
+  /**
+   * @param string $jsonConfig
+   *
+   * @return $this
+   */
+  public function setJsonConfig($jsonConfig) {
+    $this->jsonConfig = $jsonConfig;
+
+    return $this;
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Model/ReportConfigurationAgeGroup.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Model/ReportConfigurationAgeGroup.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * Contains properties to represent a report configuration age group.
+ */
+class CRM_HRCore_Model_ReportConfigurationAgeGroup {
+
+  /**
+   * @var int
+   *   The ID of the age group on the host machine
+   */
+  protected $id;
+
+
+  /**
+   * @var int
+   *   The age this age group starts from
+   */
+  protected $ageFrom;
+
+  /**
+   * @var int
+   *   The age this age group extends to
+   */
+  protected $ageTo;
+
+  /**
+   * @var string
+   *   The label for this age group
+   */
+  protected $label;
+
+  /**
+   * @return int
+   */
+  public function getId() {
+    return $this->id;
+  }
+
+  /**
+   * @param int $id
+   *
+   * @return $this
+   */
+  public function setId($id) {
+    $this->id = $id;
+
+    return $this;
+  }
+
+  /**
+   * @return int
+   */
+  public function getAgeFrom() {
+    return $this->ageFrom;
+  }
+
+  /**
+   * @param int $ageFrom
+   *
+   * @return $this
+   */
+  public function setAgeFrom($ageFrom) {
+    $this->ageFrom = $ageFrom;
+
+    return $this;
+  }
+
+  /**
+   * @return int
+   */
+  public function getAgeTo() {
+    return $this->ageTo;
+  }
+
+  /**
+   * @param int $ageTo
+   *
+   * @return $this
+   */
+  public function setAgeTo($ageTo) {
+    $this->ageTo = $ageTo;
+
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getLabel() {
+    return $this->label;
+  }
+
+  /**
+   * @param string $label
+   *
+   * @return $this
+   */
+  public function setLabel($label) {
+    $this->label = $label;
+
+    return $this;
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/CiviHRStatisticsJSONConvertor.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/CiviHRStatisticsJSONConvertor.php
@@ -1,0 +1,119 @@
+<?php
+
+use CRM_HRCore_Model_CiviHRStatistics as CiviHRStatistics;
+use CRM_HRCore_Model_ReportConfiguration as ReportConfig;
+use CRM_HRCore_Model_ReportConfigurationAgeGroup as AgeGroup;
+
+/**
+ * Responsible for converting a CiviHRStatistics object to JSON
+ */
+class CRM_HRCore_Service_CiviHRStatisticsJSONConvertor {
+
+  /**
+   * Takes a statistics class and converts it to a JSON string.
+   *
+   * @param CiviHRStatistics $stats
+   *
+   * @return string
+   */
+  public static function toJson(CiviHRStatistics $stats) {
+    $array = [
+      'siteUrl' => $stats->getSiteUrl(),
+      'siteName' => $stats->getSiteName(),
+      'generationDate' => self::formatDate($stats->getGenerationDate()),
+    ];
+
+    self::addRoleLoginData($stats, $array);
+
+    foreach ($stats->getEntityCounts() as $entity => $count) {
+      $array[$entity . 'Count'] = $count;
+    }
+
+    foreach ($stats->getContactSubtypeCounts() as $subtype => $count) {
+      $array['contactPerSubTypeCount'][$subtype] = $count;
+    }
+
+    foreach ($stats->getReportConfigurations() as $config) {
+      $array['reportConfigurations'][] = self::reportConfigurationToArray($config);
+    }
+
+    foreach ($stats->getReportConfigurationAgeGroups() as $ageGroup) {
+      $array['reportConfigurationAgeGroups'][] = self::ageGroupToArray($ageGroup);
+    }
+
+    return json_encode($array);
+  }
+
+  /**
+   * Adds most recent login data for each of the system roles.
+   *
+   * @param CiviHRStatistics $stats
+   * @param $array
+   */
+  private static function addRoleLoginData(CiviHRStatistics $stats, &$array) {
+    $defaultRoles = [
+      'CiviHR Admin',
+      'CiviHR Staff',
+      'CiviHR Manager',
+      'CiviHR Admin Local',
+    ];
+
+    foreach ($defaultRoles as $role) {
+      $key = sprintf('last%sLogin', str_replace(' ', '', $role));
+      $array[$key] = self::formatDate($stats->getMostRecentLoginByRole($role));
+    }
+
+    foreach ($stats->getMostRecentLogins() as $role => $mostRecentLogin) {
+      if (!in_array($role, $defaultRoles)) {
+        $array['lastLoginOtherRoles'][$role] = self::formatDate($mostRecentLogin);
+      }
+    }
+  }
+
+  /**
+   * Converts a ReportConfiguration object to an array.
+   *
+   * @param ReportConfig $config
+   *
+   * @return array
+   */
+  private static function reportConfigurationToArray(ReportConfig $config) {
+    return [
+      'id' => $config->getId(),
+      'report_name' => $config->getName(),
+      'label' => $config->getLabel(),
+      'json_config' => $config->getJsonConfig(),
+    ];
+  }
+
+  /**
+   * Converts an age group to an array
+   *
+   * @param AgeGroup $ageGroup
+   * @return array
+   */
+  private static function ageGroupToArray(AgeGroup $ageGroup) {
+    return [
+      'id' => $ageGroup->getId(),
+      'label' => $ageGroup->getLabel(),
+      'age_from' => $ageGroup->getAgeFrom(),
+      'age_to' => $ageGroup->getAgeTo(),
+    ];
+  }
+
+  /**
+   * Formats dates to ISO standard
+   *
+   * @param \DateTime $date
+   *
+   * @return string
+   */
+  private static function formatDate($date) {
+    if (!$date instanceof \DateTime) {
+      return '';
+    }
+
+    return $date->format($date::ISO8601);
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/CiviHRStatisticsJSONConvertor.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/CiviHRStatisticsJSONConvertor.php
@@ -17,31 +17,33 @@ class CRM_HRCore_Service_CiviHRStatisticsJSONConvertor {
    * @return string
    */
   public static function toJson(CiviHRStatistics $stats) {
-    $array = [
+    $statsAsArray = [
       'siteUrl' => $stats->getSiteUrl(),
       'siteName' => $stats->getSiteName(),
       'generationDate' => self::formatDate($stats->getGenerationDate()),
     ];
 
-    self::addRoleLoginData($stats, $array);
+    self::addRoleLoginData($stats, $statsAsArray);
 
     foreach ($stats->getEntityCounts() as $entity => $count) {
-      $array[$entity . 'Count'] = $count;
+      $statsAsArray[$entity . 'Count'] = $count;
     }
 
     foreach ($stats->getContactSubtypeCounts() as $subtype => $count) {
-      $array['contactPerSubTypeCount'][$subtype] = $count;
+      $statsAsArray['contactPerSubTypeCount'][$subtype] = $count;
     }
 
     foreach ($stats->getReportConfigurations() as $config) {
-      $array['reportConfigurations'][] = self::reportConfigurationToArray($config);
+      $configAsArray = self::reportConfigurationToArray($config);
+      $statsAsArray['reportConfigurations'][] = $configAsArray;
     }
 
     foreach ($stats->getReportConfigurationAgeGroups() as $ageGroup) {
-      $array['reportConfigurationAgeGroups'][] = self::ageGroupToArray($ageGroup);
+      $ageGroupAsArray = self::ageGroupToArray($ageGroup);
+      $statsAsArray['reportConfigurationAgeGroups'][] = $ageGroupAsArray;
     }
 
-    return json_encode($array);
+    return json_encode($statsAsArray);
   }
 
   /**
@@ -65,7 +67,8 @@ class CRM_HRCore_Service_CiviHRStatisticsJSONConvertor {
 
     foreach ($stats->getMostRecentLogins() as $role => $mostRecentLogin) {
       if (!in_array($role, $defaultRoles)) {
-        $array['lastLoginOtherRoles'][$role] = self::formatDate($mostRecentLogin);
+        $formattedDate = self::formatDate($mostRecentLogin);
+        $array['lastLoginOtherRoles'][$role] = $formattedDate;
       }
     }
   }

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Files/statistics_sample_request.json
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Files/statistics_sample_request.json
@@ -1,0 +1,41 @@
+{
+  "siteUrl": "compucorp.civihrhosting.co.uk",
+  "siteName": "Compucorp",
+  "lastCiviHRAdminLogin": "2012-04-23T18:25:43+0000",
+  "lastCiviHRStaffLogin": "2012-04-23T18:25:43+0000",
+  "lastCiviHRManagerLogin": "2012-04-23T18:25:43+0000",
+  "lastCiviHRAdminLocalLogin": "2012-04-23T18:25:43+0000",
+  "lastLoginOtherRoles": {
+    "Administrator": "2012-04-23T18:25:43+0000",
+    "CustomRole": "2012-04-23T18:25:43+0000"
+  },
+  "drupalUserCount": 21,
+  "assignmentCount": 10,
+  "taskCount": 14,
+  "documentCount": 3,
+  "leaveRequestCount": 2,
+  "leaveRequestInLast100DaysCount": 2,
+  "contactPerSubTypeCount": {
+    "Individual": 35,
+    "Organization": 1
+  },
+  "vacancyCount": 1,
+  "reportConfigurationCount": 1,
+  "generationDate": "2012-04-23T18:25:43+0000",
+  "reportConfigurations": [
+    {
+      "id": 1,
+      "report_name": "people",
+      "label": "Test",
+      "json_config": "{\"menuLimit\":\"200\",\"unusedAttrsVertical\":\"false\",\"autoSortUnusedAttrs\":\"false\",\"rendererName\":\"Table\",\"aggregatorName\":\"Count\"}"
+    }
+  ],
+  "reportConfigurationAgeGroups": [
+    {
+      "id": 1,
+      "age_from": 0,
+      "age_to": 25,
+      "label": "Young"
+    }
+  ]
+}

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/CiviHRStatisticsConvertorTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/CiviHRStatisticsConvertorTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use CRM_HRCore_Service_CiviHRStatisticsJSONConvertor as CiviHRStatisticsConvertor;
+use CRM_HRCore_Model_CiviHRStatistics as CiviHRStatistics;
+use CRM_HRCore_Model_ReportConfigurationAgeGroup as AgeGroup;
+use CRM_HRCore_Model_ReportConfiguration as ReportConfiguration;
+
+class CiviHRStatisticsConvertorTest extends PHPUnit_Framework_TestCase {
+
+  public function testConversionOfEmptyStatsClass() {
+    $stats = new CiviHRStatistics();
+    $json = CiviHRStatisticsConvertor::toJson($stats);
+    $array = json_decode($json, TRUE);
+
+    $this->assertEquals(JSON_ERROR_NONE, json_last_error());
+    $this->assertArrayHasKey('siteName', $array);
+    $this->assertNull($array['siteName']);
+  }
+
+  public function testConversionWillMatchExpectedJSONFile() {
+    $dateForAll = new \DateTime('2012-04-23T18:25:43+0000');
+
+    $reportConfig = new ReportConfiguration();
+    $reportConfig
+      ->setId(1)
+      ->setName('people')
+      ->setLabel('Test')
+      ->setJsonConfig(json_encode([
+        'menuLimit' => '200',
+        'unusedAttrsVertical' => 'false',
+        'autoSortUnusedAttrs' => 'false',
+        'rendererName' => 'Table',
+        'aggregatorName' => 'Count',
+      ]));
+
+    $ageGroup = new AgeGroup();
+    $ageGroup
+      ->setId(1)
+      ->setAgeFrom(0)
+      ->setAgeTo(25)
+      ->setLabel('Young');
+
+    $stats = new CiviHRStatistics();
+    $stats
+      ->setSiteUrl('compucorp.civihrhosting.co.uk')
+      ->setSiteName('Compucorp')
+      ->setGenerationDate($dateForAll)
+      ->setMostRecentLoginForRole('CiviHR Admin', $dateForAll)
+      ->setMostRecentLoginForRole('CiviHR Staff', $dateForAll)
+      ->setMostRecentLoginForRole('CiviHR Manager', $dateForAll)
+      ->setMostRecentLoginForRole('CiviHR Admin Local', $dateForAll)
+      ->setMostRecentLoginForRole('Administrator', $dateForAll)
+      ->setMostRecentLoginForRole('CustomRole', $dateForAll)
+      ->setEntityCount('drupalUser', 21)
+      ->setEntityCount('assignment', 10)
+      ->setEntityCount('task', 14)
+      ->setEntityCount('document', 3)
+      ->setEntityCount('leaveRequest', 2)
+      ->setEntityCount('leaveRequestInLast100Days', 2)
+      ->setEntityCount('vacancy', 1)
+      ->setEntityCount('reportConfiguration', 1)
+      ->setContactSubtypeCount('Individual', 35)
+      ->setContactSubtypeCount('Organization', 1)
+      ->addReportConfiguration($reportConfig)
+      ->addReportConfigurationAgeGroup($ageGroup);
+
+    $json = CiviHRStatisticsConvertor::toJson($stats);
+    $testFile = __DIR__ . '/../Files/statistics_sample_request.json';
+    $expected = file_get_contents($testFile);
+    $asArray = json_decode($json, TRUE);
+    $expectedAsArray = json_decode($expected, TRUE);
+    asort($asArray);
+    asort($expectedAsArray);
+
+    $this->assertEquals($expectedAsArray, $asArray);
+  }
+
+}


### PR DESCRIPTION
## Overview

To make it easier to deal with the statistics that we will send, and avoid using large, complicated arrays these classes will represent all data to be send in the statistics request. 

The goal is to produce a JSON string with [this format](https://gist.github.com/mickadoo/3eb09bafa18760c12fcccced7a1afc33).

## Before

There were no classes to use when gathering and sending statistics.

## After

There are classes to represent all the data being sent. Another class is responsible for producing a JSON string to match the [expected specification](https://gist.github.com/mickadoo/3eb09bafa18760c12fcccced7a1afc33).
