### PR TITLE
PCHR-2984: Add SSP Calendar's tooltip BackstopJS scenarios

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/ssp-leave-absences/staff/my-leave-calendar_tooltip.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/ssp-leave-absences/staff/my-leave-calendar_tooltip.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var page = require('../../../page-objects/ssp-leave-absences-my-leave-calendar');
+
+module.exports = function (casper) {
+  page.init(casper)
+    .clearAllSelectedMonths()
+    .showMonth('February')
+    .showYear(2016)
+    .showTooltip();
+};

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/ssp-leave-absences/staff/my-leave-calendar_tooltip.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/casper_scripts/ssp-leave-absences/staff/my-leave-calendar_tooltip.js
@@ -4,7 +4,7 @@ var page = require('../../../page-objects/ssp-leave-absences-my-leave-calendar')
 
 module.exports = function (casper) {
   page.init(casper)
-    .clearAllSelectedMonths()
+    .clearCurrentlySelectedMonth()
     .showMonth('February')
     .showYear(2016)
     .showTooltip();

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-calendar.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-calendar.js
@@ -1,9 +1,36 @@
+/* globals jQuery */
+
 var page = require('./page');
 
 module.exports = (function () {
   return page.extend({
     /**
-     * Wait for the page to be ready by looking at 
+     * Clears all selected months from the calendar "Selected Months" field.
+     */
+    clearAllSelectedMonths: function () {
+      this.casper.evaluate(function () {
+        jQuery('.chr_leave-calendar__day-selector .close.ui-select-match-close')
+          .each(function () {
+            jQuery(this).click();
+          });
+      });
+
+      return this;
+    },
+
+    /**
+     * Display all months for the leave calendar by clearing the
+     * "Selected Months" field.
+     */
+    showAllMonths: function () {
+      this.clearAllSelectedMonths();
+      this.waitUntilVisible('leave-calendar-month:nth-child(12) leave-calendar-day');
+
+      return this;
+    },
+
+    /**
+     * Wait for the page to be ready by looking at
      * the visibility of a leave calendar item element
      */
     waitForReady: function () {

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-calendar.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-calendar.js
@@ -52,6 +52,21 @@ module.exports = (function () {
     },
 
     /**
+     * Hovers on top of a leave day visible on the calendar until a tooltip
+     * pops up.
+     *
+     * @returns {Object} - returns a reference to itself.
+     */
+    showTooltip: function () {
+      this.casper.then(function () {
+        this.mouse.move('.chr_leave-calendar__item a');
+      });
+      this.waitUntilVisible('.tooltip');
+
+      return this;
+    },
+
+    /**
      * Displays the leave information for a particular year in the leave calendar.
      *
      * @param {Number} year - the year to select from the absence period options.

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-calendar.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-calendar.js
@@ -6,6 +6,8 @@ module.exports = (function () {
   return page.extend({
     /**
      * Clears all selected months from the calendar "Selected Months" field.
+     *
+     * @returns {Object} - returns a reference to itself.
      */
     clearAllSelectedMonths: function () {
       this.casper.evaluate(function () {
@@ -21,10 +23,30 @@ module.exports = (function () {
     /**
      * Display all months for the leave calendar by clearing the
      * "Selected Months" field.
+     *
+     * @returns {Object} - returns a reference to itself.
      */
     showAllMonths: function () {
       this.clearAllSelectedMonths();
       this.waitUntilVisible('leave-calendar-month:nth-child(12) leave-calendar-day');
+
+      return this;
+    },
+
+    /**
+     * Displays the leave information for a particular month in the leave
+     * calendar.
+     *
+     * @param {String} monthName - the month of the name as it appear in the
+     * "Selected Months" options.
+     * @returns {Object} - returns a reference to itself.
+     */
+    showMonth: function (monthName) {
+      this.casper.click('.chr_leave-calendar__day-selector input');
+      this.casper.evaluate(function (monthName) {
+        jQuery('.ui-select-choices-row:contains(' + monthName + ')').click();
+      }, monthName);
+      this.waitUntilVisible('leave-calendar-month leave-calendar-day');
 
       return this;
     },

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-calendar.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-calendar.js
@@ -5,21 +5,16 @@ var page = require('./page');
 module.exports = (function () {
   return page.extend({
     /**
-     * Clears all selected months from the calendar "Selected Months" field.
+     * Clears the currently selected month from the calendar "Selected Months"
+     * field.
      *
      * @returns {Object} - returns a reference to itself.
      */
-    clearAllSelectedMonths: function () {
-      this.casper.evaluate(function () {
-        jQuery('.chr_leave-calendar__day-selector .close.ui-select-match-close')
-          .each(function () {
-            jQuery(this).click();
-          });
-      });
+    clearCurrentlySelectedMonth: function () {
+      this.casper.click('.chr_leave-calendar__day-selector .close.ui-select-match-close');
 
       return this;
     },
-
 
     /**
      * Displays the leave information for a particular month in the leave

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-calendar.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-calendar.js
@@ -8,7 +8,7 @@ module.exports = (function () {
      * Clears the currently selected month from the calendar "Selected Months"
      * field.
      *
-     * @returns {Object} - returns a reference to itself.
+     * @returns {Object} - returns a reference to the page object.
      */
     clearCurrentlySelectedMonth: function () {
       this.casper.click('.chr_leave-calendar__day-selector .close.ui-select-match-close');
@@ -22,7 +22,7 @@ module.exports = (function () {
      *
      * @param {String} monthName - the month of the name as it appear in the
      * "Selected Months" options.
-     * @returns {Object} - returns a reference to itself.
+     * @returns {Object} - returns a reference to the page object.
      */
     showMonth: function (monthName) {
       this.casper.click('.chr_leave-calendar__day-selector input');
@@ -38,7 +38,7 @@ module.exports = (function () {
      * Hovers on top of a leave day visible on the calendar until a tooltip
      * pops up.
      *
-     * @returns {Object} - returns a reference to itself.
+     * @returns {Object} - returns a reference to the page object.
      */
     showTooltip: function () {
       this.casper.then(function () {
@@ -53,7 +53,7 @@ module.exports = (function () {
      * Displays the leave information for a particular year in the leave calendar.
      *
      * @param {Number} year - the year to select from the absence period options.
-     * @returns {Object} - returns a reference to itself.
+     * @returns {Object} - returns a reference to the page object.
      */
     showYear: function (year) {
       this.casper.evaluate(function (year) {

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-calendar.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-calendar.js
@@ -20,18 +20,6 @@ module.exports = (function () {
       return this;
     },
 
-    /**
-     * Display all months for the leave calendar by clearing the
-     * "Selected Months" field.
-     *
-     * @returns {Object} - returns a reference to itself.
-     */
-    showAllMonths: function () {
-      this.clearAllSelectedMonths();
-      this.waitUntilVisible('leave-calendar-month:nth-child(12) leave-calendar-day');
-
-      return this;
-    },
 
     /**
      * Displays the leave information for a particular month in the leave

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-calendar.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-calendar.js
@@ -52,6 +52,24 @@ module.exports = (function () {
     },
 
     /**
+     * Displays the leave information for a particular year in the leave calendar.
+     *
+     * @param {Number} year - the year to select from the absence period options.
+     * @returns {Object} - returns a reference to itself.
+     */
+    showYear: function (year) {
+      this.casper.evaluate(function (year) {
+        var select = jQuery('.chr_manager_calendar__sub-header select');
+        var yearValue = select.find('option:contains(' + year + ')').attr('value');
+
+        select.val(yearValue).change();
+      }, year);
+      this.waitUntilVisible('leave-calendar-month leave-calendar-day');
+
+      return this;
+    },
+
+    /**
      * Wait for the page to be ready by looking at
      * the visibility of a leave calendar item element
      */

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-my-leave-calendar.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/ssp-la-my-leave-calendar.json
@@ -5,6 +5,12 @@
       "url": "my-leave#/my-leave/calendar",
       "onReadyScript": "ssp-leave-absences/staff/my-leave-calendar_current-month-visible",
       "credential": "staff"
+    },
+    {
+      "label": "My Leave Calendar tooltip",
+      "url": "my-leave#/my-leave/calendar",
+      "onReadyScript": "ssp-leave-absences/staff/my-leave-calendar_tooltip",
+      "credential": "staff"
     }
   ]
 }


### PR DESCRIPTION
## Overview
This PR adds Backstop scenarios for the Leave Calendar tooltip.

After Shoreditch was removed from SSP ([in this PR](https://github.com/compucorp/civihr-employee-portal/pull/396)) the tooltip styles provided by Shoreditch were also removed. This could have been avoided if BackstopJS scenarios were implemented for it.

## Technical details

In order to display the tooltip, a new methods were added to the `ssp-leave-absences-my-leave-calendar.js` page object:

### Clear all selected months

Just clears all selected months and doesn't wait for anything:
```js
// Script:
page.init(casper).clearAllSelectedMonths();

// Page Object Method:
clearAllSelectedMonths: function () {
  this.casper.evaluate(function () {
    jQuery('.chr_leave-calendar__day-selector .close.ui-select-match-close')
      .each(function () {
        jQuery(this).click();
      });
  });

  return this;
}
```

### Show months

Displays the leave information for a specific month. Can be chained:

```js
// Script:
page.init(casper)
    .clearAllSelectedMonths()
    .showMonth('February')
    .showMonth('May')
    .showMonth('December');

// Page Object Method:
showMonth: function (monthName) {
  this.casper.click('.chr_leave-calendar__day-selector input');
  this.casper.evaluate(function (monthName) {
    jQuery('.ui-select-choices-row:contains(' + monthName + ')').click();
  }, monthName);
  this.waitUntilVisible('leave-calendar-month leave-calendar-day');

  return this;
}
```
![civihr_my_leave_calendar_tooltip_0_document_0_desktop 3](https://user-images.githubusercontent.com/1642119/35121939-911811fa-fc73-11e7-8d20-8975aa40ca90.png)

### Show Year
Changes the selected year:
```js
// Script:
page.init(casper)
    .showMonth('February')
    .showYear(2016);

// Page Object method:
showYear: function (year) {
  this.casper.evaluate(function (year) {
    var select = jQuery('.chr_manager_calendar__sub-header select');
    var yearValue = select.find('option:contains(' + year + ')').attr('value');

    select.val(yearValue).change();
  }, year);
  this.waitUntilVisible('leave-calendar-month leave-calendar-day');

  return this;
}
```

![civihr_my_leave_calendar_tooltip_0_document_0_desktop 1](https://user-images.githubusercontent.com/1642119/35121713-bb6af39c-fc72-11e7-9f64-b2c7c7f57a66.png)

### Show all months

Displays all months by clearing the selected months and waiting for all calendar months to be displayed:

```js
// Script:
page.init(casper).showAllMonths();

// Page Object method:
showAllMonths: function () {
  this.clearAllSelectedMonths();
  this.waitUntilVisible('leave-calendar-month:nth-child(12) leave-calendar-day');

  return this;
}
```

![civihr_my_leave_calendar_tooltip_0_document_0_desktop](https://user-images.githubusercontent.com/1642119/35121662-8af64f2c-fc72-11e7-96aa-0a38e8886cd7.png)

### Show tooltip

Displays the tooltip for the first leave in the calendar:

```js
// Script:
page.init(casper).showTooltip();

// Page Object Method:
showTooltip: function () {
  this.casper.then(function () {
    this.mouse.move('.chr_leave-calendar__item a');
  });
  this.waitUntilVisible('.tooltip');

  return this;
}
```

![civihr_my_leave_calendar_tooltip_0_document_0_desktop 2](https://user-images.githubusercontent.com/1642119/35121844-3d8bbfe6-fc73-11e7-8d0a-2048d6fcc8c2.png)

### Leave Calendar Tooltip script

Since the sample data adds a few leaves for staff on February 2016 this was selected using the script so we avoid adding new requirements that could be potentially outdated every month or every year:

```js
module.exports = function (casper) {
  page.init(casper)
    .clearAllSelectedMonths()
    .showMonth('February')
    .showYear(2016)
    .showTooltip();
};
```

### Comments

The SSP Theme changes for this Backstop scenario was added in this PR:
https://github.com/compucorp/civihr-employee-portal-theme/pull/299

