### PR TITLE
PCHR-3056: Use Closest Absence Period to Current Date For Manage Entitlement Calculation

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsencePeriod.php
@@ -631,7 +631,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
    * period in the future is preferred, If that does not exists, then
    * the closest absence period in the past is considered.
    *
-   * @return AbsencePeriod|null
+   * @return \CRM_HRLeaveAndAbsences_BAO_AbsencePeriod|null
    *   Returns null if there are no absence periods.
    */
   public static function getClosestToCurrentDate() {
@@ -652,15 +652,12 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriod extends CRM_HRLeaveAndAbsences_DA
       $absencePeriod = CRM_Core_DAO::executeQuery($query, [], true, self::class);
     }
 
-
-    if($absencePeriod->N == 1) {
-      while($absencePeriod->fetch()) {
-        $absencePeriod = $absencePeriod;
-      }
-
-      return $absencePeriod;
+    if ($absencePeriod->N !== 1) {
+      return null;
     }
 
-    return null;
+    $absencePeriod->fetch();
+
+    return $absencePeriod;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
@@ -142,8 +142,12 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
   private function getAbsencePeriodFromRequest() {
     $periodId = CRM_Utils_Request::retrieve('id', 'Integer');
     if(!$periodId) {
-      return AbsencePeriod::getCurrentPeriod();
+      $today = new DateTime('today');
+      $absencePeriods = AbsencePeriod::getPeriodsBetweenDates($today);
+
+      return $absencePeriods[0];
     }
+
     return AbsencePeriod::findById((int)$periodId);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.php
@@ -142,10 +142,7 @@ class CRM_HRLeaveAndAbsences_Form_ManageEntitlements extends CRM_Core_Form {
   private function getAbsencePeriodFromRequest() {
     $periodId = CRM_Utils_Request::retrieve('id', 'Integer');
     if(!$periodId) {
-      $today = new DateTime('today');
-      $absencePeriods = AbsencePeriod::getPeriodsBetweenDates($today);
-
-      return $absencePeriods[0];
+      return AbsencePeriod::getClosestToCurrentDate();
     }
 
     return AbsencePeriod::findById((int)$periodId);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
@@ -940,7 +940,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseHeadlessTest {
     $this->assertEquals($period2->id, $closestPeriod->id);
   }
 
-  public function testGetClosestToCurrentDateReturnsCorrectlyWhenClosestPeriodIsPeriodBeforeCurrentDate() {
+  public function testGetClosestToCurrentDateReturnsCorrectlyWhenClosestPeriodIsBeforeCurrentDateButAFuturePeriodAlsoExists() {
     $period1 = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('-10 days'),
       'end_date' => CRM_Utils_Date::processDate('-3 days'),
@@ -951,9 +951,10 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseHeadlessTest {
       'end_date' => CRM_Utils_Date::processDate('+10 days'),
     ]);
 
-    //Period one is closer to the current date.
+    //Period one is closer to the current date but period two will be returned because
+    //more priority is given to absence periods in the future.
     $closestPeriod = AbsencePeriod::getClosestToCurrentDate();
-    $this->assertEquals($period1->id, $closestPeriod->id);
+    $this->assertEquals($period2->id, $closestPeriod->id);
   }
 
   public function testGetClosestToCurrentDateReturnsCorrectlyWhenClosestPeriodIsPeriodContainingTheCurrentDate() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsencePeriodTest.php
@@ -923,4 +923,94 @@ class CRM_HRLeaveAndAbsences_BAO_AbsencePeriodTest extends BaseHeadlessTest {
     $absencePeriods = AbsencePeriod::getPeriodsBetweenDates($fromDate, $toDate);
     $this->assertEmpty($absencePeriods);
   }
+
+  public function testGetClosestToCurrentDateReturnsCorrectlyWhenClosestPeriodIsPeriodAfterCurrentDate() {
+    $period1 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-10 days'),
+      'end_date' => CRM_Utils_Date::processDate('-5 days'),
+    ]);
+
+    $period2 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('+1 day'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days'),
+    ]);
+
+    //Period two is closer to the current date.
+    $closestPeriod = AbsencePeriod::getClosestToCurrentDate();
+    $this->assertEquals($period2->id, $closestPeriod->id);
+  }
+
+  public function testGetClosestToCurrentDateReturnsCorrectlyWhenClosestPeriodIsPeriodBeforeCurrentDate() {
+    $period1 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-10 days'),
+      'end_date' => CRM_Utils_Date::processDate('-3 days'),
+    ]);
+
+    $period2 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('+7 day'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days'),
+    ]);
+
+    //Period one is closer to the current date.
+    $closestPeriod = AbsencePeriod::getClosestToCurrentDate();
+    $this->assertEquals($period1->id, $closestPeriod->id);
+  }
+
+  public function testGetClosestToCurrentDateReturnsCorrectlyWhenClosestPeriodIsPeriodContainingTheCurrentDate() {
+    $period1 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-10 days'),
+      'end_date' => CRM_Utils_Date::processDate('-3 days'),
+    ]);
+
+    $period2 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-2 day'),
+      'end_date' => CRM_Utils_Date::processDate('+5 days'),
+    ]);
+
+    $period3 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('+6 day'),
+      'end_date' => CRM_Utils_Date::processDate('+10 days'),
+    ]);
+
+    //Period two is closer to the current date and also contains the current date
+    $closestPeriod = AbsencePeriod::getClosestToCurrentDate();
+    $this->assertEquals($period2->id, $closestPeriod->id);
+  }
+
+  public function testGetClosestToCurrentDateReturnsCorrectlyWhenThereIsNoPeriodAfterTheCurrentDate() {
+    $period1 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-10 days'),
+      'end_date' => CRM_Utils_Date::processDate('-9 days'),
+    ]);
+
+    $period2 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('-8 days'),
+      'end_date' => CRM_Utils_Date::processDate('-7 days'),
+    ]);
+
+    //Period two is closer to the current date
+    $closestPeriod = AbsencePeriod::getClosestToCurrentDate();
+    $this->assertEquals($period2->id, $closestPeriod->id);
+  }
+
+  public function testGetClosestToCurrentDateReturnsCorrectlyWhenThereIsNoPeriodBeforeTheCurrentDate() {
+    $period1 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('+2 days'),
+      'end_date' => CRM_Utils_Date::processDate('+9 days'),
+    ]);
+
+    $period2 = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('+10 days'),
+      'end_date' => CRM_Utils_Date::processDate('+11 days'),
+    ]);
+
+    //Period one is closer to the current date
+    $closestPeriod = AbsencePeriod::getClosestToCurrentDate();
+    $this->assertEquals($period1->id, $closestPeriod->id);
+  }
+
+  public function testGetClosestToCurrentDateReturnsNullWhenThereIsNoAbsencePeriod() {
+    $closestPeriod = AbsencePeriod::getClosestToCurrentDate();
+    $this->assertNull($closestPeriod);
+  }
 }


### PR DESCRIPTION
## Overview
When there is no absence period with dates containing the current date and a user tries to update entitlements after creating/updating a contract, an Error 500 page appears. This PR fixes the issue by redirecting to Manage entitlements calculation page to calculate entitlements for the closest absence period to the current date after creating/updating a contract. 

## Before
- When a user tries to update entitlements after creating/updating a contract, entitlements is calculated for the absence period with dates containing the current date.

## After
- Rather than calculate entitlements for the absence period explicitly with dates containing the current date when a user tries to update entitlements after creating/updating a contract, entitlements is calculated for the closest absence period to the current date.

## Comments
- FE will use the existing `AbsencePeriod.get()` API to display a text on the Leave tab of the Job contract modal incase there is no absence period.
If the count property for the API response is Zero, that means there is no absence period.