### PR TITLE
PCHR-3354: Add permission 'access root menu items and configurations'

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -249,11 +249,13 @@ function hrcore_civicrm_alterMenu(&$items) {
  * Implements hook_civicrm_permission().
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/
+ *
+ * @param array $permissions
  */
 function hrcore_civicrm_permission(&$permissions) {
-  $permissions += [
-    'access CiviCRM developer menu and tools' => ts('Access CiviCRM developer menu and tools')
-  ];
+  $prefix = ts('CiviHR') . ': ';
+  $permissions['access CiviCRM developer menu and tools'] = ts('Access CiviCRM developer menu and tools');
+  $permissions['access root menu items and configurations'] = $prefix . ts('Access root menu items and configurations');
 }
 
 /**


### PR DESCRIPTION
## Overview

This PR adds a new permission that will be used in subsequent tickets to check if a user has permission to access certain menu items or access certain configuration options.

## Before

The 'access root menu items and configurations' did not exist.

## After

The 'access root menu items and configurations' was added (not in use yet).

## Comments

https://github.com/compucorp/civihr-employee-portal/pull/450 updates the permission to match the changes here.
