### PR TITLE
(Proof of Concept) Unified gulpfile

### DIFF
--- a/hrjobcontract/gulp-tasks/sass.js
+++ b/hrjobcontract/gulp-tasks/sass.js
@@ -1,0 +1,18 @@
+var exec = require('child_process').exec;
+
+module.exports = function (SubTask) {
+  return {
+    full: full
+  };
+
+  /**
+   * The app style relies on compass's gems, so we need to rely on it
+   * for the time being
+   */
+  function full (cb) {
+    exec('compass compile', { cwd: __dirname + '/../' }, function (_, stdout, stderr) {
+      console.log(stdout);
+      cb();
+    });
+  }
+};

--- a/hrjobcontract/gulp-tasks/sass.js
+++ b/hrjobcontract/gulp-tasks/sass.js
@@ -1,18 +1,10 @@
 var exec = require('child_process').exec;
 
 module.exports = function (SubTask) {
-  return {
-    full: full
-  };
-
-  /**
-   * The app style relies on compass's gems, so we need to rely on it
-   * for the time being
-   */
-  function full (cb) {
+  return function (cb) {
     exec('compass compile', { cwd: __dirname + '/../' }, function (_, stdout, stderr) {
       console.log(stdout);
       cb();
     });
-  }
+  };
 };

--- a/hrjobcontract/gulp-tasks/sass.js
+++ b/hrjobcontract/gulp-tasks/sass.js
@@ -1,10 +1,12 @@
 var exec = require('child_process').exec;
 
-module.exports = function (SubTask) {
-  return function (cb) {
-    exec('compass compile', { cwd: __dirname + '/../' }, function (_, stdout, stderr) {
-      console.log(stdout);
-      cb();
-    });
+module.exports = function () {
+  return {
+    main: function (done) {
+      exec('compass compile', { cwd: __dirname + '/../' }, function (_, stdout, stderr) {
+        console.log(stdout);
+        done();
+      });
+    }
   };
 };

--- a/hrjobcontract/gulp-tasks/sass.js
+++ b/hrjobcontract/gulp-tasks/sass.js
@@ -2,6 +2,8 @@ var exec = require('child_process').exec;
 
 module.exports = function () {
   return {
+    // @NOTE this will replace the original "sass:main" task, as job contract
+    // needs a completely different logic for compiling sass
     main: function (done) {
       exec('compass compile', { cwd: __dirname + '/../' }, function (_, stdout, stderr) {
         console.log(stdout);

--- a/org.civicrm.bootstrapcivihr/gulp-tasks/sass.js
+++ b/org.civicrm.bootstrapcivihr/gulp-tasks/sass.js
@@ -6,14 +6,21 @@ var bootstrapNamespace = '#bootstrap-theme';
 var outsideNamespaceRegExp = /^\.___outside-namespace/;
 
 module.exports = function (SubTask) {
-  return SubTask.pipe(postcss, [postcssPrefix({
-    prefix: bootstrapNamespace + ' ',
-    exclude: [
-      /^html/, /^body/, /page-civi/, /crm-container/, outsideNamespaceRegExp
-    ]
-  })])
-  .pipe(transformSelectors, namespaceRootElements, { splitOnCommas: true })
-  .pipe(transformSelectors, removeOutsideNamespaceMarker, { splitOnCommas: true });
+  return {
+    post: post
+  };
+
+  function post () {
+    return SubTask.pipe(postcss, [postcssPrefix({
+      prefix: bootstrapNamespace + ' ',
+      exclude: [
+        /^html/, /^body/, /page-civi/, /crm-container/, outsideNamespaceRegExp
+      ]
+    })])
+    .pipe(transformSelectors, namespaceRootElements, { splitOnCommas: true })
+    .pipe(transformSelectors, removeOutsideNamespaceMarker, { splitOnCommas: true })
+    .run();
+  }
 };
 
 /**

--- a/org.civicrm.bootstrapcivihr/gulp-tasks/sass.js
+++ b/org.civicrm.bootstrapcivihr/gulp-tasks/sass.js
@@ -1,3 +1,4 @@
+var gulp = require('gulp');
 var postcss = require('gulp-postcss');
 var postcssPrefix = require('postcss-prefix-selector');
 var transformSelectors = require('gulp-transform-selectors');
@@ -7,20 +8,26 @@ var outsideNamespaceRegExp = /^\.___outside-namespace/;
 
 module.exports = function (SubTask) {
   return {
-    post: post
-  };
+    post: [
+      {
+        name: 'sass:namespace',
+        fn: function () {
+          var cssDir = __dirname + '/../' + 'css/';
 
-  function post () {
-    return SubTask.pipe(postcss, [postcssPrefix({
-      prefix: bootstrapNamespace + ' ',
-      exclude: [
-        /^html/, /^body/, /page-civi/, /crm-container/, outsideNamespaceRegExp
-      ]
-    })])
-    .pipe(transformSelectors, namespaceRootElements, { splitOnCommas: true })
-    .pipe(transformSelectors, removeOutsideNamespaceMarker, { splitOnCommas: true })
-    .run();
-  }
+          return gulp.src(cssDir +  '*.css')
+            .pipe(postcss([postcssPrefix({
+              prefix: bootstrapNamespace + ' ',
+              exclude: [
+                /^html/, /^body/, /page-civi/, /crm-container/, outsideNamespaceRegExp
+              ]
+            })]))
+            .pipe(transformSelectors(namespaceRootElements, { splitOnCommas: true }))
+            .pipe(transformSelectors(removeOutsideNamespaceMarker, { splitOnCommas: true }))
+            .pipe(gulp.dest(cssDir));
+        }
+      }
+    ]
+  };
 };
 
 /**

--- a/org.civicrm.bootstrapcivihr/gulp-tasks/sass.js
+++ b/org.civicrm.bootstrapcivihr/gulp-tasks/sass.js
@@ -1,0 +1,39 @@
+var postcss = require('gulp-postcss');
+var postcssPrefix = require('postcss-prefix-selector');
+var transformSelectors = require('gulp-transform-selectors');
+
+var bootstrapNamespace = '#bootstrap-theme';
+var outsideNamespaceRegExp = /^\.___outside-namespace/;
+
+module.exports = function (SubTask) {
+  return SubTask.pipe(postcss, [postcssPrefix({
+    prefix: bootstrapNamespace + ' ',
+    exclude: [
+      /^html/, /^body/, /page-civi/, /crm-container/, outsideNamespaceRegExp
+    ]
+  })])
+  .pipe(transformSelectors, namespaceRootElements, { splitOnCommas: true })
+  .pipe(transformSelectors, removeOutsideNamespaceMarker, { splitOnCommas: true });
+};
+
+/**
+ * Apply the namespace on html and body elements
+ *
+ * @param  {string} selector the current selector to be transformed
+ * @return string
+ */
+function namespaceRootElements (selector) {
+  var regex = /^(body|html)/;
+
+  if (regex.test(selector)) {
+    selector = selector.replace(regex, function (match) {
+      return match + bootstrapNamespace;
+    }) + ',\n' + selector.replace(regex, bootstrapNamespace);
+  }
+
+  return selector;
+}
+
+function removeOutsideNamespaceMarker (selector) {
+  return outsideNamespaceRegExp.test(selector) ? selector.replace(outsideNamespaceRegExp, '') : selector;
+}

--- a/org.civicrm.bootstrapcivihr/gulp-tasks/sass.js
+++ b/org.civicrm.bootstrapcivihr/gulp-tasks/sass.js
@@ -8,7 +8,10 @@ var outsideNamespaceRegExp = /^\.___outside-namespace/;
 
 module.exports = function (SubTask) {
   return {
+    // @NOTE here bootstrapcivihr needs to apply the bootstrap namespace after
+    // the sass had been compiled.
     post: [
+      // @NOTE each task is an object with the name of the task and the actual code
       {
         name: 'sass:namespace',
         fn: function () {

--- a/uk.co.compucorp.civicrm.hrcore/gulpfile.js
+++ b/uk.co.compucorp.civicrm.hrcore/gulpfile.js
@@ -165,26 +165,25 @@ var xml = require("xml-parse");
   var sass = require('gulp-sass');
   var stripCssComments = require('gulp-strip-css-comments');
 
-  gulp.task('sass', ['sass:sync'], function (cb) {
+  gulp.task('sass', function (cb) {
+    var sequence = amendTasksSequenceWithExtensionTasks(['sass:main'], 'sass');
+
+    gulpSequence.apply(null, sequence)(cb);
+  });
+
+  gulp.task('sass:main', ['sass:sync'], function (cb) {
     var extPath = getExtensionPath();
-    var customLogic = getExtensionCustomPluginLogic(extPath, 'sass')
 
-    if (_.isFunction(customLogic)) {
-      return customLogic(cb);
-    }
-
-    return gulp.src(extPath + '/scss/*.scss')
+    return gulp.src(path.join(extPath, '/scss/*.scss'))
       .pipe(bulk())
-      .pipe(customLogic.pre ? customLogic.pre() : gutil.noop())
       .pipe(sass({
         outputStyle: 'compressed',
         includePaths: civicrmScssRoot.getPath(),
         precision: 10
       }).on('error', sass.logError))
       .pipe(stripCssComments({ preserve: false }))
-      .pipe(customLogic.post ? customLogic.post() : gutil.noop())
-      .pipe(gulp.dest(extPath + '/css/'));
-  });
+      .pipe(gulp.dest(path.join(extPath, '/css/')));
+  })
 
   gulp.task('sass:sync', function () {
     civicrmScssRoot.updateSync();

--- a/uk.co.compucorp.civicrm.hrcore/gulpfile.js
+++ b/uk.co.compucorp.civicrm.hrcore/gulpfile.js
@@ -168,8 +168,8 @@ var xml = require("xml-parse");
     var extPath = getExtensionPath();
     var customLogic = getExtensionCustomPluginLogic(extPath, 'sass')
 
-    if (customLogic.full) {
-      return customLogic.full(cb);
+    if (_.isFunction(customLogic)) {
+      return customLogic(cb);
     }
 
     return gulp.src(extPath + '/scss/*.scss')

--- a/uk.co.compucorp.civicrm.hrcore/gulpfile.js
+++ b/uk.co.compucorp.civicrm.hrcore/gulpfile.js
@@ -201,8 +201,7 @@ var xml = require("xml-parse");
 
 // RequireJS
 (function () {
-  var rjs = require('gulp-requirejs');
-  var readFiles = require('read-vinyl-file-stream');
+  var exec = require('child_process').exec;
   var map = require('map-stream');
 
   gulp.task('requirejs', function (cb) {
@@ -215,18 +214,14 @@ var xml = require("xml-parse");
 
     return gulp.src(extPath + '/js/build.js')
       .pipe(customLogic.pre ? customLogic.pre() : gutil.noop())
-      .pipe(readFiles(function (content, file, stream, cb) {
-        var newContent = addExtentionPathToBuildConfig(content, extPath);
-
-        return cb(null, newContent);
+      .pipe(map(function (file, cb) {
+        exec('r.js -o ' + file.path, function (err, stdout, stderr) {
+          err && err.code && console.log(stdout);
+          cb();
+        });
       }))
-      .pipe(map(function(file, cb) {
-        rjs(eval(file.contents.toString()))
-          .pipe(customLogic.post ? customLogic.post() : gutil.noop())
-          .pipe(gulp.dest('.'));
-
-        cb();
-      }));
+      .pipe(customLogic.post ? customLogic.post() : gutil.noop())
+      .pipe(gulp.dest('.'));
   });
 
   function addExtentionPathToBuildConfig (file, extPath) {

--- a/uk.co.compucorp.civicrm.hrcore/gulpfile.js
+++ b/uk.co.compucorp.civicrm.hrcore/gulpfile.js
@@ -229,6 +229,94 @@ var xml = require("xml-parse");
   });
 }());
 
+// Test
+(function () {
+  var find = require('find');
+  var karma = require('karma');
+  gulp.task('test', function (cb) {
+    var sequence = addExtensionCustomTasksToSequence(['test:main'], 'test');
+
+    gulpSequence.apply(null, sequence)(cb);
+  });
+
+  gulp.task('test:main', function () {
+    test.all();
+  });
+
+  var test = (function () {
+    /**
+     * Runs the karma server which does a single run of the test/s
+     *
+     * @param {string} configFile - The full path to the karma config file
+     * @param {Function} cb - The callback to call when the server closes
+     */
+    function runServer (configFile, cb) {
+      var reporters = argv.reporters ? argv.reporters.split(',') : ['progress'];
+
+      new karma.Server({
+        configFile: configFile,
+        reporters: reporters,
+        singleRun: true
+      }, function () {
+        cb && cb();
+      }).start();
+    }
+
+    return {
+
+      /**
+       * Runs all the tests
+       */
+      all: function () {
+        var configFile = find.fileSync('karma.conf.js', getExtensionPath() + '/js')[0];
+
+        runServer(configFile);
+      },
+
+      /**
+       * Runs the tests for a specific source file
+       *
+       * Looks for a test file (*.spec.js) in `test/`, using the same path
+       * of the source file in `src/job-roles/`
+       *   i.e. src/job-roles/models/model.js -> test/models/model.spec.js
+       *
+       * @param {string} srcFile
+       */
+      for: function (srcFile) {
+        var srcFileNoExt = path.basename(srcFile, path.extname(srcFile));
+        var testFile = srcFile
+          .replace('src/job-roles/', 'test/')
+          .replace(srcFileNoExt + '.js', srcFileNoExt + '.spec.js');
+
+        fs.statSync(testFile).isFile() && this.single(testFile);
+      },
+
+      /**
+       * Runs a single test file
+       *
+       * It passes to the karma server a temporary config file
+       * which is deleted once the test has been run
+       *
+       * @param {string} testFile - The full path of a test file
+       */
+      single: function (testFile) {
+        var configFile = 'karma.' + path.basename(testFile, path.extname(testFile)) + '.conf.temp.js';
+
+        gulp
+          .src(path.join(__dirname, '/js/karma.conf.js'))
+          .pipe(replace('*.spec.js', path.basename(testFile)))
+          .pipe(rename(configFile))
+          .pipe(gulp.dest(path.join(__dirname, '/js')))
+          .on('end', function () {
+            runServer(configFile, function () {
+              gulp.src(path.join(__dirname, '/js/', configFile), { read: false }).pipe(clean());
+            });
+          });
+      }
+    };
+  })();
+}());
+
 function addExtensionCustomTasksToSequence(sequence, taskName) {
   var customTasks = getExtensionTasks(taskName)
 

--- a/uk.co.compucorp.civicrm.hrcore/gulpfile.js
+++ b/uk.co.compucorp.civicrm.hrcore/gulpfile.js
@@ -11,6 +11,8 @@ var fs = require('fs');
 var path = require('path');
 var Promise = require('es6-promise').Promise;
 var cv = require('civicrm-cv')({ mode: 'sync' });
+var findUp = require('find-up');
+var xml = require("xml-parse");
 
 // BackstopJS tasks
 (function () {
@@ -186,7 +188,25 @@ var cv = require('civicrm-cv')({ mode: 'sync' });
   gulp.task('sass:sync', function () {
     civicrmScssRoot.updateSync();
   });
+
+  gulp.task('sass:watch', function () {
+    gulp.watch('../**/scss/**/*.scss').on('change', function (file) {
+      var extensionName = getExtensionNameFromFile(file);
+
+      argv.ext = extensionName; // TEMP
+      gulp.start('sass');
+    });
+  });
 }());
+
+function getExtensionNameFromFile (file) {
+  var infoXMLPath = findUp.sync('info.xml', { cwd: file.path });
+  var parsedXML = xml.parse(fs.readFileSync(infoXMLPath, 'utf8'));
+
+  return _.find(parsedXML, function (node) {
+    return node.tagName && node.tagName === 'extension';
+  }).attributes.key;
+}
 
 function getExtensionCustomPluginLogic (extensionPath, pluginName) {
   var filePath = path.join(extensionPath, '/gulp-tasks/', pluginName + '.js');

--- a/uk.co.compucorp.civicrm.hrcore/gulpfile.js
+++ b/uk.co.compucorp.civicrm.hrcore/gulpfile.js
@@ -218,6 +218,15 @@ var xml = require("xml-parse");
       done();
     });
   });
+
+  gulp.task('requirejs:watch', function () {
+    gulp.watch('../**/src/**/*.js').on('change', function (file) {
+      var extensionName = getExtensionNameFromFile(file);
+
+      argv.ext = extensionName; // TEMP
+      gulp.start('requirejs');
+    });
+  });
 }());
 
 function addExtensionCustomTasksToSequence(sequence, taskName) {

--- a/uk.co.compucorp.civicrm.hrcore/package.json
+++ b/uk.co.compucorp.civicrm.hrcore/package.json
@@ -11,10 +11,8 @@
     "gulp-clean": "^0.3.2",
     "gulp-color": "0.0.1",
     "gulp-file": "^0.3.0",
-    "gulp-requirejs": "^1.0.0",
     "lodash": "^4.17.4",
     "map-stream": "0.0.7",
-    "read-vinyl-file-stream": "^2.0.3",
     "yargs": "^6.6.0"
   }
 }

--- a/uk.co.compucorp.civicrm.hrcore/package.json
+++ b/uk.co.compucorp.civicrm.hrcore/package.json
@@ -11,7 +11,10 @@
     "gulp-clean": "^0.3.2",
     "gulp-color": "0.0.1",
     "gulp-file": "^0.3.0",
+    "gulp-requirejs": "^1.0.0",
     "lodash": "^4.17.4",
+    "map-stream": "0.0.7",
+    "read-vinyl-file-stream": "^2.0.3",
     "yargs": "^6.6.0"
   }
 }

--- a/uk.co.compucorp.civicrm.hrcore/package.json
+++ b/uk.co.compucorp.civicrm.hrcore/package.json
@@ -13,6 +13,13 @@
     "gulp-color": "0.0.1",
     "gulp-file": "^0.3.0",
     "gulp-sequence": "^0.4.6",
+    "jasmine-core": "^2.4.1",
+    "karma": "^0.13.15",
+    "karma-chrome-launcher": "^0.2.2",
+    "karma-jasmine": "^0.3.6",
+    "karma-junit-reporter": "^1.2.0",
+    "karma-ng-html2js-preprocessor": "^0.2.0",
+    "karma-requirejs": "^0.2.2",
     "lodash": "^4.17.4",
     "map-stream": "0.0.7",
     "yargs": "^6.6.0"

--- a/uk.co.compucorp.civicrm.hrcore/package.json
+++ b/uk.co.compucorp.civicrm.hrcore/package.json
@@ -12,6 +12,8 @@
     "gulp-clean": "^0.3.2",
     "gulp-color": "0.0.1",
     "gulp-file": "^0.3.0",
+    "gulp-rename": "^1.2.2",
+    "gulp-replace": "^0.5.4",
     "gulp-sequence": "^0.4.6",
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.15",

--- a/uk.co.compucorp.civicrm.hrcore/package.json
+++ b/uk.co.compucorp.civicrm.hrcore/package.json
@@ -7,10 +7,12 @@
   "devDependencies": {
     "backstopjs": "^2.3.7",
     "es6-promise": "^4.0.5",
+    "find": "^0.2.7",
     "gulp": "^3.9.1",
     "gulp-clean": "^0.3.2",
     "gulp-color": "0.0.1",
     "gulp-file": "^0.3.0",
+    "gulp-sequence": "^0.4.6",
     "lodash": "^4.17.4",
     "map-stream": "0.0.7",
     "yargs": "^6.6.0"

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/gulp-tasks/requirejs.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/gulp-tasks/requirejs.js
@@ -4,9 +4,14 @@ var rename = require('gulp-rename');
 var path = require('path');
 
 module.exports = function () {
+  // @NOTE one thing to keep in mind is that the custom task always needs to use
+  // __dirname for paths, otherwise the paths will be relative to hrcore
   var distFolder = path.join(__dirname, '..', 'js/angular/dist/');
 
   return {
+    // @NOTE here L&A needs to perform to tasks after r.js had run, both for
+    // cleaning the dist/ folder. Notice that the order of the tasks is the
+    // order in which they will be called
     post: [
       {
         name: 'requirejs:rename',

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/gulp-tasks/requirejs.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/gulp-tasks/requirejs.js
@@ -1,0 +1,36 @@
+var gulp = require('gulp');
+var clean = require('gulp-clean');
+var rename = require('gulp-rename');
+var path = require('path');
+
+module.exports = function () {
+  var distFolder = path.join(__dirname, '..', 'js/angular/dist/');
+
+  return {
+    post: [
+      {
+        name: 'requirejs:rename',
+        fn: function () {
+          return gulp.src(path.join(distFolder, '*.js'))
+            .pipe(rename(function (path) {
+              path.basename += '.min';
+            }))
+            .pipe(gulp.dest(distFolder));
+        }
+      },
+      {
+        name: 'requirejs:clean',
+        fn: function () {
+          return gulp.src([
+            path.join(distFolder, 'leave-absences/'),
+            path.join(distFolder, '', 'build.txt'),
+            path.join(distFolder, '', '*.js'),
+            path.join(distFolder, 'mocks/'),
+            '!' + path.join(distFolder, '*.min.js')
+          ], {read: false})
+          .pipe(clean({ force: true }));
+        }
+      }
+    ]
+  };
+};


### PR DESCRIPTION
This is the poc for a unified gulpfile for all the civihr extensions.

## Problem
Currently each extension has a separate gulpfile, but the tasks are basically always the same (sass, requirejs, task) with some custom logic here and there. This leads to a lot of duplication that is hard to maintain and that will only grow overt ime

## Solution
The idea is to have a single gulpfile under the hrcore extension, that will be able to run any common task for any given extension, and to watch for any changes of any files in any extension and to react accordingly.

This is how it can be used currently
```bash
gulp sass --ext {extension-name}
gulp requirejs --ext {extension-name}
gulp test --ext {extension-name}

gulp sass:watch
gulp requirejs:watch
gulp test:watch
```
The main tasks (sass, requirejs, test) needs the extension name passed, otherwise they will error out
The watchers (xyz:watch) do not need the extension name, they watch files in every extension. Once a file change, they will find the extension they belong to and then call the main task for that extension

### Custom logic
An extension might have some custom logic for a given task that it needs to run. It could either be some logic that needs to run before or after the main task, or it could be a logic that needs to replace the main task altogether.

To support this, the gulpfile, for any main task, will look for a file under a `gulp-tasks/` folder with the same name as the task. If this file exists, it needs to define a function that once invoked return an object with any of these properties: `main`, `pre`, `post`

`main`: it's a function that replaces the main task altogether, see [here](https://github.com/civicrm/civihr/pull/2366/files#diff-5f9221f200b064549a705645668004eeR7) for an example;
`pre`: it's an array of objects, each object representing a task that needs to be run before the main task;
`post`: it's an array of objects, each object representing a task that needs to be run after the main task;

### Notes
* I left `@NOTE`s in the code to give more details on the proposed solution
* The watchers take something like 20 seconds to start, the final gulpfile will have to be a little bit smarter with the selectors
* The `requirejs` task currently does not support the cross-extension dependencies, unlike what you can find for example in the [hrjobcontract gulpfile](https://github.com/civicrm/civihr/blob/staging/hrjobcontract/gulpfile.js#L21-L25). This was skipped for time constraints, but it shouldn't be a technical problem to implement
* This gulpfile does not cover either T&A or Shoreditch, as those are extensions used in CiviHR, *not* CiviHR extensions