### PR TITLE
PCHR-3138: Add UserAccount Interface and related classes

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserAccount/Drupal.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserAccount/Drupal.php
@@ -51,7 +51,7 @@ class CRM_HRCore_CMSData_UserAccount_Drupal implements UserAccountInterface {
   public function disable($contactData) {
     $user = $this->getUser($contactData);
 
-    return user_save($user, ['status'=> 0]);
+    return user_save($user, ['status' => 0]);
   }
 
   /**
@@ -60,7 +60,7 @@ class CRM_HRCore_CMSData_UserAccount_Drupal implements UserAccountInterface {
   public function enable($contactData) {
     $user = $this->getUser($contactData);
 
-    return user_save($user, ['status'=> 1]);
+    return user_save($user, ['status' => 1]);
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserAccount/Drupal.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserAccount/Drupal.php
@@ -1,0 +1,74 @@
+<?php
+
+use CRM_HRCore_CMSData_UserAccountInterface as UserAccountInterface;
+
+/**
+ * Class CRM_HRCore_CMSData_UserAccount_Drupal
+ */
+class CRM_HRCore_CMSData_UserAccount_Drupal implements UserAccountInterface {
+
+  /**
+   * Gets the Drupal user object
+   *
+   * @param array $contactData
+   *
+   * @return \stdClass
+   */
+  private function getUser($contactData) {
+    return user_load($contactData['cmsId']);
+  }
+
+  /**
+   * Cancel the user account by deleting the account
+   * and make its content belong to the Anonymous user.
+   *
+   * @param array $contactData
+   *
+   * @return mixed
+   */
+  public function cancel($contactData) {
+    $user = $this->getUser($contactData);
+
+    $result = user_cancel(
+      [
+        'user_cancel_notify' => FALSE,
+        'user_cancel_method' => 'user_cancel_reassign',
+      ],
+      $user->uid,
+      'user_cancel_reassign'
+    );
+
+    $batch = &batch_get();
+    $batch['progressive'] = FALSE;
+    batch_process();
+
+    return $result;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function disable($contactData) {
+    $user = $this->getUser($contactData);
+
+    return user_save($user, ['status'=> 0]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function enable($contactData) {
+    $user = $this->getUser($contactData);
+
+    return user_save($user, ['status'=> 1]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isUserDisabled($contactData) {
+    $user = $this->getUser($contactData);
+
+    return $user->status;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserAccountFactory.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserAccountFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+use CRM_HRCore_CMSData_UserAccountInterface as UserAccountInterface;
+use CRM_HRCore_CMSData_UserAccount_Drupal as DrupalUserAccount;
+
+class CRM_HRCore_CMSData_UserAccountFactory {
+
+  /**
+   * Creates an object of the UserAccount class based on the
+   * CMS framework in use.
+   *
+   * @return UserAccountInterface;
+   *
+   * @throws \Exception
+   */
+  public static function create() {
+    $cmsFramework = CRM_Core_Config::singleton()->userFramework;
+
+    if ($cmsFramework == 'Drupal') {
+      return new DrupalUserAccount();
+    }
+
+    $msg = sprintf('Unrecognized CMS: "%s"', $cmsFramework);
+    throw new \Exception($msg);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserAccountInterface.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserAccountInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Interface CRM_HRCore_CMSData_UserAccountInterface
+ *
+ * This interface will be extended by the CMS class
+ * that wants to provide functionality for taking
+ * some actions/providing some information on a user
+ * account.
+ */
+interface CRM_HRCore_CMSData_UserAccountInterface {
+
+  /**
+   * Cancel User account.
+   *
+   * @param array $contactData
+   *
+   * @return mixed
+   */
+  public function cancel($contactData);
+
+  /**
+   * Disable User account.
+   *
+   * @param array $contactData
+   *
+   * @return mixed
+   */
+  public function disable($contactData);
+
+  /**
+   * Enable user account.
+   *
+   * @param array $contactData
+   *
+   * @return mixed
+   */
+  public function enable($contactData);
+
+  /**
+   * Checks if user account is disabled
+   *
+   * @param array $contactData
+   *
+   * @return boolean
+   */
+  public function isUserDisabled($contactData);
+}

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserAccount/DrupalTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserAccount/DrupalTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use CRM_HRCore_CMSData_UserAccount_Drupal as DrupalUserAccount;
+
+/**
+ * Class CRM_HRCore_CMSData_UserAccount_DrupalTest
+ *
+ * @group headless
+ */
+class CRM_HRCore_CMSData_UserAccount_DrupalTest extends CRM_HRCore_Test_BaseHeadlessTest {
+
+  public function testCancelUserAccount() {
+    $contactData = ['cmsId' => 1];
+    $userAccount = new DrupalUserAccount();
+    $result = $userAccount->cancel($contactData);
+    $this->assertEquals($contactData['cmsId'], $result['uid']);
+    $this->assertEquals('user_cancel_reassign', $result['method']);
+    $this->assertEquals(FALSE, $result['params']['user_cancel_notify']);
+    $this->assertEquals('user_cancel_reassign', $result['params']['user_cancel_method']);
+  }
+
+  public function testDisableUserAccount() {
+    $contactData = ['cmsId' => 1];
+    $userAccount = new DrupalUserAccount();
+    $user = $userAccount->disable($contactData);
+
+    $this->assertEquals(0, $user->status);
+  }
+
+  public function testEnableUserAccount() {
+    $contactData = ['cmsId' => 1];
+    $userAccount = new DrupalUserAccount();
+    $user = $userAccount->enable($contactData);
+
+    $this->assertEquals(1, $user->status);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserAccountFactoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserAccountFactoryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use CRM_HRCore_CMSData_UserAccountFactory as UserAccountFactory;
+use CRM_HRCore_CMSData_UserAccountInterface as UserAccountInterface;
+
+/**
+ * Class CRM_HRCore_CMSData_UserAccountFactoryTest
+ *
+ * @group headless
+ */
+class CRM_HRCore_CMSData_UserAccountFactoryTest extends CRM_HRCore_Test_BaseHeadlessTest {
+
+  public function testItReturnsAnInstanceOfTheExpectedClassWhenCMSIsSupported() {
+    $previousUserFramework = CRM_Core_Config::singleton()->userFramework;
+    //We need to manually set this value because civicrm sets it to some other value
+    //when running in testing environment.
+    CRM_Core_Config::singleton()->userFramework = 'Drupal';
+    $userAccount= UserAccountFactory::create();
+    $this->assertInstanceOf(UserAccountInterface::class, $userAccount);
+    CRM_Core_Config::singleton()->userFramework = $previousUserFramework;
+  }
+
+  public function testItThrowsAnExceptionWhenCMSIsNotSupported() {
+    $previousUserFramework = CRM_Core_Config::singleton()->userFramework;
+    //We need to manually set this value because civicrm sets it to some other value
+    //when running in testing environment.
+    $cmsFramework = 'UnrecognizedCMS';
+    CRM_Core_Config::singleton()->userFramework = $cmsFramework;
+    $msg = sprintf('Unrecognized CMS: "%s"', $cmsFramework);
+    $this->setExpectedException('Exception', $msg);
+
+    UserAccountFactory::create();
+    CRM_Core_Config::singleton()->userFramework = $previousUserFramework;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/drupal_function_mocks.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/drupal_function_mocks.php
@@ -34,9 +34,22 @@ function user_save($user, $params) {
 function user_load($userID) {
   $user = new stdClass();
   $user->roles = [1 => 'Fake Role'];
+  $user->uid = $userID;
   return $user;
 }
 
 function _user_mail_notify($operation, $user) {
   return ['user' => $user, 'operation' => $operation];
 }
+
+function user_cancel($params, $uid, $method) {
+  return ['params' => $params, 'uid' => $uid, 'method' => $method];
+}
+
+function &batch_get() {
+  $batch = ['progressive' => ''];
+
+  return $batch;
+}
+
+function batch_process() {}


### PR DESCRIPTION
## Overview
This PR adds some generic CMS related classes and interfaces to the HRCore extension that can be used by other extension to display and perform CMS framework related actions.
The class added in this PR is the UserAccount Interface and its related classes.

## Before
CMS User interfaces and classes related to User Account were not present.

## After
The following interface was added in this PR:

- CRM_HRCore_CMSData_UserAccountInterface: This interface provides methods functionality for taking some actions/providing some information on a user account. Currently it provides method for cancelling, enabling and disabling a user account and also provides information on whether a user account is disabled or not.

The following class was added to implement the Interface
- The CRM_HRCore_CMSData_UserAccount_Drupal class

The following factory class was added:
- The CRM_HRCore_CMSData_UserAccountFactory.

## Comments
- These classes were added primarily to aid the task being done for https://compucorp.atlassian.net/browse/PCHR-3138
- The cancel method implementation in the CRM_HRCore_CMSData_UserAccount_Drupal allows a user account to be cancelled and make its content belong to the Anonymous user. This has been tested locally on my machine and works as expected.