### PR TITLE
PCHR-3120: Add "core overrides" section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,5 +10,14 @@ _What has been changed. Please provide screenshots or gifs ([LICEcap](http://www
 ## Technical Details
 _If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_
 
+### Core overrides
+_If the PR overrides/patches a core file, then please explain here, for each file:_
+
+1. _Which file it is_
+2. _The reason why it was overridden/patched_
+3. _What the override/patch consists of_
+
+_Also make sure to update this [wiki page](https://compucorp.atlassian.net/wiki/spaces/PCHR/pages/100532509/Overridden+CiviCRM+files) with your changes_
+
 ## Comments
 _Anything else you would like the reviewer to note_


### PR DESCRIPTION
The PR template does not have a section regarding overridden/patched core files, which could be overlooked by a dev when she documents the PR. This PR adds one
