### PR TITLE
PCHR-3073: Modify UserNotifier Interface and related classes.

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserMailNotifier/Drupal.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserMailNotifier/Drupal.php
@@ -8,25 +8,29 @@ use CRM_HRCore_CMSData_UserMailNotifierInterface as UserMailNotifierInterface;
 class CRM_HRCore_CMSData_UserMailNotifier_Drupal implements UserMailNotifierInterface {
 
   /**
-   *{@inheritdoc}
+   * Gets the Drupal user object
+   *
+   * @param array $contactData
    *
    * @return \stdClass
    */
-  public function getUser($contactData) {
+  private function getUser($contactData) {
     return user_load($contactData['cmsId']);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function sendWelcomeEmail($user) {
-   return _user_mail_notify('register_admin_created', $user);
+  public function sendWelcomeEmail($contactData) {
+    $user = $this->getUser($contactData);
+    return _user_mail_notify('register_admin_created', $user);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function sendPasswordResetEmail($user) {
+  public function sendPasswordResetEmail($contactData) {
+    $user = $this->getUser($contactData);
     return _user_mail_notify('password_reset', $user);
   }
 }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserMailNotifier/Drupal.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserMailNotifier/Drupal.php
@@ -8,30 +8,25 @@ use CRM_HRCore_CMSData_UserMailNotifierInterface as UserMailNotifierInterface;
 class CRM_HRCore_CMSData_UserMailNotifier_Drupal implements UserMailNotifierInterface {
 
   /**
-   * @var stdClass
-   */
-  private $user;
-
-  /**
-   * CRM_HRCore_CMSData_UserMailNotifier_Drupal constructor.
+   *{@inheritdoc}
    *
-   * @param array $contactData
+   * @return \stdClass
    */
-  public function __construct($contactData) {
-    $this->user = user_load($contactData['cmsId']);
+  public function getUser($contactData) {
+    return user_load($contactData['cmsId']);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function sendWelcomeEmail() {
-   return _user_mail_notify('register_admin_created', $this->user);
+  public function sendWelcomeEmail($user) {
+   return _user_mail_notify('register_admin_created', $user);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function sendPasswordResetEmail() {
-    return _user_mail_notify('password_reset', $this->user);
+  public function sendPasswordResetEmail($user) {
+    return _user_mail_notify('password_reset', $user);
   }
 }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserMailNotifierFactory.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserMailNotifierFactory.php
@@ -12,16 +12,15 @@ class CRM_HRCore_CMSData_UserMailNotifierFactory {
    * Creates an object of the UserMailNotifier class based on the
    * CMS framework in use.
    *
-   * @param array $contactData
-   * @param string $cmsFramework
-   *
    * @return UserMailNotifierInterface;
    *
    * @throws \Exception
    */
-  public static function create($cmsFramework, $contactData) {
+  public static function create() {
+    $cmsFramework = CRM_Core_Config::singleton()->userFramework;
+
     if ($cmsFramework == 'Drupal') {
-      return new DrupalUserMailNotifier($contactData);
+      return new DrupalUserMailNotifier();
     }
 
     $msg = sprintf('Unrecognized CMS: "%s"', $cmsFramework);

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserMailNotifierInterface.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserMailNotifierInterface.php
@@ -10,29 +10,20 @@
 interface CRM_HRCore_CMSData_UserMailNotifierInterface {
 
   /**
-   * Get the user object.
+   * Sends a welcome email to the user.
    *
    * @param array $contactData
    *
-   * @return object
-   */
-  public function getUser($contactData);
-
-  /**
-   * Sends a welcome email to the user.
-   *
-   * @param object $user
-   *
    * @return mixed
    */
-  public function sendWelcomeEmail($user);
+  public function sendWelcomeEmail($contactData);
 
   /**
    * Sends a password reset email to the user.
    *
-   * @param object $user
+   * @param array $contactData
    *
    * @return mixed
    */
-  public function sendPasswordResetEmail($user);
+  public function sendPasswordResetEmail($contactData);
 }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserMailNotifierInterface.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserMailNotifierInterface.php
@@ -2,7 +2,7 @@
 
 /**
  * Interface CRM_HRCore_CMSData_UserMailNotifierInterface
- * 
+ *
  * This interface will be extended by the CMS class
  * that wants to provide functionality for sending emails notifications
  * (mainly password reset and welcome emails).
@@ -10,18 +10,29 @@
 interface CRM_HRCore_CMSData_UserMailNotifierInterface {
 
   /**
-   * Sends a welcome email to the user object represented in this
-   * class.
+   * Get the user object.
    *
-   * @return mixed
+   * @param array $contactData
+   *
+   * @return object
    */
-  public function sendWelcomeEmail();
+  public function getUser($contactData);
 
   /**
-   * Sends a password reset email to the user object represented in
-   * this class.
+   * Sends a welcome email to the user.
+   *
+   * @param object $user
    *
    * @return mixed
    */
-  public function sendPasswordResetEmail();
+  public function sendWelcomeEmail($user);
+
+  /**
+   * Sends a password reset email to the user.
+   *
+   * @param object $user
+   *
+   * @return mixed
+   */
+  public function sendPasswordResetEmail($user);
 }

--- a/uk.co.compucorp.civicrm.hrcore/config/container/container.xml
+++ b/uk.co.compucorp.civicrm.hrcore/config/container/container.xml
@@ -1,0 +1,20 @@
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+  <services>
+    <service id="drupal_role_service" class="CRM_HRCore_Service_DrupalRoleService"/>
+    <service id="drupal_user_service" class="CRM_HRCore_Service_DrupalUserService">
+      <argument type="service" id="drupal_role_service"/>
+    </service>
+
+    <service id="hrcore.cms_notifier"
+             class="CRM_HRCore_CMSData_UserMailNotifierInterface"
+             factory-class="CRM_HRCore_CMSData_UserMailNotifierFactory"
+             factory-method="create">
+    </service>
+  </services>
+
+</container>
+
+

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -4,10 +4,9 @@ require_once 'hrcore.civix.php';
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\Reference as Reference;
-use CRM_HRCore_Service_DrupalUserService as DrupalUserService;
-use CRM_HRCore_Service_DrupalRoleService as DrupalRoleService;
 use CRM_HRCore_SearchTask_ContactFormSearchTaskAdder as ContactFormSearchTaskAdder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\Config\FileLocator;
 
 /**
  * Implements hook_civicrm_config().
@@ -60,11 +59,8 @@ function hrcore_civicrm_summaryActions( &$actions, $contactID ) {
  * @param ContainerBuilder $container
  */
 function hrcore_civicrm_container($container) {
-  $container->register('drupal_role_service', DrupalRoleService::class);
-  $container->setDefinition(
-    'drupal_user_service',
-    new Definition(DrupalUserService::class, [new Reference('drupal_role_service')])
-  );
+  $loader = new XmlFileLoader($container, new FileLocator(__DIR__));
+  $loader->load('config/container/container.xml');
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserMailNotifier/DrupalTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserMailNotifier/DrupalTest.php
@@ -10,8 +10,9 @@ class CRM_HRCore_CMSData_UserMailNotifier_DrupalTest extends CRM_HRCore_Test_Bas
 
   public function testUserNotifyIsCalledForPasswordResetEmail() {
     $contactData = ['cmsId' => 1];
-    $userMailNotifier = new DrupalUserMailNotifier($contactData);
-    $result = $userMailNotifier->sendPasswordResetEmail();
+    $userMailNotifier = new DrupalUserMailNotifier();
+    $user = $userMailNotifier->getUser($contactData);
+    $result = $userMailNotifier->sendPasswordResetEmail($user);
     $expectedOperation = 'password_reset';
     $this->assertEquals($expectedOperation, $result['operation']);
     $this->assertInstanceOf(stdClass::class, $result['user']);
@@ -19,10 +20,18 @@ class CRM_HRCore_CMSData_UserMailNotifier_DrupalTest extends CRM_HRCore_Test_Bas
 
   public function testUserNotifyIsCalledForWelcomeEmail() {
     $contactData = ['cmsId' => 1];
-    $userMailNotifier = new DrupalUserMailNotifier($contactData);
-    $result = $userMailNotifier->sendWelcomeEmail();
+    $userMailNotifier = new DrupalUserMailNotifier();
+    $user = $userMailNotifier->getUser($contactData);
+    $result = $userMailNotifier->sendWelcomeEmail($user);
     $expectedOperation = 'register_admin_created';
     $this->assertEquals($expectedOperation, $result['operation']);
     $this->assertInstanceOf(stdClass::class, $result['user']);
+  }
+
+  public function testGetUserReturnsAnObject() {
+    $contactData = ['cmsId' => 1];
+    $userMailNotifier = new DrupalUserMailNotifier();
+    $user = $userMailNotifier->getUser($contactData);
+    $this->assertInstanceOf(StdClass::class, $user);
   }
 }

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserMailNotifier/DrupalTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserMailNotifier/DrupalTest.php
@@ -11,8 +11,7 @@ class CRM_HRCore_CMSData_UserMailNotifier_DrupalTest extends CRM_HRCore_Test_Bas
   public function testUserNotifyIsCalledForPasswordResetEmail() {
     $contactData = ['cmsId' => 1];
     $userMailNotifier = new DrupalUserMailNotifier();
-    $user = $userMailNotifier->getUser($contactData);
-    $result = $userMailNotifier->sendPasswordResetEmail($user);
+    $result = $userMailNotifier->sendPasswordResetEmail($contactData);
     $expectedOperation = 'password_reset';
     $this->assertEquals($expectedOperation, $result['operation']);
     $this->assertInstanceOf(stdClass::class, $result['user']);
@@ -21,17 +20,9 @@ class CRM_HRCore_CMSData_UserMailNotifier_DrupalTest extends CRM_HRCore_Test_Bas
   public function testUserNotifyIsCalledForWelcomeEmail() {
     $contactData = ['cmsId' => 1];
     $userMailNotifier = new DrupalUserMailNotifier();
-    $user = $userMailNotifier->getUser($contactData);
-    $result = $userMailNotifier->sendWelcomeEmail($user);
+    $result = $userMailNotifier->sendWelcomeEmail($contactData);
     $expectedOperation = 'register_admin_created';
     $this->assertEquals($expectedOperation, $result['operation']);
     $this->assertInstanceOf(stdClass::class, $result['user']);
-  }
-
-  public function testGetUserReturnsAnObject() {
-    $contactData = ['cmsId' => 1];
-    $userMailNotifier = new DrupalUserMailNotifier();
-    $user = $userMailNotifier->getUser($contactData);
-    $this->assertInstanceOf(StdClass::class, $user);
   }
 }

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserMailNotifierFactoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserMailNotifierFactoryTest.php
@@ -11,17 +11,22 @@ use CRM_HRCore_CMSData_UserMailNotifierInterface as UserMailNotifierInterface;
 class CRM_HRCore_CMSData_CMSUserMailNotifierFactoryTest extends CRM_HRCore_Test_BaseHeadlessTest {
 
   public function testItReturnsAnInstanceOfTheExpectedClassWhenCMSIsSupported() {
-    $contactData = ['cmsId' => 1];
-    $mailNotifier = UserMailNotifierFactory::create('Drupal', $contactData);
+    //We need to manually set this value because civicrm sets it to UnitTests
+    //when running in testing environment.
+    CRM_Core_Config::singleton()->userFramework = 'Drupal';
+    $mailNotifier = UserMailNotifierFactory::create();
     $this->assertInstanceOf(UserMailNotifierInterface::class, $mailNotifier);
   }
 
   public function testItThrowsAnExceptionWhenCMSIsNotSupported() {
+    //We need to manually set this value because civicrm sets it to UnitTests
+    //when running in testing environment.
     $cmsFramework = 'UnrecognizedCMS';
+    CRM_Core_Config::singleton()->userFramework = $cmsFramework;
     $msg = sprintf('Unrecognized CMS: "%s"', $cmsFramework);
     $this->setExpectedException('Exception', $msg);
 
-    UserMailNotifierFactory::create($cmsFramework, []);
+    UserMailNotifierFactory::create();
   }
 }
 

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserMailNotifierFactoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserMailNotifierFactoryTest.php
@@ -11,16 +11,18 @@ use CRM_HRCore_CMSData_UserMailNotifierInterface as UserMailNotifierInterface;
 class CRM_HRCore_CMSData_CMSUserMailNotifierFactoryTest extends CRM_HRCore_Test_BaseHeadlessTest {
 
   public function testItReturnsAnInstanceOfTheExpectedClassWhenCMSIsSupported() {
-    //We need to manually set this value because civicrm sets it to UnitTests
+    $previousUserFramework = CRM_Core_Config::singleton()->userFramework;
+    //We need to manually set this value because civicrm sets it to some other value
     //when running in testing environment.
     CRM_Core_Config::singleton()->userFramework = 'Drupal';
     $mailNotifier = UserMailNotifierFactory::create();
     $this->assertInstanceOf(UserMailNotifierInterface::class, $mailNotifier);
-    CRM_Core_Config::singleton()->userFramework = 'UnitTests';
+    CRM_Core_Config::singleton()->userFramework = $previousUserFramework;
   }
 
   public function testItThrowsAnExceptionWhenCMSIsNotSupported() {
-    //We need to manually set this value because civicrm sets it to UnitTests
+    $previousUserFramework = CRM_Core_Config::singleton()->userFramework;
+    //We need to manually set this value because civicrm sets it to some other value
     //when running in testing environment.
     $cmsFramework = 'UnrecognizedCMS';
     CRM_Core_Config::singleton()->userFramework = $cmsFramework;
@@ -28,7 +30,7 @@ class CRM_HRCore_CMSData_CMSUserMailNotifierFactoryTest extends CRM_HRCore_Test_
     $this->setExpectedException('Exception', $msg);
 
     UserMailNotifierFactory::create();
-    CRM_Core_Config::singleton()->userFramework = 'UnitTests';
+    CRM_Core_Config::singleton()->userFramework = $previousUserFramework;
   }
 }
 

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserMailNotifierFactoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserMailNotifierFactoryTest.php
@@ -16,6 +16,7 @@ class CRM_HRCore_CMSData_CMSUserMailNotifierFactoryTest extends CRM_HRCore_Test_
     CRM_Core_Config::singleton()->userFramework = 'Drupal';
     $mailNotifier = UserMailNotifierFactory::create();
     $this->assertInstanceOf(UserMailNotifierInterface::class, $mailNotifier);
+    CRM_Core_Config::singleton()->userFramework = 'UnitTests';
   }
 
   public function testItThrowsAnExceptionWhenCMSIsNotSupported() {
@@ -27,6 +28,7 @@ class CRM_HRCore_CMSData_CMSUserMailNotifierFactoryTest extends CRM_HRCore_Test_
     $this->setExpectedException('Exception', $msg);
 
     UserMailNotifierFactory::create();
+    CRM_Core_Config::singleton()->userFramework = 'UnitTests';
   }
 }
 


### PR DESCRIPTION
## Overview
This PR is a follow up to [#2399](https://github.com/civicrm/civihr/pull/2399)
It modifies the UserNotifier Interface so that a single instance of the class can be used to send notifications to multiple users, Also the UserInterface Factory now gets the CmsFramework parameter from inside the create method.

## Before
- A new instance of the UserNotifier class would have to be created per user to send notification to multiple users.

## After
- A new getUser method was added to the UserMailNotifierInterface class and the constructor method was removed.
- The create method of the UserMailNotifierFactory was modified to get the userFramework within the method, This is to allow the UserMailNotifier class to be easily made into a civi container that can be called from any extension. There were some issues in passing the userFramework into the create method using civi containers as the `Symfony\Component\ExpressionLanguage\Expression` is not bundled with civi core and its a requirement to add expression in the container.xml file.

