### PR TITLE
PCHR-2760: Fix Onboarding Wizard backstop JS Tests

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/data/onboarding-wizard-data.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/data/onboarding-wizard-data.js
@@ -1,35 +1,5 @@
 module.exports = (function () {
   return {
-    personalDetails: {
-      '#edit-submitted-civicrm-1-contact-1-contact-first-name' : 'Duke',
-      '#edit-submitted-civicrm-1-contact-1-contact-last-name' : 'Duke',
-      '#edit-submitted-civicrm-1-contact-1-contact-birth-date' : '2017-10-11',
-      '#edit-submitted-civicrm-1-contact-1-cg5-custom-15' : '1002'
-    },
-    address: {
-      '#edit-submitted-civicrm-1-contact-1-address-street-address' : 'Duke',
-      '#edit-submitted-civicrm-1-contact-1-address-supplemental-address-1' : 'Duke',
-      '#edit-submitted-civicrm-1-contact-1-address-supplemental-address-2' :  'Duke',
-      '#edit-submitted-civicrm-1-contact-1-address-city' : 'Duke',
-      '#edit-submitted-civicrm-1-contact-1-address-postal-code' : 'Duke',
-      '#edit-submitted-civicrm-1-contact-1-address-country-id' : '1226'
-    },
-    contactInfo: {
-      '#edit-submitted-civicrm-1-contact-1-contact-nick-name' : 'Duke'
-    },
-    payroll: {
-      '#edit-submitted-civicrm-1-contact-1-cg4-custom-7' : 'Duke',
-      '#edit-submitted-civicrm-1-contact-1-cg4-custom-8' : 'Duke',
-      '#edit-submitted-civicrm-1-contact-1-cg4-custom-9' : 'Duke',
-      '#edit-submitted-civicrm-1-contact-1-cg4-custom-10' : 'Duke',
-      '#edit-submitted-civicrm-1-contact-1-cg16-custom-72' : 'Duke',
-      '#edit-submitted-civicrm-1-contact-1-cg5-custom-19' : 'single'
-    },
-    emergencyContacts: {
-      '#edit-submitted-emergency-contact-civicrm-1-contact-1-cg99999-custom-100000' : 'Duke',
-      '#edit-submitted-emergency-contact-civicrm-1-contact-1-cg99999-custom-100001' : 'Duke',
-      '#edit-submitted-emergency-contact-civicrm-1-contact-1-cg99999-custom-100010' : 'parent'
-    },
     dependents: {
       '#edit-submitted-first-dependant-civicrm-1-contact-3-cg99999-custom-100000' : 'Duke',
       '#edit-submitted-first-dependant-civicrm-1-contact-3-cg99999-custom-100001' : '1234',

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/onboarding-wizard.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/onboarding-wizard.js
@@ -1,5 +1,5 @@
-var page = require('./../page');
-var data = require('./../../data/onboarding-wizard-data');
+var page = require('./page');
+var data = require('./../data/onboarding-wizard-data');
 
 module.exports = (function () {
   return page.extend({
@@ -11,13 +11,11 @@ module.exports = (function () {
     reachAddressPage: function () {
       var casper = this.casper;
 
-      casper.fillSelectors('form.webform-client-form', data.personalDetails, false);
-
       casper.click('.webform-next');
 
       return casper.waitForSelector('input[value="Address"]');
     },
-    
+
     /**
      * Navigate to Contact Info Page
      *
@@ -27,8 +25,6 @@ module.exports = (function () {
       var casper = this.casper;
 
       return this.reachAddressPage().then(function () {
-        casper.fillSelectors('form.webform-client-form', data.address, false);
-
         casper.click('.webform-next');
 
         return casper.waitForSelector('input[value="Contact Info"]');
@@ -44,8 +40,6 @@ module.exports = (function () {
       var casper = this.casper;
 
       return this.reachContactInfoPage().then(function () {
-        casper.fillSelectors('form.webform-client-form', data.contactInfo, false);
-
         casper.click('.webform-next');
 
         return casper.waitForSelector('input[value="Payroll"]');
@@ -61,8 +55,6 @@ module.exports = (function () {
       var casper = this.casper;
 
       return this.reachPayrollPage().then(function () {
-        casper.fillSelectors('form.webform-client-form', data.payroll, false);
-
         casper.click('.webform-next');
 
         return casper.waitForSelector('input[value="Emergency Contact"]');
@@ -78,8 +70,6 @@ module.exports = (function () {
       var casper = this.casper;
 
       return this.reachEmergencyContactPage().then(function () {
-        casper.fillSelectors('form.webform-client-form', data.emergencyContacts, false);
-
         casper.click('.webform-next');
 
         return casper.waitForSelector('input[value="Dependants"]', function () {


### PR DESCRIPTION
## Overview
This PR fixes the backstop js tests for Onboarding Wizard, which was introduced on https://github.com/civicrm/civihr/pull/2247.

## Problem
1. The Path was wrong for the some of the JS files
2. For the test cases to work, the form needed to be submitted once.
3. Some of the form data used was not necessary as the already submitted form data could have been used.

## After
1. Fixed the paths in https://github.com/civicrm/civihr/pull/2363/files#diff-633654d50389da72e0fb1986cb0b4928L1

2. Added the requirement of form submission in 
https://compucorp.atlassian.net/wiki/spaces/PCHR/pages/117984407/BackstopJS+CiviHR

3. Removed the unnecessary form data, only kept dependents data, as backstop is not able to use the same from saved data.

