### PR TITLE
PCHR-3344: Fix Contact Summary Page error for  a Contact without User Account

### DIFF
--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/hrcontactactionsmenu.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/hrcontactactionsmenu.php
@@ -26,9 +26,6 @@ function hrcontactactionsmenu_addContactMenuActions(ActionsMenu $menu) {
   if (!$contactID) {
     return;
   }
-  $cmsUserPath = '';
-  $cmsUserRole = '';
-  $cmsUserAccount = '';
 
   $contactUserInfo = ContactHelper::getUserInformation($contactID);
   if(!empty($contactUserInfo['cmsId'])) {
@@ -40,9 +37,9 @@ function hrcontactactionsmenu_addContactMenuActions(ActionsMenu $menu) {
 
   $userInformationActionGroup = new UserInformationActionGroupHelper(
     $contactUserInfo,
-    $cmsUserPath,
-    $cmsUserRole,
-    $cmsUserAccount
+    !empty($cmsUserPath) ? $cmsUserPath : null,
+    !empty($cmsUserRole) ? $cmsUserRole : null,
+    !empty($cmsUserAccount) ? $cmsUserAccount : null
   );
   $menu->addToHighlightedPanel($userInformationActionGroup->get());
 


### PR DESCRIPTION
## Overview
After the changes [here](https://github.com/civicrm/civihr/pull/2486/files#diff-04d94654672bea1a580ad62a06c751c9R45), The UserInformationActionGroup constructor will only accept null if the respective CMS related interface is not passed.
For the instance where the Contact does not have a user account, empty string are passed for the CMS related interface parameters causing an error to be thrown.

## Before
Error is thrown when viewing the contact page of a contact with no CMS user.

## After
The The UserInformationActionGroup constructor is passed null for the CMS interface related parameters when Contact has no CMS user and no error is thrown when viewing the contact summary page of such a Contact.
