### PR TITLE
PCHR-3130: Fix for Wrong Select Field values sent to backend in Absence Type Page

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/AbsenceType.tpl
@@ -183,7 +183,7 @@
 
                 function hideToilExpiration() {
                   document.getElementById('accrual_expiration_duration').value = '';
-                  $('#accrual_expiration_unit').select2('val', '');
+                  $('#accrual_expiration_unit').select2('val', '').trigger("change");
                   $('.toil-expiration').hide();
                 }
 
@@ -234,7 +234,7 @@
 
                 function hideCarryForwardExpirationDuration() {
                   document.getElementById('carry_forward_expiration_duration').value = '';
-                  $('#carry_forward_expiration_unit').select2('val', '');
+                  $('#carry_forward_expiration_unit').select2('val', '').trigger("change");
                   $('.carry-forward-expiration-duration').hide();
                 }
 


### PR DESCRIPTION
## Overview
It's not possible to disable carry forward per leave type once enabled. This PR fixes that bug.
The same bug was present for TOIL Expiry select field, that is fixed too.

## Before
**Carry Forward**
![b](https://user-images.githubusercontent.com/5058867/34711446-6f322a4c-f545-11e7-9fae-44ec289eee57.gif)

**TOIL**
![toil_expiry](https://user-images.githubusercontent.com/5058867/34716679-928e75b6-f556-11e7-82e9-bddf22f884f6.gif)

## After
**Carry Forward**
![a](https://user-images.githubusercontent.com/5058867/34711400-4deb2a78-f545-11e7-88f7-e966d2cdd250.gif)

**TOIL**
![toil_expirya](https://user-images.githubusercontent.com/5058867/34716735-c0641f04-f556-11e7-916e-76fd7a77884d.gif)

## Technical Details

This is a regression issue. In https://github.com/civicrm/civihr/pull/2300, we have added hidden fields to store the select values, but when we untick the select fields from code, the change event(https://github.com/civicrm/civihr/pull/2300/files#diff-80451403917186e0141a3b6700e2b299R357) does not get fired. So added the same in all places where we change the value of select from code.

  
  
  