### PR TITLE
PCHR-3072: Hide buttons via css

### DIFF
--- a/hrui/css/hrui.css
+++ b/hrui/css/hrui.css
@@ -33,3 +33,9 @@
 #crm-main-content-wrapper #contactDetails #govID span {
   margin-right: 1%;
 }
+
+.crm-contact-restore, 
+.crm-contact-delete,
+.crm-contact-permanently-delete {
+  display: none;
+}

--- a/hrui/css/hrui.css
+++ b/hrui/css/hrui.css
@@ -34,8 +34,8 @@
   margin-right: 1%;
 }
 
-.crm-contact-restore, 
 .crm-contact-delete,
-.crm-contact-permanently-delete {
+.crm-contact-permanently-delete
+.crm-contact-restore {
   display: none;
 }


### PR DESCRIPTION
## Overview
This PR hides "Delete", "Restore from Trash" and "Delete Permanently" buttons form contact page.

## Before
1. Delete botton:
<img width="798" alt="screen shot 2018-01-12 at 9 59 19 pm" src="https://user-images.githubusercontent.com/6307362/34947783-4b566208-fa33-11e7-9d1a-71838fdce258.png">

2. Restore and delete permanently buttons
<img width="728" alt="screen shot 2018-01-12 at 10 04 22 pm" src="https://user-images.githubusercontent.com/6307362/34947835-70a9d3dc-fa33-11e7-8da5-a72863fa03ad.png">

## After
1. Delete button hidden. 
<img width="1414" alt="screen shot 2018-01-15 at 8 04 02 pm" src="https://user-images.githubusercontent.com/6307362/34947909-ac9e0d68-fa33-11e7-8d69-fd299c0cae25.png">

2. restore and delete permanently hidden:
<img width="1680" alt="screen shot 2018-01-15 at 8 27 02 pm" src="https://user-images.githubusercontent.com/6307362/34947882-94523e8c-fa33-11e7-9a8d-bd18561cb5cc.png"> 

## Technical Details
1.Add following css rule to hide `.crm-contact-restore`, `.crm-contact-delete` and `.crm-contact-permanently-delete` in file [hrui.css](https://github.com/civicrm/civihr/blob/staging/hrui/css/hrui.css)

```css
.crm-contact-restore, 
.crm-contact-delete,
.crm-contact-permanently-delete {
   display: none;
}
```
**Note:** Here the buttons could have been removed frm templates but it would require an override to  CiviCRM core template file, which is a complex process for just to hide buttons, so css is used instead.

## Comments
- These buttons from current place is hidden and will be added in the contact actions menu as per new design.

## Tests:
✅ CSS distributive files - not needed to run
⏹ Jasmine Tests - n/a
⏹ JS distributive files - n/a
⏹ Backstop Tests - n/a
⏹ PHP Unit Tests - not needed to run