### PR TITLE
PCHR-3096: Send Hipchat notifications for Jenkins builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -225,7 +225,7 @@ def sendBuildFailureNotification() {
  * Sends a notification to Hipchat
  */
 def sendHipchatNotification(String color, String message) {
-  hipchatSend color: color, message: message
+  hipchatSend color: color, message: message, notify: true
 }
 
 /*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,8 @@ pipeline {
   stages {
     stage('Pre-tasks execution') {
       steps {
+        sendBuildStartdNotification()
+
         // Print all Environment variables
         sh 'printenv | sort'
 
@@ -185,7 +187,81 @@ pipeline {
         }
       }
     }
+    success {
+      sendBuildSuccessNotification()
+    }
+    failure {
+      sendBuildFailureNotification()
+    }
   }
+}
+
+/*
+ * Sends a notification when the build starts
+ */
+def sendBuildStartdNotification() {
+  def message = 'Building ' + getBuildTargetLink() + '. ' + getReportLink()
+
+  sendHipchatNotification('YELLOW', message)
+}
+
+/*
+ * Sends a notification when the build is completed successfully
+ */
+def sendBuildSuccessNotification() {
+  def message = getBuildTargetLink() + ' built successfully. Time: $BUILD_DURATION. ' + getReportLink()
+  sendHipchatNotification('GREEN', message)
+}
+
+/*
+ * Sends a notification when the build fails
+ */
+def sendBuildFailureNotification() {
+  def message = 'Failed to build ' + getBuildTargetLink() + '. Time: $BUILD_DURATION. No. of failed tests: ${TEST_COUNTS,var=\"fail\"}. ' + getReportLink()
+  sendHipchatNotification('RED', message)
+}
+
+/*
+ * Sends a notification to Hipchat
+ */
+def sendHipchatNotification(String color, String message) {
+  hipchatSend color: color, message: message
+}
+
+/*
+ * Returns a link to what is being built. If it's a PR, then it's a link to the pull request itself.
+ * If it's a branch, then it's a link in the format http://github.com/org/repo/tree/branch
+ */
+def getBuildTargetLink() {
+  if(buildIsForAPullRequest()) {
+    return "<a href=\"${env.CHANGE_URL}\">\"${env.CHANGE_TITLE}\"</a>"
+  }
+
+  return '<a href="' + getRepositoryUrlForBuildBranch() + '">"' + env.BRANCH_NAME + '"</a>'
+}
+
+/*
+ * Returns true if this build as triggered by a Pull Request.
+ */
+def buildIsForAPullRequest() {
+  return env.CHANGE_URL != null
+}
+
+/*
+ * Returns a URL pointing to branch currently being built
+ */
+def getRepositoryUrlForBuildBranch() {
+  def repositoryURL = env.GIT_URL
+  repositoryURL = repositoryURL.replace('.git', '')
+
+  return repositoryURL + '/tree/' + env.BRANCH_NAME
+}
+
+/*
+ * Returns the Blue Ocean build report URL for the current job
+ */
+def getReportLink() {
+ return 'Click <a href="$BLUE_OCEAN_URL">here</a> to see the build report'
 }
 
 /*


### PR DESCRIPTION
## Overview

This PR updates the Jenkinsfile so that notifications are sent to Hipchat once a build starts and once it  completes (successfully or not).

## Before

No notifications were sent from Jenkins to Hipchat

## After

A notification is sent when the build starts:

![captura de tela de 2017-12-28 10-24-50](https://user-images.githubusercontent.com/388373/34410723-5ff08b68-ebb9-11e7-90b6-e8790edfd32c.png )

It contains a link to the PR or branch being built, as well a link to the report on the Blue Ocean UI, in Jenkins.

When the build finishes, you have different messages for when it was successful:

![captura de tela de 2017-12-28 10-26-48](https://user-images.githubusercontent.com/388373/34410802-da07eeb4-ebb9-11e7-97e4-ad9355fc6884.png)

Or for when it failed:

![captura de tela de 2017-12-28 10-27-20](https://user-images.githubusercontent.com/388373/34410782-b8de33ba-ebb9-11e7-92d4-feb15f844e64.png)

## Technical Details

In parts of the file, it's possible to see that double quotes were used for String interpolation:

```groovy
return "<a href=\"${env.CHANGE_URL}\">\"${env.CHANGE_TITLE}\"</a>"
```

However, in other places, it seems that single quotes have been used for the same purpose:

```groovy
return 'Click <a href="$BLUE_OCEAN_URL">here</a> to see the build report'
```

In the second example, `$BLUE_OCEN_URL` is not really a variable, but a token that will be parsed by Hipchat plugin, so it's mandatory for it to be enclosed in single quotes (otherwise the string will be interpolated and the plugin will get the interpolated value instead of the token).

For reference, here's an issue from the plugin repository where one of the devs says that single quotes should be used for such tokens: https://github.com/jenkinsci/hipchat-plugin/issues/103

## Comments

The messages are sent using the Jenkins [Hipchat Plugin](https://wiki.jenkins.io/display/JENKINS/HipChat+Plugin). Settings like API version, Sender and Room are all set in the Jenkins configuration.
