### PR TITLE
PCHR-3075:  Display Leave Info on Contact Actions Menu

### DIFF
--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/templates/CRM/HRContactActionsMenu/Page/Inline/Actions.tpl
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/templates/CRM/HRContactActionsMenu/Page/Inline/Actions.tpl
@@ -51,26 +51,6 @@
       </div>
       <div class="crm_contact-actions__panel crm_contact-actions__panel--secondary">
         <div class="crm_contact-actions__panel__body">
-          <div class="crm_contact-actions__group">
-            <h3>Leave:</h3>
-            <div class="crm_contact-actions__action">
-              <a href="#" class="btn btn-primary-outline">
-                <i class="fa fa-plus"></i> Record New
-              </a>
-            </div>
-            <div class="crm_contact-actions__action">
-              <a href="#" class="btn btn-primary-outline">
-                <i class="fa fa-search"></i> View Entitlements
-              </a>
-            </div>
-            <hr>
-            <h4>Leave Approver(s):</h4>
-            <p><a href="#" class="text-primary">John Snow</a></p>
-            <p><a href="#" class="text-primary">Allan Wite</a></p>
-            <div class="crm_contact-actions__action">
-              <a href="#" class="btn btn-secondary">Manage Leave Approver</a>
-            </div>
-          </div>
           {foreach from=$menu->getMainPanelItems() item='group'}
             <div class="crm_contact-actions__group">
               <h3>{$group->getTitle()}</h3>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Component/ContactActionsMenu/LeaveApproversListItem.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Component/ContactActionsMenu/LeaveApproversListItem.php
@@ -1,0 +1,46 @@
+<?php
+
+use CRM_HRContactActionsMenu_Component_GroupItem as ActionsGroupItemInterface;
+use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Component_ContactActionsMenu_LeaveApproversListItem
+ */
+class CRM_HRLeaveAndAbsences_Component_ContactActionsMenu_LeaveApproversListItem
+  implements ActionsGroupItemInterface {
+
+  /**
+   * @var LeaveManagerService
+   */
+  private $leaveManagerService;
+
+  /**
+   * @var int
+   */
+  private $contactID;
+
+  /**
+   * LeaveApproversListItem constructor.
+   *
+   * @param LeaveManagerService $leaveManagerService
+   * @param int $contactID
+   */
+  public function __construct(LeaveManagerService $leaveManagerService, $contactID) {
+    $this->leaveManagerService = $leaveManagerService;
+    $this->contactID = $contactID;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render() {
+    $leaveApprovers = $this->leaveManagerService->getLeaveApproversForContact($this->contactID);
+    $markup = '<h4>Leave Approver(s): </h4>';
+
+    foreach($leaveApprovers as $leaveApprover) {
+      $markup .= '<p><a href="#" class="text-primary"> ' . $leaveApprover . ' </a></p>';
+    }
+
+    return $markup;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Component/ContactActionsMenu/LeaveApproversListItem.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Component/ContactActionsMenu/LeaveApproversListItem.php
@@ -20,7 +20,7 @@ class CRM_HRLeaveAndAbsences_Component_ContactActionsMenu_LeaveApproversListItem
    * @param array $leaveApprovers
    */
   public function __construct(array $leaveApprovers) {
-    $this->leaveApprovers= $leaveApprovers;
+    $this->leaveApprovers = $leaveApprovers;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Component/ContactActionsMenu/LeaveApproversListItem.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Component/ContactActionsMenu/LeaveApproversListItem.php
@@ -10,34 +10,26 @@ class CRM_HRLeaveAndAbsences_Component_ContactActionsMenu_LeaveApproversListItem
   implements ActionsGroupItemInterface {
 
   /**
-   * @var LeaveManagerService
+   * @var array
    */
-  private $leaveManagerService;
-
-  /**
-   * @var int
-   */
-  private $contactID;
+  private $leaveApprovers;
 
   /**
    * LeaveApproversListItem constructor.
    *
-   * @param LeaveManagerService $leaveManagerService
-   * @param int $contactID
+   * @param array $leaveApprovers
    */
-  public function __construct(LeaveManagerService $leaveManagerService, $contactID) {
-    $this->leaveManagerService = $leaveManagerService;
-    $this->contactID = $contactID;
+  public function __construct(array $leaveApprovers) {
+    $this->leaveApprovers= $leaveApprovers;
   }
 
   /**
    * {@inheritdoc}
    */
   public function render() {
-    $leaveApprovers = $this->leaveManagerService->getLeaveApproversForContact($this->contactID);
     $markup = '<h4>Leave Approver(s): </h4>';
 
-    foreach($leaveApprovers as $leaveApprover) {
+    foreach($this->leaveApprovers as $leaveApprover) {
       $markup .= '<p><a href="#" class="text-primary"> ' . $leaveApprover . ' </a></p>';
     }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Component/ContactActionsMenu/NoSelectedLeaveApproverItem.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Component/ContactActionsMenu/NoSelectedLeaveApproverItem.php
@@ -1,0 +1,17 @@
+<?php
+
+use CRM_HRContactActionsMenu_Component_GroupItem as ActionsGroupItemInterface;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Component_ContactActionsMenu_NoSelectedLeaveApproverItem
+ */
+class CRM_HRLeaveAndAbsences_Component_ContactActionsMenu_NoSelectedLeaveApproverItem
+  implements ActionsGroupItemInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render() {
+    return '<p>You have not selected a Leave Approver</p>';
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Helper/ContactActionsMenu/LeaveActionGroup.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Helper/ContactActionsMenu/LeaveActionGroup.php
@@ -52,7 +52,7 @@ class CRM_HRLeaveAndAbsences_Helper_ContactActionsMenu_LeaveActionGroup {
     $leaveApprovers = $this->getLeaveApprovers();
 
     if ($leaveApprovers) {
-      $leaveApproversListItem = new LeaveApproversListItem($this->leaveManagerService, $this->contactID);
+      $leaveApproversListItem = new LeaveApproversListItem($leaveApprovers);
       $actionsGroup->addItem($leaveApproversListItem);
       $actionsGroup->addItem($this->getManageLeaveApproverButton());
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Helper/ContactActionsMenu/LeaveActionGroup.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Helper/ContactActionsMenu/LeaveActionGroup.php
@@ -1,0 +1,230 @@
+<?php
+
+use CRM_HRContactActionsMenu_Component_Group as ActionsGroup;
+use CRM_HRContactActionsMenu_Component_GroupButtonItem as ActionsGroupButtonItem;
+use CRM_HRContactActionsMenu_Component_GroupSeparatorItem as GroupSeparatorItem;
+use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
+use CRM_HRLeaveAndAbsences_Component_ContactActionsMenu_NoSelectedLeaveApproverItem as NoSelectedLeaveApproverItem;
+use CRM_HRLeaveAndAbsences_Component_ContactActionsMenu_LeaveApproversListItem as LeaveApproversListItem;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Helper_ContactActionsMenu_LeaveActionGroup
+ */
+class CRM_HRLeaveAndAbsences_Helper_ContactActionsMenu_LeaveActionGroup {
+
+  use CRM_HRLeaveAndAbsences_Service_SettingsManagerTrait;
+
+  /**
+   * @var LeaveManagerService
+   */
+  private $leaveManagerService;
+
+  /**
+   * @var int
+   */
+  private $contactID;
+
+  /**
+   * CRM_HRLeaveAndAbsences_Helper_ContactActionsMenu_LeaveActionGroup constructor.
+   *
+   * @param \CRM_HRLeaveAndAbsences_Service_LeaveManager $leaveManagerService
+   * @param int $contactID
+   */
+  public function __construct(LeaveManagerService $leaveManagerService, $contactID) {
+    $this->leaveManagerService = $leaveManagerService;
+    $this->contactID = $contactID;
+  }
+
+  /**
+   * Gets Leave Menu Group with menu items already
+   * added.
+   *
+   * @return ActionsGroup
+   */
+  public function get() {
+    $actionsGroup = new ActionsGroup('Leave:');
+    $actionsGroup->addItem($this->getRecordLeaveButton());
+    $actionsGroup->addItem($this->getRecordSicknessButton());
+    $actionsGroup->addItem($this->getRecordOvertimeButton());
+    $actionsGroup->addItem($this->getViewEntitlementsButton());
+    $actionsGroup->addItem(new GroupSeparatorItem());
+
+    $leaveApprovers = $this->getLeaveApprovers();
+
+    if ($leaveApprovers) {
+      $leaveApproversListItem = new LeaveApproversListItem($this->leaveManagerService, $this->contactID);
+      $actionsGroup->addItem($leaveApproversListItem);
+      $actionsGroup->addItem($this->getManageLeaveApproverButton());
+    }
+    else {
+      $noLeaveApprovertItem = new NoSelectedLeaveApproverItem();
+      $actionsGroup->addItem($noLeaveApprovertItem);
+      $actionsGroup->addItem($this->getAddLeaveApproverButton());
+    }
+
+    return $actionsGroup;
+  }
+
+  /**
+   * Gets the View Entitlement button
+   *
+   * @return ActionsGroupButtonItem
+   */
+  private function getViewEntitlementsButton() {
+    $params = [
+      'label' => 'View Entitlements',
+      'class' => 'btn-primary-outline',
+      'icon' => 'fa-search',
+      'url' => $this->getLeaveTabUrl()
+    ];
+
+    return $this->getMenuButton($params);
+  }
+
+  /**
+   * Gets the Add Leave Approver button.
+   *
+   * @return ActionsGroupButtonItem
+   */
+  private function getAddLeaveApproverButton() {
+    $relTypeID = $this->getLeaveApproverRelationshipTypeSelectId();
+    $attribute = ['onclick' => "CRM.loadForm('/civicrm/contact/view/rel?cid={$this->contactID}&action=add&relTypeId={$relTypeID}')"];
+    $params = [
+      'label' => 'Add Leave Approver',
+      'class' => 'btn-secondary-outline',
+      'icon' => '',
+      'url' => '#'
+    ];
+
+    return $this->getMenuButton($params, $attribute);
+  }
+
+  /**
+   * Gets the Manage Leave Approver button
+   *
+   * @return ActionsGroupButtonItem
+   */
+  private function getManageLeaveApproverButton() {
+    $url = CRM_Utils_System::url(
+      'civicrm/contact/view',
+      "reset=1&cid={$this->contactID}&selectedChild=rel"
+    );
+    $params = [
+      'label' => 'Manage Leave Approver',
+      'class' => 'btn btn-secondary',
+      'icon' => '',
+      'url' => $url
+    ];
+
+    return $this->getMenuButton($params);
+  }
+
+  /**
+   * Gets the Record Sickness button.
+   *
+   * @return ActionsGroupButtonItem
+   */
+  private function getRecordSicknessButton() {
+    return $this->getLeaveButton('Record Sickness', 'fa-stethoscope', 'sickness');
+  }
+
+  /**
+   * Gets the Record Leave button.
+   *
+   * @return \CRM_HRContactActionsMenu_Component_GroupButtonItem
+   */
+  private function getRecordLeaveButton() {
+    return $this->getLeaveButton('Record Leave', 'fa-briefcase', 'leave');
+  }
+
+  /**
+   * Gets the Record Overtime button.
+   *
+   * @return ActionsGroupButtonItem
+   */
+  private function getRecordOvertimeButton() {
+    return $this->getLeaveButton('Record Overtime', 'fa-calendar-plus-o', 'toil');
+  }
+
+  /**
+   * Gets the Leave button based on parameters passed in.
+   *
+   * @param string $label
+   * @param string $icon
+   * @param string $modalType
+   *
+   * @return ActionsGroupButtonItem
+   */
+  private function getLeaveButton($label, $icon, $modalType) {
+    $params = [
+      'label' => $label,
+      'class' => 'btn-primary-outline',
+      'icon' => $icon,
+      'url' => $this->getLeaveTabUrl(['openModal' => $modalType])
+    ];
+
+    return $this->getMenuButton($params);
+  }
+
+  /**
+   * Gets the URl for the Leave tab on the contact summary page.
+   *
+   * @param array $queryParameters
+   *
+   * @return mixed
+   */
+  private function getLeaveTabUrl($queryParameters = []) {
+    $defaultParameters = ['reset' => 1, 'cid' => $this->contactID, 'selectedChild' => 'absence'];
+    $queryParameters = array_merge($defaultParameters, $queryParameters);
+
+    $url = CRM_Utils_System::url(
+      'civicrm/contact/view',
+      http_build_query($queryParameters)
+    );
+
+    return $url;
+  }
+
+  /**
+   * Returns an instance of an ActionsGroupButtonItem
+   *
+   * @param array $params
+   * @param array $attributes
+   *
+   * @return ActionsGroupButtonItem
+   */
+  private function getMenuButton($params, array $attributes = []) {
+    $button = new ActionsGroupButtonItem($params['label']);
+    $button->setClass($params['class'])
+      ->setIcon($params['icon'])
+      ->setUrl($params['url']);
+
+    foreach($attributes as $attribute => $value) {
+      $button->setAttribute($attribute, $value);
+    }
+
+    return $button;
+  }
+
+  /**
+   * Gets Leave Approvers for the contact.
+   *
+   * @return array
+   */
+  private function getLeaveApprovers() {
+    return $this->leaveManagerService->getLeaveApproversForContact($this->contactID);
+  }
+
+  /**
+   * Returns the relationship type Id for the `has Leave Approved by`
+   * relationship used to default to the relationship type
+   * in the relationship type select field on the Add relationship modal.
+   *
+   * @return string
+   */
+  private function getLeaveApproverRelationshipTypeSelectId() {
+    $leaveApproverRelationshipTypes = $this->getLeaveApproverRelationshipsTypes();
+
+    return $leaveApproverRelationshipTypes[0] . '_a_b';
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Helper/ContactActionsMenu/LeaveActionGroup.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Helper/ContactActionsMenu/LeaveActionGroup.php
@@ -131,7 +131,7 @@ class CRM_HRLeaveAndAbsences_Helper_ContactActionsMenu_LeaveActionGroup {
   /**
    * Gets the Record Leave button.
    *
-   * @return \CRM_HRContactActionsMenu_Component_GroupButtonItem
+   * @return ActionsGroupButtonItem
    */
   private function getRecordLeaveButton() {
     return $this->getLeaveButton('Record Leave', 'fa-briefcase', 'leave');

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -57,7 +57,8 @@ function civicrm_api3_leave_request_create($params) {
 
 function civicrm_api3_leave_request_get_from_email_for_notifications($leaveRequest) {
   $leaveRequestTemplateFactory = new CRM_HRLeaveAndAbsences_Factory_RequestNotificationTemplate();
-  $message = new CRM_HRLeaveAndAbsences_Mail_Message($leaveRequest, $leaveRequestTemplateFactory);
+  $leaveManagerService = new CRM_HRLeaveAndAbsences_Service_LeaveManager();
+  $message = new CRM_HRLeaveAndAbsences_Mail_Message($leaveRequest, $leaveRequestTemplateFactory, $leaveManagerService);
 
   return $message->getFromEmail();
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -18,6 +18,8 @@ use CRM_HRLeaveAndAbsences_Mail_Message as Message;
 use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestMailNotificationSender as LeaveRequestMailNotificationSenderService;
 use CRM_HRLeaveAndAbsences_Factory_RequestNotificationTemplate as RequestNotificationTemplateFactory;
+use CRM_HRContactActionsMenu_Component_Menu as ActionsMenu;
+use CRM_HRLeaveAndAbsences_Helper_ContactActionsMenu_LeaveActionGroup as LeaveActionGroupHelper;
 
 require_once 'hrleaveandabsences.civix.php';
 
@@ -446,6 +448,25 @@ function hrleaveandabsences_civicrm_apiWrappers(&$wrappers, $apiRequest) {
   $wrappers[] = new CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestDates();
 }
 
+
+/**
+ * Implementation of hook_addContactMenuActions to add the
+ * Leave menu group to the contact actions menu.
+ *
+ * @param ActionsMenu $menu
+ */
+function hrleaveandabsences_addContactMenuActions(ActionsMenu $menu){
+  $contactID = empty($_GET['cid']) ? '' : $_GET['cid'];
+  if (!$contactID) {
+    return;
+  }
+
+  $leaveManagerService = new LeaveManagerService();
+  $leaveActionGroup = new LeaveActionGroupHelper($leaveManagerService, $contactID);
+  $leaveActionGroup = $leaveActionGroup->get();
+  $leaveActionGroup->setWeight(1);
+  $menu->addToMainPanel($leaveActionGroup);
+}
 //----------------------------------------------------------------------------//
 //                               Helper Functions                             //
 //----------------------------------------------------------------------------//

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -15,7 +15,7 @@
 use CRM_HRLeaveAndAbsences_Factory_PublicHolidayLeaveRequestService as PublicHolidayLeaveRequestServiceFactory;
 use CRM_HRLeaveAndAbsences_Service_AbsenceType as AbsenceTypeService;
 use CRM_HRLeaveAndAbsences_Mail_Message as Message;
-use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestMailNotificationSender as LeaveRequestMailNotificationSenderService;
 use CRM_HRLeaveAndAbsences_Factory_RequestNotificationTemplate as RequestNotificationTemplateFactory;
 
@@ -652,7 +652,8 @@ function _hrleaveandabsences_civicrm_post_leaverequest($op, $objectId, &$objectR
   try {
     //get the message for the leave request
     $leaveRequestTemplateFactory = new RequestNotificationTemplateFactory();
-    $message = new Message($objectRef, $leaveRequestTemplateFactory);
+    $leaveManagerService = new LeaveManagerService();
+    $message = new Message($objectRef, $leaveRequestTemplateFactory, $leaveManagerService);
 
     if (!$message->getTemplateID()) {
       return;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Helper/ContactActionsMenu/LeaveActionGroupTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Helper/ContactActionsMenu/LeaveActionGroupTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
+use CRM_HRLeaveAndAbsences_Helper_ContactActionsMenu_LeaveActionGroup as LeaveActionGroupHelper;
+use CRM_HRLeaveAndAbsences_Component_ContactActionsMenu_LeaveApproversListItem as LeaveApproversListItem;
+use CRM_HRLeaveAndAbsences_Component_ContactActionsMenu_NoSelectedLeaveApproverItem as NoSelectedLeaveApproverItem;
+use CRM_HRContactActionsMenu_Component_GroupButtonItem as GroupButtonItem;
+use CRM_HRContactActionsMenu_Component_GroupSeparatorItem as GroupSeparatorItem;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_Helper_ContactActionsMenu_LeaveActionGroupTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_Helper_ContactActionsMenu_LeaveActionGroupTest extends BaseHeadlessTest {
+  public function testMenuItemsAreCorrectlyAddedWhenContactHasNoLeaveApprover() {
+    $contactID = 2;
+    $leaveManagerService = $this->prophesize(LeaveManagerService::class);
+    $leaveManagerService->getLeaveApproversForContact($contactID)->willReturn([]);
+    $leaveActionGroupHelper = new LeaveActionGroupHelper($leaveManagerService->reveal(), $contactID);
+    $leaveActionGroup = $leaveActionGroupHelper->get();
+
+    //When user has no leave approver, seven items are expected,
+    //Record Leave, Record Sickness, Record Overtime, View Entitlements buttons,
+    //No Leave Approver Text Item and Add Leave Approver button with a separator item.
+    $leaveActionGroupItems = $leaveActionGroup->getItems();
+    $this->assertCount(7, $leaveActionGroupItems);
+    $this->assertDefaultLeaveGroupItems($leaveActionGroupItems);
+    $this->assertInstanceOf(NoSelectedLeaveApproverItem::class, $leaveActionGroupItems[5]);
+    $this->assertInstanceOf(GroupButtonItem::class, $leaveActionGroupItems[6]);
+
+    //check that the group title is correct
+    $this->assertEquals('Leave:', $leaveActionGroup->getTitle());
+  }
+
+  public function testMenuItemsAreCorrectlyAddedWhenContactHasALeaveApprover() {
+    $contactID = 2;
+    $leaveManagerService = $this->prophesize(LeaveManagerService::class);
+    $leaveManagerService->getLeaveApproversForContact($contactID)->willReturn([1 => 'Test Leave Approver']);
+    $leaveActionGroupHelper = new LeaveActionGroupHelper($leaveManagerService->reveal(), $contactID);
+    $leaveActionGroup = $leaveActionGroupHelper->get();
+
+    //When user has no leave approver, seven items are expected,
+    //Record Leave, Record Sickness, Record Overtime, View Entitlements buttons,
+    //Leave Approvers List and Manage Leave Approver button with a separator item.
+    //When user has no line manager, nine items are expected,
+    $leaveActionGroupItems = $leaveActionGroup->getItems();
+    $this->assertCount(7, $leaveActionGroupItems);
+    $this->assertDefaultLeaveGroupItems($leaveActionGroupItems);
+    $this->assertInstanceOf(LeaveApproversListItem::class, $leaveActionGroupItems[5]);
+    $this->assertInstanceOf(GroupButtonItem::class, $leaveActionGroupItems[6]);
+
+    //check that the group title is correct
+    $this->assertEquals('Leave:', $leaveActionGroup->getTitle());
+  }
+
+  private function assertDefaultLeaveGroupItems($leaveActionGroupItems) {
+    $this->assertInstanceOf(GroupButtonItem::class, $leaveActionGroupItems[0]);
+    $this->assertInstanceOf(GroupButtonItem::class, $leaveActionGroupItems[1]);
+    $this->assertInstanceOf(GroupButtonItem::class, $leaveActionGroupItems[2]);
+    $this->assertInstanceOf(GroupButtonItem::class, $leaveActionGroupItems[3]);
+    $this->assertInstanceOf(GroupSeparatorItem::class, $leaveActionGroupItems[4]);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveManagerTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveManagerTest.php
@@ -184,4 +184,28 @@ class CRM_HRLeaveAndAbsences_Service_LeaveManagerTest extends BaseHeadlessTest {
     $leaveApprovers = $this->leaveManagerService->getLeaveApproversForContact($contactID);
     $this->assertEquals([], $leaveApprovers);
   }
+
+  public function testGetLeaveApproversForContactReturnsEmptyWhenLeaveApproverRelationshipIsInactive() {
+    $contact = ContactFabricator::fabricate();
+    $manager1 = ContactFabricator::fabricate(['display_name' => 'Manager 1']);
+
+    // Set manager1 to be leave approver for the contact but set relationship to be inactive
+    $this->setContactAsLeaveApproverOf($manager1, $contact, null, null, false);
+
+    $leaveApprovers = $this->leaveManagerService->getLeaveApproversForContact($contact['id']);
+
+    $this->assertEquals([], $leaveApprovers);
+  }
+
+  public function testGetLeaveApproversForContactReturnsEmptyWhenLeaveApproverRelationshipHasExpired() {
+    $contact = ContactFabricator::fabricate();
+    $manager1 = ContactFabricator::fabricate(['display_name' => 'Manager 1']);
+
+    // Set manager1 to be leave approver for the contact but set relationship to be expired
+    $this->setContactAsLeaveApproverOf($manager1, $contact, '2016-01-01', '2016-12-31');
+
+    $leaveApprovers = $this->leaveManagerService->getLeaveApproversForContact($contact['id']);
+
+    $this->assertEquals([], $leaveApprovers);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveManagerTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveManagerTest.php
@@ -159,4 +159,29 @@ class CRM_HRLeaveAndAbsences_Service_LeaveManagerTest extends BaseHeadlessTest {
 
     $this->assertTrue($this->leaveManagerService->currentUserIsAdmin());
   }
+
+  public function testGetLeaveApproversForContact() {
+    $contact = ContactFabricator::fabricate();
+    $manager1 = ContactFabricator::fabricate(['display_name' => 'Manager 1']);
+    $manager2 = ContactFabricator::fabricate(['display_name' => 'Manager 2']);
+
+    // Set manager1 and manager2 to be leave aprovers for the leave contact
+    $this->setContactAsLeaveApproverOf($manager1, $contact);
+    $this->setContactAsLeaveApproverOf($manager2, $contact);
+
+    $leaveApprovers = $this->leaveManagerService->getLeaveApproversForContact($contact['id']);
+
+    $expectedResult = [
+      $manager1['id'] => $manager1['display_name'],
+      $manager2['id'] => $manager2['display_name'],
+    ];
+
+    $this->assertEquals($expectedResult, $leaveApprovers);
+  }
+
+  public function testGetLeaveApproversForContactReturnsEmptyWhenContactHasNoLeaveApprover() {
+    $contactID = 6;
+    $leaveApprovers = $this->leaveManagerService->getLeaveApproversForContact($contactID);
+    $this->assertEquals([], $leaveApprovers);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestMailNotificationSenderTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestMailNotificationSenderTest.php
@@ -5,6 +5,7 @@ use CRM_HRLeaveAndAbsences_Service_LeaveRequestMailNotificationSender as LeaveRe
 use CRM_HRLeaveAndAbsences_Factory_RequestNotificationTemplate as RequestNotificationTemplateFactory;
 use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
+use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
 
 /**
  * Class CRM_HRLeaveAndAbsences_Service_LeaveRequestMailNotificationSenderTest
@@ -52,7 +53,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestMailNotificationSenderTest exte
     $this->assertEquals(0, $result->N);
 
     $leaveRequestTemplateFactory = new RequestNotificationTemplateFactory();
-    $message = new Message($leaveRequest, $leaveRequestTemplateFactory);
+    $managerService = new LeaveManagerService();
+    $message = new Message($leaveRequest, $leaveRequestTemplateFactory, $managerService);
 
     $leaveMailSenderService = new LeaveRequestMailNotificationSenderService();
     $leaveMailSenderService->send($message);
@@ -90,7 +92,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestMailNotificationSenderTest exte
     ], false);
 
     $leaveRequestTemplateFactory = new RequestNotificationTemplateFactory();
-    $message = new Message($leaveRequest, $leaveRequestTemplateFactory);
+    $managerService = new LeaveManagerService();
+    $message = new Message($leaveRequest, $leaveRequestTemplateFactory, $managerService);
 
     $leaveMailSenderService = new LeaveRequestMailNotificationSenderService();
 


### PR DESCRIPTION
## Overview
This PR displays the Leave related menu items on the main panel of the Contact Actions menu using the hook provided by the contactactionsmenu extension.

## Before
Leave related menu Items were displayed statically.

## After
The Leave related menu items are now displayed dynamically depending on the contact being viewed on the contact summary page.

## Technical Details
The Leave and Absences extension implements the `addContactMenuActions` hook to display Leave related menu items on the Contact Actions menu.

With Contact Having no Leave Approver

![civihr_staff compucorp co uk _ staging17 2018-02-07 14-22-08](https://user-images.githubusercontent.com/6951813/35919010-fd53a88e-0c13-11e8-97a4-78b68557f9db.png)

With Contact Having a Leave Approver

![civihr_staff compucorp co uk _ staging17 2018-02-07 14-24-40](https://user-images.githubusercontent.com/6951813/35919021-0bf65c10-0c14-11e8-993f-7f3f521d9680.png)

When the Add Leave Approver Button is clicked

![addleaveapprover](https://user-images.githubusercontent.com/6951813/35919053-1e2e59b4-0c14-11e8-853c-85f2d46ac046.gif)

When the Record Leave button is clicked

![recordleave](https://user-images.githubusercontent.com/6951813/35930537-79406180-0c32-11e8-8d47-9c0777619aa8.gif)
