### PR TITLE
PCHR-3103: Multi Credential Support for Backstop JS

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/login.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/login.js
@@ -10,9 +10,7 @@ module.exports = function (casper, scenario) {
       if (casper.exists('a[href="/user/logout"]')) {
         casper.echo('Current scenario has different login credentials from previous, logging out is necessary', 'INFO');
         casper.echo('Logging Out', 'INFO');
-        return casper.evaluate(function () {
-          jQuery('a[href="/user/logout"]')[0].click();
-        });
+        return phantom.clearCookies();
       }
     })
     .then(function () {

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/login.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/login.js
@@ -1,11 +1,23 @@
 'use strict';
 
-module.exports = function (casper) {
+module.exports = function (casper, scenario) {
   var config = require('../site-config');
   var loginFormSelector = 'form#user-login-form';
+  var credentials = config.credentials[scenario.credential || 'admin'];  
 
   casper
-    .echo('Logging in before starting...', 'INFO')
+    .then(function () {
+      if(casper.exists('a[href="/user/logout"]')) {
+        casper.echo('Current scenario has different login credentials from previous, logging out is necessary', 'INFO');
+        casper.echo('Logging Out', 'INFO');
+        return casper.evaluate(function() {
+          jQuery('a[href="/user/logout"]')[0].click()
+        });
+      }
+    })
+    .then(function () {
+      casper.echo('Logging in with "' + (scenario.credential || 'admin') + '" credentials before starting ...', 'INFO')
+    })
     .thenOpen(config.url + '/welcome-page', function () {
       casper.then(function () {
         casper.waitForSelector(loginFormSelector, function () {
@@ -14,7 +26,7 @@ module.exports = function (casper) {
           }, function () {
             casper.echo('Login form visible and timeout reached!', 'RED_BAR');
           }, 5000);
-          casper.fill(loginFormSelector, config.credentials, true);
+          casper.fill(loginFormSelector, credentials, true);
         }, function () {
           casper.echo('Login form not found!', 'RED_BAR');
         }, 8000);

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/login.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/login.js
@@ -10,6 +10,7 @@ module.exports = function (casper, scenario) {
       if (casper.exists('a[href="/user/logout"]')) {
         casper.echo('Current scenario has different login credentials from previous, logging out is necessary', 'INFO');
         casper.echo('Logging Out', 'INFO');
+
         return phantom.clearCookies();
       }
     })

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/login.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/login.js
@@ -3,11 +3,11 @@
 module.exports = function (casper, scenario) {
   var config = require('../site-config');
   var loginFormSelector = 'form#user-login-form';
-  var credentials = config.credentials[scenario.credential || 'admin'];
+  var credentials = config.credentials[scenario.credential];
 
   casper
     .then(function () {
-      if (casper.exists('a[href="/user/logout"]')) {
+      if (scenario.performLogout) {
         casper.echo('Current scenario has different login credentials from previous, logging out is necessary', 'INFO');
         casper.echo('Logging Out', 'INFO');
 

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/login.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/login.js
@@ -3,20 +3,20 @@
 module.exports = function (casper, scenario) {
   var config = require('../site-config');
   var loginFormSelector = 'form#user-login-form';
-  var credentials = config.credentials[scenario.credential || 'admin'];  
+  var credentials = config.credentials[scenario.credential || 'admin'];
 
   casper
     .then(function () {
-      if(casper.exists('a[href="/user/logout"]')) {
+      if (casper.exists('a[href="/user/logout"]')) {
         casper.echo('Current scenario has different login credentials from previous, logging out is necessary', 'INFO');
         casper.echo('Logging Out', 'INFO');
-        return casper.evaluate(function() {
-          jQuery('a[href="/user/logout"]')[0].click()
+        return casper.evaluate(function () {
+          jQuery('a[href="/user/logout"]')[0].click();
         });
       }
     })
     .then(function () {
-      casper.echo('Logging in with "' + (scenario.credential || 'admin') + '" credentials before starting ...', 'INFO')
+      casper.echo('Logging in with "' + (scenario.credential || 'admin') + '" credentials before starting ...', 'INFO');
     })
     .thenOpen(config.url + '/welcome-page', function () {
       casper.then(function () {
@@ -31,5 +31,5 @@ module.exports = function (casper, scenario) {
           casper.echo('Login form not found!', 'RED_BAR');
         }, 8000);
       });
-  });
+    });
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/ssp/edit-emergency-contact.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/ssp/edit-emergency-contact.js
@@ -1,7 +1,0 @@
-'use strict';
-
-var page = require('../../page-objects/ssp/my-details');
-
-module.exports = function (casper) {
-  page.init(casper).showEditEmergencyContactPopup();
-};

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/page.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/page.js
@@ -56,7 +56,7 @@ module.exports = {
     clearDialogs = typeof clearDialogs !== 'undefined' ? !!clearDialogs : true;
 
     this.casper = customCasperJS(casper);
-    this.casper.options.waitTimeout = 10000;
+    this.casper.options.waitTimeout = 60000;
 
     !!this.waitForReady && this.casper.then(function () {
       this.waitForReady();

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/page.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/page.js
@@ -56,7 +56,7 @@ module.exports = {
     clearDialogs = typeof clearDialogs !== 'undefined' ? !!clearDialogs : true;
 
     this.casper = customCasperJS(casper);
-    this.casper.options.waitTimeout = 60000;
+    this.casper.options.waitTimeout = 10000;
 
     !!this.waitForReady && this.casper.then(function () {
       this.waitForReady();

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp/my-details.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp/my-details.js
@@ -17,22 +17,6 @@ module.exports = (function () {
       }.bind(this));
 
       return this;
-    },
-
-    /**
-     * Opens Edit Emergency Contact Popup
-     *
-     * @return {object}
-     */
-    showEditEmergencyContactPopup: function () {
-      var casper = this.casper;
-
-      casper.then(function () {
-        casper.click('[href="/emergency_contacts/nojs/view"]');
-        casper.waitUntilVisible('.modal-civihr-custom__section');
-      }.bind(this));
-
-      return this;
     }
   });
 })();

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/contact-access-rights.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/contact-access-rights.json
@@ -3,12 +3,14 @@
     {
       "label": "Contact Access Rights",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-access-rights/show"
+      "onReadyScript": "contact-access-rights/show",
+      "credential": "admin"
     },
     {
       "label": "Contact Access Rights / Open ui select",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-access-rights/open-ui-select"
+      "onReadyScript": "contact-access-rights/open-ui-select",
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/contact-edit-form.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/contact-edit-form.json
@@ -4,7 +4,8 @@
       "label": "Contact Edit Form",
       "delay": 5000,
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact/contact-edit"
+      "onReadyScript": "contact/contact-edit",
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/contact-summary.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/contact-summary.json
@@ -3,12 +3,14 @@
     {
       "label": "Contact Summary",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "close-any-modal"
+      "onReadyScript": "close-any-modal",
+      "credential": "admin"
     },
     {
       "label": "Contact Summary / Actions",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/show-actions"
+      "onReadyScript": "contact-summary/show-actions",
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-absence-admin-absence-periods.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-absence-admin-absence-periods.json
@@ -2,11 +2,13 @@
   "scenarios": [
     {
       "label": "Absence Periods list",
-      "url": "civicrm/admin/leaveandabsences/periods?action=browse"
+      "url": "civicrm/admin/leaveandabsences/periods?action=browse",
+      "credential": "admin"
     },
     {
       "label": "Absence Periods form",
-      "url": "civicrm/admin/leaveandabsences/periods?action=add"
+      "url": "civicrm/admin/leaveandabsences/periods?action=add",
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-absence-admin-absence-types.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-absence-admin-absence-types.json
@@ -2,11 +2,13 @@
   "scenarios": [
     {
       "label": "Absence Types list",
-      "url": "civicrm/admin/leaveandabsences/types?action=browse"
+      "url": "civicrm/admin/leaveandabsences/types?action=browse",
+      "credential": "admin"
     },
     {
       "label": "Absence Types form",
-      "url": "civicrm/admin/leaveandabsences/types?action=add"
+      "url": "civicrm/admin/leaveandabsences/types?action=add",
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-absence-admin-general-settings.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-absence-admin-general-settings.json
@@ -2,7 +2,8 @@
   "scenarios": [
     {
       "label": "General Settings",
-      "url": "civicrm/admin/leaveandabsences/general_settings"
+      "url": "civicrm/admin/leaveandabsences/general_settings",
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-absence-admin-import.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-absence-admin-import.json
@@ -2,22 +2,26 @@
   "scenarios": [
     {
       "label": "Leave & Absences Import - Step 1",
-      "url": "civicrm/admin/leaveandabsences/import"
+      "url": "civicrm/admin/leaveandabsences/import",
+      "credential": "admin"
     },
     {
       "label": "Leave & Absences Import - Step 2",
       "url": "civicrm/admin/leaveandabsences/import",
-      "onReadyScript": "leave-absence-dashboard/import/step-2"
+      "onReadyScript": "leave-absence-dashboard/import/step-2",
+      "credential": "admin"
     },
     {
       "label": "Leave & Absences Import - Step 3",
       "url": "civicrm/admin/leaveandabsences/import",
-      "onReadyScript": "leave-absence-dashboard/import/step-3"
+      "onReadyScript": "leave-absence-dashboard/import/step-3",
+      "credential": "admin"
     },
     {
       "label": "Leave & Absences Import - Step 4",
       "url": "civicrm/admin/leaveandabsences/import",
-      "onReadyScript": "leave-absence-dashboard/import/step-4"
+      "onReadyScript": "leave-absence-dashboard/import/step-4",
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-absence-admin-public-holidays.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-absence-admin-public-holidays.json
@@ -2,11 +2,13 @@
   "scenarios": [
     {
       "label": "Public Holidays list",
-      "url": "civicrm/admin/leaveandabsences/public_holidays?action=browse"
+      "url": "civicrm/admin/leaveandabsences/public_holidays?action=browse",
+      "credential": "admin"
     },
     {
       "label": "Public Holidays form",
-      "url": "civicrm/admin/leaveandabsences/public_holidays?action=add"
+      "url": "civicrm/admin/leaveandabsences/public_holidays?action=add",
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-absence-admin-work-patterns.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-absence-admin-work-patterns.json
@@ -2,16 +2,19 @@
   "scenarios": [
     {
       "label": "Work Patterns list",
-      "url": "civicrm/admin/leaveandabsences/work_patterns?action=browse"
+      "url": "civicrm/admin/leaveandabsences/work_patterns?action=browse",
+      "credential": "admin"
     },
     {
       "label": "Work Pattern description form",
-      "url": "civicrm/admin/leaveandabsences/work_patterns?action=add"
+      "url": "civicrm/admin/leaveandabsences/work_patterns?action=add",
+      "credential": "admin"
     },
     {
       "label": "Work Pattern calendar form",
       "url": "civicrm/admin/leaveandabsences/work_patterns?action=add",
-      "onReadyScript": "work-patterns/show-calendar-form"
+      "onReadyScript": "work-patterns/show-calendar-form",
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-absence-dashboard-leave-calendar.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-absence-dashboard-leave-calendar.json
@@ -3,7 +3,8 @@
     {
       "label": "Leave Absence Dashboard Leave Calendar",
       "url": "civicrm/leaveandabsences/dashboard#/calendar",
-      "onReadyScript": "leave-absence-dashboard/leave-calendar/leave-calendar"
+      "onReadyScript": "leave-absence-dashboard/leave-calendar/leave-calendar",
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-absence-dashboard-leave-requests.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-absence-dashboard-leave-requests.json
@@ -3,12 +3,14 @@
     {
       "label": "Leave Absence Dashboard Leave Requests",
       "url": "civicrm/leaveandabsences/dashboard#/requests",
-      "onReadyScript": "leave-absence-dashboard/leave-requests/leave-requests"
+      "onReadyScript": "leave-absence-dashboard/leave-requests/leave-requests",
+      "credential": "admin"
     },
     {
       "label": "Leave Absence Dashboard Leave Requests with filters",
       "url": "civicrm/leaveandabsences/dashboard#/requests",
-      "onReadyScript": "leave-absence-dashboard/leave-requests/leave-requests-with-filters"
+      "onReadyScript": "leave-absence-dashboard/leave-requests/leave-requests-with-filters",
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-balances.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-balances.json
@@ -3,12 +3,14 @@
     {
       "label": "SSP: Leave Balances",
       "url": "manager-leave#/manager-leave/leave-balances",
-      "onReadyScript": "ssp-leave-absences/manager/leave-balances"
+      "onReadyScript": "ssp-leave-absences/manager/leave-balances",
+      "credential": "manager"
     },
     {
       "label": "Admin Portal: Leave Balances",
       "url": "civicrm/leaveandabsences/dashboard#/leave-balances",
-      "onReadyScript": "leave-absence-dashboard/leave-balances/leave-balances"
+      "onReadyScript": "leave-absence-dashboard/leave-balances/leave-balances",
+      "credential": "manager"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-manager-leave-calendar.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-manager-leave-calendar.json
@@ -3,17 +3,20 @@
     {
       "label": "Current Month: Manager Leave Calendar",
       "url": "manager-leave#/manager-leave/calendar",
-      "onReadyScript": "ssp-leave-absences/manager/manager-leave-calendar_current-month-visible"
+      "onReadyScript": "ssp-leave-absences/manager/manager-leave-calendar_current-month-visible",
+      "credential": "manager"
     },
     {
       "label": "Legend expanded: Manager Leave Calendar",
       "url": "manager-leave#/manager-leave/calendar",
-      "onReadyScript": "ssp-leave-absences/manager/manager-leave-calendar_legend-expanded"
+      "onReadyScript": "ssp-leave-absences/manager/manager-leave-calendar_legend-expanded",
+      "credential": "manager"
     },
     {
       "label": "Show all contacts: Manager Leave Calendar",
       "url": "manager-leave#/manager-leave/calendar",
-      "onReadyScript": "ssp-leave-absences/manager/manager-leave-calendar_all-contacts"
+      "onReadyScript": "ssp-leave-absences/manager/manager-leave-calendar_all-contacts",
+      "credential": "manager"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-manager-leave-requests-by-admin.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-manager-leave-requests-by-admin.json
@@ -4,13 +4,13 @@
       "label": "SSP Leave and Absences: Admin: Manager Leave: Leave Requests",
       "url": "manager-leave#/manager-leave/requests",
       "onReadyScript": "ssp-leave-absences/admin/manager-leave-requests",
-      "credential": "manager"
+      "credential": "admin"
     },
     {
       "label": "SSP Leave and Absences: Admin: Manager Leave: Leave Requests: All Requests",
       "url": "manager-leave#/manager-leave/requests",
       "onReadyScript": "ssp-leave-absences/admin/manager-leave-requests-all-requests",
-      "credential": "manager"
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-manager-leave-requests-by-admin.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-manager-leave-requests-by-admin.json
@@ -3,12 +3,14 @@
     {
       "label": "SSP Leave and Absences: Admin: Manager Leave: Leave Requests",
       "url": "manager-leave#/manager-leave/requests",
-      "onReadyScript": "ssp-leave-absences/admin/manager-leave-requests"
+      "onReadyScript": "ssp-leave-absences/admin/manager-leave-requests",
+      "credential": "manager"
     },
     {
       "label": "SSP Leave and Absences: Admin: Manager Leave: Leave Requests: All Requests",
       "url": "manager-leave#/manager-leave/requests",
-      "onReadyScript": "ssp-leave-absences/admin/manager-leave-requests-all-requests"
+      "onReadyScript": "ssp-leave-absences/admin/manager-leave-requests-all-requests",
+      "credential": "manager"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-manager-leave-requests.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-manager-leave-requests.json
@@ -2,42 +2,50 @@
   "scenarios": [{
       "label": "Leave and Absences: Manager Leave Requests: Show actions",
       "url": "manager-leave#/manager-leave/requests",
-      "onReadyScript": "ssp-leave-absences/manager/leave-requests-show-actions"
+      "onReadyScript": "ssp-leave-absences/manager/leave-requests-show-actions",
+      "credential": "manager"
     },
     {
       "label": "Leave and Absences: Manager Leave Requests: Show Without Filters",
       "url": "manager-leave#/manager-leave/requests",
-      "onReadyScript": "ssp-leave-absences/manager/leave-requests-without-filters"
+      "onReadyScript": "ssp-leave-absences/manager/leave-requests-without-filters",
+      "credential": "manager"
     },
     {
       "label": "Leave and Absences: Manager Leave Requests: Show With Filters",
       "url": "manager-leave#/manager-leave/requests",
-      "onReadyScript": "ssp-leave-absences/manager/leave-requests-with-filters"
+      "onReadyScript": "ssp-leave-absences/manager/leave-requests-with-filters",
+      "credential": "manager"
     },
     {
       "label": "Leave and Absences: Manager Leave Requests: Show staff edit toil request",
       "url": "manager-leave#/manager-leave/requests",
-      "onReadyScript": "ssp-leave-absences/manager/leave-requests-of-staff-edit-toil"
+      "onReadyScript": "ssp-leave-absences/manager/leave-requests-of-staff-edit-toil",
+      "credential": "manager"
     },
     {
       "label": "Leave and Absences: Manager Leave Requests: Show staff edit sickness request",
       "url": "manager-leave#/manager-leave/requests",
-      "onReadyScript": "ssp-leave-absences/manager/leave-requests-of-staff-edit-sickness"
+      "onReadyScript": "ssp-leave-absences/manager/leave-requests-of-staff-edit-sickness",
+      "credential": "manager"
     },
     {
       "label": "Leave and Absences: Manager Leave Requests: Apply leave on behalf of staff",
       "url": "manager-leave#/manager-leave/requests",
-      "onReadyScript": "ssp-leave-absences/manager/leave-requests-on-behalf-of-staff"
+      "onReadyScript": "ssp-leave-absences/manager/leave-requests-on-behalf-of-staff",
+      "credential": "manager"
     },
     {
       "label": "Leave and Absences: Manager Leave Requests: Apply sickness on behalf of staff",
       "url": "manager-leave#/manager-leave/requests",
-      "onReadyScript": "ssp-leave-absences/manager/sick-requests-on-behalf-of-staff"
+      "onReadyScript": "ssp-leave-absences/manager/sick-requests-on-behalf-of-staff",
+      "credential": "manager"
     },
     {
       "label": "Leave and Absences: Manager Leave Requests: Apply toil on behalf of staff",
       "url": "manager-leave#/manager-leave/requests",
-      "onReadyScript": "ssp-leave-absences/manager/toil-requests-on-behalf-of-staff"
+      "onReadyScript": "ssp-leave-absences/manager/toil-requests-on-behalf-of-staff",
+      "credential": "manager"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-my-leave-calendar.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-my-leave-calendar.json
@@ -3,7 +3,8 @@
     {
       "label": "Current Month: My Leave Calendar",
       "url": "my-leave#/my-leave/calendar",
-      "onReadyScript": "ssp-leave-absences/staff/my-leave-calendar_current-month-visible"
+      "onReadyScript": "ssp-leave-absences/staff/my-leave-calendar_current-month-visible",
+      "credential": "staff"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-my-report-leave-request-modal.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-my-report-leave-request-modal.json
@@ -3,17 +3,20 @@
     {
       "label": "Leave and Absences: My report: Show comments in leave request",
       "url": "my-leave#/my-leave/report",
-      "onReadyScript": "ssp-leave-absences/staff/my-report-pending-show-comments"
+      "onReadyScript": "ssp-leave-absences/staff/my-report-pending-show-comments",
+      "credential": "staff"
     },
     {
       "label": "Leave and Absences: My report: Show manager's comments in leave request",
       "url": "my-leave#/my-leave/report",
-      "onReadyScript": "ssp-leave-absences/staff/my-report-manager-show-comments"
+      "onReadyScript": "ssp-leave-absences/staff/my-report-manager-show-comments",
+      "credential": "staff"
     },
     {
       "label": "Leave and Absences: My report: Show toil in edit mode",
       "url": "my-leave#/my-leave/report",
-      "onReadyScript": "ssp-leave-absences/staff/my-report-staff-toil-edit"
+      "onReadyScript": "ssp-leave-absences/staff/my-report-staff-toil-edit",
+      "credential": "staff"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-my-report.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-my-report.json
@@ -3,7 +3,8 @@
     {
       "label": "Leave and Absences: My report",
       "url": "my-leave#/my-leave/report",
-      "onReadyScript": "ssp-leave-absences/staff/my-report"
+      "onReadyScript": "ssp-leave-absences/staff/my-report",
+      "credential": "staff"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-manager-absence-approval.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-manager-absence-approval.json
@@ -1,8 +1,0 @@
-{
-  "scenarios": [
-    {
-      "label": "SSP - Manager Absence Approval",
-      "url": "manager-absence-approval"
-    }
-  ]
-}

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-my-details.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-my-details.json
@@ -8,11 +8,6 @@
       "label": "SSP - Edit My Details",
       "url": "hr-details",
       "onReadyScript": "ssp/edit-my-details"
-    },
-    {
-      "label": "SSP - Edit Emergency Contact",
-      "url": "hr-details",
-      "onReadyScript": "ssp/edit-emergency-contact"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ta-calendar.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ta-calendar.json
@@ -3,7 +3,8 @@
     {
       "label": "T&A / Calendar",
       "url": "civicrm/tasksassignments/dashboard#/calendar",
-      "onReadyScript": "close-any-modal"
+      "onReadyScript": "close-any-modal",
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ta-documents.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ta-documents.json
@@ -3,37 +3,44 @@
     {
       "label": "T&A / Documents",
       "url": "civicrm/tasksassignments/dashboard#/documents",
-      "onReadyScript": "close-any-modal"
+      "onReadyScript": "close-any-modal",
+      "credential": "admin"
     },
     {
       "label": "T&A / Documents / Advanced Filters",
       "url": "civicrm/tasksassignments/dashboard#/documents",
-      "onReadyScript": "documents/advanced-filters"
+      "onReadyScript": "documents/advanced-filters",
+      "credential": "admin"
     },
     {
       "label": "T&A / Documents / Document / Add",
       "url": "civicrm/tasksassignments/dashboard#/documents",
-      "onReadyScript": "documents/document/add"
+      "onReadyScript": "documents/document/add",
+      "credential": "admin"
     },
     {
       "label": "T&A / Documents / Document / Show All Fields",
       "url": "civicrm/tasksassignments/dashboard#/documents",
-      "onReadyScript": "documents/document/show-all-fields"
+      "onReadyScript": "documents/document/show-all-fields",
+      "credential": "admin"
     },
     {
       "label": "T&A / Documents / Document / Select Type",
       "url": "civicrm/tasksassignments/dashboard#/documents",
-      "onReadyScript": "documents/document/select-type"
+      "onReadyScript": "documents/document/select-type",
+      "credential": "admin"
     },
     {
       "label": "T&A / Documents / Document / Select Assignee",
       "url": "civicrm/tasksassignments/dashboard#/documents",
-      "onReadyScript": "documents/document/select-assignee"
+      "onReadyScript": "documents/document/select-assignee",
+      "credential": "admin"
     },
     {
       "label": "T&A / Documents / Document / Pick Due Date",
       "url": "civicrm/tasksassignments/dashboard#/documents",
-      "onReadyScript": "documents/document/pick-due-date"
+      "onReadyScript": "documents/document/pick-due-date",
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ta-tasks.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ta-tasks.json
@@ -3,102 +3,122 @@
     {
       "label": "T&A / Tasks",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "close-any-modal"
+      "onReadyScript": "close-any-modal",
+      "credential": "admin"
     },
     {
       "label": "T&A / Tasks / Advanced Filters",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "tasks/advanced-filters"
+      "onReadyScript": "tasks/advanced-filters",
+      "credential": "admin"
     },
     {
       "label": "T&A / Tasks / Select Dates",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "tasks/select-dates"
+      "onReadyScript": "tasks/select-dates",
+      "credential": "admin"
     },
     {
       "label": "T&A / Tasks / Assignment / Add",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "tasks/assignment/add"
+      "onReadyScript": "tasks/assignment/add",
+      "credential": "admin"
     },
     {
       "label": "T&A / Tasks / Assignment / Select Type",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "tasks/assignment/select-type"
+      "onReadyScript": "tasks/assignment/select-type",
+      "credential": "admin"
     },
     {
       "label": "T&A / Tasks / Assignment / Add Task",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "tasks/assignment/add-task"
+      "onReadyScript": "tasks/assignment/add-task",
+      "credential": "admin"
     },
     {
       "label": "T&A / Tasks / Assignment / Add Document",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "tasks/assignment/add-document"
+      "onReadyScript": "tasks/assignment/add-document",
+      "credential": "admin"
     },
     {
       "label": "T&A / Tasks / Assignment / Pick Date",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "tasks/assignment/pick-date"
+      "onReadyScript": "tasks/assignment/pick-date",
+      "credential": "admin"
     },
     {
       "label": "T&A / Tasks / Task / In Place Edit / Due Date",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "tasks/task/editable-date"
+      "onReadyScript": "tasks/task/editable-date",
+      "credential": "admin"
     },
     {
       "label": "T&A / Tasks / Task / In Place Edit / Subject",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "tasks/task/editable-subject"
+      "onReadyScript": "tasks/task/editable-subject",
+      "credential": "admin"
     },
     {
       "label": "T&A / Tasks / Task / In Place Edit / Target",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "tasks/task/editable-target"
+      "onReadyScript": "tasks/task/editable-target",
+      "credential": "admin"
     },
     {
       "label": "T&A / Tasks / Task / In Place Edit / Assigned To",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "tasks/task/editable-assigned"
+      "onReadyScript": "tasks/task/editable-assigned",
+      "credential": "admin"
     },
     {
       "label": "T&A / Tasks / Task / Add",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "tasks/task/add"
+      "onReadyScript": "tasks/task/add",
+      "credential": "admin"
     },
     {
       "label": "T&A / Tasks / Task / Pick Date",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "tasks/task/pick-date"
+      "onReadyScript": "tasks/task/pick-date",
+      "credential": "admin"
     },
     {
       "label": "T&A / Tasks / Task / Select Assignee",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "tasks/task/select-assignee"
+      "onReadyScript": "tasks/task/select-assignee",
+      "credential": "admin"
     },
     {
       "label": "T&A / Tasks / Task / Select Type",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "tasks/task/select-type"
+      "onReadyScript": "tasks/task/select-type",
+      "credential": "admin"
     },
     {
       "label": "T&A / Tasks / Task / Show All Fields",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "tasks/task/show-all-fields"
+      "onReadyScript": "tasks/task/show-all-fields",
+      "credential": "admin"
     },
     {
       "label": "T&A / Tasks / Task / Show More",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "tasks/task/show-more"
+      "onReadyScript": "tasks/task/show-more",
+      "credential": "admin"
     },
     {
       "label": "T&A / Tasks / Task / Actions",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "tasks/task/actions"
+      "onReadyScript": "tasks/task/actions",
+      "credential": "admin"
     },
     {
       "label": "T&A / Tasks / Task / Open",
       "url": "civicrm/tasksassignments/dashboard#/tasks",
-      "onReadyScript": "tasks/task/open"
+      "onReadyScript": "tasks/task/open",
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/tab-absence.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/tab-absence.json
@@ -3,42 +3,50 @@
     {
       "label": "Absence / Report",
       "url": "civicrm/contact/view?reset=1&cid=2&selectedChild=absence",
-      "onReadyScript": "contact-summary/absence/tab-report"
+      "onReadyScript": "contact-summary/absence/tab-report",
+      "credential": "admin"
     },
     {
       "label": "Absence / Report / Open Section",
       "url": "civicrm/contact/view?reset=1&cid=2&selectedChild=absence",
-      "onReadyScript": "contact-summary/absence/tab-report-open-section"
+      "onReadyScript": "contact-summary/absence/tab-report-open-section",
+      "credential": "admin"
     },
     {
       "label": "Absence / Report / Actions",
       "url": "civicrm/contact/view?reset=1&cid=2&selectedChild=absence",
-      "onReadyScript": "contact-summary/absence/tab-report-actions"
+      "onReadyScript": "contact-summary/absence/tab-report-actions",
+      "credential": "admin"
     },
     {
       "label": "Absence / Calendar / Current Month",
       "url": "civicrm/contact/view?reset=1&cid=2&selectedChild=absence",
-      "onReadyScript": "contact-summary/absence/tab-calendar"
+      "onReadyScript": "contact-summary/absence/tab-calendar",
+      "credential": "admin"
     },
     {
       "label": "Absence /Calendar / All Months",
       "url": "civicrm/contact/view?reset=1&cid=2&selectedChild=absence",
-      "onReadyScript": "contact-summary/absence/tab-calendar-all-months"
+      "onReadyScript": "contact-summary/absence/tab-calendar-all-months",
+      "credential": "admin"
     },
     {
       "label": "Absence / Entitlements",
       "url": "civicrm/contact/view?reset=1&cid=2&selectedChild=absence",
-      "onReadyScript": "contact-summary/absence/tab-entitlements"
+      "onReadyScript": "contact-summary/absence/tab-entitlements",
+      "credential": "admin"
     },
     {
       "label": "Absence / Work Patterns",
       "url": "civicrm/contact/view?reset=1&cid=2&selectedChild=absence",
-      "onReadyScript": "contact-summary/absence/tab-work-patterns"
+      "onReadyScript": "contact-summary/absence/tab-work-patterns",
+      "credential": "admin"
     },
     {
       "label": "Absence / Work Patterns / Custom Work Patterns Modal",
       "url": "civicrm/contact/view?reset=1&cid=2&selectedChild=absence",
-      "onReadyScript": "contact-summary/absence/tab-work-patterns-modal"
+      "onReadyScript": "contact-summary/absence/tab-work-patterns-modal",
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/tab-documents.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/tab-documents.json
@@ -3,7 +3,8 @@
     {
       "label": "Documents",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/documents/show"
+      "onReadyScript": "contact-summary/documents/show",
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/tab-job-contract.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/tab-job-contract.json
@@ -3,62 +3,74 @@
     {
       "label": "Job Contract",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-contract/summary"
+      "onReadyScript": "contact-summary/job-contract/summary",
+      "credential": "admin"
     },
     {
       "label": "Job Contract / Full History",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-contract/full-history"
+      "onReadyScript": "contact-summary/job-contract/full-history",
+      "credential": "admin"
     },
     {
       "label": "Job Contract / Delete Dialog",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-contract/delete-dialog"
+      "onReadyScript": "contact-summary/job-contract/delete-dialog",
+      "credential": "admin"
     },
     {
       "label": "Job Contract / Modal / Tab / General",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-contract/tab-general"
+      "onReadyScript": "contact-summary/job-contract/tab-general",
+      "credential": "admin"
     },
     {
       "label": "Job Contract / Modal / Tab / Hours",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-contract/tab-hours"
+      "onReadyScript": "contact-summary/job-contract/tab-hours",
+      "credential": "admin"
     },
     {
       "label": "Job Contract / Modal / Tab / Pay",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-contract/tab-pay"
+      "onReadyScript": "contact-summary/job-contract/tab-pay",
+      "credential": "admin"
     },
     {
       "label": "Job Contract / Modal / Tab / Leave",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-contract/tab-leave"
+      "onReadyScript": "contact-summary/job-contract/tab-leave",
+      "credential": "admin"
     },
     {
       "label": "Job Contract / Modal / Tab / Insurance",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-contract/tab-insurance"
+      "onReadyScript": "contact-summary/job-contract/tab-insurance",
+      "credential": "admin"
     },
     {
       "label": "Job Contract / Modal / Tab / Pension",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-contract/tab-pension"
+      "onReadyScript": "contact-summary/job-contract/tab-pension",
+      "credential": "admin"
     },
     {
       "label": "Job Contract / Modal / Tab / Funding",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-contract/tab-funding"
+      "onReadyScript": "contact-summary/job-contract/tab-funding",
+      "credential": "admin"
     },
     {
       "label": "Job Contract / Modal / Correct Error ",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-contract/correct-error"
+      "onReadyScript": "contact-summary/job-contract/correct-error",
+      "credential": "admin"
     },
     {
       "label": "Job Contract / Modal / Change Terms ",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-contract/change-terms"
+      "onReadyScript": "contact-summary/job-contract/change-terms",
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/tab-job-roles.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/tab-job-roles.json
@@ -3,47 +3,56 @@
     {
       "label": "Job Roles / Basic Details",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-roles/basic-details"
+      "onReadyScript": "contact-summary/job-roles/basic-details",
+      "credential": "admin"
     },
     {
       "label": "Job Roles / Funding",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-roles/funding"
+      "onReadyScript": "contact-summary/job-roles/funding",
+      "credential": "admin"
     },
     {
       "label": "Job Roles / Cost Centres",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-roles/cost-centres"
+      "onReadyScript": "contact-summary/job-roles/cost-centres",
+      "credential": "admin"
     },
     {
       "label": "Job Roles / Delete Dialog",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-roles/delete-dialog"
+      "onReadyScript": "contact-summary/job-roles/delete-dialog",
+      "credential": "admin"
     },
     {
       "label": "Job Roles / Add New",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-roles/add-new"
+      "onReadyScript": "contact-summary/job-roles/add-new",
+      "credential": "admin"
     },
     {
       "label": "Job Roles / Basic Details / Edit",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-roles/basic-details-edit"
+      "onReadyScript": "contact-summary/job-roles/basic-details-edit",
+      "credential": "admin"
     },
     {
       "label": "Job Roles / Basic Details / Open ui select",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-roles/open-ui-select"
+      "onReadyScript": "contact-summary/job-roles/open-ui-select",
+      "credential": "admin"
     },
     {
       "label": "Job Roles / Funding / Edit",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-roles/funding-edit"
+      "onReadyScript": "contact-summary/job-roles/funding-edit",
+      "credential": "admin"
     },
     {
       "label": "Job Roles / Cost Centres / Edit",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/job-roles/cost-centres-edit"
+      "onReadyScript": "contact-summary/job-roles/cost-centres-edit",
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/tab-tasks.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/tab-tasks.json
@@ -3,7 +3,8 @@
     {
       "label": "Tasks",
       "url": "index.php?q=civicrm/contact/view&reset=1&cid=2",
-      "onReadyScript": "contact-summary/tasks/show"
+      "onReadyScript": "contact-summary/tasks/show",
+      "credential": "admin"
     }
   ]
 }

--- a/uk.co.compucorp.civicrm.hrcore/gulpfile.js
+++ b/uk.co.compucorp.civicrm.hrcore/gulpfile.js
@@ -13,11 +13,11 @@ var Promise = require('es6-promise').Promise;
   var backstopDir = 'backstop_data/';
   var files = { config: 'site-config.json', tpl: 'backstop.tpl.json' };
   var configTpl = {
-    "url": "http://%{site-host}",
-    "credentials": {
-      "admin"  : { "name": "%{admin-name}"  , "pass": "%{admin-password}"   },
-      "manager": { "name": "%{manager-name}", "pass": "%{manager-password}" },
-      "staff"  : { "name": "%{staff-name}"  , "pass": "%{staff-password}"   }
+    'url': 'http://%{site-host}',
+    'credentials': {
+      'admin': { 'name': '%{admin-name}', 'pass': '%{admin-password}' },
+      'manager': { 'name': '%{manager-name}', 'pass': '%{manager-password}' },
+      'staff': { 'name': '%{staff-name}', 'pass': '%{staff-password}' }
     }
   };
 
@@ -51,7 +51,7 @@ var Promise = require('es6-promise').Promise;
    *
    * @return {Boolean} [description]
    */
-  function isConfigFilePresent() {
+  function isConfigFilePresent () {
     var check = true;
 
     try {
@@ -73,17 +73,17 @@ var Promise = require('es6-promise').Promise;
    * @param  {string} command
    * @return {Promise}
    */
-  function runBackstopJS(command) {
+  function runBackstopJS (command) {
     var destFile = 'backstop.temp.json';
 
     if (!isConfigFilePresent()) {
       console.log(color(
-        "No site-config.json file detected!\n" +
-        "One has been created for you under " + backstopDir + "\n" +
-        "Please insert the real value for each placholder and try again", "RED"
+        'No site-config.json file detected!\n' +
+        'One has been created for you under ' + backstopDir + '\n' +
+        'Please insert the real value for each placholder and try again', 'RED'
       ));
 
-      return Promise.reject();
+      return Promise.reject(new Error());
     }
 
     return new Promise(function (resolve) {
@@ -111,7 +111,7 @@ var Promise = require('es6-promise').Promise;
    *
    * @return {string}
    */
-  function tempFileContent() {
+  function tempFileContent () {
     var config = JSON.parse(fs.readFileSync(backstopDir + files.config));
     var content = JSON.parse(fs.readFileSync(backstopDir + files.tpl));
 
@@ -132,7 +132,7 @@ var Promise = require('es6-promise').Promise;
    *
    * @return {Array}
    */
-  function scenariosList() {
+  function scenariosList () {
     var scenariosPath = backstopDir + 'scenarios/';
 
     return _(fs.readdirSync(scenariosPath))
@@ -151,9 +151,9 @@ var Promise = require('es6-promise').Promise;
 
         scenarios.forEach(function (scenario) {
           if (previousCredential !== scenario.credential) {
-            scenario.onBeforeScript = "login";   
+            scenario.onBeforeScript = 'login';
           }
-  
+
           previousCredential = scenario.credential;
         });
 

--- a/uk.co.compucorp.civicrm.hrcore/gulpfile.js
+++ b/uk.co.compucorp.civicrm.hrcore/gulpfile.js
@@ -147,10 +147,10 @@ var Promise = require('es6-promise').Promise;
         return _.assign(scenario, { delay: scenario.delay || 6000 });
       })
       .tap(function (scenarios) {
-        var previousCredential;
+        var previousCredential = null;
 
         scenarios.forEach(function (scenario) {
-          if (previousCredential !== scenario.credential) {
+          if (previousCredential !== scenario.credential || previousCredential === null) {
             scenario.onBeforeScript = 'login';
           }
 


### PR DESCRIPTION
## Overview
This PR adds the ability to specify different login credentials for different Backstop JS scenarios.

## Problem
Previously we could specify a single credential for the entire Backstop JS suite. But different scenarios needed different login credentials. For example: In L&A we have scenarios for `staff`, `manager` or `admin`. So it was never possible to execute all scenarios at one go.

## Solution
1. In `gulpfile.js`, changed the credentials template to 
```
'credentials': {
    'admin': { 'name': '%{admin-name}', 'pass': '%{admin-password}' },
    'manager': { 'name': '%{manager-name}', 'pass': '%{manager-password}' },
    'staff': { 'name': '%{staff-name}', 'pass': '%{staff-password}' }
 }
```

So now its possible to specify login credentials for all type of roles.

2. If the credentials for one scenario is different than the previous one, then it is necessary to logout and re login. To implement that

In `gulpfile.js`, the login script is being called again different credentials are detected.
In `login.js`, script has been added to logout before logging in again.

3. If a scenario needs a different logon information than the default one, it needs to be specified in the scenario JSON itself, example
```
{
  "scenarios": [
    {
      "label": "<label>",
      "url": "<url>",
      "onReadyScript": "<file name>",
      "credential": "<manager/staff/etc>"
    }
  ]
}
```
`ssp-la-manager-leave-calendar.json` and `ssp-la-my-report.json` is updated to show how we need to specify the credential information.

4. Backstop will use `admin` logon information as default, if no `credential` is mentioned in the scenario.

5. If you have a .DS_Store file or anything else other than a `.json` file in the folder, the code tries to read that file too and the tasks stop without any error. To prevent that the following code has been added `scenario.endsWith('.json')` at

https://github.com/civicrm/civihr/pull/2378/files/88ef00c200ff8b9d73ee13624e305d1fb2998707#diff-cd91b40c4aa1a3aa35c573b56c5cce09R140


## Comments
Part of this feature was developed in https://github.com/civicrm/civihr/pull/1785, which was still in progress.

### Removed Scenario
`SSP - Manager Absence Approval`, `SSP - Edit Emergency Contact` and related files has been removed because both these pages does not exist anymore.

### Failing Scenarios
Some of the missing required data has been updated in https://compucorp.atlassian.net/wiki/spaces/PCHR/pages/117984407/BackstopJS+CiviHR

All the scenarios has been run, and these following does not run
1. leave-balances.json
2. ssp-la-manager-leave-requests.json
3. ta-documents.json

They need to be fixed in future PRs.
Also note that though some of the scenarios working, it has been noticed that few screenshots are not for what they meant to be, so a through check is required in future.


  
  
  