### PR TITLE
PCHR-3083: Make Line Manger and Leave Approver Relationship Types reserved

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -14,6 +14,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1004;
   use CRM_HRCore_Upgrader_Steps_1005;
   use CRM_HRCore_Upgrader_Steps_1006;
+  use CRM_HRCore_Upgrader_Steps_1007;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1007.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1007.php
@@ -1,0 +1,21 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1007 {
+
+  /**
+   * Make the Line Manager/Line Manager is Relationship
+   * to be reserved.
+   *
+   * @return bool
+   */
+  public function upgrade_1007() {
+    civicrm_api3('RelationshipType', 'get', [
+      'sequential' => 1,
+      'name_a_b' => 'Line Manager is',
+      'name_b_a' => 'Line Manager',
+      'api.RelationshipType.create' => ['id' => '$value.id', 'is_reserved' => 1],
+    ]);
+
+    return TRUE;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1007.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1007.php
@@ -3,8 +3,7 @@
 trait CRM_HRCore_Upgrader_Steps_1007 {
 
   /**
-   * Make the Line Manager/Line Manager is Relationship
-   * to be reserved.
+   * Make the 'Line Manager/Line Manager is' Relationship to be reserved.
    *
    * @return bool
    */

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
@@ -23,6 +23,7 @@ class CRM_HRLeaveAndAbsences_Upgrader extends CRM_HRLeaveAndAbsences_Upgrader_Ba
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1015;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1016;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1017;
+  use CRM_HRLeaveAndAbsences_Upgrader_Step_1018;
 
   /**
    * A list of directories to be scanned for XML installation files

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1018.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1018.php
@@ -3,8 +3,8 @@
 trait CRM_HRLeaveAndAbsences_Upgrader_Step_1018 {
 
   /**
-   * Make the is Leave Approver of/has Leave Approved by Relationship
-   * to be reserved.
+   * Make the 'is Leave Approver of/has Leave Approved by'
+   * Relationship to be reserved.
    *
    * @return bool
    */
@@ -15,7 +15,7 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1018 {
       'name_b_a' => 'is Leave Approver of',
       'api.RelationshipType.create' => ['id' => '$value.id', 'is_reserved' => 1],
     ]);
-    
+
     return TRUE;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1018.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1018.php
@@ -1,0 +1,21 @@
+<?php
+
+trait CRM_HRLeaveAndAbsences_Upgrader_Step_1018 {
+
+  /**
+   * Make the is Leave Approver of/has Leave Approved by Relationship
+   * to be reserved.
+   *
+   * @return bool
+   */
+  public function upgrade_1018() {
+    civicrm_api3('RelationshipType', 'get', [
+      'sequential' => 1,
+      'name_a_b' => 'has Leave Approved by',
+      'name_b_a' => 'is Leave Approver of',
+      'api.RelationshipType.create' => ['id' => '$value.id', 'is_reserved' => 1],
+    ]);
+    
+    return TRUE;
+  }
+}


### PR DESCRIPTION
## Overview
This PR makes the `Line Manager/Line Manager is` Relationship and the `Leave Approver of/has Leave Approved by` Relationship types reserved.

## Before
The `Line Manager/Line Manager is` Relationship and the `Leave Approver of/has Leave Approved by` Relationship types are not reserved and can be disabled or deleted.

## After
The `Line Manager/Line Manager is` Relationship and the `Leave Approver of/has Leave Approved by` Relationship types are now reserved and can not be disabled or deleted.

## Technical Details
- Since the HR core extension is responsible for creating the `Line Manager/Line Manager is `Relationship type, An upgrader was added in this extension to make the relationship type reserved.
-  Since the Leave and Absence extension is responsible for creating the ` Leave Approver of/has Leave Approved by` Relationship type, An upgrader was added in this extension to make the relationship type reserved.
