### PR TITLE
PCHR-3094: Fix validation errors after changing Leave Request's Absence Type

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -1378,8 +1378,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    *
    * @param array $params
    *
-   * @return mixed
-   * @throws \Exception
+   * @return array
+   *   The $params array with empty values for the non-mandatory fields
    */
   private static function resetNonMandatoryDateFieldsIfCalculationUnitChanged($params) {
     if (self::calculationUnitChanged($params)) {
@@ -1394,6 +1394,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
         $params['to_date_amount']   = '';
       }
     }
+
     return $params;
   }
 
@@ -1412,13 +1413,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
   private static function calculationUnitChanged($params) {
     if (empty($params['id'])) {
       // New Leave Request being created, so it didn't change
-      return false;
+      return FALSE;
     }
 
     $currentAbsenceType = self::getCurrentAbsenceType($params['id']);
 
     if ($currentAbsenceType->id == $params['type_id']) {
-      return false;
+      return FALSE;
     }
 
     $newAbsenceType = AbsenceType::findById($params['type_id']);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -49,6 +49,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     unset($params['is_deleted']);
 
     $datesChanged = self::datesChanged($params);
+
+    $params = self::resetNonMandatoryDateFieldsIfCalculationUnitChanged($params);
+
     $instance = new self();
     $instance->copyValues($params);
 
@@ -102,8 +105,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     if($validationMode != self::IMPORT_VALIDATION) {
       self::validateEntitlementAndWorkingDayAndBalanceChange($params, $absenceType, $absencePeriod);
     }
-
-
   }
 
   /**
@@ -1363,5 +1364,79 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     }
 
     return self::calculateBalanceChangeFromCreateParams($params);
+  }
+
+  /**
+   * There are some fields that are only required according to the calculation
+   * unit of the Leave Request's Absence Type. This method makes sure that the
+   * non-required fields according to the calculation unit will be reset.
+   *
+   * When the calculation unit is hours, the from_date_type and to_date_type
+   * fields are not required, while the from_date_amount and to_date_amount are.
+   * When the calculation unit is in days, the from_date_amount and to_date_amount
+   * are required and the from_date_type and to_date_type are not.
+   *
+   * @param array $params
+   *
+   * @return mixed
+   * @throws \Exception
+   */
+  private static function resetNonMandatoryDateFieldsIfCalculationUnitChanged($params) {
+    if (self::calculationUnitChanged($params)) {
+      $absenceType = AbsenceType::findById($params['type_id']);
+
+      if ($absenceType->isCalculationUnitInHours()) {
+        $params['from_date_type'] = '';
+        $params['to_date_type']   = '';
+      }
+      else {
+        $params['from_date_amount'] = '';
+        $params['to_date_amount']   = '';
+      }
+    }
+    return $params;
+  }
+
+  /**
+   * Returns whether the Calculation Unit used for this Leave Request is being
+   * changed or not.
+   *
+   * The calculation unit is defined by the Absence Type. If the user changes
+   * the Leave Request's Absence Type to another type with a different
+   * calculation unit, this method will return true.
+   *
+   * @param array $params
+   *
+   * @return bool
+   */
+  private static function calculationUnitChanged($params) {
+    if (empty($params['id'])) {
+      // New Leave Request being created, so it didn't change
+      return false;
+    }
+
+    $currentAbsenceType = self::getCurrentAbsenceType($params['id']);
+
+    if ($currentAbsenceType->id == $params['type_id']) {
+      return false;
+    }
+
+    $newAbsenceType = AbsenceType::findById($params['type_id']);
+
+    return $newAbsenceType->calculation_unit != $currentAbsenceType->calculation_unit;
+  }
+
+  /**
+   * Returns the current Absence Type for the Leave Request with the given ID.
+   *
+   * @param int $leaveRequestID
+   *
+   * @return AbsenceType
+   * @throws \Exception
+   */
+  private static function getCurrentAbsenceType($leaveRequestID) {
+    $currentLeaveRequest = LeaveRequest::findById($leaveRequestID);
+
+    return AbsenceType::findById($currentLeaveRequest->type_id);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -40,12 +40,6 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
   protected $oldLeaveRequest;
 
   /**
-   * @var array|null
-   *   Stores the list of option values for the LeaveRequest status_id field.
-   */
-  private $leaveStatuses;
-
-  /**
    * @var boolean|null
    *   Stores whether the dates has changed for the
    *   current leave request to be updated or not.

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
@@ -22,6 +22,7 @@ class CRM_HRLeaveAndAbsences_Upgrader extends CRM_HRLeaveAndAbsences_Upgrader_Ba
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1014;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1015;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1016;
+  use CRM_HRLeaveAndAbsences_Upgrader_Step_1017;
 
   /**
    * A list of directories to be scanned for XML installation files

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1017.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1017.php
@@ -1,0 +1,71 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+
+trait CRM_HRLeaveAndAbsences_Upgrader_Step_1017 {
+
+  /**
+   * Before PCHR-3094, changing the Absence Type of a Leave Request to
+   * another one with a different calculation unit would result in the
+   * respective record in the database having non-mandatory fields with
+   * wrong values. For example, if it was changed from an Absence Type in
+   * days, to another one in hours, the from_date_type and to_date_type
+   * (which are required only for Leave Requests in days) would still
+   * keep the old values and this would cause validation issues that
+   * prevented the Leave Request from being updated.
+   *
+   * This upgrader searches for any Leave Request in that situation and
+   * sets the optional fields (according to the calculation unit) as NULL.
+   *
+   * @return bool
+   */
+  public function upgrade_1017() {
+    $calculationUnits = array_flip(AbsenceType::buildOptions('calculation_unit', 'validate'));
+
+    $leaveRequestTable = LeaveRequest::getTableName();
+    $absenceTypeTable = AbsenceType::getTableName();
+
+    $query = "
+    SELECT a.calculation_unit, lr.id
+      FROM {$leaveRequestTable} lr
+      INNER JOIN {$absenceTypeTable} a ON lr.type_id = a.id
+    WHERE
+      (a.calculation_unit = %1 AND (lr.from_date_amount IS NOT NULL OR lr.to_date_amount IS NOT NULL ))
+      OR
+      (a.calculation_unit = %2 AND (lr.from_date_type IS NOT NULL OR lr.to_date_type IS NOT NULL ))
+    ";
+
+    $params = [
+      1 => [$calculationUnits['days'], 'Integer'],
+      2 => [$calculationUnits['hours'], 'Integer'],
+    ];
+
+    $recordToUpdate = CRM_Core_DAO::executeQuery($query, $params);
+
+    while ($recordToUpdate->fetch()) {
+      $leaveRequest = new LeaveRequest();
+      $leaveRequest->id = $recordToUpdate->id;
+
+      switch ($recordToUpdate->calculation_unit) {
+
+        case $calculationUnits['days']:
+          $leaveRequest->from_date_amount = 'null';
+          $leaveRequest->to_date_amount = 'null';
+          break;
+
+        case $calculationUnits['hours']:
+          $leaveRequest->from_date_type = 'null';
+          $leaveRequest->to_date_type = 'null';
+          break;
+      }
+
+      // Since this is just fixing a data issue rather than a normal update,
+      // we don't need the hooks to be triggered
+      $callHooks = FALSE;
+      $leaveRequest->save($callHooks);
+    }
+
+    return TRUE;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -4384,7 +4384,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'from_date_type' => $dayTypes['all_day'],
       'to_date_type' => $dayTypes['all_day']
     ];
-
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($leaveRequestParams);
 
     // Change absence type to one in hours
@@ -4395,8 +4394,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'to_date_amount' => 7.5,
       'from_date_amount' => 0,
     ]);
-
-    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($leaveRequestParams);
+    $leaveRequest = LeaveRequest::create($leaveRequestParams, LeaveRequest::VALIDATIONS_OFF);
 
     // Here, fields required for absence types in days were set to null,
     // whereas the ones required for absence types in hours were not touched.
@@ -4412,8 +4410,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $leaveRequestParams = array_merge($leaveRequestParams, [
       'type_id' => $absenceTypeInDays->id,
     ]);
-
-    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($leaveRequestParams);
+    $leaveRequest = LeaveRequest::create($leaveRequestParams, LeaveRequest::VALIDATIONS_OFF);
 
     // Here, fields required for absence types in hours were set to null,
     // whereas the ones required for absence types in days were not touched.

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -103,7 +103,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromDate = new DateTime();
     $date = $fromDate->format('YmdHis');
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
       'from_date' => $date,
@@ -3305,8 +3305,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   public function testLeaveDatesAreNotDeletedAndRecreatedWhenUpdatingALeaveRequestAndLeaveDatesDidNotChange() {
     $fromDate = CRM_Utils_Date::processDate('2016-01-08');
     $toDate = CRM_Utils_Date::processDate('2016-01-10');
+
     $params = [
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
       'from_date' => $fromDate,
@@ -4360,5 +4361,65 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     );
 
     $this->assertEquals($expectedResultsBreakdown, $result);
+  }
+
+  public function testNonMandatoryFieldsAreResetWhenAbsenceTypeChangedToOneWithADifferentCalculationUnit() {
+    $calculationUnits = array_flip(AbsenceType::buildOptions('calculation_unit', 'validate'));
+    $dayTypes = array_flip(LeaveRequest::buildOptions('from_date_type', 'validate'));
+
+    $absenceTypeInDays = AbsenceTypeFabricator::fabricate([
+      'calculation_unit' => $calculationUnits['days']
+    ]);
+
+    $absenceTypeInHours = AbsenceTypeFabricator::fabricate([
+      'calculation_unit' => $calculationUnits['hours']
+    ]);
+
+    $leaveRequestParams = [
+      'contact_id' => 1,
+      'type_id' => $absenceTypeInDays->id,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      //The types are required when absence type is in days
+      'from_date_type' => $dayTypes['all_day'],
+      'to_date_type' => $dayTypes['all_day']
+    ];
+
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($leaveRequestParams);
+
+    // Change absence type to one in hours
+    $leaveRequestParams = array_merge($leaveRequestParams, [
+      'id' => $leaveRequest->id,
+      'type_id' => $absenceTypeInHours->id,
+      // These two are required for Leave in Hours
+      'to_date_amount' => 7.5,
+      'from_date_amount' => 0,
+    ]);
+
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($leaveRequestParams);
+
+    // Here, fields required for absence types in days were set to null,
+    // whereas the ones required for absence types in hours were not touched.
+    // Because of how the DB_DataObject null and empty strings,
+    // civi will set those fields to the string 'null' rather than
+    // a normal empty string
+    $this->assertEquals('null', $leaveRequest->from_date_type);
+    $this->assertEquals('null', $leaveRequest->to_date_type);
+    $this->assertEquals($leaveRequestParams['from_date_amount'], $leaveRequest->from_date_amount);
+    $this->assertEquals($leaveRequestParams['to_date_amount'], $leaveRequest->to_date_amount);
+
+    // Change absence type to one in days again
+    $leaveRequestParams = array_merge($leaveRequestParams, [
+      'type_id' => $absenceTypeInDays->id,
+    ]);
+
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($leaveRequestParams);
+
+    // Here, fields required for absence types in hours were set to null,
+    // whereas the ones required for absence types in days were not touched.
+    $this->assertEquals('null', $leaveRequest->from_date_amount);
+    $this->assertEquals('null', $leaveRequest->to_date_amount);
+    $this->assertEquals($leaveRequestParams['from_date_type'], $leaveRequest->from_date_type);
+    $this->assertEquals($leaveRequestParams['to_date_type'], $leaveRequest->to_date_type);
   }
 }


### PR DESCRIPTION
## Overview

After changing the Leave Request's Absence Type to a type with a different calculation unit, users were not able to update the request status. Staff members would get an error saying that one of the date type or date amount fields had to be empty and Managers would get an error saying that they could not change the request dates (even though they were not changing any date).

## Before

As a staff member, trying to update the status of a Leave Request that had its Absence Type changed to another one with a different calculation unit would result in a validation error:

![before_staff](https://user-images.githubusercontent.com/388373/35097846-14aea94c-fc39-11e7-824e-ad9c7f41b195.gif)


As a manager, trying to update the status of the same Leave Request would result in a validation error saying that the dates could not be changed:

![manager_before](https://user-images.githubusercontent.com/388373/35097852-1cd9f6ee-fc39-11e7-9058-0d00d9e638b0.gif)


## After

Staff members can now update the Leave Request status after it had its Absence Type changed to another type with a different calculation unit:

![staff_after](https://user-images.githubusercontent.com/388373/35098128-1e319e7e-fc3a-11e7-9f67-22725afc57f4.gif)

Managers can update the status of the that Leave Request:

![manager_after](https://user-images.githubusercontent.com/388373/35098131-2155e664-fc3a-11e7-9ca9-58eefd71970d.gif)

## Technical Details

There are a few fields in the Leave Request table that are required to be empty according to the calculation unit of the request's Absence Type. For calculation unit in days, the `from_date_amount` and `to_date_amount` should be empty. For calculation unit in hours, the `from_date_type` and `to_date_type` are the ones that should be empty. 

When switching the Absence Type of a Leave Request to another one with a different calculation unit, the fields required to be empty in the database were not reset and this was causing the errors mentioned above. Example:

- First create a Leave Request for an Absence Type in days. 
  - The FE will not send values for the `from_date_amount` and `to_date_amount` fields (because they're not required for requests in days)
  - In the database, the `from_date_type` and `to_date_type` will not be empty, while the `from_date_amount` and `to_date_amount` will.
- Edit the Leave Request and change the Absence Type to one in hours
  - The FE will not send values for the `from_date_type` and `to_date_type` fields (because they are not required for requests in hours)
  - In the database, the `from_date_type` and `to_date_type` will not be touched (because no value was sent) and old value will be kept. Values will be set for `from_date_amount` and `to_date_amount`
- Now, when we update (to change its status, for example) the Leave Request, all the fields will not be empty and since the calculation unit is now in hours, the validation will give an error saying that the `from_date_type` field should be empty.

The fix here was to, right before saving the updates for a Leave Request, to check if the calculation unit has changed and, in that case reset the values of the fields that should be empty.

This, however, would not work for Leave Requests that were created before this fix and already had the problem. For this reason, an upgrader was added to fix them