### PR TITLE
PCHR-3222 change absence tab name and icon

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/tab-absence.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/tab-absence.json
@@ -2,43 +2,43 @@
   "scenarios": [
     {
       "label": "Absence / Report",
-      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=absence",
+      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=leave",
       "onReadyScript": "contact-summary/absence/tab-report",
       "credential": "admin"
     },
     {
       "label": "Absence / Report / Open Section",
-      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=absence",
+      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=leave",
       "onReadyScript": "contact-summary/absence/tab-report-open-section",
       "credential": "admin"
     },
     {
       "label": "Absence / Report / Actions",
-      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=absence",
+      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=leave",
       "onReadyScript": "contact-summary/absence/tab-report-actions",
       "credential": "admin"
     },
     {
       "label": "Absence / Calendar / Current Month",
-      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=absence",
+      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=leave",
       "onReadyScript": "contact-summary/absence/tab-calendar",
       "credential": "admin"
     },
     {
       "label": "Absence / Entitlements",
-      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=absence",
+      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=leave",
       "onReadyScript": "contact-summary/absence/tab-entitlements",
       "credential": "admin"
     },
     {
       "label": "Absence / Work Patterns",
-      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=absence",
+      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=leave",
       "onReadyScript": "contact-summary/absence/tab-work-patterns",
       "credential": "admin"
     },
     {
       "label": "Absence / Work Patterns / Custom Work Patterns Modal",
-      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=absence",
+      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=leave",
       "onReadyScript": "contact-summary/absence/tab-work-patterns-modal",
       "credential": "admin"
     }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/tab-absence.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/scenarios/tab-absence.json
@@ -2,43 +2,43 @@
   "scenarios": [
     {
       "label": "Absence / Report",
-      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=leave",
+      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=absence",
       "onReadyScript": "contact-summary/absence/tab-report",
       "credential": "admin"
     },
     {
       "label": "Absence / Report / Open Section",
-      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=leave",
+      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=absence",
       "onReadyScript": "contact-summary/absence/tab-report-open-section",
       "credential": "admin"
     },
     {
       "label": "Absence / Report / Actions",
-      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=leave",
+      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=absence",
       "onReadyScript": "contact-summary/absence/tab-report-actions",
       "credential": "admin"
     },
     {
       "label": "Absence / Calendar / Current Month",
-      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=leave",
+      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=absence",
       "onReadyScript": "contact-summary/absence/tab-calendar",
       "credential": "admin"
     },
     {
       "label": "Absence / Entitlements",
-      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=leave",
+      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=absence",
       "onReadyScript": "contact-summary/absence/tab-entitlements",
       "credential": "admin"
     },
     {
       "label": "Absence / Work Patterns",
-      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=leave",
+      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=absence",
       "onReadyScript": "contact-summary/absence/tab-work-patterns",
       "credential": "admin"
     },
     {
       "label": "Absence / Work Patterns / Custom Work Patterns Modal",
-      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=leave",
+      "url": "civicrm/contact/view?reset=1&cid={{contactId:staff}}&selectedChild=absence",
       "onReadyScript": "contact-summary/absence/tab-work-patterns-modal",
       "credential": "admin"
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -369,7 +369,7 @@ function hrleaveandabsences_civicrm_tabset($tabsetName, &$tabs, $context) {
   if ($tabsetName == 'civicrm/contact/view') {
     $contactId = $context['contact_id'];
     $tabs[] = [
-      'id'        => 'leave',
+      'id'        => 'absence',
       'url'       => CRM_Utils_System::url('civicrm/contact/view/absence', ['cid' => $contactId]),
       'title'     => ts('Leave'),
       'weight'    => 10

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -369,9 +369,9 @@ function hrleaveandabsences_civicrm_tabset($tabsetName, &$tabs, $context) {
   if ($tabsetName == 'civicrm/contact/view') {
     $contactId = $context['contact_id'];
     $tabs[] = [
-      'id'        => 'absence',
+      'id'        => 'leave',
       'url'       => CRM_Utils_System::url('civicrm/contact/view/absence', ['cid' => $contactId]),
-      'title'     => ts('Absence'),
+      'title'     => ts('Leave'),
       'weight'    => 10
     ];
   }


### PR DESCRIPTION
## Overview
This PR renames the Absence tab in the Contact's view to "Leave".

## Before
![civihr_manager compucorp co uk hr17 9000 1](https://user-images.githubusercontent.com/1642119/35451195-d47e6de2-0298-11e8-8fbc-3d33038174b1.png)

## After
![civihr_manager compucorp co uk hr17 9000](https://user-images.githubusercontent.com/1642119/35451079-67f85994-0298-11e8-95f6-d14061cb3e3c.png)


## Technical Details

The hrleaveandabsences_civicrm_tabset function in hrleaveandabsences.php was modified in order to rename the absence title:

```php
function hrleaveandabsences_civicrm_tabset($tabsetName, &$tabs, $context) {
  //check if the tabset is Contact Summary Page
  if ($tabsetName == 'civicrm/contact/view') {
    $contactId = $context['contact_id'];
    $tabs[] = [
      'id'        => 'absence',
      'url'       => CRM_Utils_System::url('civicrm/contact/view/absence', ['cid' => $contactId]),
      'title'     => ts('Leave'),
      'weight'    => 10
    ];
  }
}
```

BackstopJS scenarios for absence-tab ran successfully, with the only issue being that the change was not detected in Backstopjs 2.x but it did in 3.x

### Comments

This PR is related to https://github.com/compucorp/org.civicrm.shoreditch/pull/82 since that other one changes the icon.