### PR TITLE
PCHR-3349: Allow to filter the Authenticated User role.

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserRole/Drupal.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserRole/Drupal.php
@@ -26,7 +26,13 @@ class CRM_HRCore_CMSData_UserRole_Drupal implements UserRoleInterface {
    *
    * @return array
    */
-  public function getRoles() {
-    return $this->user->roles;
+  public function getRoles($excludeAuthenticatedRole = FALSE) {
+    $roles = $this->user->roles;
+
+    if ($excludeAuthenticatedRole) {
+      unset($roles[DRUPAL_AUTHENTICATED_RID]);
+    }
+
+    return $roles;
   }
 }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserRoleInterface.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/UserRoleInterface.php
@@ -9,7 +9,11 @@ interface CRM_HRCore_CMSData_UserRoleInterface {
    * Returns the roles of the user object represented
    * in this class.
    *
+   * @param bool $excludeAuthenticatedRole
+   *   If true the authenticated user role will
+   *   be excluded from the roles returned.
+   *
    * @return array
    */
-  public function getRoles();
+  public function getRoles($excludeAuthenticatedRole = FALSE);
 }


### PR DESCRIPTION
## Overview
This PR modifies the UserRole interface `getRoles` method to allow the Authenticated Role for a user to be filtered off from the list of user roles returned.

## Before
The Authenticated Role is returned along with the list of user roles by default when calling the getRoles method of the User Roles interface.

## After
The Authenticated Role can be excluded from the list of user roles by default when calling the getRoles method of the User Roles interface.

## Comments
- This PR is needed for the task to be done on https://compucorp.atlassian.net/browse/PCHR-3349.
