### PR TITLE
PCHR-3291: Rename Communications Menu Title

### DIFF
--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Helper/CommunicationActionGroup.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Helper/CommunicationActionGroup.php
@@ -34,7 +34,7 @@ class CRM_HRContactActionsMenu_Helper_CommunicationActionGroup {
    * @return ActionsGroup
    */
   public function get() {
-    $actionsGroup = new ActionsGroup('Communicate:');
+    $actionsGroup = new ActionsGroup('Communications:');
     $actionsGroup->addItem($this->getSendEmailButton());
     $actionsGroup->addItem($this->getRecordMeetingButton());
     $actionsGroup->addItem($this->getCreatePdfLetterButton());

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/tests/phpunit/CRM/HRContactActionsMenu/Helper/CommunicationActionGroupTest.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/tests/phpunit/CRM/HRContactActionsMenu/Helper/CommunicationActionGroupTest.php
@@ -24,6 +24,6 @@ class CRM_HRContactActionsMenu_Helper_CommunicationActionGroupTest extends BaseH
     $this->assertInstanceOf(GroupButtonItem::class, $communicationGroupItems[2]);
 
     //check that the group title is correct
-    $this->assertEquals('Communicate:', $communicationGroup->getTitle());
+    $this->assertEquals('Communications:', $communicationGroup->getTitle());
   }
 }


### PR DESCRIPTION
## Overview
This PR renames the Communications menu group title to follow what is the original wireframe rather than the mockup. The title is changed from `Communicate` to `Communications`

## Before
![civihr_staff compucorp co uk _ staging17 2018-02-15 15-03-44](https://user-images.githubusercontent.com/6951813/36262038-a132af7e-1266-11e8-8e17-6d6a722ed541.png)


## After
![civihr_staff compucorp co uk _ staging17 2018-02-15 15-07-28](https://user-images.githubusercontent.com/6951813/36262066-b4cfd02a-1266-11e8-9d8f-64ffc5a14a2c.png)

