### PR TITLE
PCHR-3069: Add the addContactMenuActions Hook implementation

### DIFF
--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Hook/AddContactMenuActions.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Hook/AddContactMenuActions.php
@@ -1,0 +1,32 @@
+<?php
+
+use CRM_HRContactActionsMenu_Component_Menu as ActionsMenu;
+
+/**
+ * Class CRM_HRContactActionsMenu_Hook_AddContactMenuActions
+ */
+class CRM_HRContactActionsMenu_Hook_AddContactMenuActions {
+
+  /**
+   * Runs all extensions implementation of
+   * hook_addContactMenuActions and returns the
+   * menu object.
+   *
+   * @return \CRM_HRContactActionsMenu_Component_Menu
+   */
+  public static function invoke() {
+    $menu =  new ActionsMenu;
+
+    CRM_Utils_Hook::singleton()->invoke(['menu'],
+      $menu,
+      CRM_Utils_Hook::$_nullObject,
+      CRM_Utils_Hook::$_nullObject,
+      CRM_Utils_Hook::$_nullObject,
+      CRM_Utils_Hook::$_nullObject,
+      CRM_Utils_Hook::$_nullObject,
+      'addContactMenuActions'
+    );
+
+    return $menu;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/tests/phpunit/CRM/HRContactActionsMenu/Hook/AddContactMenuActionsTest.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/tests/phpunit/CRM/HRContactActionsMenu/Hook/AddContactMenuActionsTest.php
@@ -14,11 +14,7 @@ class CRM_HRContactActionsMenu_Hook_AddContactMenuActionsTest extends BaseHeadle
 
   private $groupTitle;
 
-  public function setUp() {
-    CRM_Utils_Hook::singleton()->setHook('addContactMenuActions', array($this, 'hook_civicrm_addContactMenuActions'));
-  }
-
-  public function hook_civicrm_addContactMenuActions(ActionsMenu $menu) {
+  public function hook_addContactMenuActions(ActionsMenu $menu) {
     $this->groupTitle = 'Test Group';
     $testGroup = new ActionsGroup($this->groupTitle);
     $menu->addToMainPanel($testGroup);

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/tests/phpunit/CRM/HRContactActionsMenu/Hook/AddContactMenuActionsTest.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/tests/phpunit/CRM/HRContactActionsMenu/Hook/AddContactMenuActionsTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use CRM_HRContactActionsMenu_Hook_AddContactMenuActions as AddContactMenuActionsHook;
+use CRM_HRContactActionsMenu_Component_Menu as ActionsMenu;
+
+/**
+ * Class CRM_HRContactActionsMenu_Hook_AddContactMenuActionsTest
+ *
+ * @group headless
+ */
+class CRM_HRContactActionsMenu_Hook_AddContactMenuActionsTest extends BaseHeadlessTest {
+
+  public function testInvokeReturnsAnActionsMenuInstance() {
+    $this->assertInstanceOf(ActionsMenu::class, AddContactMenuActionsHook::invoke());
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/tests/phpunit/CRM/HRContactActionsMenu/Hook/AddContactMenuActionsTest.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/tests/phpunit/CRM/HRContactActionsMenu/Hook/AddContactMenuActionsTest.php
@@ -2,15 +2,33 @@
 
 use CRM_HRContactActionsMenu_Hook_AddContactMenuActions as AddContactMenuActionsHook;
 use CRM_HRContactActionsMenu_Component_Menu as ActionsMenu;
+use CRM_HRContactActionsMenu_Component_Group as ActionsGroup;
+use Civi\Test\HookInterface as HookInterface;
 
 /**
  * Class CRM_HRContactActionsMenu_Hook_AddContactMenuActionsTest
  *
  * @group headless
  */
-class CRM_HRContactActionsMenu_Hook_AddContactMenuActionsTest extends BaseHeadlessTest {
+class CRM_HRContactActionsMenu_Hook_AddContactMenuActionsTest extends BaseHeadlessTest implements HookInterface {
 
-  public function testInvokeReturnsAnActionsMenuInstance() {
-    $this->assertInstanceOf(ActionsMenu::class, AddContactMenuActionsHook::invoke());
+  private $groupTitle;
+
+  public function setUp() {
+    CRM_Utils_Hook::singleton()->setHook('addContactMenuActions', array($this, 'hook_civicrm_addContactMenuActions'));
+  }
+
+  public function hook_civicrm_addContactMenuActions(ActionsMenu $menu) {
+    $this->groupTitle = 'Test Group';
+    $testGroup = new ActionsGroup($this->groupTitle);
+    $menu->addToMainPanel($testGroup);
+  }
+
+  public function testInvokeInvokesTheAddContactMenuActionsHook() {
+    $menu = AddContactMenuActionsHook::invoke();
+    $this->assertInstanceOf(ActionsMenu::class, $menu);
+    $groups = $menu->getMainPanelItems();
+    $this->assertCount(1, $groups);
+    $this->assertEquals($this->groupTitle, $groups[0]->getTitle());
   }
 }


### PR DESCRIPTION
## Overview
This HRContactActionsMenu provides functionality that allows other extensions to add menu items to the contact actions menu on contact summary page via the `addContactMenuActions` hook.
This PR defines the hook and the parameter that other extensions calling the hook will expect.

## Before
- The impementation for the  addContactMenuActions hook was not present.

## After
- The implementation for the  addContactMenuActions hook was added.
- The action to invoke the addContactMenuActions hook will be added in the `contactactionsmenu_civicrm_pageRun` hook implementation. This will be added in subsequent PR when the template for the contact actions menu is added.

 ## Technical Details
A sample implementation of the hook e.g by the Leave and Absence extension will be:
```php
function hrleaveandabsences_addContactActions(ActionsMenu $menu) {
//code 
}
```