### PR TITLE
PCHR-3286: Rename Contact Access Rights menu group title

### DIFF
--- a/contactaccessrights/CRM/Contactaccessrights/Helper/ContactActionsMenu/ContactAccessActionGroup.php
+++ b/contactaccessrights/CRM/Contactaccessrights/Helper/ContactActionsMenu/ContactAccessActionGroup.php
@@ -161,7 +161,7 @@ class CRM_Contactaccessrights_Helper_ContactActionsMenu_ContactAccessActionGroup
   private function getGroupTitle() {
     $groupTitleToolTip = new GroupTitleToolTipItem();
 
-    return 'User Has Access To: ' . $groupTitleToolTip->render();
+    return 'User Has CiviHR Admin Access To: ' . $groupTitleToolTip->render();
   }
 
   /**

--- a/contactaccessrights/tests/phpunit/CRM/Contactaccessrights/Helper/ContactActionsMenu/ContactAccessGroupTest.php
+++ b/contactaccessrights/tests/phpunit/CRM/Contactaccessrights/Helper/ContactActionsMenu/ContactAccessGroupTest.php
@@ -224,6 +224,6 @@ class CRM_Contactaccessrights_Helper_ContactAccessGroupTest extends BaseHeadless
   private function getGroupTitle() {
     $groupTitleToolTip = new GroupTitleToolTipItem();
 
-    return 'User Has Access To: ' . $groupTitleToolTip->render();
+    return 'User Has CiviHR Admin Access To: ' . $groupTitleToolTip->render();
   }
 }


### PR DESCRIPTION
## Overview
This PR renames the Contact Access Rights menu group title to follow what is the original wireframe rather than the mockup. The title is changed from `User Has Access To:` to  `User Has CiviHR Admin Access To:`

## Before
![civihr_staff compucorp co uk _ staging17 2018-02-15 14-52-45](https://user-images.githubusercontent.com/6951813/36259892-fc3e90b0-125f-11e8-8761-fa190ee88f1a.png)


## After
![civihr_staff compucorp co uk _ staging17 2018-02-15 14-51-51](https://user-images.githubusercontent.com/6951813/36259885-f35b708a-125f-11e8-8014-32f4d1c8bd12.png)

