### PR TITLE
PCHR-3099: Make sure LeaveRequest.get and .getFull API will return requests ending on the last day of a period

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Wrapper/LeaveRequestDates.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Wrapper/LeaveRequestDates.php
@@ -1,0 +1,161 @@
+<?php
+
+class CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestDates implements API_Wrapper {
+
+  /**
+   * Adds Hours to the from_date and to_date fields, in case they're present but
+   * don't have that information.
+   *
+   * For the from_date field, the hour will be set to 00:00:00. For the to_date
+   * field, it will be set to 23:59:59
+   *
+   * @param array $apiRequest
+   *
+   * @return array
+   *   modified $apiRequest
+   */
+  public function fromApiInput($apiRequest) {
+    if ($this->canHandleTheRequest($apiRequest)) {
+      $this->prepareDates($apiRequest);
+    }
+
+    return $apiRequest;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function toApiOutput($apiRequest, $result) {
+    return $result;
+  }
+
+  /**
+   * Returns whether this Wrapper can handle the given $apiRequest or not. It
+   * can only handle the `get` and `getFull` actions of the LeaveRequest API.
+   *
+   * @param array $apiRequest
+   *
+   * @return bool
+   */
+  private function canHandleTheRequest($apiRequest) {
+    $targetActions = ['get', 'getfull'];
+    $isTargetAction = in_array($apiRequest['action'], $targetActions);
+
+    return $apiRequest['entity'] === 'LeaveRequest' && $isTargetAction;
+  }
+
+  /**
+   * If the query contains values for the from_date and to_date fields, this
+   * method makes sure they will always contain information about the hour.
+   *
+   * For the from_date field, it will set the hour as 00:00:00 if it's not
+   * present. For the to_date field, it will set it as 23:59:59 if it's not
+   * present.
+   *
+   * These are datetime fields, and the reason for this is that if there's a
+   * query like "to_date <= 2018-01-09" it will include all the leave requests
+   * ending on that date, regardless of the hour. Without this, such a query
+   * would be interpreted as "to_date <= 2018-01-09 00:00:00" by the database,
+   * and most of the requests ending on 2018-01-09 would not be included in the
+   * result.
+   *
+   * @param array $apiRequest
+   */
+  private function prepareDates(&$apiRequest) {
+    $params = &$apiRequest['params'];
+
+    $fromDate = $this->getValueFromParams($params, 'from_date');
+
+    if ($this->dateIsValid($fromDate) && $this->dateIsMissingHours($fromDate)) {
+      $fromDate = (new DateTime($fromDate))->format('Y-m-d 00:00:00');
+      $this->setValueOfParam($params, 'from_date', $fromDate);
+    }
+
+    $toDate = $this->getValueFromParams($params, 'to_date');
+
+    if ($this->dateIsValid($toDate) && $this->dateIsMissingHours($toDate)) {
+      $toDate = (new DateTime($toDate))->format('Y-m-d 23:59:59');
+      $this->setValueOfParam($params, 'to_date', $toDate);
+    }
+  }
+
+  /**
+   * Check whether the given value is a valid date.
+   *
+   * @param string $date
+   *
+   * @return bool
+   */
+  private function dateIsValid($date) {
+    $date = date_parse($date);
+
+    return $date['error_count'] === 0 && $date['warning_count'] === 0;
+  }
+
+  /**
+   * Checks if the given $date string contains information about hours
+   *
+   * @param string $date
+   *  A string in any of the formats supported by strtotime()
+   *
+   * @return bool
+   */
+  private function dateIsMissingHours($date) {
+    $date = date_parse($date);
+
+    return $date['hour'] === FALSE ||
+           $date['minute'] === FALSE ||
+           $date['second'] === FALSE;
+  }
+
+  /**
+   * Gets the value of the given $field in the $params array.
+   *
+   * This method works for both simple params ($field => $value) and params with
+   * operators ($field => [$operator => $value])
+   *
+   * @param array $params
+   * @param string $field
+   *
+   * @return mixed|null
+   */
+  private function getValueFromParams($params, $field) {
+    if (empty($params[$field])) {
+      return NULL;
+    }
+
+    // When using other operators than =
+    // the param will be an array in this format:
+    // [<operator> => <value>]
+    if (is_array($params[$field])) {
+      return reset($params[$field]);
+    }
+
+    return $params[$field];
+  }
+
+  /**
+   * Sets the value of the given $field in $params to the given $value.
+   *
+   * This method works for both simple params ($field => $value) and params with
+   * operators ($field => [$operator => $value]).
+   *
+   * @param array $params
+   * @param string $field
+   * @param mixed $value
+   */
+  private function setValueOfParam(&$params, $field, $value) {
+    if (!array_key_exists($field, $params)) {
+      return;
+    }
+
+    if (is_array($params[$field])) {
+      $key = key($params[$field]);
+      $params[$field][$key] = $value;
+    }
+    else {
+      $params[$field] = $value;
+    }
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -436,6 +436,16 @@ function hrleaveandabsences_civicrm_validateForm($formName, &$fields, &$files, &
   }
 }
 
+/**
+ * Implementation of the hook_civicrm_apiWrappers hook
+ *
+ * @param array $wrappers
+ * @param array $apiRequest
+ */
+function hrleaveandabsences_civicrm_apiWrappers(&$wrappers, $apiRequest) {
+  $wrappers[] = new CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestDates();
+}
+
 //----------------------------------------------------------------------------//
 //                               Helper Functions                             //
 //----------------------------------------------------------------------------//

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Wrapper/LeaveRequestDatesTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Wrapper/LeaveRequestDatesTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestDates as LeaveRequestDates;
+
+/**
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestDatesTest extends BaseHeadlessTest {
+
+  /**
+   * @var LeaveRequestDates
+   */
+  private $wrapper;
+
+  public function setUp() {
+    $this->wrapper = new LeaveRequestDates();
+  }
+
+  public function testRequestParamsAreNotUpdatedIfTheRequestIsNotForLeaveRequestGetOrGetFull() {
+    $apiRequest = [
+      'entity' => 'LeaveRequest',
+      //some random action name, so that we have different actions for different tests
+      'action' => 'get' . rand(10, 1000),
+      'params' => [
+        'from_date' => '2016-01-01',
+        'to_date' => '2016-01-01'
+      ]
+    ];
+
+    $wrappedRequest = $this->wrapper->fromApiInput($apiRequest);
+
+    $this->assertEquals($apiRequest, $wrappedRequest);
+  }
+
+  /**
+   * @dataProvider supportedActions
+   */
+  public function testToAndFromDateHoursAreSetIfTheGivenDatesDontHaveHour($action) {
+    $apiRequest = [
+      'entity' => 'LeaveRequest',
+      'action' => $action,
+      'params' => [
+        'from_date' => '2016-02-01',
+        'to_date' => '2016-02-03'
+      ]
+    ];
+
+    $wrappedRequest = $this->wrapper->fromApiInput($apiRequest);
+
+    $this->assertEquals('2016-02-01 00:00:00', $wrappedRequest['params']['from_date']);
+    $this->assertEquals('2016-02-03 23:59:59', $wrappedRequest['params']['to_date']);
+  }
+
+  /**
+   * @dataProvider supportedActions
+   */
+  public function testToAndFromDateHoursAreSetIfTheGivenDatesDontHaveHourAndTheParamsHaveOperators($action) {
+    $apiRequest = [
+      'entity' => 'LeaveRequest',
+      'action' => $action,
+      'params' => [
+        'from_date' => ['>' => '2016-02-01'],
+        'to_date' => ['<=' => '2016-02-03']
+      ]
+    ];
+
+    $wrappedRequest = $this->wrapper->fromApiInput($apiRequest);
+
+    $this->assertEquals(['>' => '2016-02-01 00:00:00'], $wrappedRequest['params']['from_date']);
+    $this->assertEquals(['<=' => '2016-02-03 23:59:59'], $wrappedRequest['params']['to_date']);
+  }
+
+  /**
+   * @dataProvider supportedActions
+   */
+  public function testToAndFromDateHoursAreNotTouchedIfTheGivenDatesAlreadyHaveHours($action) {
+    $apiRequest = [
+      'entity' => 'LeaveRequest',
+      'action' => $action,
+      'params' => [
+        'from_date' => '2016-02-01 11:53:00',
+        'to_date' => '2016-02-03 17:15:10'
+      ]
+    ];
+
+    $wrappedRequest = $this->wrapper->fromApiInput($apiRequest);
+
+    $this->assertEquals('2016-02-01 11:53:00', $wrappedRequest['params']['from_date']);
+    $this->assertEquals('2016-02-03 17:15:10', $wrappedRequest['params']['to_date']);
+  }
+
+  public function testTheOutputIsNeverChanged() {
+    $result = [
+      'test' => '1234'
+    ];
+
+    $wrappedResult = $this->wrapper->toApiOutput([], $result);
+
+    $this->assertEquals($result, $wrappedResult);
+  }
+
+  public function supportedActions() {
+    return [
+      ['get'],
+      ['getfull']
+    ];
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
@@ -8,6 +8,11 @@ ini_set('memory_limit', '2G');
 ini_set('safe_mode', 0);
 eval(cv('php:boot --level=full -t', 'phpcode'));
 
+// While running the tests, the autoloader is not able to find this class, so we
+// need to manually require it in here in order to be able to
+// test API wrappers
+require_once 'api/Wrapper.php';
+
 require_once 'BaseHeadlessTest.php';
 require_once 'helpers/OptionGroupHelpersTrait.php';
 require_once 'helpers/ContractHelpersTrait.php';


### PR DESCRIPTION
## Overview

Leave Requests ending on the last day of an Absence Period were not being displayed on the Absence Report and on the Leave Calendar.

## Before

![before_3099](https://user-images.githubusercontent.com/388373/34777020-16da995e-f600-11e7-8459-ab7c9611975b.gif)


## After
 
![after_3099](https://user-images.githubusercontent.com/388373/34777025-1c67d4fe-f600-11e7-8daf-b8150f1e0a08.gif)

## Technical Details

This was a regression introduced by https://github.com/civicrm/civihr/pull/2260. In that PR, two changes related to the `from_date` and `to_date` fields were made in order to support Leave Request in hours:

- Their type [changed from date to datetime](https://github.com/civicrm/civihr/pull/2260/files#diff-0c81d1d212efc488e009f00d2cad8678R338)
- The LeaveRequest.create API was changed ([here](https://github.com/civicrm/civihr/pull/2260/files#diff-7bf537a036f3438a73ec57bd207d87daR37) and [here](https://github.com/civicrm/civihr/pull/2260/files#diff-7bf537a036f3438a73ec57bd207d87daR784)) to automatically set the hour in case it was not present (i.e. it's a Leave Request in days rather than hours). For the `from_date` field, the hour is set to `00:00:00` and for `to_date` it is set to `23:59:59`

The `LeaveRequest.get` and `getFull` APIs, however, were not updated to follow this change. So, imagine a call like this is sent:

```php
civicrm_api3('LeaveRequest', 'get', [
  'to_date' => ['<=' => '2018-12-31'],
]);
```

When that happens, civi will check that this is a datetime field, will accept the value (since it's a valid date, even though it doesn't have the hour) and convert it to a date time, which will result in a value like this: `20181231000000`. This will then result in a query like `WHERE to_date <= '20181231000000'` and, since during the request creation we automatically set the to_date hour to `23:59:00`, it will not find requests ending on that date.

In order to fix that, an API Wrapper was added to handle the API params and make sure they will always include hours. The logic is the same as the one used for when a Leave Request is created. For `from_date`, we set the hour to `00:00:00` and for `to_date` we set it to `23:59:59`. The decision to use an API wrapper for this is that we need to handle these values before they pass through the validation which converts the value to a datetime. The wrapper is the only way to do that, since the wrappers are always called before the validation by Civi.
