### PR TITLE
PCHR-3095: Add support for running tests in Jenkins for feature branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,6 @@ pipeline {
   agent any
 
   parameters {
-    string(name: 'CIVIHR_BRANCH', defaultValue: '', description: 'Default build branch of CiviHR to build site using CiviCRM-Buildkit')
     string(name: 'CIVIHR_BUILDNAME', defaultValue: "hr17-dev_$BRANCH_NAME", description: 'CiviHR site name')
     booleanParam(name: 'DESTROY_SITE', defaultValue: true, description: 'Destroy built site after build finish')
   }
@@ -44,14 +43,8 @@ pipeline {
     stage('Build site') {
       steps {
         script {
-          // Setup Building branch with
-          // CIVIHR_BRANCH parameter from manually build with parameter
-          // or PR target branch (CHANGE_TARGET) from building pull request
-          // or branch (BRANCH_NAME) from building individual branch
-          def buildBranch = params.CIVIHR_BRANCH != '' ? params.CIVIHR_BRANCH : env.CHANGE_TARGET != null ? env.CHANGE_TARGET : env.BRANCH_NAME != null ? env.BRANCH_NAME : 'staging'
-
           // Build site with CV Buildkit
-          sh "civibuild create ${params.CIVIHR_BUILDNAME} --type hr17 --civi-ver 4.7.27 --hr-ver ${buildBranch} --url $WEBURL --admin-pass $ADMIN_PASS"
+          sh "civibuild create ${params.CIVIHR_BUILDNAME} --type hr17 --civi-ver 4.7.27 --hr-ver staging --url $WEBURL --admin-pass $ADMIN_PASS"
           sh """
             cd $DRUPAL_MODULES_ROOT/civicrm
             wget -O attachments.patch https://gist.githubusercontent.com/davialexandre/199b3ebb2c69f43c07dde0f51fb02c8b/raw/0f11edad8049c6edddd7f865c801ecba5fa4c052/attachments-4.7.27.patch


### PR DESCRIPTION
## Problem

With our current workflow, not all Pull Requests target staging. Most of the time, a PR will target a feature branch, which groups a number of PRs for smaller tasks, until the feature is complete and finally ready to be merged to staging. 

It was not possible for Jenkins to run the tests for such Pull Requests. Before running the tests, a new site is created using `civibuild` and the PR's branch as the value for the `--hr-ver` option. The command then tries to pull the code from this branch in all the repositories used by CiviHR but, in most of the cases, the branch will only exist in one or two of them and the installation will fail, making Jenkins mark the build as failed.

## Solution

After the site is created and before running the tests, Jenkins:
- Checks out the PR branch
- Merge the PR target branch into the PR branch
- Run upgraders

This is enough to guarantee the tests will run on top of the correct branch. For that reason, for tests, the branch used during the site creation is not really important. Based on that, the solution was to update the Jenkinsfile so that the `staging` branch will always be used while creating the site.