### PR TITLE
PCHR-3088: Fix bug in Drupal User Account isUserDisabled method

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserAccount/Drupal.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserAccount/Drupal.php
@@ -69,6 +69,6 @@ class CRM_HRCore_CMSData_UserAccount_Drupal implements UserAccountInterface {
   public function isUserDisabled($contactData) {
     $user = $this->getUser($contactData);
 
-    return $user->status;
+    return !$user->status ? true : false;
   }
 }

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserAccount/DrupalTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserAccount/DrupalTest.php
@@ -34,4 +34,20 @@ class CRM_HRCore_CMSData_UserAccount_DrupalTest extends CRM_HRCore_Test_BaseHead
 
     $this->assertEquals(1, $user->status);
   }
+
+  public function testIsUserDisabledReturnsFalseWhenUserStatusIsActive() {
+    $contactData = ['cmsId' => 1];
+    $userAccount = new DrupalUserAccount();
+
+    $this->assertFalse($userAccount->isUserDisabled($contactData));
+  }
+
+  public function testIsUserDisabledReturnsTrueWhenUserStatusIsNotActive() {
+    //passing 0 to the user_load mock function would create a user object
+    //with status inactive
+    $contactData = ['cmsId' => 0];
+    $userAccount = new DrupalUserAccount();
+
+    $this->assertTrue($userAccount->isUserDisabled($contactData));
+  }
 }

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/drupal_function_mocks.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/drupal_function_mocks.php
@@ -35,6 +35,12 @@ function user_load($userID) {
   $user = new stdClass();
   $user->roles = [1 => 'Fake Role'];
   $user->uid = $userID;
+  $user->status = 1;
+
+  if($userID == 0) {
+    $user->status = 0;
+  }
+
   return $user;
 }
 


### PR DESCRIPTION
## Overview
This PR fixes a bug in the isUserDisabled method added in #2408

## Before
The isUserDisabled method of the CRM_HRCore_CMSData_UserAccount_Drupal class was not returning correctly.

## After
The isUserDisabled method of the CRM_HRCore_CMSData_UserAccount_Drupal class was fixed to returning correctly.