### PR TITLE
PCHR-3078: Display Communications Info on Contact Actions Menu

### DIFF
--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Helper/CommunicationActionGroup.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Helper/CommunicationActionGroup.php
@@ -1,0 +1,178 @@
+<?php
+
+use CRM_HRContactActionsMenu_Component_Group as ActionsGroup;
+use CRM_HRContactActionsMenu_Component_GroupButtonItem as ActionsGroupButtonItem;
+
+/**
+ * Class CRM_HRContactActionsMenu_Helper_CommunicationActionGroup
+ */
+class CRM_HRContactActionsMenu_Helper_CommunicationActionGroup {
+
+  /**
+   * @var array
+   */
+  private $communicationActivityTypes;
+
+  /**
+   * @var int
+   */
+  private $contactID;
+
+  /**
+   * CRM_HRContactActionsMenu_Helper_CommunicationActionGroup constructor
+   *
+   * @param int $contactID
+   */
+  public function __construct($contactID) {
+    $this->contactID = $contactID;
+  }
+
+  /**
+   * Gets Communicate Menu Group with menu items already
+   * added.
+   *
+   * @return ActionsGroup
+   */
+  public function get() {
+    $actionsGroup = new ActionsGroup('Communicate:');
+    $actionsGroup->addItem($this->getSendEmailButton());
+    $actionsGroup->addItem($this->getRecordMeetingButton());
+    $actionsGroup->addItem($this->getCreatePdfLetterButton());
+
+    return $actionsGroup;
+  }
+
+  /**
+   * Gets the Send Email Button Item.
+   *
+   * @return ActionsGroupButtonItem
+   */
+  private function getSendEmailButton() {
+    $activityValue = $this->getActivityTypeValue('Email');
+    $formUrl = $this->getAddActivityUrl(['atype' => $activityValue], 'email');
+    $attribute = ['onclick' => "CRM.loadForm('{$formUrl}')"];
+    $params = [
+      'label' => 'Send Email',
+      'class' => 'btn-primary-outline',
+      'icon' => 'fa-envelope-o',
+      'url' => '#'
+    ];
+
+    return $this->getMenuButton($params, $attribute);
+  }
+
+  /**
+   * Gets the Record Meeting Button Item.
+   *
+   * @return ActionsGroupButtonItem
+   */
+  private function getRecordMeetingButton(){
+    $activityValue = $this->getActivityTypeValue('Meeting');
+    $formUrl = $this->getAddActivityUrl(['atype' => $activityValue]);
+    $attribute = ['onclick' => "CRM.loadForm('{$formUrl}')"];
+    $params = [
+      'label' => 'Record Meeting',
+      'class' => 'btn-primary-outline',
+      'icon' => 'fa-users',
+      'url' => '#'
+    ];
+
+    return $this->getMenuButton($params, $attribute);
+  }
+
+  /**
+   * Gets the Create PDF Letter Button Item.
+   *
+   * @return ActionsGroupButtonItem
+   */
+  private function getCreatePdfLetterButton() {
+    $activityValue = $this->getActivityTypeValue('Print PDF Letter');
+    $formUrl = $this->getAddActivityUrl(['atype' => $activityValue], 'pdf');
+    $attribute = ['onclick' => "CRM.loadForm('{$formUrl}')"];
+    $params = [
+      'label' => 'Create PDF Letter',
+      'class' => 'btn-primary-outline',
+      'icon' => 'fa-file-pdf-o',
+      'url' => '#'
+    ];
+
+    return $this->getMenuButton($params, $attribute);
+  }
+
+  /**
+   * Returns an instance of an ActionsGroupButtonItem
+   *
+   * @param array $params
+   * @param array $attributes
+   *
+   * @return ActionsGroupButtonItem
+   */
+  private function getMenuButton($params, array $attributes = []) {
+    $button = new ActionsGroupButtonItem($params['label']);
+    $button->setClass($params['class'])
+      ->setIcon($params['icon'])
+      ->setUrl($params['url']);
+
+    foreach($attributes as $attribute => $value) {
+      $button->setAttribute($attribute, $value);
+    }
+
+    return $button;
+  }
+
+  /**
+   * Gets the Add Activity URL depending on the activity type
+   * and query parameters.
+   *
+   * @param array $queryParameters
+   * @param string $type
+   *
+   * @return string
+   */
+  private function getAddActivityUrl($queryParameters = [], $type = '') {
+    $defaultParameters = ['action' => 'add', 'cid' => $this->contactID];
+    $queryParameters = array_merge($defaultParameters, $queryParameters);
+    $url = 'civicrm/activity/add';
+
+    if ($type) {
+      $url = "civicrm/activity/{$type}/add";
+    }
+
+    return CRM_Utils_System::url(
+      $url,
+      http_build_query($queryParameters)
+    );
+  }
+
+  /**
+   * Returns the communication related activity types.
+   *
+   * @return array
+   *   The activity option values indexed by their names
+   */
+  private function getCommunicationActivityTypes() {
+    if(!$this->communicationActivityTypes) {
+      $result = civicrm_api3('OptionValue', 'get', [
+        'option_group_id' => 'activity_type',
+        'name' => ['IN' => ['Print PDF Letter', 'Meeting', 'Email']],
+      ]);
+
+      $this->communicationActivityTypes = array_column($result['values'], 'value', 'name');
+    }
+
+    return $this->communicationActivityTypes;
+  }
+
+  /**
+   * Returns the Activity type option value
+   *
+   * @param string $activityName
+   *
+   * @return string
+   */
+  private function getActivityTypeValue($activityName) {
+    $activityTypes = $this->getCommunicationActivityTypes();
+
+    return isset($activityTypes[$activityName]) ? $activityTypes[$activityName] : '';
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/hrcontactactionsmenu.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/hrcontactactionsmenu.php
@@ -5,6 +5,7 @@ require_once 'hrcontactactionsmenu.civix.php';
 use CRM_HRContactActionsMenu_ExtensionUtil as E;
 use CRM_HRContactActionsMenu_Component_Menu as ActionsMenu;
 use CRM_HRContactActionsMenu_Helper_UserInformationActionGroup as UserInformationActionGroupHelper;
+use CRM_HRContactActionsMenu_Helper_CommunicationActionGroup as CommunicationActionGroupHelper;
 use CRM_HRContactActionsMenu_Helper_Contact as ContactHelper;
 use CRM_HRCore_CMSData_UserRoleFactory as CMSUserRoleFactory;
 use CRM_HRCore_CMSData_PathsFactory as CMSUserPathFactory;
@@ -13,7 +14,8 @@ use CRM_HRCore_CMSData_UserAccountFactory as UserAccountFactory;
 
 /**
  * Implementation of hook_addContactMenuActions to add the
- * User Information menu group to the contact actions menu.
+ * User Information menu group and the Communicate menu group
+ * to the contact actions menu.
  *
  * @param \CRM_HRContactActionsMenu_Component_Menu $menu
  *
@@ -36,6 +38,11 @@ function hrcontactactionsmenu_addContactMenuActions(ActionsMenu $menu) {
 
   $userInformationActionGroup = new UserInformationActionGroupHelper($contactUserInfo, $cmsUserPath, $cmsUserRole);
   $menu->addToHighlightedPanel($userInformationActionGroup->get());
+
+  $communicationActionGroup = new CommunicationActionGroupHelper($contactID);
+  $communicationActionGroup = $communicationActionGroup->get();
+  $communicationActionGroup->setWeight(3);
+  $menu->addToMainPanel($communicationActionGroup);
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/templates/CRM/HRContactActionsMenu/Page/Inline/Actions.tpl
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/templates/CRM/HRContactActionsMenu/Page/Inline/Actions.tpl
@@ -59,24 +59,6 @@
               {/foreach}
             </div>
           {/foreach}
-          <div class="crm_contact-actions__group">
-            <h3>Communicate </h3>
-            <div class="crm_contact-actions__action">
-              <a href="#" class="btn btn-primary-outline">
-                <i class="fa fa-envelope-o"></i> Send Email
-              </a>
-            </div>
-            <div class="crm_contact-actions__action">
-              <a href="#" class="btn btn-primary-outline">
-                <i class="fa fa-users"></i> Record Meeting
-              </a>
-            </div>
-            <div class="crm_contact-actions__action">
-              <a href="#" class="btn btn-primary-outline">
-                <i class="fa fa-file-pdf-o"></i> Create PDF Letter
-              </a>
-            </div>
-          </div>
         </div>
         <div class="crm_contact-actions__panel__footer">
           {if call_user_func(array('CRM_Core_Permission','check'), 'delete contacts')}

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/tests/phpunit/CRM/HRContactActionsMenu/Helper/CommunicationActionGroupTest.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/tests/phpunit/CRM/HRContactActionsMenu/Helper/CommunicationActionGroupTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use CRM_HRContactActionsMenu_Helper_CommunicationActionGroup as CommunicationActionGroupHelper;
+use CRM_HRContactActionsMenu_Component_GroupButtonItem as GroupButtonItem;
+
+/**
+ * Class CRM_HRContactActionsMenu_Helper_CommunicationActionGroupTest
+ *
+ * @group headless
+ */
+class CRM_HRContactActionsMenu_Helper_CommunicationActionGroupTest extends BaseHeadlessTest {
+
+  public function testMenuItemsAreAddedCorrectly() {
+    $contactID = 5;
+    $communicationGroupHelper = new CommunicationActionGroupHelper($contactID);
+    $communicationGroup = $communicationGroupHelper->get();
+    $communicationGroupItems = $communicationGroup->getItems();
+    $this->assertCount(3, $communicationGroupItems);
+
+    //Three buttons are expected, The Send email, Record meeting and
+    //create PDF letter buttons.
+    $this->assertInstanceOf(GroupButtonItem::class, $communicationGroupItems[0]);
+    $this->assertInstanceOf(GroupButtonItem::class, $communicationGroupItems[1]);
+    $this->assertInstanceOf(GroupButtonItem::class, $communicationGroupItems[2]);
+
+    //check that the group title is correct
+    $this->assertEquals('Communicate:', $communicationGroup->getTitle());
+  }
+}


### PR DESCRIPTION
## Overview
This PR displays the Communication related menu items on the main panel of the Contact Actions menu using the hook provided by the contactactionsmenu extension.

## Before
Communication related menu Items were displayed statically.

## After
The Communication related menu items are now displayed with dynamic links depending on the contact being viewed on the contact summary page.

![civihr_staff compucorp co uk _ staging17 2018-02-08 15-23-39](https://user-images.githubusercontent.com/6951813/35978058-fbe78b2e-0ce4-11e8-93f2-2ba4001739e7.png)


When the Send Email Button is clicked:

![sendemail](https://user-images.githubusercontent.com/6951813/35978083-0c1a10b6-0ce5-11e8-9324-49d2358e2907.gif)


When the Record Meeting Button is clicked:

![recordmeeting](https://user-images.githubusercontent.com/6951813/35978106-1a2912f6-0ce5-11e8-9415-567238cd2bf2.gif)


When the Create PDF Letter Button is clicked.

![createpdf](https://user-images.githubusercontent.com/6951813/35978127-27b978e8-0ce5-11e8-9dbe-5dc0c598d4ce.gif)
