### PR TITLE
PCHR-3081: Modify the CiviCRM activity tab to only show activities of certain types only

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/ActivityFilterSelectFieldsModifier.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/ActivityFilterSelectFieldsModifier.php
@@ -1,0 +1,72 @@
+<?php
+
+class CRM_HRCore_Hook_BuildForm_ActivityFilterSelectFieldsModifier {
+
+  /**
+   * Determines what happens if the hook is handled.
+   * Basically, it modifies the include and exclude
+   * activity type fields.
+   *
+   * @param string $formName
+   * @param object $form
+   */
+  public function handle($formName, &$form) {
+    if (!$this->shouldHandle($formName)) {
+      return;
+    }
+
+    $this->modifyExcludeAndIncludeActivityTypeFields($form);
+  }
+
+  /**
+   * Checks if the hook should be handled.
+   *
+   * @param string $formName
+   *
+   * @return bool
+   */
+  private function shouldHandle($formName) {
+    if($formName == 'CRM_Activity_Form_ActivityFilter') {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+  
+  /**
+   * Overrides the include and exclude select activity Form fields on the
+   * activities tab of the contact summary page to display only activities of
+   * type Email, Inbound Email, Reminder Sent, Print PDf Letter.
+   *
+   * @param object $form
+   */
+  private function modifyExcludeAndIncludeActivityTypeFields($form) {
+    $allowedActivityTypes = $this->getAllowedActivityTypes();
+
+    $activityTypes = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'activity_type',
+      'name' => ['IN' => $allowedActivityTypes],
+    ]);
+
+    $formActivityTypes = [];
+    foreach ($activityTypes['values'] as $activityType) {
+      $formActivityTypes[$activityType['value']] = $activityType['label'];
+    }
+
+    $form->add('select', 'activity_type_filter_id', ts('Include'), $formActivityTypes);
+    $form->add('select',
+      'activity_type_exclude_filter_id',
+      ts('Exclude'),
+      ['' => ts('- select activity type -')] + $formActivityTypes
+    );
+  }
+
+  /**
+   * Returns the allowed activity types.
+   *
+   * @return array
+   */
+  private function getAllowedActivityTypes() {
+    return ['Email',  'Inbound Email', 'Reminder Sent', 'Print PDF Letter'];
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/ActivityLinksFilter.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/ActivityLinksFilter.php
@@ -1,0 +1,66 @@
+<?php
+
+class CRM_HRCore_Hook_BuildForm_ActivityLinksFilter {
+
+  /**
+   * Determines what happens if the hook is handled.
+   * Basically, it filters the activity type links on
+   * the activities tab.
+   * 
+   * @param string $formName
+   * @param object $form
+   */
+  public function handle($formName, &$form) {
+    if (!$this->shouldHandle($formName)) {
+      return;
+    }
+
+    $this->filterActivityTypeLinks($form);
+  }
+
+  /**
+   * Checks if the hook should be handled.
+   * 
+   * @param string $formName
+   * 
+   * @return bool
+   */
+  private function shouldHandle($formName) {
+    if($formName == 'CRM_Activity_Form_ActivityLinks') {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Filters the activity type links on the activities tab on the
+   * contact summary page so that only links related to the Email,
+   * Inbound Email, Reminder Sent and Print PDf Letter activity types
+   * are returned.
+   *
+   * @param object $form
+   */
+  private function filterActivityTypeLinks($form) {
+    $allowedActivities = $this->getAllowedActivityTypes();
+    $activityTypes = [];
+    $activityTypeLinks = $form->get_template_vars('activityTypes');
+
+    foreach($activityTypeLinks as $id => $activityTypeLink) {
+      if(in_array($activityTypeLink['name'], $allowedActivities))  {
+        $activityTypes[$id] = $activityTypeLink;
+      }
+    }
+
+    $form->assign('activityTypes', $activityTypes);
+  }
+
+  /**
+   * Returns the allowed activity types.
+   * 
+   * @return array
+   */
+  private function getAllowedActivityTypes() {
+    return ['Email',  'Inbound Email', 'Reminder Sent', 'Print PDF Letter'];
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -15,6 +15,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1005;
   use CRM_HRCore_Upgrader_Steps_1006;
   use CRM_HRCore_Upgrader_Steps_1007;
+  use CRM_HRCore_Upgrader_Steps_1008;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1008.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1008.php
@@ -63,7 +63,7 @@ trait CRM_HRCore_Upgrader_Steps_1008 {
     }
 
     civicrm_api3('OptionValue', 'create', [
-      'id' => $activityType['label'],
+      'id' => $activityType['id'],
       'label' => $newLabel,
     ]);
   }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1008.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1008.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Trait CRM_HRCore_Upgrader_Steps_1008
+ */
+trait CRM_HRCore_Upgrader_Steps_1008 {
+
+  /**
+   * This upgrader makes changes necessary to display custom
+   * activity types on the activities tab of the contact summary page.
+   *
+   * Basically, It updates the filter column of some activity types to zero
+   * so that they can show up on the add activity links and also updates the
+   * label of the Print PDF Letter activity option value from Print/Merge Document
+   * to Print PDF letter.
+   */
+  public function upgrade_1008() {
+    $toSetFilterToZero = ['Inbound Email', 'Reminder Sent'];
+    $printPdfActivity = ['Print PDF Letter'];
+    $allActivityTypes = $this->getActivityTypes(array_merge($toSetFilterToZero, $printPdfActivity));
+
+    foreach($toSetFilterToZero as $activityType) {
+      if(isset($allActivityTypes[$activityType])) {
+        $this->up1008_setFilterColumnToZero($allActivityTypes[$activityType]);
+      }
+    }
+
+    if(isset($allActivityTypes[$printPdfActivity[0]])){
+      $this->up1008_updateActivityTypeLabel($allActivityTypes[$printPdfActivity[0]], 'Print PDF Letter');
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Sets the filter column on the activity type option value
+   * to zero. We need to do this because civi will not show
+   * add activity links for activity types whose filter column is
+   * not null or have a value of zero by default.
+   *
+   * @param array $activityType
+   */
+  private function up1008_setFilterColumnToZero($activityType) {
+    if($activityType['filter'] == 0){
+      return;
+    }
+
+    civicrm_api3('OptionValue', 'create', [
+      'id' => $activityType['id'],
+      'filter' => 0,
+    ]);
+  }
+
+  /**
+   * Updates the activity type option value's label.
+   *
+   * @param array $activityType
+   * @param string $newLabel
+   */
+  private function up1008_updateActivityTypeLabel($activityType, $newLabel) {
+    if($activityType['label'] == $newLabel) {
+      return;
+    }
+
+    civicrm_api3('OptionValue', 'create', [
+      'id' => $activityType['label'],
+      'label' => $newLabel,
+    ]);
+  }
+
+  /**
+   * Gets the activity types with the given names from the
+   * db. Returns in an array of the activity type indexed by the name.
+   *
+   * @param array $activityTypeNames
+   *
+   * @return array
+   */
+  private function getActivityTypes($activityTypeNames) {
+    $result = civicrm_api3('OptionValue', 'get',[
+      'option_group_id' => 'activity_type',
+      'name' => ['IN' => $activityTypeNames],
+    ]);
+
+    $activityTypes = [];
+
+    foreach($result['values'] as $activity) {
+      $activityTypes[$activity['name']] = $activity;
+    }
+
+    return $activityTypes;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1008.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1008.php
@@ -17,7 +17,7 @@ trait CRM_HRCore_Upgrader_Steps_1008 {
   public function upgrade_1008() {
     $toSetFilterToZero = ['Inbound Email', 'Reminder Sent'];
     $printPdfActivity = ['Print PDF Letter'];
-    $allActivityTypes = $this->getActivityTypes(array_merge($toSetFilterToZero, $printPdfActivity));
+    $allActivityTypes = $this->up1008_getActivityTypes(array_merge($toSetFilterToZero, $printPdfActivity));
 
     foreach($toSetFilterToZero as $activityType) {
       if(isset($allActivityTypes[$activityType])) {
@@ -41,7 +41,7 @@ trait CRM_HRCore_Upgrader_Steps_1008 {
    * @param array $activityType
    */
   private function up1008_setFilterColumnToZero($activityType) {
-    if($activityType['filter'] == 0){
+    if($activityType['filter'] == 0) {
       return;
     }
 
@@ -76,7 +76,7 @@ trait CRM_HRCore_Upgrader_Steps_1008 {
    *
    * @return array
    */
-  private function getActivityTypes($activityTypeNames) {
+  private function up1008_getActivityTypes($activityTypeNames) {
     $result = civicrm_api3('OptionValue', 'get',[
       'option_group_id' => 'activity_type',
       'name' => ['IN' => $activityTypeNames],

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -64,6 +64,22 @@ function hrcore_civicrm_container($container) {
 }
 
 /**
+ * Implements hook_civicrm_buildForm
+ *
+ * @param string $formName
+ * @param object $form
+ */
+function hrcore_civicrm_buildForm($formName, &$form) {
+  if($formName == 'CRM_Activity_Form_ActivityFilter') {
+    _hrcore_modifyExcludeAndIncludeActivityTypeFields($form);
+  }
+
+  if($formName == 'CRM_Activity_Form_ActivityLinks') {
+    _hrcore_filterActivityTypeLinks($form);
+  }
+}
+
+/**
  * Implements hook_civicrm_xmlMenu().
  *
  * @param array $files
@@ -261,4 +277,64 @@ function _hrcore_add_js_session_vars() {
   CRM_Core_Resources::singleton()->addVars('session', [
     'contact_id' => CRM_Core_Session::getLoggedInContactID()
   ]);
+}
+
+/**
+ * Overrides the include and exclude select activity Form fields on the
+ * activities tab of the contact summary page to display only activities of
+ * type Email, Inbound Email, Reminder Sent, Print PDf Letter.
+ *
+ * @param object $form
+ */
+function _hrcore_modifyExcludeAndIncludeActivityTypeFields($form) {
+  $allowedActivityTypes = _hrcore_getAllowedActivityTypesForActivitiesTab();
+
+  $activityTypes = civicrm_api3('OptionValue', 'get', [
+    'option_group_id' => 'activity_type',
+    'name' => ['IN' => $allowedActivityTypes],
+  ]);
+
+  $formActivityTypes = [];
+  foreach ($activityTypes['values'] as $activityType) {
+    $formActivityTypes[$activityType['value']] = $activityType['label'];
+  }
+
+  $form->add('select', 'activity_type_filter_id', ts('Include'), $formActivityTypes);
+  $form->add('select',
+    'activity_type_exclude_filter_id',
+    ts('Exclude'),
+    ['' => ts('- select activity type -')] + $formActivityTypes
+  );
+}
+
+/**
+ * Filters the activity type links on the activities tab on the
+ * contact summary page so that only links related to the Email,
+ * Inbound Email, Reminder Sent and Print PDf Letter activity types
+ * are returned.
+ *
+ * @param object $form
+ */
+function _hrcore_filterActivityTypeLinks($form) {
+  $allowedActivities = _hrcore_getAllowedActivityTypesForActivitiesTab();
+  $activityTypes = [];
+  $activityTypeLinks = $form->get_template_vars('activityTypes');
+
+  foreach($activityTypeLinks as $id => $activityTypeLink) {
+    if(in_array($activityTypeLink['name'], $allowedActivities))  {
+      $activityTypes[$id] = $activityTypeLink;
+    }
+  }
+
+  $form->assign('activityTypes', $activityTypes);
+}
+
+/**
+ * Returns the allowed activity types for the activities tab on the
+ * contact summary page.
+ *
+ * @return array
+ */
+function _hrcore_getAllowedActivityTypesForActivitiesTab() {
+  return ['Email',  'Inbound Email', 'Reminder Sent', 'Print PDF Letter'];
 }


### PR DESCRIPTION
## Overview
The Civicrm activity tab was enabled in a recent PR: #2434, This PR modifies the results and activity type filters on the activity tab page to only consider activities of type 
- Email
-  Inbound email 
- Reminder Sent
- Print PDF Letter.

## Before
- All active activity types are displayed and can be filtered by on the activity tab page.

![civihr_staff compucorp co uk _ staging17 2018-01-29 19-06-10](https://user-images.githubusercontent.com/6951813/35526398-887feeb6-0527-11e8-9388-f88eb852c9da.png)

![civihr_staff compucorp co uk _ staging17 2018-01-29 19-06-58](https://user-images.githubusercontent.com/6951813/35526424-9fdd5882-0527-11e8-8f51-7c5fc2898b50.png)


## After
- The `Add New activity` link tab was modified to only display links related to the chosen activity types mentioned in the PR description.
To achieve this, the hrcore_civicrm_buildForm was implemented to intercept the `CRM_Activity_Form_ActivityLinks` form responsible for supplying the activity links and then the list was filtered to only include the needed activity types.
Also after implementing the hook, the Inbound email and Reminder Sent activity types were not showing up in the links, This was due to the fact that for the activity types to show up, the filter column of the option value must evaluate to false(i.e set to 0 or null) See [Here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Activity/Form/ActivityLinks.php#L92):
An upgrader was added to implement this change.

![civihr_staff compucorp co uk _ staging17 2018-01-29 18-50-30](https://user-images.githubusercontent.com/6951813/35525910-2faa7f32-0526-11e8-8933-c0eb1d5d2c4e.png)

- The Include and Exclude Activity type select fields was also overridden and the activity type values listed in the PR description was added as the select field options. This was achieved by implementing hrcore_civicrm_buildForm and overriding the fields which is provided by the `CRM_Activity_Form_ActivityFilter` form.

![civihr_staff compucorp co uk _ staging17 2018-01-29 19-00-00](https://user-images.githubusercontent.com/6951813/35526084-abec6506-0526-11e8-8483-d9f9c72b88f8.png)

- The label of the Print PDF Letter option value was also updated to match the name Print PDF Letter as the default label is Print/Merge Document.
