### PR TITLE
PCHR-3201: Fix Tests

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/Paths/DrupalTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/Paths/DrupalTest.php
@@ -1,27 +1,19 @@
 <?php
 
-use Civi\Test\HeadlessInterface;
-use Civi\Test\TransactionalInterface;
-
 use CRM_HRCore_CMSData_Paths_Drupal as DrupalPaths;
+use CRM_HRCore_Test_BaseHeadlessTest as BaseHeadlessTest;
 
 /**
  * Class CRM_HRCore_CMSData_Paths_DrupalTest
  *
  * @group headless
  */
-class CRM_HRCore_CMSData_Paths_DrupalTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface, TransactionalInterface {
+class CRM_HRCore_CMSData_Paths_DrupalTest extends BaseHeadlessTest {
 
   /**
-   * @var CRM_HRCore_CMSData_PathsInterface
+   * @var CRM_HRCore_CMSData_Paths_PathsInterface
    */
   protected $drupalPaths;
-
-  public function setUpHeadless() {
-    return \Civi\Test::headless()
-      ->installMe(__DIR__)
-      ->apply();
-  }
 
   public function setUp() {
     $contactData = [ 'cmsId' => '4' ];
@@ -39,13 +31,5 @@ class CRM_HRCore_CMSData_Paths_DrupalTest extends \PHPUnit_Framework_TestCase im
   public function testItReturnsTheDrupalLogoutLink() {
     $this->assertEquals($this->drupalPaths->getLogoutPath(), '/user/logout');
   }
-}
 
-/**
- * Mock of the original drupal function
- *
- * @return string
- */
-function drupal_get_path() {
-  return 'foo/bar';
 }

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/PathsFactoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/PathsFactoryTest.php
@@ -1,22 +1,14 @@
 <?php
 
-use Civi\Test\HeadlessInterface;
-use Civi\Test\TransactionalInterface;
-
 use CRM_HRCore_CMSData_PathsFactory as CMSPathsFactory;
+use CRM_HRCore_Test_BaseHeadlessTest as BaseHeadlessTest;
 
 /**
  * Class CRM_HRCore_CMSData_PathsFactoryTest
  *
  * @group headless
  */
-class CRM_HRCore_CMSData_PathsFactoryTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface, TransactionalInterface {
-
-  public function setUpHeadless() {
-    return \Civi\Test::headless()
-      ->installMe(__DIR__)
-      ->apply();
-  }
+class CRM_HRCore_CMSData_PathsFactoryTest extends BaseHeadlessTest {
 
   public function testItReturnsAClassWithImplementingTheExpectedInterface() {
     $contactData = [];
@@ -31,6 +23,7 @@ class CRM_HRCore_CMSData_PathsFactoryTest extends \PHPUnit_Framework_TestCase im
     $this->setExpectedException('Exception', "CMS \"{$cmsName}\" not recognized");
 
     $contactData = [];
-    $pathsClass = CMSPathsFactory::create($cmsName, $contactData);
+    CMSPathsFactory::create($cmsName, $contactData);
   }
+
 }

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsGathererTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsGathererTest.php
@@ -92,8 +92,8 @@ class StatsGathererTest extends CRM_HRCore_Test_BaseHeadlessTest {
     TaskFabricator::fabricate($params);
 
     // expect 1 Assignment
-    CaseTypeFabricator::fabricate();
-    AssignmentFabricator::fabricate();
+    $caseType = CaseTypeFabricator::fabricate();
+    AssignmentFabricator::fabricate(['case_type_id' => $caseType['id']]);
 
     // expect 2 Documents
     $params['activity_type_id'] = $documentType['value'];
@@ -221,7 +221,9 @@ class StatsGathererTest extends CRM_HRCore_Test_BaseHeadlessTest {
     $task = TaskFabricator::fabricate($params);
     civicrm_api3('Task', 'delete', ['id' => $task['id']]);
 
-    $assignment = AssignmentFabricator::fabricate();
+    $caseType = CaseTypeFabricator::fabricate();
+    $assignmentParams = ['case_type_id' => $caseType['id']];
+    $assignment = AssignmentFabricator::fabricate($assignmentParams);
     civicrm_api3('Assignment', 'delete', ['id' => $assignment->id]);
 
     $document = DocumentFabricator::fabricate($params);

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/drupal_function_mocks.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/drupal_function_mocks.php
@@ -65,3 +65,7 @@ function _get_uf_match_contact() {}
 function user_access() {
   return TRUE;
 }
+
+function drupal_get_path() {
+  return 'foo/bar';
+}


### PR DESCRIPTION
## Overview

After the T&A extension changed how its [fabricators worked](https://github.com/compucorp/civihr-tasks-assignments/pull/297/files#diff-64f828f0a371ef227c3feb21c1c04973R29) some of the tests in CiviHR will break because they lack arguments previously provided by defaults.

## Before

Some tests fail because of missing arguments to T&A fabricators

## After

All tests pass