### PR TITLE
PCHR-3015: Fix Leave Balances URL

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
@@ -21,6 +21,7 @@ class CRM_HRLeaveAndAbsences_Upgrader extends CRM_HRLeaveAndAbsences_Upgrader_Ba
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1013;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1014;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1015;
+  use CRM_HRLeaveAndAbsences_Upgrader_Step_1016;
 
   /**
    * A list of directories to be scanned for XML installation files

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1016.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1016.php
@@ -1,6 +1,7 @@
 <?php
 
 trait CRM_HRLeaveAndAbsences_Upgrader_Step_1016 {
+
   /**
    * Updates the URL for the Leave Balances menu item.
    *
@@ -12,7 +13,7 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1016 {
     $leaveBalances->save();
     CRM_Core_BAO_Navigation::resetNavigation();
 
-    return true;
+    return TRUE;
   }
 
   /**
@@ -26,4 +27,5 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1016 {
 
     return CRM_Core_BAO_Navigation::retrieve($menuItemQueryParams, $default);
   }
+
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1016.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1016.php
@@ -1,0 +1,29 @@
+<?php
+
+trait CRM_HRLeaveAndAbsences_Upgrader_Step_1016 {
+  /**
+   * Updates the URL for the Leave Balances menu item.
+   *
+   * @return bool
+   */
+  public function upgrade_1016() {
+    $leaveBalances = $this->up1016_getLeaveBalancesMenuItem();
+    $leaveBalances->url = 'civicrm/leaveandabsences/dashboard#/leave-balances';
+    $leaveBalances->save();
+    CRM_Core_BAO_Navigation::resetNavigation();
+
+    return true;
+  }
+
+  /**
+   * Returns the the navigation menu item for Leave Balances.
+   *
+   * @return CRM_Core_BAO_Navigation
+   */
+  private function up1016_getLeaveBalancesMenuItem() {
+    $default = [];
+    $menuItemQueryParams = ['name' => 'leave_and_absences_leave_balances'];
+
+    return CRM_Core_BAO_Navigation::retrieve($menuItemQueryParams, $default);
+  }
+}


### PR DESCRIPTION
## Overview
This PR fixes the the URL for the Leave Balances tab in the main menu.

## Before
![anim](https://user-images.githubusercontent.com/1642119/34731818-d92c5ab4-f539-11e7-9b9b-17331f6cfe37.gif)

## After
![anim](https://user-images.githubusercontent.com/1642119/34732205-f0dcc526-f53a-11e7-955b-13931760c4b8.gif)

## Technical Details
This issue was introduced due to the way we used to merge incomplete code into `la-milestone-3` instead of using a feature branch.

The first URL for the Leave Balances tab was `#/balance-report` introduced by #2045 and the [1007 upgrader referenced it](https://github.com/civicrm/civihr/blob/staging/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1007.php#L53).

After discussing the changes with @jamienovick the tab URL was changed to `#/leave-balances` and updated in #2070 before the 1007 upgrader was merged in #2240

To fix this issue a new 1016 upgrader has been added which updates the URL of leave balances to the right one:

```php
<?php

trait CRM_HRLeaveAndAbsences_Upgrader_Step_1016 {
  public function upgrade_1016() {
    $leaveBalances = $this->up1016_getLeaveBalancesMenuItem();
    $leaveBalances->url = 'civicrm/leaveandabsences/dashboard#/leave-balances';
    $leaveBalances->save();
    CRM_Core_BAO_Navigation::resetNavigation();

    return true;
  }

  private function up1016_getLeaveBalancesMenuItem() {
    $default = [];
    $menuItemQueryParams = ['name' => 'leave_and_absences_leave_balances'];

    return CRM_Core_BAO_Navigation::retrieve($menuItemQueryParams, $default);
  }
}

```

  