### PR TITLE
PCHR-3074: Add the CMS User Permission Interface and related classes

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserPermission/Drupal.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserPermission/Drupal.php
@@ -5,7 +5,7 @@ use CRM_HRCore_CMSData_UserPermissionInterface as UserPermissionInterface;
 /**
  * Class CRM_HRCore_CMSData_UserPermission_Drupal
  */
-class CRM_HRCore_CMSData_UserPermission_Drupal implements UserPermissionInterface{
+class CRM_HRCore_CMSData_UserPermission_Drupal implements UserPermissionInterface {
 
   /**
    * Gets the Drupal user object

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserPermission/Drupal.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserPermission/Drupal.php
@@ -1,0 +1,35 @@
+<?php
+
+use CRM_HRCore_CMSData_UserPermissionInterface as UserPermissionInterface;
+
+/**
+ * Class CRM_HRCore_CMSData_UserPermission_Drupal
+ */
+class CRM_HRCore_CMSData_UserPermission_Drupal implements UserPermissionInterface{
+
+  /**
+   * Gets the Drupal user object
+   *
+   * @param array $contactData
+   *
+   * @return \stdClass
+   */
+  private function getUser($contactData) {
+    return user_load($contactData['cmsId']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function check($contactData, array $permissions = []) {
+    $user = $this->getUser($contactData);
+
+    foreach($permissions as $permission) {
+      if (user_access($permission, $user)) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserPermissionFactory.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserPermissionFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+use CRM_HRCore_CMSData_UserPermission_Drupal as DrupalUserPermission;
+use CRM_HRCore_CMSData_UserPermissionInterface as UserPermissionInterface;
+
+class CRM_HRCore_CMSData_UserPermissionFactory {
+
+  /**
+   * Creates an object of the UserPermissionInterface class based on the
+   * CMS framework in use.
+   *
+   * @return UserPermissionInterface;
+   *
+   * @throws \Exception
+   */
+  public static function create() {
+    $cmsFramework = CRM_Core_Config::singleton()->userFramework;
+
+    if ($cmsFramework == 'Drupal') {
+      return new DrupalUserPermission();
+    }
+
+    $msg = sprintf('Unrecognized CMS: "%s"', $cmsFramework);
+    throw new \Exception($msg);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserPermissionInterface.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserPermissionInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+interface CRM_HRCore_CMSData_UserPermissionInterface {
+
+  /**
+   * Checks if the user has any of the permissions
+   * in permissions array.
+   *
+   * @param array $contactData
+   * @param array $permissions
+   *
+   * @return bool
+   */
+  public function check($contactData, array $permissions = []);
+}

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserAccountFactoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserAccountFactoryTest.php
@@ -10,18 +10,25 @@ use CRM_HRCore_CMSData_UserAccountInterface as UserAccountInterface;
  */
 class CRM_HRCore_CMSData_UserAccountFactoryTest extends CRM_HRCore_Test_BaseHeadlessTest {
 
+  private $previousUserFramework;
+
+  public function setUp() {
+    $this->previousUserFramework = CRM_Core_Config::singleton()->userFramework;
+  }
+
+  public function tearDown() {
+    CRM_Core_Config::singleton()->userFramework = $this->previousUserFramework;
+  }
+
   public function testItReturnsAnInstanceOfTheExpectedClassWhenCMSIsSupported() {
-    $previousUserFramework = CRM_Core_Config::singleton()->userFramework;
     //We need to manually set this value because civicrm sets it to some other value
     //when running in testing environment.
     CRM_Core_Config::singleton()->userFramework = 'Drupal';
     $userAccount= UserAccountFactory::create();
     $this->assertInstanceOf(UserAccountInterface::class, $userAccount);
-    CRM_Core_Config::singleton()->userFramework = $previousUserFramework;
   }
 
   public function testItThrowsAnExceptionWhenCMSIsNotSupported() {
-    $previousUserFramework = CRM_Core_Config::singleton()->userFramework;
     //We need to manually set this value because civicrm sets it to some other value
     //when running in testing environment.
     $cmsFramework = 'UnrecognizedCMS';
@@ -30,6 +37,5 @@ class CRM_HRCore_CMSData_UserAccountFactoryTest extends CRM_HRCore_Test_BaseHead
     $this->setExpectedException('Exception', $msg);
 
     UserAccountFactory::create();
-    CRM_Core_Config::singleton()->userFramework = $previousUserFramework;
   }
 }

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserMailNotifierFactoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserMailNotifierFactoryTest.php
@@ -10,18 +10,25 @@ use CRM_HRCore_CMSData_UserMailNotifierInterface as UserMailNotifierInterface;
  */
 class CRM_HRCore_CMSData_CMSUserMailNotifierFactoryTest extends CRM_HRCore_Test_BaseHeadlessTest {
 
+  private $previousUserFramework;
+
+  public function setUp() {
+    $this->previousUserFramework = CRM_Core_Config::singleton()->userFramework;
+  }
+
+  public function tearDown() {
+    CRM_Core_Config::singleton()->userFramework = $this->previousUserFramework;
+  }
+
   public function testItReturnsAnInstanceOfTheExpectedClassWhenCMSIsSupported() {
-    $previousUserFramework = CRM_Core_Config::singleton()->userFramework;
     //We need to manually set this value because civicrm sets it to some other value
     //when running in testing environment.
     CRM_Core_Config::singleton()->userFramework = 'Drupal';
     $mailNotifier = UserMailNotifierFactory::create();
     $this->assertInstanceOf(UserMailNotifierInterface::class, $mailNotifier);
-    CRM_Core_Config::singleton()->userFramework = $previousUserFramework;
   }
 
   public function testItThrowsAnExceptionWhenCMSIsNotSupported() {
-    $previousUserFramework = CRM_Core_Config::singleton()->userFramework;
     //We need to manually set this value because civicrm sets it to some other value
     //when running in testing environment.
     $cmsFramework = 'UnrecognizedCMS';
@@ -30,7 +37,6 @@ class CRM_HRCore_CMSData_CMSUserMailNotifierFactoryTest extends CRM_HRCore_Test_
     $this->setExpectedException('Exception', $msg);
 
     UserMailNotifierFactory::create();
-    CRM_Core_Config::singleton()->userFramework = $previousUserFramework;
   }
 }
 

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserPermission/DrupalTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserPermission/DrupalTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use CRM_HRCore_CMSData_UserPermission_Drupal as DrupalUserPermissions;
+
+/**
+ * Class CRM_HRCore_CMSData_UserPermission_DrupalTest
+ *
+ * @group headless
+ */
+class CRM_HRCore_CMSData_UserPermission_DrupalTest extends CRM_HRCore_Test_BaseHeadlessTest {
+
+  public function testCheckPermissionsReturnsTrueWhenUserHasThePermission() {
+    $contactData = ['cmsId' => 2];
+    $userPermission = new DrupalUserPermissions();
+    $result = $userPermission->check($contactData, ['sample permission']);
+
+    $this->assertTrue($result);
+  }
+
+  public function testCheckPermissionsReturnsFalseWhenUserDoesNotHaveThePermission() {
+    //setting a user ID of 0 will allow us to test the scenario for when a user
+    //has no permission.
+
+    $contactData = ['cmsId' => 0];
+    $userPermission = new DrupalUserPermissions();
+    $result = $userPermission->check($contactData, ['sample permission']);
+
+    $this->assertFalse($result);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserPermission/DrupalTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserPermission/DrupalTest.php
@@ -19,7 +19,8 @@ class CRM_HRCore_CMSData_UserPermission_DrupalTest extends CRM_HRCore_Test_BaseH
 
   public function testCheckPermissionsReturnsFalseWhenUserDoesNotHaveThePermission() {
     //setting a user ID of 0 will allow us to test the scenario for when a user
-    //has no permission.
+    //has no permission as this will return false when passed to the user_access
+    //drupal mock function.
 
     $contactData = ['cmsId' => 0];
     $userPermission = new DrupalUserPermissions();

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserPermissionFactoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserPermissionFactoryTest.php
@@ -8,7 +8,7 @@ use CRM_HRCore_CMSData_UserPermissionInterface as UserPermissionInterface;
  *
  * @group headless
  */
-class UserPermissionFactoryTest extends CRM_HRCore_Test_BaseHeadlessTest {
+class CRM_HRCore_CMSData_UserPermissionFactoryTest extends CRM_HRCore_Test_BaseHeadlessTest {
 
   private $previousUserFramework;
 

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserPermissionFactoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserPermissionFactoryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use CRM_HRCore_CMSData_UserPermissionFactory as UserPermissionFactory;
+use CRM_HRCore_CMSData_UserPermissionInterface as UserPermissionInterface;
+
+/**
+ * Class CRM_HRCore_CMSData_UserPermissionFactoryTest
+ *
+ * @group headless
+ */
+class UserPermissionFactoryTest extends CRM_HRCore_Test_BaseHeadlessTest {
+
+  public function testItReturnsAnInstanceOfTheExpectedClassWhenCMSIsSupported() {
+    $previousUserFramework = CRM_Core_Config::singleton()->userFramework;
+    //We need to manually set this value because civicrm sets it to some other value
+    //when running in testing environment.
+    CRM_Core_Config::singleton()->userFramework = 'Drupal';
+    $userPermission = UserPermissionFactory::create();
+    $this->assertInstanceOf(UserPermissionInterface::class, $userPermission);
+    CRM_Core_Config::singleton()->userFramework = $previousUserFramework;
+  }
+
+  public function testItThrowsAnExceptionWhenCMSIsNotSupported() {
+    $previousUserFramework = CRM_Core_Config::singleton()->userFramework;
+    //We need to manually set this value because civicrm sets it to some other value
+    //when running in testing environment.
+    $cmsFramework = 'UnrecognizedCMS';
+    CRM_Core_Config::singleton()->userFramework = $cmsFramework;
+    $msg = sprintf('Unrecognized CMS: "%s"', $cmsFramework);
+    $this->setExpectedException('Exception', $msg);
+
+    UserPermissionFactory::create();
+    CRM_Core_Config::singleton()->userFramework = $previousUserFramework;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserPermissionFactoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/CMSData/UserPermissionFactoryTest.php
@@ -10,18 +10,25 @@ use CRM_HRCore_CMSData_UserPermissionInterface as UserPermissionInterface;
  */
 class UserPermissionFactoryTest extends CRM_HRCore_Test_BaseHeadlessTest {
 
+  private $previousUserFramework;
+
+  public function setUp() {
+    $this->previousUserFramework = CRM_Core_Config::singleton()->userFramework;
+  }
+
+  public function tearDown() {
+    CRM_Core_Config::singleton()->userFramework = $this->previousUserFramework;
+  }
+
   public function testItReturnsAnInstanceOfTheExpectedClassWhenCMSIsSupported() {
-    $previousUserFramework = CRM_Core_Config::singleton()->userFramework;
     //We need to manually set this value because civicrm sets it to some other value
     //when running in testing environment.
     CRM_Core_Config::singleton()->userFramework = 'Drupal';
     $userPermission = UserPermissionFactory::create();
     $this->assertInstanceOf(UserPermissionInterface::class, $userPermission);
-    CRM_Core_Config::singleton()->userFramework = $previousUserFramework;
   }
 
   public function testItThrowsAnExceptionWhenCMSIsNotSupported() {
-    $previousUserFramework = CRM_Core_Config::singleton()->userFramework;
     //We need to manually set this value because civicrm sets it to some other value
     //when running in testing environment.
     $cmsFramework = 'UnrecognizedCMS';
@@ -30,6 +37,6 @@ class UserPermissionFactoryTest extends CRM_HRCore_Test_BaseHeadlessTest {
     $this->setExpectedException('Exception', $msg);
 
     UserPermissionFactory::create();
-    CRM_Core_Config::singleton()->userFramework = $previousUserFramework;
   }
+
 }

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/drupal_function_mocks.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/drupal_function_mocks.php
@@ -62,7 +62,10 @@ function batch_process() {}
 
 function _get_uf_match_contact() {}
 
-function user_access() {
+function user_access($permission, $user) {
+  if($user->uid == 0) {
+    return FALSE;
+  }
   return TRUE;
 }
 


### PR DESCRIPTION
## Overview
This PR adds some generic CMS related classes and interfaces to the HRCore extension that can be used by other extensions.
The class added in this PR is the UserPermission Interface and its related classes

## Before
CMS UserPermission interface and related classes were not present.

## After
The following interface was added in this PR:
- CRM_HRCore_CMSData_UserPermissiontInterface: This interface provides functionality to check if a CMS user has access to certain permissions or not.

The following class was added to implement the Interface
- The CRM_HRCore_CMSData_UserPermission_Drupal class

The following factory class was added:
- The CRM_HRCore_CMSData_UserPermissionFactory.



## Comments
- These classes were added primarily to aid the task being done in https://compucorp.atlassian.net/browse/PCHR-3074
