### PR TITLE
PCHR-3151: Fix backstop tests

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/document.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/document.js
@@ -12,7 +12,7 @@ module.exports = (function () {
       var casper = this.casper;
 
       casper.then(function () {
-        casper.click(this.modalRoot + ' [ng-model="document.activity_date_time"]');
+        casper.click(this.modalRoot + ' [ng-model="documentModal.document.activity_date_time"]');
         casper.waitUntilVisible('.uib-datepicker-popup');
       }.bind(this));
 
@@ -44,7 +44,7 @@ module.exports = (function () {
       var casper = this.casper;
 
       casper.then(function () {
-        casper.click(this.modalRoot + ' [ng-model="document.assignee_contact"] .ui-select-match');
+        casper.click(this.modalRoot + ' [ng-model="documentModal.document.assignee_contact"] .ui-select-match');
         casper.waitUntilVisible('.select2-with-searchbox');
       }.bind(this));
 
@@ -60,7 +60,7 @@ module.exports = (function () {
       var casper = this.casper;
 
       casper.then(function () {
-        casper.click(this.modalRoot + ' [ng-model="document.activity_type_id"] .ui-select-match');
+        casper.click(this.modalRoot + ' [ng-model="documentModal.document.activity_type_id"] .ui-select-match');
         casper.waitUntilVisible('.select2-with-searchbox');
       }.bind(this));
 
@@ -76,7 +76,7 @@ module.exports = (function () {
       var casper = this.casper;
 
       casper.then(function () {
-        casper.click(this.modalRoot + ' [heading="' + tabName + '"] a');
+        casper.click(this.modalRoot + ' a[data-target="#' + tabName.toLowerCase() + 'Tab"]');
         casper.wait(200);
       }.bind(this));
 

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-manager-leave-requests.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-manager-leave-requests.js
@@ -107,17 +107,15 @@ module.exports = (function () {
 
       return new Promise(function (resolve) {
         casper.then(function () {
-          var selector = '.button-container button:nth-child(' + (leaveType === 'leave' ? 1 : 2) + ')';
+          var selector = '.button-container leave-request-record-actions .dropdown-toggle';
 
           casper.click(selector);
         });
 
         casper.then(function () {
-          if (leaveType === 'sickness') {
-            casper.click('.button-container li:nth-child(1) a');
-          } else if (leaveType === 'toil') {
-            casper.click('.button-container li:nth-child(2) a');
-          }
+          var leaveSerialNo = leaveType === 'leave' ? 1 : leaveType === 'sickness' ? 2 : 3;
+
+          casper.click('.button-container li:nth-child(' + leaveSerialNo + ') a');
         });
 
         casper.then(function () {

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-balances.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/leave-balances.json
@@ -10,7 +10,7 @@
       "label": "Admin Portal: Leave Balances",
       "url": "civicrm/leaveandabsences/dashboard#/leave-balances",
       "onReadyScript": "leave-absence-dashboard/leave-balances/leave-balances",
-      "credential": "manager"
+      "credential": "admin"
     }
   ]
 }


### PR DESCRIPTION
## Overview
This PR fixes Backstop tests which were throwing errors or did not complete.

## Technical Details
### leave-balances.json
This scenario was not completing

"Admin Portal: Leave Balances"

The credential was wrong, so it has been changed to `admin`.

### ssp-la-manager-leave-requests.json
These 3 scenarios were not completing

"Leave and Absences: Manager Leave Requests: Apply leave on behalf of staff"
"Leave and Absences: Manager Leave Requests: Apply sickness on behalf of staff"
"Leave and Absences: Manager Leave Requests: Apply toil on behalf of staff"

The selector to open the dropdown buttons to choose the leave type, was wrong. So changed it to `.button-container leave-request-record-actions .dropdown-toggle'`.

### ta-documents.json
These 3 scenarios were not completing

"T&A / Documents / Document / Select Type"
"T&A / Documents / Document / Select Assignee"
"T&A / Documents / Document / Pick Due Date"

1. The `ng-model` fields has changed in the HTML as `documentModal.` prefix has been added, the tests has been updated accordingly.

2. In https://github.com/compucorp/civihr-tasks-assignments/commit/5146bc61c431cc4833d95b0f3954540a7e7ec140#diff-3bff2e674dba86e0306a58c897adbe8cR42 `<uib-tab heading="` has been removed from HTML. Updated the tests accordingly.
From `casper.click(this.modalRoot + ' [heading="' + tabName + '"] a');`
To `casper.click(this.modalRoot + ' a[data-target="#' + tabName.toLowerCase() + 'Tab"]');`