### PR TITLE
PCHR-2502: Remove Unused Custom Groups

### DIFF
--- a/hrcase/CRM/HRCase/Upgrader.php
+++ b/hrcase/CRM/HRCase/Upgrader.php
@@ -159,6 +159,31 @@ class CRM_HRCase_Upgrader extends CRM_HRCase_Upgrader_Base {
   }
 
   /**
+   * Deletes unused custom groups. The XML files to create these groups were
+   * removed from this extension, but for some sites that already had them,
+   * the custom groups still exist.
+   *
+   * @return TRUE
+   */
+  public function upgrade_1431() {
+    $groupsToRemove = ['Exiting_Data', 'Joining_Data'];
+
+    foreach ($groupsToRemove as $groupName) {
+      $customGroup = civicrm_api3('CustomGroup', 'get', ['name' => $groupName]);
+
+      if ($customGroup['count'] != 1) {
+        continue;
+      }
+
+      $customGroup = array_shift($customGroup['values']);
+
+      civicrm_api3('CustomGroup', 'delete', ['id' => $customGroup['id']]);
+    }
+
+    return TRUE;
+  }
+
+  /**
    * Replaces (Case) keyword and (Open Case) keyword with (Assignment) keyword
    * and (Created New Assignment) keyword respectively and vise versa for
    * civicrm default activity types labels when installing/uninstalling the extension.


### PR DESCRIPTION
## What is the bug

After clearing the cache some sites show an error that:
 
```
CRM_Core_Exception: 
Invalid Entity Filter in CRM_Core_BAO_CustomGroup::validateSubTypeByEntity()
```

## Why does it happen

It happens when this method call is made:

```CRM_Core_BAO_CustomGroup::validateSubTypeByEntity('Case', 'Exiting')```

For custom groups not based on Contacts, `validateSubTypeByEntity` expects an integer as the second argument. This has been the case ever since it was introduced in [April, 2016](https://github.com/civicrm/civicrm-core/commit/79363422d47677e58596798ed26304c8c4b9953c#diff-d9f1be3fcfd7cea0a4864a21997c258aR642).
 
This call is triggered after clearing the cache. During rebuilding of the cache the views plugin data cache is rebuilt . This leads to a call to `civicrm_views_data_alter` when CiviCRM tries to load all custom groups for use in views. It fetches all custom groups and calls `getTree`, which leads to `validateSubTypeByEntity` and the exception.
 
## When was it introduced

Way back in [November, 2013](https://github.com/civicrm/civihr/commit/499f5d38ae0e8714e1b38778ccfeadbea7a56266#diff-3d2c1367309540a7d924211b721fef59R6) the "Exiting Data" and "Joining Data" custom groups were added for use with Cases. Later the `extends_entity_colum_value` was [updated](https://github.com/civicrm/civihr/commit/56045b05613a1cad7a21ea4ef4545d12e39f6a5f#diff-90cd08cb2f10713350003bb817322235R10). In December, 2016 the XML to auto-import these custom groups was [removed](https://github.com/civicrm/civihr/commit/50b22e07ee08471d05a4d9b9439abda0d0bd8836) _but_ for existing sites that already had these custom groups in the database, nothing was changed.

The problem of using a string instead of the ID in `extends_entity_column_value` seems to have been known, and for the "Application" case type custom group some steps were taken to [fix it](https://github.com/civicrm/civihr/commit/6a33bd60088c2ed3574d2376cae225480685e881#diff-079ab34a2d20aee0f15ad48f3de31b13R152), however no such measures were taken for the "Joining" and "Exiting" custom groups.

## Steps to reproduce

- Copy some file with 'Case' custom group XML (I used hrrecruitment auto_install.xml)
- Delete everything except a single `<CustomGroup>` element 
- Change the name, title and table_name fields, they should be unique
- Set `extends_entity_column_value` to 'Application', or some CaseType name
- Use `executeCustomDataFile` to import the file (just like extension install)
- Check `SELECT * FROM civicrm_custom_group WHERE extends = 'Case'`
- It will show a string value in `extends_entity_column_value` 
- Clear the cache
- Refresh the page 
- "Invalid entity filter" error is displayed

## How did you fix it

The "Exiting Data" and "Joining Data" custom groups are not used anywhere. They were removed from the codebase and only exist in sites that were created before this. They are not used on any production, demo, or test sites, and do not exist on local development sites. The fix is then to remove them using the upgrader from this PR.