### PR TITLE
PCHR-3138: Add Page URL Callbacks for Disabling/Enabling and Deleting User Account

### DIFF
--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Page/UserAccount.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Page/UserAccount.php
@@ -13,13 +13,7 @@ class CRM_HRContactActionsMenu_Page_UserAccount {
    * contact.
    */
   public static function delete() {
-    $contactID = CRM_Utils_Array::value('cid', $_GET);
-    $contactInfo = ContactHelper::getUserInformation($contactID);
-    $userAccount = UserAccountFactory::create();
-    $userAccount->cancel($contactInfo);
-
-    CRM_Core_Session::setStatus(ts('User account has been deleted'), 'Success', 'success');
-    self::redirectToContactSummaryPage($contactID);
+    self::doUserAction('delete', 'User account has been deleted');
   }
 
   /**
@@ -27,13 +21,7 @@ class CRM_HRContactActionsMenu_Page_UserAccount {
    * contact.
    */
   public static function disable() {
-    $contactID = CRM_Utils_Array::value('cid', $_GET);
-    $contactInfo = ContactHelper::getUserInformation($contactID);
-    $userAccount = UserAccountFactory::create();
-    $userAccount->disable($contactInfo);
-
-    CRM_Core_Session::setStatus(ts('User account has been disabled'), 'Success', 'success');
-    self::redirectToContactSummaryPage($contactID);
+    self::doUserAction('disable', 'User account has been disabled');
   }
 
   /**
@@ -41,21 +29,25 @@ class CRM_HRContactActionsMenu_Page_UserAccount {
    * contact.
    */
   public static function enable() {
-    $contactID = CRM_Utils_Array::value('cid', $_GET);
-    $contactInfo = ContactHelper::getUserInformation($contactID);
-    $userAccount = UserAccountFactory::create();
-    $userAccount->enable($contactInfo);
-
-    CRM_Core_Session::setStatus(ts('User account has been enabled'), 'Success', 'success');
-    self::redirectToContactSummaryPage($contactID);
+    self::doUserAction('enable', 'User account has been enabled');
   }
 
   /**
-   * Redirects to the Contact summary page.
+   * Function to execute the required method of the User Account
+   * object based on the action passed in.
+   * After execution, the success message is displayed and the
+   * user redirected to contact summary page.
    *
-   * @param int $contactID
+   * @param string $action
+   * @param string $successMessage
    */
-  private static function redirectToContactSummaryPage($contactID) {
+  private static function doUserAction($action, $successMessage) {
+    $contactID = CRM_Utils_Array::value('cid', $_GET);
+    $contactInfo = ContactHelper::getUserInformation($contactID);
+    $userAccount = UserAccountFactory::create();
+    $userAccount->$action($contactInfo);
+    CRM_Core_Session::setStatus(ts($successMessage), 'Success', 'success');
+
     $url = CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid=$contactID");
     CRM_Utils_System::redirect($url);
   }

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Page/UserAccount.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Page/UserAccount.php
@@ -1,0 +1,58 @@
+<?php
+
+use CRM_HRContactActionsMenu_Helper_Contact as ContactHelper;
+use CRM_HRCore_CMSData_UserAccountFactory as UserAccountFactory;
+
+/**
+ * Class CRM_HRContactActionsMenu_Page_UserAccount
+ */
+class CRM_HRContactActionsMenu_Page_UserAccount {
+
+  /**
+   * Function to delete the CMS user account of the
+   * contact.
+   */
+  public static function delete() {
+    $contactID = CRM_Utils_Array::value('cid', $_GET);
+    $contactInfo = ContactHelper::getUserInformation($contactID);
+    $userAccount = UserAccountFactory::create();
+    $userAccount->cancel($contactInfo);
+
+    CRM_Core_Session::setStatus(ts('User account has been deleted'), 'Success', 'success');
+
+    $url = CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid=$contactID");
+    CRM_Utils_System::redirect($url);
+  }
+
+  /**
+   * Function to disable the CMS user account of the
+   * contact.
+   */
+  public static function disable() {
+    $contactID = CRM_Utils_Array::value('cid', $_GET);
+    $contactInfo = ContactHelper::getUserInformation($contactID);
+    $userAccount = UserAccountFactory::create();
+    $userAccount->disable($contactInfo);
+
+    CRM_Core_Session::setStatus(ts('User account has been disabled'), 'Success', 'success');
+
+    $url = CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid=$contactID");
+    CRM_Utils_System::redirect($url);
+  }
+
+  /**
+   * Function to enable the CMS user account of the
+   * contact.
+   */
+  public static function enable() {
+    $contactID = CRM_Utils_Array::value('cid', $_GET);
+    $contactInfo = ContactHelper::getUserInformation($contactID);
+    $userAccount = UserAccountFactory::create();
+    $userAccount->enable($contactInfo);
+
+    CRM_Core_Session::setStatus(ts('User account has been enabled'), 'Success', 'success');
+
+    $url = CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid=$contactID");
+    CRM_Utils_System::redirect($url);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Page/UserAccount.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Page/UserAccount.php
@@ -19,9 +19,7 @@ class CRM_HRContactActionsMenu_Page_UserAccount {
     $userAccount->cancel($contactInfo);
 
     CRM_Core_Session::setStatus(ts('User account has been deleted'), 'Success', 'success');
-
-    $url = CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid=$contactID");
-    CRM_Utils_System::redirect($url);
+    self::redirectToContactSummaryPage($contactID);
   }
 
   /**
@@ -35,9 +33,7 @@ class CRM_HRContactActionsMenu_Page_UserAccount {
     $userAccount->disable($contactInfo);
 
     CRM_Core_Session::setStatus(ts('User account has been disabled'), 'Success', 'success');
-
-    $url = CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid=$contactID");
-    CRM_Utils_System::redirect($url);
+    self::redirectToContactSummaryPage($contactID);
   }
 
   /**
@@ -51,7 +47,15 @@ class CRM_HRContactActionsMenu_Page_UserAccount {
     $userAccount->enable($contactInfo);
 
     CRM_Core_Session::setStatus(ts('User account has been enabled'), 'Success', 'success');
+    self::redirectToContactSummaryPage($contactID);
+  }
 
+  /**
+   * Redirects to the Contact summary page.
+   *
+   * @param int $contactID
+   */
+  private static function redirectToContactSummaryPage($contactID) {
     $url = CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid=$contactID");
     CRM_Utils_System::redirect($url);
   }

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/hrcontactactionsmenu.civix.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/hrcontactactionsmenu.civix.php
@@ -77,7 +77,7 @@ class CRM_HRContactActionsMenu_ExtensionUtil {
 
 }
 
-use CRM_Hrcontactactionsmenu_ExtensionUtil as E;
+use CRM_HRContactActionsMenu_ExtensionUtil as E;
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/hrcontactactionsmenu.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/hrcontactactionsmenu.php
@@ -1,14 +1,12 @@
 <?php
 
-use CRM_Hrcontactactionsmenu_ExtensionUtil as E;
+require_once 'hrcontactactionsmenu.civix.php';
+
 use CRM_HRContactActionsMenu_Component_Menu as ActionsMenu;
 use CRM_HRContactActionsMenu_Helper_UserInformationActionGroup as UserInformationActionGroupHelper;
 use CRM_HRContactActionsMenu_Helper_Contact as ContactHelper;
 use CRM_HRCore_CMSData_UserRoleFactory as CMSUserRoleFactory;
 use CRM_HRCore_CMSData_PathsFactory as CMSUserPathFactory;
-
-require_once 'hrcontactactionsmenu.civix.php';
-
 
 /**
  * Implementation of hook_addContactMenuActions to add the

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/hrcontactactionsmenu.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/hrcontactactionsmenu.php
@@ -1,5 +1,6 @@
 <?php
 
+use CRM_Hrcontactactionsmenu_ExtensionUtil as E;
 use CRM_HRContactActionsMenu_Component_Menu as ActionsMenu;
 use CRM_HRContactActionsMenu_Helper_UserInformationActionGroup as UserInformationActionGroupHelper;
 use CRM_HRContactActionsMenu_Helper_Contact as ContactHelper;

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/hrcontactactionsmenu.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/hrcontactactionsmenu.php
@@ -2,6 +2,7 @@
 
 require_once 'hrcontactactionsmenu.civix.php';
 
+use CRM_HRContactActionsMenu_ExtensionUtil as E;
 use CRM_HRContactActionsMenu_Component_Menu as ActionsMenu;
 use CRM_HRContactActionsMenu_Helper_UserInformationActionGroup as UserInformationActionGroupHelper;
 use CRM_HRContactActionsMenu_Helper_Contact as ContactHelper;

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/xml/Menu/hrcontactactionsmenu.xml
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/xml/Menu/hrcontactactionsmenu.xml
@@ -10,4 +10,19 @@
     <page_callback>CRM_HRContactActionsMenu_Page_UserMailNotifier::sendWelcomeEmail</page_callback>
     <access_arguments>edit all contacts</access_arguments>
   </item>
+  <item>
+    <path>civicrm/contactactionsmenu/deleteuseraccount</path>
+    <page_callback>CRM_HRContactActionsMenu_Page_UserAccount::delete</page_callback>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
+  <item>
+    <path>civicrm/contactactionsmenu/disableuseraccount</path>
+    <page_callback>CRM_HRContactActionsMenu_Page_UserAccount::disable</page_callback>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
+  <item>
+    <path>civicrm/contactactionsmenu/enableuseraccount</path>
+    <page_callback>CRM_HRContactActionsMenu_Page_UserAccount::enable</page_callback>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
 </menu>

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/xml/Menu/hrcontactactionsmenu.xml
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/xml/Menu/hrcontactactionsmenu.xml
@@ -3,12 +3,12 @@
   <item>
     <path>civicrm/contactactionsmenu/sendpasswordresetmail</path>
     <page_callback>CRM_HRContactActionsMenu_Page_UserMailNotifier::sendPasswordResetEmail</page_callback>
-    <access_arguments>edit all contacts</access_arguments>
+    <access_arguments>access CiviCRM</access_arguments>
   </item>
   <item>
     <path>civicrm/contactactionsmenu/sendwelcomemail</path>
     <page_callback>CRM_HRContactActionsMenu_Page_UserMailNotifier::sendWelcomeEmail</page_callback>
-    <access_arguments>edit all contacts</access_arguments>
+    <access_arguments>access CiviCRM</access_arguments>
   </item>
   <item>
     <path>civicrm/contactactionsmenu/deleteuseraccount</path>


### PR DESCRIPTION
## Overview
This PR adds the page URL's for disabling, enabling and deleting the CMS user of a contact and the Page callbacks that handles these functionalities.

## Before
The functionality for disabling, enabling and deleting the CMS user of a contact does not exist.

## After
- The User account interface and related classes added in #2408, were utilized to implement the needed functionalities, The disable, enable and cancel methods on this interface were used after getting the appropriate CMS object from the factory.

## Comments
- Commits 57074b5 fixes the access arguments for the User notifier related paths added in a previous PR, the arguments needed is 'access CiviCRM' rather than 'edit all contacts'
- Also there's an error about the CRM_Hrcontactactionsmenu_ExtensionUtil not found in the hrcontactactionsmenu.php file, this was also fixed.
- Also tasks for https://compucorp.atlassian.net/browse/PCHR-3139 has been merged with https://compucorp.atlassian.net/browse/PCHR-3138 and the former will be closed as the tasks are better done in a single PR.