### PR TITLE
PCHR-3029: Sending Stats

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Model/CiviHRStatistics.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Model/CiviHRStatistics.php
@@ -112,11 +112,13 @@ class CRM_HRCore_Model_CiviHRStatistics {
 
   /**
    * @param $roleName
-   * @param DateTime $time
+   *   The name of the role
+   * @param DateTime|null $time
+   *   The most recent login time, NULL if no login exists
    *
    * @return $this
    */
-  public function setMostRecentLoginForRole($roleName, \DateTime $time) {
+  public function setMostRecentLoginForRole($roleName, $time) {
     $this->mostRecentLogins[$roleName] = $time;
 
     return $this;

--- a/uk.co.compucorp.civicrm.hrcore/api/v3/Job/CheckCivihrVersion.php
+++ b/uk.co.compucorp.civicrm.hrcore/api/v3/Job/CheckCivihrVersion.php
@@ -7,7 +7,7 @@
  */
 function civicrm_api3_job_check_civihr_version() {
   $container = Civi::container();
-  $currentStats = Civi::container()->get('civihr_stats_cache')->fetchCurrent();
+  $currentStats = $container->get('civihr_stats_cache')->fetchCurrent();
   $container->get('civihr_stats_sender')->send($currentStats);
 
   return civicrm_api3_create_success();

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsSenderTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsSenderTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use CRM_HRCore_Service_Stats_StatsSender as StatsSender;
+use CRM_Utils_HttpClient as HttpClient;
+use CRM_HRCore_Model_CiviHRStatistics as CiviHRStatistics;
+use CRM_HRCore_Test_BaseHeadlessTest as BaseHeadlessTest;
+use CRM_HRCore_Service_Stats_StatsJSONConvertor as StatsJSONConvertor;
+
+/**
+ * @group headless
+ */
+class StatsSenderTest extends BaseHeadlessTest {
+
+  const MOCK_ENDPOINT = 'http://fake.civihr.org/civicrm/civhr-stats';
+
+  public static function setUpBeforeClass() {
+    if (defined('CIVIHR_STATISTICS_ENDPOINT')) {
+      self::fail('Please unset CIVIHR_STATISTICS_ENDPOINT in your settings file');
+    }
+
+    define('CIVIHR_STATISTICS_ENDPOINT', self::MOCK_ENDPOINT);
+  }
+
+  public function testSuccessfulResponseWillNotThrowException() {
+    $stats = new CiviHRStatistics();
+    $json = StatsJSONConvertor::toJson($stats);
+
+    $response = [HttpClient::STATUS_OK, ''];
+    $client = $this->prophesize(HttpClient::class);
+    $client->post(self::MOCK_ENDPOINT, $json)->willReturn($response);
+    
+    $sender = new StatsSender($client->reveal());
+
+    $sender->send($stats);
+  }
+
+  public function testNonOKStatusWillThrowException() {
+    $stats = new CiviHRStatistics();
+    $json = StatsJSONConvertor::toJson($stats);
+
+    $msg = 'Failed sending CiviHR stats: <error message>';
+    $this->setExpectedException(\Exception::class, $msg);
+
+    $client = $this->prophesize(HttpClient::class);
+    $response = [HttpClient::STATUS_DL_ERROR, '<error message>'];
+    $client->post(self::MOCK_ENDPOINT, $json)->willReturn($response);
+    
+    $sender = new StatsSender($client->reveal());
+
+    $sender->send($stats);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/xml/services.xml
+++ b/uk.co.compucorp.civicrm.hrcore/xml/services.xml
@@ -2,6 +2,10 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="connection_timeout">10</parameter>
+    </parameters>
+
     <services>
         <service id="drupal_role_service" class="CRM_HRCore_CMSData_Role_DrupalRoleService"/>
         <service id="drupal_user_service" class="CRM_HRCore_Service_DrupalUserService">
@@ -24,7 +28,9 @@
                 class="CRM_HRCore_CMSData_Role_RoleServiceInterface"
         />
         <service id="core.cache" class="CRM_Core_BAO_Cache"/>
-        <service id="core.http_client" class="CRM_Utils_HttpClient"/>
+        <service id="core.http_client" class="CRM_Utils_HttpClient">
+            <argument>%connection_timeout%</argument>
+        </service>
         <service id="civihr_stats_sender" class="CRM_HRCore_Service_Stats_StatsSender">
             <argument type="service" id="core.http_client"/>
             <argument type="service" id="psr_log"/>


### PR DESCRIPTION
## Overview

As part of the pingback epic CiviHR statistics will be gathered from each client site and sent to a central server. This PR deals with the sending of the statistics.

## Before

Functionality to send statistics was unfinished

## After

We have a class that accepts a statistics object, turns it to JSON and sends it to a server. The server endpoint can be overridden in your settings file. Both successful transmissions and errors will be logged.