### PR TITLE
PCHR-3289: Fix issue with Delete button, Disable button and Delete Staff member text.

### DIFF
--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Page/UserAccount.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Page/UserAccount.php
@@ -13,7 +13,7 @@ class CRM_HRContactActionsMenu_Page_UserAccount {
    * contact.
    */
   public static function delete() {
-    self::doUserAction('delete', 'User account has been deleted');
+    self::doUserAction('cancel', 'User account has been deleted');
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/hrcontactactionsmenu.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/hrcontactactionsmenu.php
@@ -197,7 +197,7 @@ function hrcontactactionsmenu_civicrm_alterSettingsFolders(&$metaDataFolders = N
  * @return bool
  */
 function _hrcontactactionsmenu_get_is_user_disabled($contactInfo) {
-  if(empty($contactInfo['id'])) {
+  if(empty($contactInfo['cmsId'])) {
     return false;
   }
   $userAccount = UserAccountFactory::create();

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/templates/CRM/HRContactActionsMenu/Page/Inline/Actions.tpl
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/templates/CRM/HRContactActionsMenu/Page/Inline/Actions.tpl
@@ -57,7 +57,7 @@
             {if call_user_func(array('CRM_Core_Permission','check'), 'delete contacts')}
               <a class="btn btn-danger pull-right"
                 href="/civicrm/contact/view/delete?reset=1&delete=1&cid={$contactInfo.contact_id}">
-                <span><i class="fa fa-trash"></i></span> Delete Staff Member
+                <span><i class="fa fa-trash"></i></span> {if !empty($contactInfo.cmsId)} Delete User And Staff Member {else} Delete Staff Member {/if}
               </a>
             {/if}
           </div>


### PR DESCRIPTION
## Overview
This PR fixes some of the issues encountered by QA while testing the [PCHR-2823](https://compucorp.atlassian.net/browse/PCHR-2823)
- The `Delete staff member` link on the contact actions menu was not working and showing an error page.
- After a user account is disabled the `Disable User Account` button remains instead of the `Enable User Account` button and there is no way to re-enable the user. 
- The Delete staff member text is supposed to be dynamic depending on whether the contact has a user account or not.

## Before
- The issues mentioned above existed.

## After
- The Delete Staff member text was made dynamic depending on whether contact has a user account or not:
![civihr_staff compucorp co uk _ staging17 2018-02-15 17-57-55 1](https://user-images.githubusercontent.com/6951813/36270072-21ce2b4a-127b-11e8-99b3-f0336c9f5b3a.png)
![civihr_staff compucorp co uk _ staging17 2018-02-15 17-52-24 1](https://user-images.githubusercontent.com/6951813/36270242-7b3dfca0-127b-11e8-969b-54752515773c.png)




- The delete link on the contact actions menu was not working and showing an error page: The error page was due to calling a wrong method on the `UserAccountInterface` when deleting a user account, The right method name is `cancel` since in reality the account is only cancelled and its contents moved to anonymous user.
- After a user account is disabled the `Disable User Account` button remains instead of the `Enable User Account` button and there is no way to re-enable the user: This is due to the function for returning if a user is disabled always returning false due to the check for a non existent member of the `contactInfo` array.
