### PR TITLE
PCHR-2588: QA Fixes

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/Role/DrupalRoleService.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/Role/DrupalRoleService.php
@@ -26,8 +26,9 @@ class CRM_HRCore_CMSData_Role_DrupalRoleService implements RoleServiceInterface{
 
     $result = $query->execute()->fetchAllKeyed();
 
-    $returnArray = [];
     $roleNames = $this->getRoleNames();
+    unset($roleNames['authenticated user'], $roleNames['anonymous user']);
+    $returnArray = array_fill_keys($roleNames, NULL);
 
     foreach ($result as $rid => $loginTimestamp) {
       if (array_key_exists($rid, $roleNames)) {

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/Stats/StatsCache.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/Stats/StatsCache.php
@@ -54,7 +54,7 @@ class CRM_HRCore_Service_Stats_StatsCache {
       return FALSE;
     }
 
-    $oneWeekAgo = new \DateTime('now - 1 week 00:00:00');
+    $oneWeekAgo = new \DateTime('now - 1 week');
 
     return $oneWeekAgo > $modified;
   }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/Stats/StatsGatherer.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/Stats/StatsGatherer.php
@@ -54,8 +54,10 @@ class CRM_HRCore_Service_Stats_StatsGatherer {
       $stats->setContactSubtypeCount($subtype, $count);
     }
 
-    foreach ($this->getReportConfigurations() as $configuration) {
+    $reportConfigs = $this->getReportConfigurations();
+    foreach ($reportConfigs as $configuration) {
       $stats->addReportConfiguration($configuration);
+      $stats->setEntityCount('reportConfiguration', count($reportConfigs));
     }
 
     foreach ($this->getAgeGroups() as $group) {

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/Stats/StatsSender.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/Stats/StatsSender.php
@@ -71,6 +71,11 @@ class CRM_HRCore_Service_Stats_StatsSender {
     $response = $this->httpClient->post($this->statsEndpoint, $json);
     list($status, $responseBody) = $response;
 
+    // Response should be empty
+    if ($responseBody) {
+      $status = HttpClient::STATUS_DL_ERROR;
+    }
+
     if (HttpClient::STATUS_OK !== $status) {
       $msg = sprintf('Failed sending CiviHR stats: %s', $responseBody);
       if ($this->logger) {

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsCacheTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsCacheTest.php
@@ -37,7 +37,7 @@ class StatsCacheTest extends BaseHeadlessTest {
   public function testWillNotFetchIfCacheIsFresh() {
     $gatherer = $this->prophesize(StatsGatherer::class);
     $cache = $this->prophesize(FileCache::class);
-    $oneWeekAgo = new \DateTime('midnight today - 7 days');
+    $oneWeekAgo = new \DateTime('now - 7 days');
     $cache->getModified(StatsCache::CACHE_KEY)->willReturn($oneWeekAgo);
     $cache->get(StatsCache::CACHE_KEY)->willReturn(new CiviHRStatistics());
     $gatherer->gather()->shouldNotBeCalled();

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsGathererTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsGathererTest.php
@@ -18,13 +18,13 @@ use CRM_HRCore_Test_Fabricator_CaseType as CaseTypeFabricator;
 use CRM_HRCore_Test_Fabricator_ContactType as ContactTypeFabricator;
 use CRM_HRCore_Test_Fabricator_OptionValue as OptionValueFabricator;
 use CRM_HRCore_Service_Stats_StatsGatherer as StatsGatherer;
+use CRM_HRCore_Test_Helpers_SessionHelper as SessionHelper;
 
 /**
  * @group headless
  */
 class StatsGathererTest extends CRM_HRCore_Test_BaseHeadlessTest {
 
-  use CRM_HRCore_Test_Helpers_SessionHelpersTrait;
   use CRM_HRCore_Test_Helpers_TableCleanupTrait;
   use CRM_HRCore_Test_Helpers_DomainConfigurationTrait;
 
@@ -74,7 +74,7 @@ class StatsGathererTest extends CRM_HRCore_Test_BaseHeadlessTest {
     ContactFabricator::fabricate();
     ContactFabricator::fabricate();
     $contactID = ContactFabricator::fabricateWithEmail()['id'];
-    $this->registerCurrentLoggedInContactInSession($contactID);
+    SessionHelper::registerCurrentLoggedInContactInSession($contactID);
 
     // expect 1 UFMatch
     UFMatchFabricator::fabricate(['contact_id' => $contactID]);
@@ -206,7 +206,7 @@ class StatsGathererTest extends CRM_HRCore_Test_BaseHeadlessTest {
     $contactID = ContactFabricator::fabricate()['id'];
     TaskTypeFabricator::fabricate();
     $this->setUpLeaveRequest($contactID);
-    $this->registerCurrentLoggedInContactInSession($contactID);
+    SessionHelper::registerCurrentLoggedInContactInSession($contactID);
 
     $ufMatch = UFMatchFabricator::fabricate();
     civicrm_api3('UFMatch', 'delete', ['id' => $ufMatch['id']]);

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsSenderTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsSenderTest.php
@@ -15,7 +15,9 @@ class StatsSenderTest extends BaseHeadlessTest {
 
   public static function setUpBeforeClass() {
     if (defined('CIVIHR_STATISTICS_ENDPOINT')) {
-      self::fail('Please unset CIVIHR_STATISTICS_ENDPOINT in your settings file');
+      $msg = 'Please unset CIVIHR_STATISTICS_ENDPOINT in your settings file'
+       . ' to avoid really sending statistics when running tests';
+      self::fail($msg);
     }
 
     define('CIVIHR_STATISTICS_ENDPOINT', self::MOCK_ENDPOINT);


### PR DESCRIPTION
## Overview

After going over the QA plan myself locally I noticed some things that could be improved. This PR fixes those.

## Before

- Roles that had no login date were excluded
- Cache expiration was checking if the cache was created earlier than 1 week ago today at 00:00:00
- Report configuration count was not included
- The warning about setting CIVIHR_STATISTICS_ENDPOINT was unclear
- Error responses from the server were not handled well. Even though an error was generated Civi doesn't really do HTTP status codes, and the HTTP client doesn't really care about them so much anyway.

## After

- Most recent login date for all roles is included (except anonymous and authenticated user)
- Cache expiration checks if the cache was created simply early than 1 week ago (from now)
- Report configuration count is included
- The warning about setting CIVIHR_STATISTICS_ENDPOINT includes a reason why
- Error responses handling is improved. Although basic, the response body is checked, and since we don't expect any response from the server, a non-zero response body is evaluated as a request error

## Notes

`CRM_HRCore_Test_Helpers_SessionHelpersTrait` was renamed and made into a class, so the tests needed to be updated