### PR TITLE
PCHR-3076: Display Workflow Info on Contact Actions Menu

### DIFF
--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Component/GroupButtonItem.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Component/GroupButtonItem.php
@@ -31,6 +31,11 @@ class CRM_HRContactActionsMenu_Component_GroupButtonItem implements ActionsGroup
   private $url;
 
   /**
+   * @var string
+   */
+  private $onClick;
+
+  /**
    * CRM_HRContactActionsMenu_Component_GroupButtonItem constructor.
    *
    * @param string $label
@@ -79,12 +84,23 @@ class CRM_HRContactActionsMenu_Component_GroupButtonItem implements ActionsGroup
   }
 
   /**
+   * Sets the onclick property for the button to the
+   * passes in expression or function
+   *
+   * @param string $expression
+   */
+  public function setOnClick($expression) {
+    $this->onClick = $expression;
+  }
+
+  /**
    * {@inheritDoc}
    */
   public function render() {
+    $onClick = empty($this->onClick) ? '' : 'onclick = "' . $this->onClick . '"';
     $buttonMarkup = '
       <div class="crm_contact-actions__action">
-        <a href="%s" class="btn %s">
+        <a href="%s" class="btn %s" ' . $onClick . '>
           <i class="fa %s"></i> %s
         </a>
       </div>';

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Component/GroupButtonItem.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Component/GroupButtonItem.php
@@ -31,9 +31,9 @@ class CRM_HRContactActionsMenu_Component_GroupButtonItem implements ActionsGroup
   private $url;
 
   /**
-   * @var string
+   * @var array
    */
-  private $onClick;
+  private $attributes = [];
 
   /**
    * CRM_HRContactActionsMenu_Component_GroupButtonItem constructor.
@@ -84,23 +84,29 @@ class CRM_HRContactActionsMenu_Component_GroupButtonItem implements ActionsGroup
   }
 
   /**
-   * Sets the onclick property for the button to the
-   * passes in expression or function
+   * Stores attribute and value in the attributes array.
    *
-   * @param string $expression
+   * @param string $attribute
+   * @param string $value
    */
-  public function setOnClick($expression) {
-    $this->onClick = $expression;
+  public function setAttribute($attribute, $value) {
+    $this->attributes[$attribute] = $value;
   }
 
   /**
    * {@inheritDoc}
    */
   public function render() {
-    $onClick = empty($this->onClick) ? '' : 'onclick = "' . $this->onClick . '"';
+    $buttonAttributes = '';
+    if ($this->attributes) {
+      foreach($this->attributes as $attribute => $value) {
+        $buttonAttributes .= $attribute . '= "' . $value . '" ';
+      }
+    }
+
     $buttonMarkup = '
       <div class="crm_contact-actions__action">
-        <a href="%s" class="btn %s" ' . $onClick . '>
+        <a href="%s" class="btn %s" ' . $buttonAttributes . '>
           <i class="fa %s"></i> %s
         </a>
       </div>';

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Helper/Contact.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Helper/Contact.php
@@ -24,6 +24,7 @@ class CRM_HRContactActionsMenu_Helper_Contact {
       //When a contact has CMS account, the cmsId parameter is needed for the
       //HRCore CMSData classes
       $output['cmsId'] = $result['id'];
+      $output['name'] = $result['name'];
     } catch(Exception $e) {}
 
     return $output;

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/templates/CRM/HRContactActionsMenu/Page/Inline/Actions.tpl
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/templates/CRM/HRContactActionsMenu/Page/Inline/Actions.tpl
@@ -51,14 +51,6 @@
       </div>
       <div class="crm_contact-actions__panel crm_contact-actions__panel--secondary">
         <div class="crm_contact-actions__panel__body">
-          {foreach from=$menu->getMainPanelItems() item='group'}
-            <div class="crm_contact-actions__group">
-              <h3>{$group->getTitle()}</h3>
-              {foreach from=$group->getItems() item='item'}
-                {$item->render()}
-              {/foreach}
-            </div>
-          {/foreach}
           <div class="crm_contact-actions__group">
             <h3>Leave:</h3>
             <div class="crm_contact-actions__action">
@@ -79,40 +71,14 @@
               <a href="#" class="btn btn-secondary">Manage Leave Approver</a>
             </div>
           </div>
-          <div class="crm_contact-actions__group">
-            <h3>Workflows:</h3>
-            <div class="crm_contact-actions__action">
-              <a href="#" class="btn btn-primary-outline">
-                <i class="fa fa-user-plus"></i> Joining
-              </a>
+          {foreach from=$menu->getMainPanelItems() item='group'}
+            <div class="crm_contact-actions__group">
+              <h3>{$group->getTitle()}</h3>
+              {foreach from=$group->getItems() item='item'}
+                {$item->render()}
+              {/foreach}
             </div>
-            <div class="crm_contact-actions__action">
-              <a href="#" class="btn btn-primary-outline">
-                <i class="fa fa-user-times"></i> Exiting
-              </a>
-            </div>
-            <div class="crm_contact-actions__action">
-              <a href="#" class="btn btn-primary-outline">Other.......</a>
-            </div>
-            <hr>
-            <div class="crm_contact-actions__action">
-              <a href="#" class="btn btn-primary-outline">
-                <i class="fa fa-check-square-o"></i> New Task
-              </a>
-            </div>
-            <div class="crm_contact-actions__action">
-              <a href="#" class="btn btn-primary-outline">
-                <i class="fa fa-id-card-o"></i> New Document
-              </a>
-            </div>
-            <hr>
-            <h4>Line Manager(s):</h4>
-            <p><a href="#" class="text-primary">John Snow</a></p>
-            <p><a href="#" class="text-primary">Allan Wite</a></p>
-            <div class="crm_contact-actions__action">
-              <a href="#" class="btn btn-secondary">Manage Line Manager</a>
-            </div>
-          </div>
+          {/foreach}
           <div class="crm_contact-actions__group">
             <h3>Communicate </h3>
             <div class="crm_contact-actions__action">

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/templates/CRM/HRContactActionsMenu/Page/Inline/Actions.tpl
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/templates/CRM/HRContactActionsMenu/Page/Inline/Actions.tpl
@@ -25,7 +25,7 @@
         </div>
         <div class="crm_contact-actions__panel__footer">
           <div class="row">
-            {if !empty($contactInfo.id)}
+            {if !empty($contactInfo.cmsId)}
               <div class="col-md-6">
                 {if $userAccountDisabled}
                   <a class="btn btn-warning"

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Component/ContactActionsMenu/LineManagersListItem.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Component/ContactActionsMenu/LineManagersListItem.php
@@ -1,0 +1,42 @@
+<?php
+
+use CRM_HRContactActionsMenu_Component_GroupItem as ActionsGroupItemInterface;
+use CRM_HRCore_Service_Manager as ManagerService;
+
+class CRM_HRCore_Component_ContactActionsMenu_LineManagersListItem implements ActionsGroupItemInterface {
+
+  /**
+   * @var ManagerService
+   */
+  private $managerService;
+
+  /**
+   * @var int
+   */
+  private $contactID;
+
+  /**
+   * CRM_HRCore_Component_ContactActionsMenu_LineManagersListItem constructor.
+   *
+   * @param ManagerService $managerService
+   * @param int $contactID
+   */
+  public function __construct(ManagerService $managerService, $contactID) {
+    $this->managerService = $managerService;
+    $this->contactID = $contactID;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render() {
+    $lineManagers = $this->managerService->getLineManagersFor($this->contactID);
+    $markup = '<h4>Line Manager(s): </h4>';
+
+    foreach($lineManagers as $lineManager) {
+      $markup .= '<p><a href="#" class="text-primary"> ' . $lineManager . ' </a></p>';
+    }
+
+    return $markup;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Component/ContactActionsMenu/NoSelectedLineManagerTextItem.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Component/ContactActionsMenu/NoSelectedLineManagerTextItem.php
@@ -1,0 +1,16 @@
+<?php
+
+use CRM_HRContactActionsMenu_Component_GroupItem as ActionsGroupItemInterface;
+
+/**
+ * Class CRM_HRCore_Component_ContactActionsMenu_NoSelectedLineManagerTextItem
+ */
+class CRM_HRCore_Component_ContactActionsMenu_NoSelectedLineManagerTextItem implements ActionsGroupItemInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render() {
+    return '<p>You have not selected a Line Manager</p>';
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Helper/ContactActionsMenu/WorkflowActionGroup.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Helper/ContactActionsMenu/WorkflowActionGroup.php
@@ -176,8 +176,7 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
    */
   public function getAddLineManagerButton() {
     $relTypeID = $this->getLineManagerRelationshipTypeSelectId();
-    $onClick = "CRM.loadForm('/civicrm/contact/view/rel?cid=$this->contactID&action=add&relTypeId=$relTypeID')";
-
+    $attribute = ['onclick' => "CRM.loadForm('/civicrm/contact/view/rel?cid=$this->contactID&action=add&relTypeId=$relTypeID')"];
     $params = [
       'label' => 'Add A Line Manager',
       'class' => 'btn btn-secondary-outline',
@@ -185,7 +184,7 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
       'url' => '#'
     ];
 
-    return $this->getMenuButton($params, $onClick);
+    return $this->getMenuButton($params, $attribute);
   }
 
   /**
@@ -212,18 +211,20 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
    * Returns an instance of an ActionsGroupButtonItem
    *
    * @param array $params
-   * @param string $onClick
+   * @param array $attributes
    *
    * @return ActionsGroupButtonItem
    */
-  private function getMenuButton($params, $onClick = '') {
+  private function getMenuButton($params, $attributes = []) {
     $button = new ActionsGroupButtonItem($params['label']);
     $button->setClass($params['class'])
       ->setIcon($params['icon'])
       ->setUrl($params['url']);
 
-    if ($onClick) {
-      $button->setOnClick($onClick);
+    if ($attributes) {
+      foreach($attributes as $attribute => $value) {
+        $button->setAttribute($attribute, $value);
+      }
     }
 
     return $button;

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Helper/ContactActionsMenu/WorkflowActionGroup.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Helper/ContactActionsMenu/WorkflowActionGroup.php
@@ -1,0 +1,283 @@
+<?php
+
+use CRM_HRContactActionsMenu_Component_Group as ActionsGroup;
+use CRM_HRContactActionsMenu_Component_GroupButtonItem as ActionsGroupButtonItem;
+use CRM_HRContactActionsMenu_Component_GroupSeparatorItem as GroupSeparatorItem;
+use CRM_HRCore_Service_Manager as ManagerService;
+use CRM_HRCore_Component_ContactActionsMenu_NoSelectedLineManagerTextItem as NoSelectedLineManagerTextItem;
+use CRM_HRCore_Component_ContactActionsMenu_LineManagersListItem as LineManagersListItem;
+
+/**
+ * Class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup
+ */
+class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
+
+  /**
+   * @var ManagerService
+   */
+  private $managerService;
+
+  /**
+   * @var array
+   */
+  private $contactID;
+
+  /**
+   * @var array
+   */
+  private $workflowCaseTypes;
+
+  /**
+   * CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup constructor.
+   *
+   * @param ManagerService $managerService
+   * @param int $contactID
+   */
+  public function __construct(ManagerService $managerService, $contactID) {
+    $this->managerService = $managerService;
+    $this->contactID = $contactID;
+  }
+
+  /**
+   * Gets Workflow Menu Group with menu items already
+   * added.
+   */
+  public function get() {
+    $actionsGroup = new ActionsGroup('Workflows:');
+    $actionsGroup->addItem($this->getWorkflowJoiningButton());
+    $actionsGroup->addItem($this->getWorkflowExitingButton());
+    $actionsGroup->addItem($this->getWorkflowOtherButton());
+    $actionsGroup->addItem(new GroupSeparatorItem());
+    $actionsGroup->addItem($this->getWorkflowNewTaskButton());
+    $actionsGroup->addItem($this->getWorkflowNewDocumentButton());
+    $actionsGroup->addItem(new GroupSeparatorItem());
+
+    $lineManagers = $this->getLineManagers();
+
+    if ($lineManagers) {
+      $lineManagersListItem = new LineManagersListItem($this->managerService, $this->contactID);
+      $actionsGroup->addItem($lineManagersListItem);
+      $actionsGroup->addItem($this->getManageLineManagerButton());
+    }
+    else {
+      $noLineManagerTextItem = new NoSelectedLineManagerTextItem();
+      $actionsGroup->addItem($noLineManagerTextItem);
+      $actionsGroup->addItem($this->getAddLineManagerButton());
+    }
+
+    return $actionsGroup;
+  }
+
+  /**
+   * Gets the Workflow Joining button
+   *
+   * @return ActionsGroupButtonItem
+   */
+  private function getWorkflowJoiningButton() {
+    $caseTypeId = $this->getCaseTypeID('Joining');
+    $url = CRM_Utils_System::url(
+      'civicrm/tasksassignments/dashboard#/tasks',
+      "reset=1&cid=$this->contactID&openModal=assignment&caseTypeId=$caseTypeId"
+    );
+    $params = [
+      'label' => 'Joining',
+      'class' => 'btn btn-primary-outline',
+      'icon' => 'fa fa-user-plus',
+      'url' => $url
+    ];
+    return $this->getMenuButton($params);
+  }
+
+  /**
+   * Gets the Workflow Exiting button
+   *
+   * @return ActionsGroupButtonItem
+   */
+  private function getWorkflowExitingButton() {
+    $caseTypeId = $this->getCaseTypeID('Exiting');
+    $url = CRM_Utils_System::url(
+      'civicrm/tasksassignments/dashboard#/tasks',
+      "reset=1&cid=$this->contactID&openModal=assignment&caseTypeId=$caseTypeId"
+    );
+    $params = [
+      'label' => 'Exiting',
+      'class' => 'btn btn-primary-outline',
+      'icon' => 'fa fa-user-times',
+      'url' => $url
+    ];
+
+    return $this->getMenuButton($params);
+  }
+
+  /**
+   * Gets the Workflow Other button
+   *
+   * @return ActionsGroupButtonItem
+   */
+  private function getWorkflowOtherButton() {
+    $url = CRM_Utils_System::url(
+      'civicrm/tasksassignments/dashboard#/tasks',
+      "reset=1&cid=$this->contactID&openModal=assignment"
+    );
+    $params = [
+      'label' => 'Other...',
+      'class' => 'btn btn-primary-outline',
+      'icon' => '',
+      'url' => $url
+    ];
+
+    return $this->getMenuButton($params);
+  }
+
+  /**
+   * Gets the Workflow New Task button
+   *
+   * @return ActionsGroupButtonItem
+   */
+  private function getWorkflowNewTaskButton() {
+    $url = CRM_Utils_System::url(
+      'civicrm/tasksassignments/dashboard#/tasks',
+      "reset=1&cid=$this->contactID&openModal=task"
+    );
+    $params = [
+      'label' => 'New Task',
+      'class' => 'btn btn-primary-outline',
+      'icon' => 'fa fa-check-square-o',
+      'url' => $url
+    ];
+
+    return $this->getMenuButton($params);
+  }
+
+  /**
+   * Gets the Workflow New Document button
+   *
+   * @return ActionsGroupButtonItem
+   */
+  private function getWorkflowNewDocumentButton() {
+    $url = CRM_Utils_System::url(
+      'civicrm/tasksassignments/dashboard#/documents',
+      "reset=1&cid=$this->contactID&openModal=document"
+    );
+    $params = [
+      'label' => 'New Document',
+      'class' => 'btn btn-primary-outline',
+      'icon' => 'fa fa-id-card-o',
+      'url' => $url
+    ];
+
+    return $this->getMenuButton($params);
+  }
+
+  /**
+   * Gets the Add A Line Manager button.
+   *
+   * @return ActionsGroupButtonItem
+   */
+  public function getAddLineManagerButton() {
+    $relTypeID = $this->getLineManagerRelationshipTypeSelectId();
+    $onClick = "CRM.loadForm('/civicrm/contact/view/rel?cid=$this->contactID&action=add&relTypeId=$relTypeID')";
+
+    $params = [
+      'label' => 'Add A Line Manager',
+      'class' => 'btn btn-secondary-outline',
+      'icon' => '',
+      'url' => '#'
+    ];
+
+    return $this->getMenuButton($params, $onClick);
+  }
+
+  /**
+   * Gets the Manage Line Manager button
+   *
+   * @return ActionsGroupButtonItem
+   */
+  public function getManageLineManagerButton() {
+    $url = CRM_Utils_System::url(
+      'civicrm/contact/view',
+      "reset=1&cid=$this->contactID&selectedChild=rel"
+    );
+    $params = [
+      'label' => 'Manage Line Manager',
+      'class' => 'btn btn-secondary',
+      'icon' => '',
+      'url' => $url
+    ];
+
+    return $this->getMenuButton($params);
+  }
+
+  /**
+   * Returns an instance of an ActionsGroupButtonItem
+   *
+   * @param array $params
+   * @param string $onClick
+   *
+   * @return ActionsGroupButtonItem
+   */
+  private function getMenuButton($params, $onClick = '') {
+    $button = new ActionsGroupButtonItem($params['label']);
+    $button->setClass($params['class'])
+      ->setIcon($params['icon'])
+      ->setUrl($params['url']);
+
+    if ($onClick) {
+      $button->setOnClick($onClick);
+    }
+
+    return $button;
+  }
+
+  /**
+   * Get the WorkFlows Case Types data
+   * Namely for the Joining and Exiting Case type.
+   */
+  private function getWorkflowCaseTypes() {
+    if(!$this->workflowCaseTypes) {
+      $result =  civicrm_api3('CaseType', 'get', [
+        'return' => ['id', 'name'],
+        'title' => ['IN' => ['Joining', 'Exiting']],
+      ]);
+
+      $this->workflowCaseTypes = array_column($result['values'], 'id', 'name');
+    }
+
+    return $this->workflowCaseTypes;
+  }
+
+  /**
+   * Returns the Case Type ID for the given Case Type name
+   *
+   * @param string $caseTypeName
+   *
+   * @return string
+   */
+  private function getCaseTypeID($caseTypeName) {
+    return isset($this->getworkflowCaseTypes()[$caseTypeName]) ? $this->getworkflowCaseTypes()[$caseTypeName] : '';
+  }
+
+  /**
+   * Gets Line managers for a contact.
+   *
+   * @return array
+   */
+  private function getLineManagers() {
+    return $this->managerService->getLineManagersFor($this->contactID);
+  }
+
+  /**
+   * Returns the relationship type Id for the `Line manager is`
+   * relationship used to default to the relationship type
+   * in the relationship type select field on the Add relationship modal.
+   *
+   * @return string
+   */
+  private function getLineManagerRelationshipTypeSelectId() {
+    $result = civicrm_api3('RelationshipType', 'getsingle', [
+      'name_a_b' => 'Line Manager Is'
+    ]);
+
+    return !empty($result['id']) ? $result['id'] . '_a_b' : '';
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Helper/ContactActionsMenu/WorkflowActionGroup.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Helper/ContactActionsMenu/WorkflowActionGroup.php
@@ -79,7 +79,7 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
       'label' => 'Joining',
       'class' => 'btn btn-primary-outline',
       'icon' => 'fa fa-user-plus',
-      'url' => $this->getButtonUrl(['openModal' => 'assignment', 'caseTypeId' => $caseTypeId], 'tasks'),
+      'url' => $this->getTasksTabUrl(['openModal' => 'assignment', 'caseTypeId' => $caseTypeId]),
     ];
     return $this->getMenuButton($params);
   }
@@ -95,7 +95,7 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
       'label' => 'Exiting',
       'class' => 'btn btn-primary-outline',
       'icon' => 'fa fa-user-times',
-      'url' => $this->getButtonUrl(['openModal' => 'assignment', 'caseTypeId' => $caseTypeId], 'tasks')
+      'url' => $this->getTasksTabUrl(['openModal' => 'assignment', 'caseTypeId' => $caseTypeId])
     ];
 
     return $this->getMenuButton($params);
@@ -111,7 +111,7 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
       'label' => 'Other...',
       'class' => 'btn btn-primary-outline',
       'icon' => '',
-      'url' => $this->getButtonUrl(['openModal' => 'assignment'], 'tasks')
+      'url' => $this->getTasksTabUrl(['openModal' => 'assignment'])
     ];
 
     return $this->getMenuButton($params);
@@ -127,7 +127,7 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
       'label' => 'New Task',
       'class' => 'btn btn-primary-outline',
       'icon' => 'fa fa-check-square-o',
-      'url' => $this->getButtonUrl(['openModal' => 'task'], 'tasks')
+      'url' => $this->getTasksTabUrl(['openModal' => 'task'])
     ];
 
     return $this->getMenuButton($params);
@@ -143,7 +143,7 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
       'label' => 'New Document',
       'class' => 'btn btn-primary-outline',
       'icon' => 'fa fa-id-card-o',
-      'url' => $this->getButtonUrl(['openModal' => 'document'], 'documents')
+      'url' => $this->getDocumentsTabUrl(['openModal' => 'document'])
     ];
 
     return $this->getMenuButton($params);
@@ -195,16 +195,14 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
    *
    * @return ActionsGroupButtonItem
    */
-  private function getMenuButton($params, $attributes = []) {
+  private function getMenuButton($params, array $attributes = []) {
     $button = new ActionsGroupButtonItem($params['label']);
     $button->setClass($params['class'])
       ->setIcon($params['icon'])
       ->setUrl($params['url']);
 
-    if ($attributes) {
-      foreach($attributes as $attribute => $value) {
-        $button->setAttribute($attribute, $value);
-      }
+    foreach($attributes as $attribute => $value) {
+      $button->setAttribute($attribute, $value);
     }
 
     return $button;
@@ -272,7 +270,7 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
    *
    * @return string
    */
-  private function getButtonUrl($queryParameters, $defaultTab) {
+  private function getTasksAndAssignmentsUrl($queryParameters, $defaultTab) {
     $defaultParameters = ['reset' => 1, 'cid' => $this->contactID];
     $queryParameters = array_merge($defaultParameters, $queryParameters);
 
@@ -282,5 +280,27 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
     );
 
     return $url;
+  }
+
+  /**
+   * Gets the Url for a Document Tab based on the query parameters
+   *
+   * @param array $queryParameters
+   *
+   * @return string
+   */
+  private function getDocumentsTabUrl($queryParameters) {
+    return $this->getTasksAndAssignmentsUrl($queryParameters, 'documents');
+  }
+
+  /**
+   * Gets the Url for a Task Tab based on the query parameters
+   *
+   * @param array $queryParameters
+   *
+   * @return string
+   */
+  private function getTasksTabUrl($queryParameters) {
+    return $this->getTasksAndAssignmentsUrl($queryParameters, 'tasks');
   }
 }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Helper/ContactActionsMenu/WorkflowActionGroup.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Helper/ContactActionsMenu/WorkflowActionGroup.php
@@ -235,7 +235,9 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
    * @return string
    */
   private function getCaseTypeID($caseTypeName) {
-    return isset($this->getworkflowCaseTypes()[$caseTypeName]) ? $this->getworkflowCaseTypes()[$caseTypeName] : '';
+    $caseTypes = $this->getWorkflowCaseTypes();
+
+    return isset($caseTypes[$caseTypeName]) ? $caseTypes[$caseTypeName] : '';
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Helper/ContactActionsMenu/WorkflowActionGroup.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Helper/ContactActionsMenu/WorkflowActionGroup.php
@@ -75,15 +75,11 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
    */
   private function getJoiningButton() {
     $caseTypeId = $this->getCaseTypeID('Joining');
-    $url = CRM_Utils_System::url(
-      'civicrm/tasksassignments/dashboard#/tasks',
-      "reset=1&cid=$this->contactID&openModal=assignment&caseTypeId=$caseTypeId"
-    );
     $params = [
       'label' => 'Joining',
       'class' => 'btn btn-primary-outline',
       'icon' => 'fa fa-user-plus',
-      'url' => $url
+      'url' => $this->getButtonUrl(['openModal' => 'assignment', 'caseTypeId' => $caseTypeId], 'tasks'),
     ];
     return $this->getMenuButton($params);
   }
@@ -95,15 +91,11 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
    */
   private function getExitingButton() {
     $caseTypeId = $this->getCaseTypeID('Exiting');
-    $url = CRM_Utils_System::url(
-      'civicrm/tasksassignments/dashboard#/tasks',
-      "reset=1&cid=$this->contactID&openModal=assignment&caseTypeId=$caseTypeId"
-    );
     $params = [
       'label' => 'Exiting',
       'class' => 'btn btn-primary-outline',
       'icon' => 'fa fa-user-times',
-      'url' => $url
+      'url' => $this->getButtonUrl(['openModal' => 'assignment', 'caseTypeId' => $caseTypeId], 'tasks')
     ];
 
     return $this->getMenuButton($params);
@@ -115,15 +107,11 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
    * @return ActionsGroupButtonItem
    */
   private function getOtherButton() {
-    $url = CRM_Utils_System::url(
-      'civicrm/tasksassignments/dashboard#/tasks',
-      "reset=1&cid=$this->contactID&openModal=assignment"
-    );
     $params = [
       'label' => 'Other...',
       'class' => 'btn btn-primary-outline',
       'icon' => '',
-      'url' => $url
+      'url' => $this->getButtonUrl(['openModal' => 'assignment'], 'tasks')
     ];
 
     return $this->getMenuButton($params);
@@ -135,15 +123,11 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
    * @return ActionsGroupButtonItem
    */
   private function getNewTaskButton() {
-    $url = CRM_Utils_System::url(
-      'civicrm/tasksassignments/dashboard#/tasks',
-      "reset=1&cid=$this->contactID&openModal=task"
-    );
     $params = [
       'label' => 'New Task',
       'class' => 'btn btn-primary-outline',
       'icon' => 'fa fa-check-square-o',
-      'url' => $url
+      'url' => $this->getButtonUrl(['openModal' => 'task'], 'tasks')
     ];
 
     return $this->getMenuButton($params);
@@ -155,15 +139,11 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
    * @return ActionsGroupButtonItem
    */
   private function getNewDocumentButton() {
-    $url = CRM_Utils_System::url(
-      'civicrm/tasksassignments/dashboard#/documents',
-      "reset=1&cid=$this->contactID&openModal=document"
-    );
     $params = [
       'label' => 'New Document',
       'class' => 'btn btn-primary-outline',
       'icon' => 'fa fa-id-card-o',
-      'url' => $url
+      'url' => $this->getButtonUrl(['openModal' => 'document'], 'documents')
     ];
 
     return $this->getMenuButton($params);
@@ -176,7 +156,7 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
    */
   public function getAddLineManagerButton() {
     $relTypeID = $this->getLineManagerRelationshipTypeSelectId();
-    $attribute = ['onclick' => "CRM.loadForm('/civicrm/contact/view/rel?cid=$this->contactID&action=add&relTypeId=$relTypeID')"];
+    $attribute = ['onclick' => "CRM.loadForm('/civicrm/contact/view/rel?cid={$this->contactID}&action=add&relTypeId={$relTypeID}')"];
     $params = [
       'label' => 'Add A Line Manager',
       'class' => 'btn btn-secondary-outline',
@@ -195,7 +175,7 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
   public function getManageLineManagerButton() {
     $url = CRM_Utils_System::url(
       'civicrm/contact/view',
-      "reset=1&cid=$this->contactID&selectedChild=rel"
+      "reset=1&cid={$this->contactID}&selectedChild=rel"
     );
     $params = [
       'label' => 'Manage Line Manager',
@@ -280,5 +260,25 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
     ]);
 
     return !empty($result['id']) ? $result['id'] . '_a_b' : '';
+  }
+
+  /**
+   * Returns the URL for the T&A related buttons.
+   *
+   * @param array $queryParameters
+   * @param string $defaultTab
+   *
+   * @return string
+   */
+  private function getButtonUrl($queryParameters, $defaultTab) {
+    $defaultParameters = ['reset' => 1, 'cid' => $this->contactID];
+    $queryParameters = array_merge($defaultParameters, $queryParameters);
+
+    $url = CRM_Utils_System::url(
+      "civicrm/tasksassignments/dashboard#/{$defaultTab}",
+      http_build_query($queryParameters)
+    );
+
+    return $url;
   }
 }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Helper/ContactActionsMenu/WorkflowActionGroup.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Helper/ContactActionsMenu/WorkflowActionGroup.php
@@ -44,12 +44,12 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
    */
   public function get() {
     $actionsGroup = new ActionsGroup('Workflows:');
-    $actionsGroup->addItem($this->getWorkflowJoiningButton());
-    $actionsGroup->addItem($this->getWorkflowExitingButton());
-    $actionsGroup->addItem($this->getWorkflowOtherButton());
+    $actionsGroup->addItem($this->getJoiningButton());
+    $actionsGroup->addItem($this->getExitingButton());
+    $actionsGroup->addItem($this->getOtherButton());
     $actionsGroup->addItem(new GroupSeparatorItem());
-    $actionsGroup->addItem($this->getWorkflowNewTaskButton());
-    $actionsGroup->addItem($this->getWorkflowNewDocumentButton());
+    $actionsGroup->addItem($this->getNewTaskButton());
+    $actionsGroup->addItem($this->getNewDocumentButton());
     $actionsGroup->addItem(new GroupSeparatorItem());
 
     $lineManagers = $this->getLineManagers();
@@ -73,7 +73,7 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
    *
    * @return ActionsGroupButtonItem
    */
-  private function getWorkflowJoiningButton() {
+  private function getJoiningButton() {
     $caseTypeId = $this->getCaseTypeID('Joining');
     $url = CRM_Utils_System::url(
       'civicrm/tasksassignments/dashboard#/tasks',
@@ -93,7 +93,7 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
    *
    * @return ActionsGroupButtonItem
    */
-  private function getWorkflowExitingButton() {
+  private function getExitingButton() {
     $caseTypeId = $this->getCaseTypeID('Exiting');
     $url = CRM_Utils_System::url(
       'civicrm/tasksassignments/dashboard#/tasks',
@@ -114,7 +114,7 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
    *
    * @return ActionsGroupButtonItem
    */
-  private function getWorkflowOtherButton() {
+  private function getOtherButton() {
     $url = CRM_Utils_System::url(
       'civicrm/tasksassignments/dashboard#/tasks',
       "reset=1&cid=$this->contactID&openModal=assignment"
@@ -134,7 +134,7 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
    *
    * @return ActionsGroupButtonItem
    */
-  private function getWorkflowNewTaskButton() {
+  private function getNewTaskButton() {
     $url = CRM_Utils_System::url(
       'civicrm/tasksassignments/dashboard#/tasks',
       "reset=1&cid=$this->contactID&openModal=task"
@@ -154,7 +154,7 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup {
    *
    * @return ActionsGroupButtonItem
    */
-  private function getWorkflowNewDocumentButton() {
+  private function getNewDocumentButton() {
     $url = CRM_Utils_System::url(
       'civicrm/tasksassignments/dashboard#/documents',
       "reset=1&cid=$this->contactID&openModal=document"

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Test/BaseHeadlessTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Test/BaseHeadlessTest.php
@@ -12,6 +12,7 @@ abstract class CRM_HRCore_Test_BaseHeadlessTest extends PHPUnit_Framework_TestCa
       'org.civicrm.hrrecruitment',
       'uk.co.compucorp.civicrm.hrleaveandabsences',
       'org.civicrm.hrjobcontract', // L&A depends on HRJobContract
+      'uk.co.compucorp.civicrm.hrcontactactionsmenu'
     ];
 
     return \Civi\Test::headless()

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -10,6 +10,7 @@ use Symfony\Component\Config\FileLocator;
 use CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup as WorkflowActionGroupHelper;
 use CRM_HRCore_Service_Manager as ManagerService;
 use CRM_HRContactActionsMenu_Component_Menu as ActionsMenu;
+use CRM_HRCore_Helper_ExtensionHelper as ExtensionHelper;
 
 /**
  * Implements hook_civicrm_config().
@@ -80,9 +81,9 @@ function hrcore_civicrm_summaryActions( &$actions, $contactID ) {
  *
  * @param ActionsMenu $menu
  */
-function tasksassignments_addContactMenuActions(ActionsMenu $menu) {
+function hrcore_addContactMenuActions(ActionsMenu $menu) {
   //We need to make sure that the T&A extension is enabled
-  if(_hrcore_isExtensionEnabled('uk.co.compucorp.civicrm.tasksassignments')) {
+  if (ExtensionHelper::isExtensionEnabled('uk.co.compucorp.civicrm.tasksassignments')) {
     $contactID = empty($_GET['cid']) ? '' : $_GET['cid'];
     if (!$contactID) {
       return;
@@ -323,21 +324,3 @@ function _hrcore_add_js_session_vars() {
   ]);
 }
 
-/**
- * Checks if an extension is installed or enabled
- *
- * @param string $key
- *   Extension unique key
- *
- * @return boolean
- */
-function _hrcore_isExtensionEnabled($key)  {
-  $isEnabled = CRM_Core_DAO::getFieldValue(
-    'CRM_Core_DAO_Extension',
-    $key,
-    'is_active',
-    'full_name'
-  );
-
-  return  !empty($isEnabled) ? true : false;
-}

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Helper/ContactActionsMenu/WorkflowActionGroupTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Helper/ContactActionsMenu/WorkflowActionGroupTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use CRM_HRCore_Test_BaseHeadlessTest as BaseHeadlessTest;
+use CRM_HRCore_Service_Manager as ManagerService;
+use CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroup as WorkflowActionGroupHelper;
+use CRM_HRCore_Component_ContactActionsMenu_NoSelectedLineManagerTextItem as NoSelectedLineManagerTextItem;
+use CRM_HRCore_Component_ContactActionsMenu_LineManagersListItem as LineManagersListItem;
+use CRM_HRContactActionsMenu_Component_GroupButtonItem as GroupButtonItem;
+use CRM_HRContactActionsMenu_Component_GroupSeparatorItem as GroupSeparatorItem;
+
+/**
+ * Class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroupTest
+ *
+ * @group headless
+ */
+class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroupTest extends BaseHeadlessTest {
+
+  public function testMenuItemsAreCorrectlyAddedWhenContactHasNoLineManager() {
+    $contactID = 2;
+    $managerService = $this->prophesize(ManagerService::class);
+    $managerService->getLineManagersFor($contactID)->willReturn([]);
+    $workflowActionGroupHelper = new WorkflowActionGroupHelper($managerService->reveal(), $contactID);
+    $workflowActionGroup = $workflowActionGroupHelper->get();
+
+    //When user has no line manager, nine items are expected,
+    //Joining, Exiting, Other, New Task, New Document buttons, No Line Manager Text Item
+    //and Add Line Manager button with two separator items.
+    $workflowActionGroupItems = $workflowActionGroup->getItems();
+    $this->assertCount(9, $workflowActionGroupItems);
+    $this->assertDefaultWorkflowItems($workflowActionGroupItems);
+    $this->assertInstanceOf(NoSelectedLineManagerTextItem::class, $workflowActionGroupItems[7]);
+    $this->assertInstanceOf(GroupButtonItem::class, $workflowActionGroupItems[8]);
+
+    //check that the group title is correct
+    $this->assertEquals('Workflows:', $workflowActionGroup->getTitle());
+  }
+
+  public function testMenuItemsAreCorrectlyAddedWhenContactHasALineManager() {
+    $contactID = 2;
+    $managerService = $this->prophesize(ManagerService::class);
+    $managerService->getLineManagersFor($contactID)->willReturn([5 => 'Test Manager']);
+    $managerService->reveal();
+    $workflowActionGroupHelper = new WorkflowActionGroupHelper($managerService->reveal(), $contactID);
+    $workflowActionGroup = $workflowActionGroupHelper->get();
+
+    //When user has no line manager, nine items are expected,
+    //Joining, Exiting, Other, New Task, New Document buttons, Line managers list
+    //and Manage Line Manager button with two separator items
+    $workflowActionGroupItems = $workflowActionGroup->getItems();
+    $this->assertCount(9, $workflowActionGroupItems);
+    $this->assertDefaultWorkflowItems($workflowActionGroupItems);
+    $this->assertInstanceOf(LineManagersListItem::class, $workflowActionGroupItems[7]);
+    $this->assertInstanceOf(GroupButtonItem::class, $workflowActionGroupItems[8]);
+
+    //check that the group title is correct
+    $this->assertEquals('Workflows:', $workflowActionGroup->getTitle());
+  }
+
+  private function assertDefaultWorkflowItems($workflowActionGroupItems) {
+    $this->assertInstanceOf(GroupButtonItem::class, $workflowActionGroupItems[0]);
+    $this->assertInstanceOf(GroupButtonItem::class, $workflowActionGroupItems[1]);
+    $this->assertInstanceOf(GroupButtonItem::class, $workflowActionGroupItems[2]);
+    $this->assertInstanceOf(GroupSeparatorItem::class, $workflowActionGroupItems[3]);
+    $this->assertInstanceOf(GroupButtonItem::class, $workflowActionGroupItems[4]);
+    $this->assertInstanceOf(GroupButtonItem::class, $workflowActionGroupItems[5]);
+    $this->assertInstanceOf(GroupSeparatorItem::class, $workflowActionGroupItems[6]);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Helper/ContactActionsMenu/WorkflowActionGroupTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Helper/ContactActionsMenu/WorkflowActionGroupTest.php
@@ -39,7 +39,6 @@ class CRM_HRCore_Helper_ContactActionsMenu_WorkflowActionGroupTest extends BaseH
     $contactID = 2;
     $managerService = $this->prophesize(ManagerService::class);
     $managerService->getLineManagersFor($contactID)->willReturn([5 => 'Test Manager']);
-    $managerService->reveal();
     $workflowActionGroupHelper = new WorkflowActionGroupHelper($managerService->reveal(), $contactID);
     $workflowActionGroup = $workflowActionGroupHelper->get();
 


### PR DESCRIPTION
## Overview
This PR displays the Workflow related menu items on the main panel of the Contact Actions menu using the hook provided by the contactactionsmenu extension.

## Before
Workflow related menu Items were displayed statically.

## After
- The Workflow related menu items are now displayed dynamically depending on the contact being viewed on the contact summary page.

## Technical Details
- The Tasks and Assignments extension being the owner of the workflow related menu items is supposed to be the one to implement the `addContactMenuActions` hook but since the extension is supposed to be a standalone and independent of CiviHR, the HRCore extension implements the hook instead with a check to make sure that the T&A extension is enabled before injecting the menu items via the hook.

With Contact having no Line Manager

![civihr_staff compucorp co uk _ staging17 2018-02-06 12-36-55](https://user-images.githubusercontent.com/6951813/35858711-c63cc050-0b3d-11e8-9921-bf86d3910858.png)

With Contact having a Line manager:

![civihr_staff compucorp co uk _ staging17 2018-02-06 12-49-09](https://user-images.githubusercontent.com/6951813/35858737-daf30766-0b3d-11e8-9309-add65bea9155.png)

When the Add a Line Manager Button is Clicked

![addlinemanger](https://user-images.githubusercontent.com/6951813/35858755-ecc1155a-0b3d-11e8-810a-6d6629daffee.gif)

When the New Document Button is Clicked

![new document](https://user-images.githubusercontent.com/6951813/35858768-f87c26aa-0b3d-11e8-8442-fd401565ecf7.gif)


When the New task Button is Clicked

![newtask](https://user-images.githubusercontent.com/6951813/35858785-0468d2ba-0b3e-11e8-8810-b482b500c57c.gif)

When the Other... button is Clicked

![otherbutton](https://user-images.githubusercontent.com/6951813/35859043-e2932086-0b3e-11e8-8a5e-abbb4a44f558.gif)


## Comments
- I did not include Gifs for the Joining and Exiting buttons because the Frontend work to make them work as it should is not completed yet See [PCHR-3145](https://compucorp.atlassian.net/browse/PCHR-3145). It would actually be similar to the Gif for Other.. button only that it will open the modal with the workflow type already selected.
