### PR TITLE
PCHR-3080: Enable the CiviCRM Activities Contact tab for new and existing installation

### DIFF
--- a/hrui/CRM/HRUI/Upgrader.php
+++ b/hrui/CRM/HRUI/Upgrader.php
@@ -38,6 +38,7 @@ class CRM_HRUI_Upgrader extends CRM_HRUI_Upgrader_Base {
   use CRM_HRUI_Upgrader_Steps_4705;
   use CRM_HRUI_Upgrader_Steps_4706;
   use CRM_HRUI_Upgrader_Steps_4707;
+  use CRM_HRUI_Upgrader_Steps_4708;
 
   public function install() {
     $this->runAllUpgraders();

--- a/hrui/CRM/HRUI/Upgrader/Steps/4708.php
+++ b/hrui/CRM/HRUI/Upgrader/Steps/4708.php
@@ -1,0 +1,31 @@
+<?php
+
+trait CRM_HRUI_Upgrader_Steps_4708 {
+
+  /**
+   * Enable the Activities tab on the contact summary page. The contact
+   * tabs are stored in the contact_view_options option group and the
+   * enabled tabs are stored in the civicrm settings table.
+   *
+   * @return bool
+   */
+  public function upgrade_4708() {
+    $result = civicrm_api3('Setting', 'get', [
+      'sequential'=> 1,
+      'return' => 'contact_view_options'
+    ]);
+    $enabledTabs = $result['values'][0]['contact_view_options'];
+
+    $options = CRM_Core_OptionGroup::values('contact_view_options', TRUE);
+    $activityTabValue = $options['Activities'];
+
+    if(in_array($activityTabValue, $enabledTabs)) {
+      return TRUE;
+    }
+
+    $enabledTabs[] = $activityTabValue;
+    civicrm_api3('Setting', 'create', ['contact_view_options' => $enabledTabs]);
+
+    return TRUE;
+  }
+}

--- a/hrui/hrui.php
+++ b/hrui/hrui.php
@@ -287,7 +287,7 @@ function hrui_civicrm_install() {
 
   // get a list of all tab options
   $options = CRM_Core_OptionGroup::values('contact_view_options', TRUE, FALSE);
-  $tabsToUnset = array($options['Activities'], $options['Tags']);
+  $tabsToUnset = array($options['Tags']);
 
   // get tab options from DB
   $options = hrui_getViewOptionsSetting();


### PR DESCRIPTION
## Overview
This PR enables the Activities Contact tab on the contact summary page for new and existing installations. The tab was previously disabled/hidden via the installation of the HRUI extension.

## Before
The Activities Contact tab is not visible on the contact summary page

![civihr_staff compucorp co uk _ staging17 2018-01-25 17-23-31](https://user-images.githubusercontent.com/6951813/35399448-89807758-01f4-11e8-8289-b2c700c14a4f.png)

## After
The Activites Contact tab is now visible on the contact summary page

![civihr_staff compucorp co uk _ staging17 2018-01-25 17-21-38](https://user-images.githubusercontent.com/6951813/35399324-49b29822-01f4-11e8-857d-be8664647bd6.png)
