### PR TITLE
PCHR-3082: Rename Activities tab to Communications.

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/Tabset/ActivityTabModifier.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/Tabset/ActivityTabModifier.php
@@ -15,8 +15,8 @@ class  CRM_HRCore_Hook_Tabset_ActivityTabModifier {
       return;
     }
 
-    foreach($tabs as $key => $tab) {
-      if($tab['id'] == 'activity') {
+    foreach ($tabs as $key => $tab) {
+      if ($tab['id'] === 'activity') {
         $tabs[$key]['title'] = 'Communications';
       }
     }
@@ -30,7 +30,7 @@ class  CRM_HRCore_Hook_Tabset_ActivityTabModifier {
    * @return bool
    */
   private function shouldHandle($tabsetName) {
-    if ($tabsetName == 'civicrm/contact/view') {
+    if ($tabsetName === 'civicrm/contact/view') {
       return TRUE;
     }
 

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/Tabset/ActivityTabModifier.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/Tabset/ActivityTabModifier.php
@@ -1,0 +1,39 @@
+<?php
+
+class  CRM_HRCore_Hook_Tabset_ActivityTabModifier {
+  /**
+   * Determines what happens if the hook is handled.
+   * Basically, renames the activity tab title on contact
+   * summary page to 'Communications'
+   *
+   * @param string $tabsetName
+   * @param array $tabs
+   * @param array $context
+   */
+  public function handle($tabsetName, &$tabs, $context) {
+    if (!$this->shouldHandle($tabsetName)) {
+      return;
+    }
+
+    foreach($tabs as $key => $tab) {
+      if($tab['id'] == 'activity') {
+        $tabs[$key]['title'] = 'Communications';
+      }
+    }
+  }
+
+  /**
+   * Checks if the hook should be handled.
+   *
+   * @param string $tabsetName
+   *
+   * @return bool
+   */
+  private function shouldHandle($tabsetName) {
+    if ($tabsetName == 'civicrm/contact/view') {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -37,6 +37,24 @@ function hrcore_civicrm_searchTasks($objectName, &$tasks) {
   }
 }
 
+/**
+ * Implements hook_civicrm_tabset().
+ *
+ * @param string $tabsetName
+ * @param array $tabs
+ * @param array $context
+ */
+function hrcore_civicrm_tabset($tabsetName, &$tabs, $context) {
+  $listeners = [
+    new CRM_HRCore_Hook_Tabset_ActivityTabModifier(),
+  ];
+
+  foreach ($listeners as $currentListener) {
+    $currentListener->handle($tabsetName, $tabs, $context);
+  }
+}
+
+
 function hrcore_civicrm_summaryActions( &$actions, $contactID ) {
   $otherActions = CRM_Utils_Array::value('otherActions', $actions, []);
   $userAdd = CRM_Utils_Array::value('user-add', $otherActions, []);


### PR DESCRIPTION
## Overview
This PR renames the Activities tab to Communications. 

## Before
The Activities tab is named as Activities

![civihr_staff compucorp co uk _ staging17 2018-01-31 11-13-06](https://user-images.githubusercontent.com/6951813/35617268-03f5734e-0678-11e8-8b45-12af5fe78893.png)


## After
The Activity tab was renamed to Communications by implementing `hook_civicrm_tabset` in the HRCore extension.

![civihr_staff compucorp co uk _ staging17 2018-01-31 11-14-10](https://user-images.githubusercontent.com/6951813/35617287-11f49d80-0678-11e8-824f-9e55065cdf1c.png)