### PR TITLE
PCHR-3079: Hide permissions and notes field

### DIFF
--- a/hrui/css/hrui.css
+++ b/hrui/css/hrui.css
@@ -39,3 +39,10 @@
 .crm-contact-restore {
   display: none;
 }
+
+/* This hides the notes and permissions field on Add Relationship Modal */
+.crm-relationship-form-block-note,
+.crm-relationship-form-block-is_permission_a_b,
+.crm-relationship-form-block-is_permission_b_a {
+  display: none;
+}


### PR DESCRIPTION
## Overview
This PR hides the notes and permissions fields on the Add relationship modal

## Before
![civihr_manager compucorp co uk _ staging17 2018-02-16 14-46-10](https://user-images.githubusercontent.com/6951813/36311558-f292ec38-132b-11e8-92ee-e1dbd62b657d.png)

## After
![civihr_manager compucorp co uk _ staging17 2018-02-16 14-55-36](https://user-images.githubusercontent.com/6951813/36311572-fbabe9d2-132b-11e8-95d6-9931d842dab6.png)
