### PR TITLE
PCHR-3073: Add CMS Data related classes

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserMailNotifier/Drupal.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserMailNotifier/Drupal.php
@@ -1,0 +1,37 @@
+<?php
+
+use CRM_HRCore_CMSData_UserMailNotifierInterface as UserMailNotifierInterface;
+
+/**
+ * Class CRM_HRCore_CMSData_UserMailNotifier_Drupal
+ */
+class CRM_HRCore_CMSData_UserMailNotifier_Drupal implements UserMailNotifierInterface {
+
+  /**
+   * @var stdClass
+   */
+  private $user;
+
+  /**
+   * CRM_HRCore_CMSData_UserMailNotifier_Drupal constructor.
+   *
+   * @param array $contactData
+   */
+  public function __construct($contactData) {
+    $this->user = user_load($contactData['cmsId']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function sendWelcomeEmail() {
+   return _user_mail_notify('register_admin_created', $this->user);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function sendPasswordResetEmail() {
+    return _user_mail_notify('password_reset', $this->user);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserMailNotifierFactory.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserMailNotifierFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+use CRM_HRCore_CMSData_UserMailNotifierInterface as UserMailNotifierInterface;
+use CRM_HRCore_CMSData_UserMailNotifier_Drupal as DrupalUserMailNotifier;
+
+/**
+ * Class CRM_HRCore_CMSData_UserMailNotifierFactory
+ */
+class CRM_HRCore_CMSData_UserMailNotifierFactory {
+
+  /**
+   * Creates an object of the UserMailNotifier class based on the
+   * CMS framework in use.
+   *
+   * @param array $contactData
+   * @param string $cmsFramework
+   *
+   * @return UserMailNotifierInterface;
+   *
+   * @throws \Exception
+   */
+  public static function create($cmsFramework, $contactData) {
+    if ($cmsFramework == 'Drupal') {
+      return new DrupalUserMailNotifier($contactData);
+    }
+
+    $msg = sprintf('Unrecognized CMS: "%s"', $cmsFramework);
+    throw new \Exception($msg);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserMailNotifierInterface.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserMailNotifierInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Interface CRM_HRCore_CMSData_UserMailNotifierInterface
+ * 
+ * This interface will be extended by the CMS class
+ * that wants to provide functionality for sending emails notifications
+ * (mainly password reset and welcome emails).
+ */
+interface CRM_HRCore_CMSData_UserMailNotifierInterface {
+
+  /**
+   * Sends a welcome email to the user object represented in this
+   * class.
+   *
+   * @return mixed
+   */
+  public function sendWelcomeEmail();
+
+  /**
+   * Sends a password reset email to the user object represented in
+   * this class.
+   *
+   * @return mixed
+   */
+  public function sendPasswordResetEmail();
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserRole/Drupal.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserRole/Drupal.php
@@ -1,0 +1,32 @@
+<?php
+
+use CRM_HRCore_CMSData_UserRoleInterface as UserRoleInterface;
+
+/**
+ * Class CRM_HRCore_CMSData_UserRole_Drupal
+ */
+class CRM_HRCore_CMSData_UserRole_Drupal implements UserRoleInterface {
+
+  /**
+   * @var stdClass
+   */
+  private $user;
+
+  /**
+   * CRM_HRCore_CMSData_UserRole_Drupal constructor.
+   *
+   * @param array $contactData
+   */
+  public function __construct($contactData) {
+    $this->user = user_load($contactData['cmsId']);
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @return array
+   */
+  public function getRoles() {
+    return $this->user->roles;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserRoleFactory.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserRoleFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+use CRM_HRCore_CMSData_UserRoleInterface as UserRoleInterface;
+use CRM_HRCore_CMSData_UserRole_Drupal as DrupalUserRole;
+
+class CRM_HRCore_CMSData_UserRoleFactory {
+
+  /**
+   * Creates an object of the UserRoleInterface class based on the
+   * CMS framework in use.
+   *
+   * @param array $contactData
+   * @param string $cmsFramework
+   * 
+   * @return UserRoleInterface;
+   *
+   * @throws \Exception
+   */
+  public static function create($cmsFramework, $contactData) {
+    if ($cmsFramework == 'Drupal') {
+      return new DrupalUserRole($contactData);
+    }
+
+    $msg = sprintf('Unrecognized CMS: "%s"', $cmsFramework);
+    throw new \Exception($msg);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserRoleInterface.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserRoleInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Interface CRM_HRCore_CMSData_UserRoleInterface
+ */
+interface CRM_HRCore_CMSData_UserRoleInterface {
+
+  /**
+   * Returns the roles of the user object represented
+   * in this class.
+   *
+   * @return array
+   */
+  public function getRoles();
+}

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserMailNotifier/DrupalTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserMailNotifier/DrupalTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use CRM_HRCore_CMSData_UserMailNotifier_Drupal as DrupalUserMailNotifier;
+/**
+ * Class CRM_HRCore_CMSData_UserMailNotifier_DrupalTest
+ *
+ * @group headless
+ */
+class CRM_HRCore_CMSData_UserMailNotifier_DrupalTest extends CRM_HRCore_Test_BaseHeadlessTest {
+
+  public function testUserNotifyIsCalledForPasswordResetEmail() {
+    $contactData = ['cmsId' => 1];
+    $userMailNotifier = new DrupalUserMailNotifier($contactData);
+    $result = $userMailNotifier->sendPasswordResetEmail();
+    $expectedOperation = 'password_reset';
+    $this->assertEquals($expectedOperation, $result['operation']);
+    $this->assertInstanceOf(stdClass::class, $result['user']);
+  }
+
+  public function testUserNotifyIsCalledForWelcomeEmail() {
+    $contactData = ['cmsId' => 1];
+    $userMailNotifier = new DrupalUserMailNotifier($contactData);
+    $result = $userMailNotifier->sendWelcomeEmail();
+    $expectedOperation = 'register_admin_created';
+    $this->assertEquals($expectedOperation, $result['operation']);
+    $this->assertInstanceOf(stdClass::class, $result['user']);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserMailNotifierFactoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserMailNotifierFactoryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use CRM_HRCore_CMSData_UserMailNotifierFactory as UserMailNotifierFactory;
+use CRM_HRCore_CMSData_UserMailNotifierInterface as UserMailNotifierInterface;
+
+/**
+ * Class CRM_HRCore_CMSData_CMSUserMailNotifierFactoryTest
+ *
+ * @group headless
+ */
+class CRM_HRCore_CMSData_CMSUserMailNotifierFactoryTest extends CRM_HRCore_Test_BaseHeadlessTest {
+
+  public function testItReturnsAnInstanceOfTheExpectedClassWhenCMSIsSupported() {
+    $contactData = ['cmsId' => 1];
+    $mailNotifier = UserMailNotifierFactory::create('Drupal', $contactData);
+    $this->assertInstanceOf(UserMailNotifierInterface::class, $mailNotifier);
+  }
+
+  public function testItThrowsAnExceptionWhenCMSIsNotSupported() {
+    $cmsFramework = 'UnrecognizedCMS';
+    $msg = sprintf('Unrecognized CMS: "%s"', $cmsFramework);
+    $this->setExpectedException('Exception', $msg);
+
+    UserMailNotifierFactory::create($cmsFramework, []);
+  }
+}
+

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserRole/DrupalTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserRole/DrupalTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use CRM_HRCore_CMSData_UserRole_Drupal as DrupalUserRole;
+
+/**
+ * Class CRM_HRCore_CMSData_UerRole_DrupalTest
+ *
+ * @group headless
+ */
+class CRM_HRCore_CMSData_UserRole_DrupalTest extends CRM_HRCore_Test_BaseHeadlessTest {
+
+  public function testGetUserRoles() {
+    $contactData = ['cmsId' => 1];
+    $userRoleService = new DrupalUserRole($contactData);
+    $expectedRoles = [1 => 'Fake Role'];
+    $this->assertEquals($expectedRoles, $userRoleService->getRoles());
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserRoleFactoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserRoleFactoryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use CRM_HRCore_CMSData_UserRoleFactory as UserRoleFactory;
+use CRM_HRCore_CMSData_UserRoleInterface as UserRoleInterface;
+
+
+/**
+ * Class CRM_HRCore_CMSData_UserRoleFactoryTest
+ *
+ * @group headless
+ */
+class CRM_HRCore_CMSData_UserRoleFactoryTest extends CRM_HRCore_Test_BaseHeadlessTest {
+
+  public function testItReturnsAnInstanceOfTheExpectedClassWhenCMSIsSupported() {
+    $contactData = ['cmsId' => 1];
+    $userRole = UserRoleFactory::create('Drupal', $contactData);
+    $this->assertInstanceOf(UserRoleInterface::class, $userRole);
+  }
+
+  public function testItThrowsAnExceptionWhenCMSIsNotSupported() {
+    $cmsFramework = 'UnrecognizedCMS';
+    $msg = sprintf('Unrecognized CMS: "%s"', $cmsFramework);
+    $this->setExpectedException('Exception', $msg);
+
+    UserRoleFactory::create($cmsFramework, []);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/drupal_function_mocks.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/drupal_function_mocks.php
@@ -30,3 +30,13 @@ function user_save($user, $params) {
 
   return $user;
 }
+
+function user_load($userID) {
+  $user = new stdClass();
+  $user->roles = [1 => 'Fake Role'];
+  return $user;
+}
+
+function _user_mail_notify($operation, $user) {
+  return ['user' => $user, 'operation' => $operation];
+}


### PR DESCRIPTION
## Overview
This PR adds some generic CMS related classes and interfaces to the HRCore extension that can be used by other extension to display and perform CMS framework related actions.

## Before
CMS User interfaces related to Roles and Mail notification were not present.

## After
The following interfaces were added in this PR:
- CRM_HRCore_CMSData_UserMailNotifierInterface: This interface provides methods for notifying the CMS user mainly for sending password reset email and welcome email functionality and can be extended by relevant CMS framework class
- CRM_HRCore_CMSData_UserRoleInterface: This interface provides information about the roles of a CMS user.

The following classes were added to implement the Interfaces
- The CRM_HRCore_CMSData_UserRole_Drupal and the CRM_HRCore_CMSData_UserMailNotifier_Drupal class was added to implement the corresponding interface.

The following factory classes were added:
- The CRM_HRCore_CMSData_UserMailNotifierFactory and CRM_HRCore_CMSData_UserRoleFactory.

## Comments
- These classes were added primarily to aid the task being done for https://compucorp.atlassian.net/browse/PCHR-3073
