### PR TITLE
PCHR-3288: Link Leave Approver to contact page

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Component/ContactActionsMenu/LeaveApproversListItem.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Component/ContactActionsMenu/LeaveApproversListItem.php
@@ -29,8 +29,9 @@ class CRM_HRLeaveAndAbsences_Component_ContactActionsMenu_LeaveApproversListItem
   public function render() {
     $markup = '<h4>Leave Approver(s): </h4>';
 
-    foreach($this->leaveApprovers as $leaveApprover) {
-      $markup .= '<p><a href="#" class="text-primary"> ' . $leaveApprover . ' </a></p>';
+    foreach($this->leaveApprovers as $contactID => $contactName) {
+      $markup .= '<p><a href="/civicrm/contact/view?reset=1&cid=' . $contactID . '" class="text-primary"> 
+        ' . $contactName . ' </a></p>';
     }
 
     return $markup;


### PR DESCRIPTION
## Overview
The leave approvers names list for a contact on the Leave Menu section on the contact actions menu are links but nothing happens when the links are clicked. Clicking on a leave approver name is actually supposed to lead to the contact summary page for the leave approver.

## Before
- Clicking on the leave approvers name does nothing.

## After
- Clicking on the leave approvers name leads to the the leave approver contact summary page.
