### PR TITLE
PCHR-3346: Add upgrader for enabling contact actions menu extension

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -17,6 +17,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1007;
   use CRM_HRCore_Upgrader_Steps_1008;
   use CRM_HRCore_Upgrader_Steps_1009;
+  use CRM_HRCore_Upgrader_Steps_1010;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1010.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1010.php
@@ -1,0 +1,23 @@
+<?php
+
+use CRM_HRCore_Helper_ExtensionHelper as ExtensionHelper;
+
+trait CRM_HRCore_Upgrader_Steps_1010 {
+
+  /**
+   * Installs the Contact Actions Menu extension if not
+   * installed already.
+   */
+  public function upgrade_1010() {
+    $key = 'uk.co.compucorp.civicrm.hrcontactactionsmenu';
+    if (ExtensionHelper::isExtensionEnabled($key)) {
+      return TRUE;
+    }
+
+    civicrm_api3('Extension', 'install', [
+      'keys' => [$key]
+    ]);
+
+    return TRUE;
+  }
+}


### PR DESCRIPTION
## Overview
This PR adds an upgrader to install the Contact actions menu extension.

## Before
No upgrader to install the Contact actions menu extension extension

## After
An upgrader in HRCore to install Contact actions menu extension is added.

The contact actions menu extension needs to be installed so that the upgraders adding `administer staff accounts` [permission](https://github.com/compucorp/civihr-employee-portal/pull/445) to respective roles can run