### PR TITLE
PCHR-3054: Order Staff names alphabetically in Leave Balance

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-balance-tab.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-balance-tab.html
@@ -23,7 +23,7 @@
                 </tr>
               </thead>
               <tbody>
-                <tr ng-repeat="record in leaveBalanceTab.report">
+                <tr ng-repeat="record in leaveBalanceTab.report | orderBy: 'contact_display_name'">
                   <td>{{record.contact_display_name}}</td>
                   <td ng-repeat-start="type in leaveBalanceTab.selectedAbsenceTypes"
                      >{{ record.absence_types[type.id].entitlement | timeUnitApplier : type.calculation_unit_name }}</td>


### PR DESCRIPTION
## Overview
In Leave Balance, staff names are not alphabetically ordered. This PR fixes the bug.

## Before
<img width="1229" alt="dashboard___civihrnew2_ _and_leave-balance-tab_html_ _civihrnew2__workspace_" src="https://user-images.githubusercontent.com/5058867/34934899-138a4ca8-fa02-11e7-8538-254e620fb04c.png">

## After
<img width="1229" alt="dashboard___civihrnew2_ _and_hipchat" src="https://user-images.githubusercontent.com/5058867/34934882-02e68d26-fa02-11e7-8980-d049bfa2ab99.png">

## Technical Details
This is not a regression issue, 

### Fix
In `leave-balance-tab.html`, added `orderBy: 'contact_display_name'` filter.