### PR TITLE
PCHR-3290: Update button text and Add Account disabled text

### DIFF
--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Component/UserInformationLinkItem.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Component/UserInformationLinkItem.php
@@ -2,6 +2,7 @@
 
 use CRM_HRContactActionsMenu_Component_GroupItem as ActionsGroupItemInterface;
 use CRM_HRCore_CMSData_Paths_PathsInterface as CMSUserPath;
+use CRM_HRCore_CMSData_UserAccountInterface as CMSUserAccount;
 
 /**
  * Class CRM_HRContactActionsMenu_Component_UserInformationLinkItem
@@ -18,13 +19,20 @@ class CRM_HRContactActionsMenu_Component_UserInformationLinkItem implements Acti
   private $contactData;
 
   /**
+   * @var CMSUserAccount
+   */
+  private $cmsUserAccount;
+
+  /**
    * CRM_HRContactActionsMenu_Component_UserInformationLinkItem constructor.
    *
    * @param CMSUserPath $cmsUserPath
+   * @param CMSUserAccount $cmsUserAccount
    * @param array $contactData
    */
-  public function __construct(CMSUserPath $cmsUserPath, $contactData) {
+  public function __construct(CMSUserPath $cmsUserPath, CMSUserAccount $cmsUserAccount, $contactData) {
     $this->cmsUserPath = $cmsUserPath;
+    $this->cmsUserAccount = $cmsUserAccount;
     $this->contactData = $contactData;
   }
 
@@ -34,11 +42,21 @@ class CRM_HRContactActionsMenu_Component_UserInformationLinkItem implements Acti
    * @return string
    */
   public function render() {
+    $userAccountDisabled = $this->cmsUserAccount->isUserDisabled($this->contactData);
+
+    if ($userAccountDisabled) {
+      $linkMarkup = '<a href="%s" class="disabled">%s</a>
+        <strong class="text-warning"> (Account disabled)</strong>';
+    }
+    else {
+      $linkMarkup = '<a href="%s">%s</a>';
+    }
+
     $userInformationMarkup = '
       <div class="crm_contact-actions__user-info">
         <dl class="dl-horizontal dl-horizontal-inline">
           <dt>User:</dt>
-          <dd><a href="%s" class="text-primary">%s</a></dd>
+          <dd>' . $linkMarkup . '</dd>
         </dl>
       </div>';
 

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Helper/UserInformationActionGroup.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Helper/UserInformationActionGroup.php
@@ -61,7 +61,7 @@ class CRM_HRContactActionsMenu_Helper_UserInformationActionGroup {
       $actionsGroup->addItem($this->getSendWelcomeMailButton($contactID));
       $actionsGroup->addItem($this->getSendPasswordResetButton($contactID));
     } else {
-      $noUserTextItem = new ParagraphItem('There is no user for this staff member');
+      $noUserTextItem = new ParagraphItem('There is no user account for this staff member');
       $actionsGroup->addItem($noUserTextItem);
       $actionsGroup->addItem($this->getCreateUserButton($contactID));
     }
@@ -133,7 +133,7 @@ class CRM_HRContactActionsMenu_Helper_UserInformationActionGroup {
   private function getCreateUserButton($contactID) {
     $url = CRM_Utils_System::url('civicrm/user/create-account', "cid=$contactID");
     $params = [
-      'label' => 'Create a user for this staff member',
+      'label' => 'Add User account',
       'class' => 'btn-primary',
       'icon' => 'fa-plus',
       'url' => $url

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Helper/UserInformationActionGroup.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Helper/UserInformationActionGroup.php
@@ -6,6 +6,7 @@ use CRM_HRContactActionsMenu_Component_UserInformationLinkItem as UserInformatio
 use CRM_HRContactActionsMenu_Component_UserRoleItem as UserRoleItem;
 use CRM_HRCore_CMSData_Paths_PathsInterface as CMSUserPath;
 use CRM_HRCore_CMSData_UserRoleInterface as CMSUserRole;
+use CRM_HRCore_CMSData_UserAccountInterface as CMSUserAccount;
 use CRM_HRContactActionsMenu_Component_ParagraphItem as ParagraphItem;
 
 /**
@@ -18,13 +19,18 @@ class CRM_HRContactActionsMenu_Helper_UserInformationActionGroup {
    */
   private $contactUserInfo;
   /**
-   * @var \CRM_HRCore_CMSData_Paths_PathsInterface
+   * @var CMSUserPath
    */
   private $cmsUserPath;
   /**
-   * @var \CRM_HRCore_CMSData_UserRoleInterface
+   * @var CMSUserRole
    */
   private $cmsUserRole;
+
+  /**
+   * @var CMSUserAccount
+   */
+  private $cmsUserAccount;
 
   /**
    * CRM_HRContactActionsMenu_Helper_UserInformationActionGroup constructor.
@@ -33,12 +39,19 @@ class CRM_HRContactActionsMenu_Helper_UserInformationActionGroup {
    *   Contact user info gotten from the contact helper
    * @param CMSUserPath|null $cmsUserPath
    * @param CMSUserRole|null $cmsUserRole
+   * @param CMSUserAccount|null $cmsUserAccount;
    *
    */
-  public function __construct($contactUserInfo, $cmsUserPath = null, $cmsUserRole = null) {
+  public function __construct(
+    $contactUserInfo,
+    CMSUserPath $cmsUserPath = null,
+    CMSUserRole $cmsUserRole = null,
+    CMSUserAccount $cmsUserAccount = null
+  ) {
     $this->contactUserInfo = $contactUserInfo;
     $this->cmsUserRole = $cmsUserRole;
     $this->cmsUserPath = $cmsUserPath;
+    $this->cmsUserAccount = $cmsUserAccount;
   }
 
   /**
@@ -52,7 +65,11 @@ class CRM_HRContactActionsMenu_Helper_UserInformationActionGroup {
     $actionsGroup = new ActionsGroup('User Information:');
 
     if(!empty($this->contactUserInfo['cmsId'])) {
-      $userInformationLinkItem = new UserInformationLinkItem($this->cmsUserPath, $this->contactUserInfo);
+      $userInformationLinkItem = new UserInformationLinkItem(
+        $this->cmsUserPath,
+        $this->cmsUserAccount,
+        $this->contactUserInfo
+      );
       $actionsGroup->addItem($userInformationLinkItem);
 
       $userRoleItem = new UserRoleItem($this->cmsUserRole);

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/hrcontactactionsmenu.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/hrcontactactionsmenu.php
@@ -28,15 +28,22 @@ function hrcontactactionsmenu_addContactMenuActions(ActionsMenu $menu) {
   }
   $cmsUserPath = '';
   $cmsUserRole = '';
+  $cmsUserAccount = '';
 
   $contactUserInfo = ContactHelper::getUserInformation($contactID);
   if(!empty($contactUserInfo['cmsId'])) {
     $cmsFramework = CRM_Core_Config::singleton()->userFramework;
     $cmsUserPath = CMSUserPathFactory::create($cmsFramework, $contactUserInfo);
     $cmsUserRole = CMSUserRoleFactory::create($cmsFramework, $contactUserInfo);
+    $cmsUserAccount = UserAccountFactory::create($contactUserInfo);
   }
 
-  $userInformationActionGroup = new UserInformationActionGroupHelper($contactUserInfo, $cmsUserPath, $cmsUserRole);
+  $userInformationActionGroup = new UserInformationActionGroupHelper(
+    $contactUserInfo,
+    $cmsUserPath,
+    $cmsUserRole,
+    $cmsUserAccount
+  );
   $menu->addToHighlightedPanel($userInformationActionGroup->get());
 
   $communicationActionGroup = new CommunicationActionGroupHelper($contactID);

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/tests/phpunit/CRM/HRContactActionsMenu/Helper/UserInformationActionGroupTest.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/tests/phpunit/CRM/HRContactActionsMenu/Helper/UserInformationActionGroupTest.php
@@ -6,6 +6,7 @@ use CRM_HRContactActionsMenu_Component_UserInformationLinkItem as UserInformatio
 use CRM_HRContactActionsMenu_Component_UserRoleItem as UserRoleItem;
 use CRM_HRCore_CMSData_UserRoleInterface as CMSUserRole;
 use CRM_HRCore_CMSData_Paths_PathsInterface as CMSUserPath;
+use CRM_HRCore_CMSData_UserAccountInterface as CMSUserAccount;
 use CRM_HRContactActionsMenu_Component_ParagraphItem as ParagraphItem;
 
 /**
@@ -19,10 +20,12 @@ class CRM_HRContactActionsMenu_Helper_UserInformationActionGroupTest extends Bas
     $contactUserInfo = ['contact_id' => 2];
     $cmsUserPath = $this->prophesize(CMSUserPath::class);
     $cmsUserRole = $this->prophesize(CMSUserRole::class);
+    $cmsUserAccount = $this->prophesize(CMSUserAccount::class);
     $userActionGroupHelper = new UserInformationActionGroupHelper(
       $contactUserInfo,
       $cmsUserPath->reveal(),
-      $cmsUserRole->reveal()
+      $cmsUserRole->reveal(),
+      $cmsUserAccount->reveal()
     );
 
     $userActionGroup = $userActionGroupHelper->get();
@@ -42,10 +45,12 @@ class CRM_HRContactActionsMenu_Helper_UserInformationActionGroupTest extends Bas
     $contactUserInfo = ['cmsId' => 3, 'name' => 'cms username', 'contact_id' => 2];
     $cmsUserPath = $this->prophesize(CMSUserPath::class);
     $cmsUserRole = $this->prophesize(CMSUserRole::class);
+    $cmsUserAccount = $this->prophesize(CMSUserAccount::class);
     $userActionGroupHelper= new UserInformationActionGroupHelper(
       $contactUserInfo,
       $cmsUserPath->reveal(),
-      $cmsUserRole->reveal()
+      $cmsUserRole->reveal(),
+      $cmsUserAccount->reveal()
     );
 
     $userActionGroup = $userActionGroupHelper->get();


### PR DESCRIPTION
## Overview
This PR updates some texts to match what is in the wireframe for the contact menu actions. The texts updated are:
- Button text to add a user account was updated from : `Create a user for this staff member` to `Add User account`
- Text display when contact has no user account was updated from: `There is no user for this staff member` to `There is no user account for this staff member`

Also the Account Disabled text was added for the scenario when User account for a contact is disabled.

## Before
- These changes above were not present.

Before updating button and text display

![civihr_staff compucorp co uk _ staging17 2018-02-15 17-52-24 2](https://user-images.githubusercontent.com/6951813/36427610-ffeb3794-164d-11e8-94d7-0e4571ecea49.png)

When User is disabled:

![civihr_staff compucorp co uk _ staging17 2018-02-20 15-03-14](https://user-images.githubusercontent.com/6951813/36428085-3d42f540-164f-11e8-8a9d-8ae38fd2d2f8.png)

## After
After updating button and text display.

![civihr_staff compucorp co uk _ staging17 2018-02-15 18-36-39](https://user-images.githubusercontent.com/6951813/36427611-001abaa0-164e-11e8-934d-aaa29955a9a4.png)

With User Disabled:

![civihr_staff compucorp co uk _ staging17 2018-02-20 13-51-29](https://user-images.githubusercontent.com/6951813/36427980-f59c9b9c-164e-11e8-97e9-96fc3d65f691.png)


