### PR TITLE
PCHR-2995: Fix Issue with Half-day not taken into Account For To date When requesting Leave

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -1009,11 +1009,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
 
         if(!$isCalculationUnitInHours) {
           if($amount == -0.5) {
-            if ($date == $fromDate) {
+            if ($date->format('Y-m-d') == $fromDate->format('Y-m-d')) {
               $dayType = $fromDateType;
             }
 
-            if($date == $toDate) {
+            if($date->format('Y-m-d') == $toDate->format('Y-m-d')) {
               $dayType = $toDateType;
             }
           }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveDateDaysAmountDeduction.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveDateDaysAmountDeduction.php
@@ -28,14 +28,16 @@ class CRM_HRLeaveAndAbsences_Service_LeaveDateDaysAmountDeduction
    */
   public function calculate(DateTime $leaveDateTime, $workDay, LeaveRequest $leaveRequest) {
     $isHalfDay = false;
+    $leaveFromDate = new DateTime($leaveRequest->from_date);
+    $leaveToDate = new DateTime($leaveRequest->to_date);
 
     $workDayAmount = empty($workDay['leave_days']) ? 0 : (float)$workDay['leave_days'];
 
-    if($leaveDateTime == new DateTime($leaveRequest->from_date)) {
+    if($leaveDateTime->format('Y-m-d') == $leaveFromDate->format('Y-m-d')) {
       $isHalfDay = $this->isHalfDay($leaveRequest->from_date_type);
     }
 
-    if($leaveDateTime == new DateTime($leaveRequest->to_date)){
+    if($leaveDateTime->format('Y-m-d') == $leaveToDate->format('Y-m-d')){
       $isHalfDay = $this->isHalfDay($leaveRequest->to_date_type);
     }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -308,6 +308,8 @@ function civicrm_api3_leave_request_calculateBalanceChange($params) {
     }
   }
 
+  _civicrm_api3_leave_request_set_time_for_leave_dates($params);
+
   $result = CRM_HRLeaveAndAbsences_BAO_LeaveRequest::calculateBalanceChange(
     $params['contact_id'],
     new DateTime($params['from_date']),

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveDateDaysAmountDeductionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveDateDaysAmountDeductionTest.php
@@ -84,6 +84,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveDateDaysAmountDeductionTest extends Ba
     ];
 
     $params = array_merge($defaultParams, $params);
+    $params['from_date'] = $params['from_date'] . ' 00:00';
+    $params['to_date'] = $params['to_date'] . ' 23:59';
     $leaveRequest = new LeaveRequest();
     $leaveRequest->copyValues($params);
 


### PR DESCRIPTION
## Overview
When saving a leave request in days with the To date being an half day type, the balance change displayed on the modal is correct but after saving the request the balance change is incorrect because instead of 0.5 to be deducted for the To date, 1 is deducted instead. This PR fixes the bug.

## Before
Half-day is not taken into account for To date when requesting Leave after the request is saved.

![beforetodate](https://user-images.githubusercontent.com/6951813/33845085-8f7363f2-dea2-11e7-9e16-4724a7816be4.gif)



## After
Half-day is taken into account for To date when requesting Leave after the request is saved.

![aftertodate](https://user-images.githubusercontent.com/6951813/33845113-a7a0d414-dea2-11e7-8b29-63066fa5025e.gif)


## Technical Details
- When calculating the balance change after a leave request is saved, because the time `00:00 and 23:59` has already been added for the leave request from date and to date respectively, There is an issue with this line [here](https://github.com/civicrm/civihr/blob/ebab52f182e811d10d68be9864c29dbbe08a9409/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveDateDaysAmountDeduction.php#L40) because the time for the `$leaveDateTime` is `00:00` which will cause the condition on the line to fail for the leave request to date. 
Since we are only interested in the leave dates and not the time at this point, the logic was changed to compare by the dates only.

## Detailed explanation about the bug.
The balance calculation details on the modal was returning the correct values because the time for the leave from and to dates when calling the Leave.calculateBalanceChange API were not adjusted and the time would be `00:00` for both dates, so [here](https://github.com/civicrm/civihr/blob/3ff1a6d2006c3de0ee7a226ef5f32bf9b845b7cd/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveDateDaysAmountDeduction.php#L38), the condition would pass because the `$leaveRequest->to_date` will have same time as `$leaveDateTime`. For the case when Leave Request has been saved and time has been adjusted, the condition would not pass because `$leaveRequest->to_date` will have `23:59` and `$leaveDateTime` will have `00:00` as the time.

The time for leave request dates are adjusted [here](https://github.com/civicrm/civihr/blob/1d36b745e6a8fccc6b1e5982ba843faf9240e03a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php#L802)

For all the dates object gotten from the DatePeriod [ here](https://github.com/civicrm/civihr/blob/b42aa53063d96a45c5a383fabd3b0ef086959057/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php#L972), the end date time will always be the time of the start date, since we needed to add one more day for the end date to be included in the date period. So if the start date has time `00:00`, the end date will also have time `00:00`.

testCalculateReturnsTheCorrectAmountWhenFromDateTypeIsHalfDay and testCalculateReturnsTheCorrectAmountWhenToDateTypeIsHalfDay were passing because the time was `00:00` for all the dates.

This is a regression and was introduced when the LeaveDateDaysAmountDeduction was added [Here](https://github.com/civicrm/civihr/commit/98cc189e5664adc7c9dddae604ebe29bce0cb680)
during the process of refactoring to cater for Leave in Hours balance calculation.

## Notes
After the change to adjust leave from and to dates when calling `LeaveRequest.calculateBalanceChange`, There was an issue with the date type being incorrect for half-day types due to the fact that when checking whether the date is the from or to date, the time for the dates are no longer the same. 

![my leave _ staging17 2017-12-12 17-36-45](https://user-images.githubusercontent.com/6951813/33896647-a74bfe78-df63-11e7-80c3-a061324f34c2.png)

This issue is fixed by making sure the comparison is by date only and not datetime.

After the Fix:
![my leave _ staging17 2017-12-12 18-05-45](https://user-images.githubusercontent.com/6951813/33897950-2f0e4494-df67-11e7-8219-53546d02ecb1.png)
