### PR TITLE
PCHR-3346: Refresh extensions

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1010.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1010.php
@@ -7,12 +7,18 @@ trait CRM_HRCore_Upgrader_Steps_1010 {
   /**
    * Installs the Contact Actions Menu extension if not
    * installed already.
+   *
+   * @return boolean
    */
   public function upgrade_1010() {
     $key = 'uk.co.compucorp.civicrm.hrcontactactionsmenu';
     if (ExtensionHelper::isExtensionEnabled($key)) {
       return TRUE;
     }
+
+    //refresh the extension list so the extension can be
+    //available.
+    civicrm_api3('Extension', 'refresh');
 
     civicrm_api3('Extension', 'install', [
       'keys' => [$key]


### PR DESCRIPTION
## Problem
When installing the Contact actions menu extension via the cli, an error is thrown that the extension does not exist. 

## Solution
The extension list is refreshed before trying to attempt to install the extension.
