### PR TITLE
PCHR-3285: Redirect from the SSP report pages to the CiviHR admin

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Page/Reports.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Page/Reports.php
@@ -8,6 +8,27 @@ class CRM_HRCore_Page_Reports extends CRM_Core_Page {
   public function run() {
     CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrcore', 'js/crm/vendor/iframeResizer.min.js');
 
+    $this->assign('reportName', $this->getReportName());
+
     return parent::run();
+  }
+
+  /**
+   * Returns the report name from the request URL
+   *
+   * The reports url follow this format: /civicrm/reports/my_report_name. This
+   * method will return the /my_report_name part.
+   *
+   * Trailing / will be removed
+   *
+   * @return string
+   */
+  private function getReportName() {
+    $baseReportsPath = '/civicrm/reports';
+    $requestPath = $_SERVER['REQUEST_URI'];
+    $reportName = str_replace($baseReportsPath, '', $requestPath);
+    $reportName = rtrim($reportName, '/');
+
+    return $reportName;
   }
 }

--- a/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Page/Reports.tpl
+++ b/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Page/Reports.tpl
@@ -1,4 +1,4 @@
-<iframe id="reportsIframe" src="/reports" frameborder="0" scrolling="no" style="width: 100%"></iframe>
+<iframe id="reportsIframe" src="/reports{$reportName}" frameborder="0" scrolling="no" style="width: 100%"></iframe>
 <script type="text/javascript">
   {literal}
   CRM.$(function() {

--- a/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Page/Reports.tpl
+++ b/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Page/Reports.tpl
@@ -1,4 +1,4 @@
-<iframe id="reportsIframe" src="/reports{$reportName}" frameborder="0" scrolling="no" style="width: 100%"></iframe>
+<iframe id="reportsIframe" src="/reports{$reportName}?iframe=1" frameborder="0" scrolling="no" style="width: 100%"></iframe>
 <script type="text/javascript">
   {literal}
   CRM.$(function() {

--- a/uk.co.compucorp.civicrm.hrcore/xml/Menu/hrcore.xml
+++ b/uk.co.compucorp.civicrm.hrcore/xml/Menu/hrcore.xml
@@ -48,4 +48,16 @@
     <page_callback>CRM_HRCore_Page_Reports</page_callback>
     <access_arguments>access hrreports</access_arguments>
   </item>
+  <item>
+    <path>civicrm/reports/people</path>
+    <title>Reports</title>
+    <page_callback>CRM_HRCore_Page_Reports</page_callback>
+    <access_arguments>access hrreports</access_arguments>
+  </item>
+  <item>
+    <path>civicrm/reports/leave_and_absence</path>
+    <title>Reports</title>
+    <page_callback>CRM_HRCore_Page_Reports</page_callback>
+    <access_arguments>access hrreports</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
This PR introduces changes necessary to support the enhancement described on https://github.com/compucorp/civihr-employee-portal/pull/440. Please check that PR for more details