### PR TITLE
PCHR-3355: Install Contact Actions Menu By Default

### DIFF
--- a/bin/drush-install.sh
+++ b/bin/drush-install.sh
@@ -34,7 +34,8 @@ org.civicrm.reqangular,\
 org.civicrm.contactsummary,\
 org.civicrm.shoreditch,\
 org.civicrm.bootstrapcivihr,\
-org.civicrm.styleguide
+org.civicrm.styleguide,\
+uk.co.compucorp.civicrm.hrcontactactionsmenu
 
 ##################################
 ## Main


### PR DESCRIPTION
## Overview
This PR adds the contact actions menu extension to the list of CiviHR extensions installed when building a site. The extension is added to the `drush-install.sh` file.

## Before
The contact actions menu extension is not part of the list of CiviHR extensions installed when building a site

## After
The contact actions menu extension is now part of the list of CiviHR extensions installed when building a site
