### PR TITLE
PCHR-3231: Fix tests failing on the last days of January

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php
@@ -165,15 +165,15 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseH
    */
   public function testItUpdateAllWhenTheContractDetailsAreCreated() {
     $period = AbsencePeriodFabricator::fabricate([
-      'start_date' => CRM_Utils_Date::processDate('last monday'),
-      'end_date'   => CRM_Utils_Date::processDate('+8 months'),
+      'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2017-08-31'),
     ]);
 
     WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
     //All the days selected for the public holidays are working days for the 40hr work week
-    $datePublicHoliday1 = new DateTime('last monday');
-    $datePublicHoliday2 = new DateTime('tuesday +3 months');
-    $datePublicHoliday3 = new DateTime('friday +7 months');
+    $datePublicHoliday1 = new DateTime('2017-06-12');
+    $datePublicHoliday2 = new DateTime('2017-07-25');
+    $datePublicHoliday3 = new DateTime('2017-08-18');
 
     PublicHolidayFabricator::fabricateWithoutValidation(['date' => $datePublicHoliday1->format('YmdHis')]);
     PublicHolidayFabricator::fabricateWithoutValidation(['date' => $datePublicHoliday2->format('YmdHis')]);
@@ -201,7 +201,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseH
       'contact_id' => $contact['id']
     ],
     [
-      'period_start_date' =>  CRM_Utils_Date::processDate('today'),
+      'period_start_date' =>  CRM_Utils_Date::processDate('2017-07-01'),
     ]);
 
     // Nothing should be created for the first public holiday as its date is
@@ -223,14 +223,14 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseH
    */
   public function testItUpdateAllInTheFutureWhenTheContractDetailsAreUpdated() {
     $period = AbsencePeriodFabricator::fabricate([
-      'start_date' => CRM_Utils_Date::processDate('next monday'),
-      'end_date'   => CRM_Utils_Date::processDate('+2 months'),
+      'start_date' => CRM_Utils_Date::processDate('2025-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2025-03-31'),
     ]);
 
     WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
     //All the days selected for the public holidays are working days for the 40hr work week
-    $datePublicHoliday1 = new DateTime('next monday');
-    $datePublicHoliday2 = new DateTime('tuesday +1 month');
+    $datePublicHoliday1 = new DateTime('2025-01-20');
+    $datePublicHoliday2 = new DateTime('2025-02-27');
 
     PublicHolidayFabricator::fabricateWithoutValidation(['date' => $datePublicHoliday1->format('YmdHis')]);
     PublicHolidayFabricator::fabricateWithoutValidation(['date' => $datePublicHoliday2->format('YmdHis')]);
@@ -251,21 +251,21 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest extends BaseH
 
     $contract = HRJobContractFabricator::fabricate(
       [ 'contact_id' => $contact['id'] ],
-      [ 'period_start_date' => CRM_Utils_Date::processDate('today') ]
+      [ 'period_start_date' => CRM_Utils_Date::processDate('2025-01-10') ]
     );
 
     $this->assertNotNull(LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $datePublicHoliday1));
     $this->assertNotNull(LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $datePublicHoliday2));
 
     // Add a new Public holiday
-    $datePublicHoliday3 = new DateTime('friday +1 month');
+    $datePublicHoliday3 = new DateTime('2025-03-18');
     PublicHolidayFabricator::fabricateWithoutValidation(['date' => $datePublicHoliday3->format('YmdHis')]);
 
     // Update the contract with an end date which will still overlap the
     // new public holiday
     civicrm_api3('HRJobDetails', 'create', [
       'jobcontract_id' => $contract['id'],
-      'period_end_date' => CRM_Utils_Date::processDate('friday +1 month')
+      'period_end_date' => CRM_Utils_Date::processDate('2025-03-28')
     ]);
 
     $this->assertNotNull(LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $datePublicHoliday1));


### PR DESCRIPTION
## Overview

The `CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest::testItUpdateAllInTheFutureWhenTheContractDetailsAreUpdated` test fails when executed near during the last days of January

## Before

The test was failing with this error:

```
There was 1 error:

1) CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestTest::testItUpdateAllInTheFutureWhenTheContractDetailsAreUpdated
PEAR_Exception: DB Error: already exists

/vagrant/hr17/sites/all/modules/civicrm/CRM/Core/Error.php:946
/vagrant/hr17/sites/all/modules/civicrm/packages/PEAR.php:921
/vagrant/hr17/sites/all/modules/civicrm/packages/DB.php:985
/vagrant/hr17/sites/all/modules/civicrm/packages/PEAR.php:575
/vagrant/hr17/sites/all/modules/civicrm/packages/PEAR.php:224
/vagrant/hr17/sites/all/modules/civicrm/packages/DB/common.php:1905
/vagrant/hr17/sites/all/modules/civicrm/packages/DB/common.php:1905
/vagrant/hr17/sites/all/modules/civicrm/packages/DB/mysqli.php:933
/vagrant/hr17/sites/all/modules/civicrm/packages/DB/mysqli.php:403
/vagrant/hr17/sites/all/modules/civicrm/packages/DB/common.php:1216
/vagrant/hr17/sites/all/modules/civicrm/packages/DB/DataObject.php:2446
/vagrant/hr17/sites/all/modules/civicrm/packages/DB/DataObject.php:1068
/vagrant/hr17/sites/all/modules/civicrm/CRM/Core/DAO.php:495
/vagrant/hr17/sites/all/modules/civicrm/tools/extensions/civihr/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/PublicHoliday.php:35
/vagrant/hr17/sites/all/modules/civicrm/tools/extensions/civihr/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestTest.php:262
/home/vagrant/buildkit/bin/phpunit4.phar:545
```

## After

The test runs successfully:

```
$ phpunit4 --testsuite="Unit Tests" --filter="testItUpdateAllInTheFutureWhenTheContractDetailsAreUpdated"
PHPUnit 4.8.21 by Sebastian Bergmann and contributors.

.

Time: 1.74 seconds, Memory: 66.25Mb

OK (1 test, 5 assertions)

```

## Technical Details

The reason for the failure was the usage of relative dates and how PHP interprets the `+ 1 month` string. The test creates 3 public holidays, using these relative dates:

- Public holiday 1: next monday
- Public holiday 2: tuesday +1 month
- Public holiday 3: friday + 1 month

Considering 2018-01-29 as today, this is the same as:

- Public holiday 1: 2018-02-05
- Public holiday 2: 2018-01-30 + 1 month
- Public holiday 3: 2018-02-02 + 1 month

When resolving the dates, both public holidays 2 and 3 will fall on the same day, which will finally result the "already exists" message on the test error. As described [here](http://blog.osmosys.asia/2015/04/24/using-1-month-with-strtotime-function-in-php/), this is how PHP handles the `+1 month` parameter:

- First, increases the month on the given date:
 - 2018-01-30 becomes 2018-02-30
 - 2018-02-02 becomes 2018-03-02
- For Public Holiday 2, since 2018-02-30 is not a valid date, PHP needs to adjust it, and the date becomes 2018-03-02 (see the link above for more details, but basically, it starts counting one month from Feb 1st). 
- For the Public Holiday 3, however, the date after the month increase is valid, so no adjustment will be necessary.

The fix was to replace the relative dates with specific ones, since relatives dates were not really necessary in this case. Note that I've also updated the `testUpdateAllForContract()` test. It was not failing, but it was also using relative dates and there was a risk of it failing in some unexpected condition in the future