### PR TITLE
PCHR-3100: Fix hremergency PHP tests

### DIFF
--- a/org.civicrm.hremergency/CRM/Hremergency/Test/BaseHeadlessTest.php
+++ b/org.civicrm.hremergency/CRM/Hremergency/Test/BaseHeadlessTest.php
@@ -8,6 +8,7 @@ abstract class CRM_Hremergency_Test_BaseHeadlessTest extends PHPUnit_Framework_T
 
   public function setUpHeadless() {
     return \Civi\Test::headless()
+      ->install('uk.co.compucorp.civicrm.hrcore')
       ->installMe(__DIR__)
       ->apply();
   }

--- a/org.civicrm.hremergency/CRM/Hremergency/Test/BaseHeadlessTest.php
+++ b/org.civicrm.hremergency/CRM/Hremergency/Test/BaseHeadlessTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+abstract class CRM_Hremergency_Test_BaseHeadlessTest extends PHPUnit_Framework_TestCase
+  implements HeadlessInterface, TransactionalInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+}

--- a/org.civicrm.hremergency/tests/phpunit/CRM/Hremergency/Service/EmergencyContactServiceTest.php
+++ b/org.civicrm.hremergency/tests/phpunit/CRM/Hremergency/Service/EmergencyContactServiceTest.php
@@ -1,22 +1,14 @@
 <?php
 
+use CRM_Hremergency_Test_BaseHeadlessTest as BaseHeadlessTest;
 use CRM_Hremergency_Test_Fabricator_EmergencyContactFabricator as EmergencyContactFabricator;
 use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
-use Civi\Test\HeadlessInterface;
-use Civi\Test\TransactionalInterface;
 use CRM_Hremergency_Service_EmergencyContactService as EmergencyContactService;
 
 /**
  * @group headless
  */
-class CRM_Hremergency_Service_EmergencyContactServiceTest extends \PHPUnit_Framework_TestCase
-  implements HeadlessInterface, TransactionalInterface {
-
-  public function setUpHeadless() {
-    return \Civi\Test::headless()
-      ->installMe(__DIR__)
-      ->apply();
-  }
+class CRM_Hremergency_Service_EmergencyContactServiceTest extends BaseHeadlessTest {
 
   public function testFind() {
     $contact = ContactFabricator::fabricate();

--- a/org.civicrm.hremergency/tests/phpunit/api/v3/Contact/DeleteemergencycontactTest.php
+++ b/org.civicrm.hremergency/tests/phpunit/api/v3/Contact/DeleteemergencycontactTest.php
@@ -1,8 +1,12 @@
 <?php
 
+use CRM_Hremergency_Test_BaseHeadlessTest as BaseHeadlessTest;
 use CRM_Hremergency_Service_EmergencyContactService as EmergencyContactService;
 
-class api_v3_Contact_DeleteEmergencyContactTest extends \PHPUnit_Framework_TestCase {
+/**
+ * @group headless
+ */
+class api_v3_Contact_DeleteEmergencyContactTest extends BaseHeadlessTest {
 
   use CRM_HRCore_Test_Helpers_SessionHelpersTrait;
 

--- a/org.civicrm.hremergency/tests/phpunit/api/v3/Contact/DeleteemergencycontactTest.php
+++ b/org.civicrm.hremergency/tests/phpunit/api/v3/Contact/DeleteemergencycontactTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use CRM_HRCore_Test_Helpers_SessionHelper as SessionHelper;
 use CRM_Hremergency_Test_BaseHeadlessTest as BaseHeadlessTest;
 use CRM_Hremergency_Service_EmergencyContactService as EmergencyContactService;
 
@@ -7,8 +8,6 @@ use CRM_Hremergency_Service_EmergencyContactService as EmergencyContactService;
  * @group headless
  */
 class api_v3_Contact_DeleteEmergencyContactTest extends BaseHeadlessTest {
-
-  use CRM_HRCore_Test_Helpers_SessionHelpersTrait;
 
   public function testDeletingNonExistentContact() {
     $id = 1;
@@ -23,7 +22,7 @@ class api_v3_Contact_DeleteEmergencyContactTest extends BaseHeadlessTest {
     $emergencyContactID = 1;
     $currentContactID = 2;
     $contactOwnerID = 3;
-    $this->registerCurrentLoggedInContactInSession($currentContactID);
+    SessionHelper::registerCurrentLoggedInContactInSession($currentContactID);
 
     // use a different owner to logged in user
     $emergencyContacts[$emergencyContactID] = ['entity_id' => $contactOwnerID];
@@ -39,7 +38,7 @@ class api_v3_Contact_DeleteEmergencyContactTest extends BaseHeadlessTest {
     $emergencyContactID = 1;
     $contactOwnerID = 2;
 
-    $this->registerCurrentLoggedInContactInSession($contactOwnerID);
+    SessionHelper::registerCurrentLoggedInContactInSession($contactOwnerID);
 
     // owner and logged in user are the same
     $emergencyContacts[$emergencyContactID] = ['entity_id' => $contactOwnerID];

--- a/org.civicrm.hremergency/tests/phpunit/bootstrap.php
+++ b/org.civicrm.hremergency/tests/phpunit/bootstrap.php
@@ -2,7 +2,7 @@
 
 ini_set('memory_limit', '2G');
 ini_set('safe_mode', 0);
-eval(cv('php:boot --level=full', 'phpcode'));
+eval(cv('php:boot --level=full -t', 'phpcode'));
 
 $hrCoreDir = __DIR__ . '/../../../uk.co.compucorp.civicrm.hrcore';
 require_once $hrCoreDir . '/CRM/HRCore/Test/Helpers/SessionHelpersTrait.php';

--- a/org.civicrm.hremergency/tests/phpunit/bootstrap.php
+++ b/org.civicrm.hremergency/tests/phpunit/bootstrap.php
@@ -4,10 +4,6 @@ ini_set('memory_limit', '2G');
 ini_set('safe_mode', 0);
 eval(cv('php:boot --level=full -t', 'phpcode'));
 
-$hrCoreDir = __DIR__ . '/../../../uk.co.compucorp.civicrm.hrcore';
-require_once $hrCoreDir . '/CRM/HRCore/Test/Helpers/SessionHelpersTrait.php';
-require_once $hrCoreDir . '/CRM/HRCore/Test/Fabricator/Contact.php';
-
 /**
  * Call the "cv" command.
  *

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Test/Helpers/SessionHelper.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Test/Helpers/SessionHelper.php
@@ -1,18 +1,18 @@
 <?php
 
-trait CRM_HRCore_Test_Helpers_SessionHelpersTrait {
+class CRM_HRCore_Test_Helpers_SessionHelper {
 
-  protected function registerCurrentLoggedInContactInSession($contactID) {
+  public static function registerCurrentLoggedInContactInSession($contactID) {
     $session = CRM_Core_Session::singleton();
     $session->set('userID', $contactID);
   }
 
-  protected function unregisterCurrentLoggedInContactFromSession() {
+  public static function unregisterCurrentLoggedInContactFromSession() {
     $session = CRM_Core_Session::singleton();
     $session->set('userID', NULL);
   }
 
-  protected function setPermissions(array $permissions = []) {
+  public static function setPermissions(array $permissions = []) {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = $permissions;
   }
 

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/DrupalUserServiceTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/DrupalUserServiceTest.php
@@ -5,14 +5,12 @@ define('REQUEST_TIME', time());
 use CRM_HRCore_Service_DrupalUserService as DrupalUserService;
 use CRM_HRCore_Service_DrupalRoleService as DrupalRoleService;
 use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
-use CRM_HRCore_Test_Helpers_SessionHelpersTrait as SessionHelpersTrait;
+use CRM_HRCore_Test_Helpers_SessionHelper as SessionHelper;
 
 /**
  * @group headless
  */
 class DrupalUserServiceTest extends CRM_HRCore_Test_BaseHeadlessTest {
-
-  use SessionHelpersTrait;
 
   /**
    * @var string
@@ -26,7 +24,7 @@ class DrupalUserServiceTest extends CRM_HRCore_Test_BaseHeadlessTest {
 
   public function setUp() {
     $this->testContact = ContactFabricator::fabricate();
-    $this->registerCurrentLoggedInContactInSession($this->testContact['id']);
+    SessionHelper::registerCurrentLoggedInContactInSession($this->testContact['id']);
   }
 
   public function tearDown() {


### PR DESCRIPTION
## Overview

Jenkins cannot run the hremergency tests. Whenever it tries it, it fails with this error:

```
[civihr_PR-2238-QTNEV4RQWI3LHQFNHVVNONTJAJCGQNOPCH4L6BQMFDWYHF7L54LQ] Running shell script
+ cd /opt/buildkit/build/hr17-dev_PR-2238/sites/all/modules/civicrm/tools/extensions/civihr/org.civicrm.hremergency
+ phpunit4 --testsuite=Unit Tests --log-junit /var/lib/jenkins/workspace/civihr_PR-2238-QTNEV4RQWI3LHQFNHVVNONTJAJCGQNOPCH4L6BQMFDWYHF7L54LQ/reports/phpunit/result-phpunit_hremergency.xml

PHPUnit 4.8.21 by Sebastian Bergmann and contributors.

RuntimeException: Suite includes headless tests (CRM_Hremergency_Service_EmergencyContactServiceTest) which require CIVICRM_UF=UnitTests.

Tip: Run the headless tests and end-to-end tests separately, e.g.
  $ phpunit4 --group headless
  $ phpunit4 --group e2e  

 in Civi\Test\CiviTestListener->autoboot() (line 184 of /opt/buildkit/build/hr17-dev_PR-2238/sites/all/modules/civicrm/Civi/Test/CiviTestListener.php).
```

These tests have been added by https://github.com/civicrm/civihr/pull/2273 and have been failing since then.

## Before

Jenkins was not able to run the hremergency tests.

## After

Jenkins can now run the hremergency tests and they all pass.

## Technical Details

The main reason for the error was that the bootstrap.php file was trying to bootstrap a regular civicrm environment instead of a test one, where the `CIVICRM_UF` constant is set to "UnitTests". This has been fixed by changing this line on the bootstrap.php file:

```php
eval(cv('php:boot --level=full', 'phpcode'));
```

to this (note the `-t` that has been added):

```php
eval(cv('php:boot --level=full -t', 'phpcode'));
```

Besides that, a few adjustments have been made to make sure the tests are consistent with the structure we've been trying to use for all extensions:

- A `BaseHeadlessTest` class was added in order to have a single `setUpHeadless()` method that can be used by all of the extension's tests
- The tests use some helpers and fabricators from hrcore. Before, it was including these files directly in the bootstrap.php file. This has been updated and now we install the hrcore ext in the `setUpHeadless()` method instead, so that these classes can be autoloaded. The reason here is so that we don't need to know the exact folder of the hrcore extension
- One of the helpers being imported from hrcore was a trait. Traits are evaluated when a class is included and this happens before the `setUpHeadless()` method gets called to install the dependencies. This means that at the moment the trait is evaluated, it was not available for autoloading yet and the test would fail. To solve this, the trait was turned into a regular class and its methods have been made static.

## Comments

The reason we didn't catch this issue right when https://github.com/civicrm/civihr/pull/2273 was created, is that we still didn't have support to run tests in Jenkins for PRs targeting a feature branch at that time.