### PR TITLE
PCHR-3287: Update Text and Add Divider After Record Leave Buttons

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Helper/ContactActionsMenu/LeaveActionGroup.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Helper/ContactActionsMenu/LeaveActionGroup.php
@@ -46,6 +46,7 @@ class CRM_HRLeaveAndAbsences_Helper_ContactActionsMenu_LeaveActionGroup {
     $actionsGroup->addItem($this->getRecordLeaveButton());
     $actionsGroup->addItem($this->getRecordSicknessButton());
     $actionsGroup->addItem($this->getRecordOvertimeButton());
+    $actionsGroup->addItem(new GroupSeparatorItem());
     $actionsGroup->addItem($this->getViewEntitlementsButton());
     $actionsGroup->addItem(new GroupSeparatorItem());
 
@@ -57,7 +58,7 @@ class CRM_HRLeaveAndAbsences_Helper_ContactActionsMenu_LeaveActionGroup {
       $actionsGroup->addItem($this->getManageLeaveApproverButton());
     }
     else {
-      $noLeaveApprovertItem = new ParagraphItem('You have not selected a Leave Approver');
+      $noLeaveApprovertItem = new ParagraphItem('The staff member does not have a leave approver');
       $actionsGroup->addItem($noLeaveApprovertItem);
       $actionsGroup->addItem($this->getAddLeaveApproverButton());
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/BaseHeadlessTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/BaseHeadlessTest.php
@@ -11,6 +11,7 @@ abstract class BaseHeadlessTest extends PHPUnit_Framework_TestCase implements
       ->install('uk.co.compucorp.civicrm.hrcore')
       ->install('org.civicrm.hrjobcontract')
       ->install('uk.co.compucorp.civicrm.hrcomments')
+      ->install('uk.co.compucorp.civicrm.hrcontactactionsmenu')
       ->installMe(__DIR__)
       ->apply();
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Helper/ContactActionsMenu/LeaveActionGroupTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Helper/ContactActionsMenu/LeaveActionGroupTest.php
@@ -20,14 +20,15 @@ class CRM_HRLeaveAndAbsences_Helper_ContactActionsMenu_LeaveActionGroupTest exte
     $leaveActionGroupHelper = new LeaveActionGroupHelper($leaveManagerService->reveal(), $contactID);
     $leaveActionGroup = $leaveActionGroupHelper->get();
 
-    //When user has no leave approver, seven items are expected,
-    //Record Leave, Record Sickness, Record Overtime, View Entitlements buttons,
-    //No Leave Approver Text Item and Add Leave Approver button with a separator item.
+    //When user has no leave approver, eight items are expected,
+    //Record Leave, Record Sickness, Record Overtime, Separator Item,
+    //View Entitlements buttons, Separator Item,
+    //No Leave Approver Text Item and Add Leave Approver button
     $leaveActionGroupItems = $leaveActionGroup->getItems();
-    $this->assertCount(7, $leaveActionGroupItems);
+    $this->assertCount(8, $leaveActionGroupItems);
     $this->assertDefaultLeaveGroupItems($leaveActionGroupItems);
-    $this->assertInstanceOf(ParagraphItem::class, $leaveActionGroupItems[5]);
-    $this->assertInstanceOf(GroupButtonItem::class, $leaveActionGroupItems[6]);
+    $this->assertInstanceOf(ParagraphItem::class, $leaveActionGroupItems[6]);
+    $this->assertInstanceOf(GroupButtonItem::class, $leaveActionGroupItems[7]);
 
     //check that the group title is correct
     $this->assertEquals('Leave:', $leaveActionGroup->getTitle());
@@ -40,15 +41,15 @@ class CRM_HRLeaveAndAbsences_Helper_ContactActionsMenu_LeaveActionGroupTest exte
     $leaveActionGroupHelper = new LeaveActionGroupHelper($leaveManagerService->reveal(), $contactID);
     $leaveActionGroup = $leaveActionGroupHelper->get();
 
-    //When user has no leave approver, seven items are expected,
-    //Record Leave, Record Sickness, Record Overtime, View Entitlements buttons,
-    //Leave Approvers List and Manage Leave Approver button with a separator item.
-    //When user has no line manager, nine items are expected,
+    //When user has leave approver, eight items are expected,
+    //Record Leave, Record Sickness, Record Overtime, Separator Item,
+    //View Entitlements button, Separator Item,
+    //Leave Approvers List and Manage Leave Approver button.
     $leaveActionGroupItems = $leaveActionGroup->getItems();
-    $this->assertCount(7, $leaveActionGroupItems);
+    $this->assertCount(8, $leaveActionGroupItems);
     $this->assertDefaultLeaveGroupItems($leaveActionGroupItems);
-    $this->assertInstanceOf(LeaveApproversListItem::class, $leaveActionGroupItems[5]);
-    $this->assertInstanceOf(GroupButtonItem::class, $leaveActionGroupItems[6]);
+    $this->assertInstanceOf(LeaveApproversListItem::class, $leaveActionGroupItems[6]);
+    $this->assertInstanceOf(GroupButtonItem::class, $leaveActionGroupItems[7]);
 
     //check that the group title is correct
     $this->assertEquals('Leave:', $leaveActionGroup->getTitle());
@@ -58,7 +59,8 @@ class CRM_HRLeaveAndAbsences_Helper_ContactActionsMenu_LeaveActionGroupTest exte
     $this->assertInstanceOf(GroupButtonItem::class, $leaveActionGroupItems[0]);
     $this->assertInstanceOf(GroupButtonItem::class, $leaveActionGroupItems[1]);
     $this->assertInstanceOf(GroupButtonItem::class, $leaveActionGroupItems[2]);
-    $this->assertInstanceOf(GroupButtonItem::class, $leaveActionGroupItems[3]);
-    $this->assertInstanceOf(GroupSeparatorItem::class, $leaveActionGroupItems[4]);
+    $this->assertInstanceOf(GroupSeparatorItem::class, $leaveActionGroupItems[3]);
+    $this->assertInstanceOf(GroupButtonItem::class, $leaveActionGroupItems[4]);
+    $this->assertInstanceOf(GroupSeparatorItem::class, $leaveActionGroupItems[5]);
   }
 }


### PR DESCRIPTION
## Overview
This PR updates the text for when a contact has no leave approver to match what is in the wireframe on the [Wiki](https://compucorp.atlassian.net/wiki/spaces/PCHR/pages/121277611/Contact+page+actions+-+UX+improvements)
Also a divider is added after the Record Leave buttons to separate it from other sections on the leave menu group.

## Before
![civihr_manager compucorp co uk _ staging17 2018-02-16 13-18-06](https://user-images.githubusercontent.com/6951813/36308936-eee0d950-1322-11e8-8930-d6f98a07bcbf.png)


## After

- The text is updated from `You have not selected a Leave Approver` to `The staff member does not have a leave approver`

![civihr_manager compucorp co uk _ staging17 2018-02-16 13-23-58](https://user-images.githubusercontent.com/6951813/36308944-f8597604-1322-11e8-8fdf-276ef77eafcf.png)
