### PR TITLE
PCHR-3251: Upgrader for single day requests in hours

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
@@ -23,6 +23,7 @@ class CRM_HRLeaveAndAbsences_Upgrader extends CRM_HRLeaveAndAbsences_Upgrader_Ba
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1015;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1016;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1017;
+  use CRM_HRLeaveAndAbsences_Upgrader_Step_1018;
 
   /**
    * A list of directories to be scanned for XML installation files

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1018.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1018.php
@@ -27,6 +27,10 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1018 {
     $result = CRM_Core_DAO::executeQuery($query)->fetchAll();
     $absenceTypesInHour = array_column($result, 'id');
 
+    if (empty($absenceTypesInHour)) {
+      return true;
+    }
+
     $leaveRequest = new LeaveRequest();
     $leaveRequest->whereAdd('from_date IS NOT NULL');
     $leaveRequest->whereAdd('from_date = to_date');

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1018.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1018.php
@@ -1,0 +1,52 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use CRM_HRLeaveAndAbsences_Service_ContactWorkPattern as ContactWorkPattern;
+
+trait CRM_HRLeaveAndAbsences_Upgrader_Step_1018 {
+
+  /**
+   * As per PCHR-3164 end time can be chosen for single day leave requests
+   * in hours calculation unit. However, existing such leave requests are
+   * storing end time currently equal to start time. This upgrader fetches such
+   * leave requests, retrieves information about work pattern day basing on the
+   * date of the leave request and, if it is still a working day, sets the end
+   * time from the working day as an end time of the leave request.
+   *
+   * @return boolean
+   */
+
+  public function upgrade_1018 () {
+    $calculationUnits = array_flip(AbsenceType::buildOptions('calculation_unit', 'validate'));
+
+    $leaveRequestTable = LeaveRequest::getTableName();
+    $absenceTypeTable = AbsenceType::getTableName();
+
+    $query = "SELECT leaveRequest.id
+      FROM {$leaveRequestTable} leaveRequest
+      INNER JOIN {$absenceTypeTable} absenceType ON leaveRequest.type_id = absenceType.id
+      WHERE
+        absenceType.calculation_unit = {$calculationUnits['hours']}
+          AND leaveRequest.from_date IS NOT NULL
+          AND leaveRequest.from_date = leaveRequest.to_date
+          AND leaveRequest.is_deleted = 0";
+
+    $leaveRequestRecord = CRM_Core_DAO::executeQuery($query);
+
+    while ($leaveRequestRecord->fetch()) {
+      $leaveRequest = LeaveRequest::findById($leaveRequestRecord->id);
+      $workDay = ContactWorkPattern::getContactWorkDayForDate(
+        $leaveRequest->contact_id, new DateTime($leaveRequest->from_date));
+
+      if (!empty($workDay['time_to'])) {
+        $leaveRequest->to_date =
+          substr($leaveRequest->from_date, 0, 10) . ' ' . $workDay['time_to'] . ':00';
+
+        $leaveRequest->save();
+      }
+    };
+
+    return true;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-calendar-day.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-calendar-day.html
@@ -48,6 +48,7 @@
     <strong>{{day.contactData.leaveRequest['type_id.title']}}</strong>
     <p>
       From: {{day.dates.from | date:'HH:mm'}}<br/>
+      To: {{day.dates.to | date:'HH:mm'}}<br/>
       For: {{ day.contactData.leaveRequest.from_date_amount | timeUnitApplier : day.calculationUnit.name }}
     </p>
   </div>


### PR DESCRIPTION
## Overview
As per https://github.com/civicrm/civihr/pull/2443 end time can be chosen for single day leave requests in hours calculation unit. However, existing such leave requests are storing end time currently equal to start time. This upgrader fetches such leave requests, retrieves information about work pattern day basing on the date of the leave request and, if it is still a working day, sets the end time from the working day as an end time of the leave request.

## Before/After

![upg](https://user-images.githubusercontent.com/3973243/35805405-9b9daf96-0a73-11e8-9614-4cdf05a11abb.gif)

## Technical Details

The upgrader simply takes "to" date of the single day request (which equals the "from" date) and  replaces the time taken from the work pattern day corresponding to this date.

```php
// Construct query that selects all existing single day leave requests in hours
$query = "SELECT leaveRequest.id
  FROM {$leaveRequestTable} leaveRequest
  INNER JOIN {$absenceTypeTable} absenceType ON leaveRequest.type_id = absenceType.id
  WHERE
    absenceType.calculation_unit = {$calculationUnits['hours']}
      AND leaveRequest.from_date IS NOT NULL
      AND leaveRequest.from_date = leaveRequest.to_date
      AND leaveRequest.is_deleted = 0";

// ...

while ($leaveRequestRecord->fetch()) {
  // Get a leave request instance by ID
  $leaveRequest = LeaveRequest::findById($leaveRequestRecord->id);
  // Get a work day info based on the contact of the leave request and "from" date
  $workDay = ContactWorkPattern::getContactWorkDayForDate(
    $leaveRequest->contact_id, new DateTime($leaveRequest->from_date));

  // If this is still a working day and end time exists
  if (!empty($workDay['time_to'])) {
    // Simply replace the request end time with the one from the work pattern day
    $leaveRequest->to_date =
      substr($leaveRequest->from_date, 0, 10) . ' ' . $workDay['time_to'] . ':00';
    // And save
    $leaveRequest->save();
  }
};
```

## Comments

### Upgrader performance

The upgrader was tested on a database of sample requests: 4000 requests to update and 10000 other requests (14K in total) and was executed in **16 sec** on a virtual machine with 4GB RAM (host machine 3.1 GHz Intel Core i7).

### Calendar tooltips

Additionally, calendar tooltip was fixed: it now shows "to" time as well as "from" time for single day requests in hours.

#### Before

![image](https://user-images.githubusercontent.com/3973243/35805097-71ed6eee-0a72-11e8-9e4f-0570d807d137.png)

#### After

![image](https://user-images.githubusercontent.com/3973243/35805125-8bd1706c-0a72-11e8-9ad0-e4302d419801.png)

### PHP unit tests

PHP unit tests in L&A passed both before and after upgrade.

---- 

✅ Manual Tests - passed
✅ PHP Unit Tests - passed
⏹ Backstop tests - omitted
⏹ CSS distributive files - not needed
⏹ Jasmine Tests - not needed
⏹ JS distributive files - not needed
