### PR TITLE
PCHR-3169: Fix Onboarding Backstop JS Test

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/onboarding-wizard.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/onboarding-wizard.js
@@ -73,7 +73,7 @@ module.exports = (function () {
         casper.click('.webform-next');
 
         return casper.waitForSelector('input[value="Dependants"]', function () {
-          casper.click('#edit-submitted-do-you-have-any-dependants-1');
+          casper.click('#edit-submitted-do-you-have-dependants-1');
         });
       });
     },
@@ -92,7 +92,7 @@ module.exports = (function () {
           casper.click('.webform-next');
 
           return casper.waitForSelector('input[value="Profile Picture"]');
-        })
+        });
       });
     }
   });


### PR DESCRIPTION
## Overview
This PR fixes the Failing Backstop test in Onboarding Wizard.

## Technical Details
In https://github.com/compucorp/civihr-employee-portal/commit/dc26aac1b158f968409b9514a6b0f63e86e582bd form key was changed to `do_you_have_any_dependants`. Updated the ID in backstop tests accordingly.
