### PR TITLE
PCHR-3349:  Hide Authenticated Role and User ID

### DIFF
--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Component/UserInformationLinkItem.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Component/UserInformationLinkItem.php
@@ -63,7 +63,7 @@ class CRM_HRContactActionsMenu_Component_UserInformationLinkItem implements Acti
     return sprintf(
       $userInformationMarkup,
       $this->cmsUserPath->getEditAccountPath(),
-      $this->contactData['cmsId'] . ' ' . $this->contactData['name']
+      $this->contactData['name']
     );
   }
 }

--- a/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Component/UserRoleItem.php
+++ b/uk.co.compucorp.civicrm.hrcontactactionsmenu/CRM/HRContactActionsMenu/Component/UserRoleItem.php
@@ -31,7 +31,7 @@ class CRM_HRContactActionsMenu_Component_UserRoleItem implements ActionsGroupIte
    * @return string
    */
   public function render() {
-    $roles = implode(', ', $this->cmsUserRole->getRoles());
+    $roles = implode(', ', $this->cmsUserRole->getRoles(TRUE));
     $userPath = $this->cmsUserPath->getEditAccountPath();
 
     $userRolesMarkup = '


### PR DESCRIPTION
## Overview
This PR hides the Authenticated User role and also the User Id of the contact from being displayed on the contact actions menu.

## Before
The Authenticate user role and the User Id is displayed on the contact actions menu.

![civihr_staff compucorp co uk _ staging17 2018-02-26 12-37-14](https://user-images.githubusercontent.com/6951813/36668857-ee2b7f60-1af2-11e8-854d-a484e84b06a2.png)


## After
The Authenticate user role and the User Id is no more displayed on the contact actions menu.


![civihr_staff compucorp co uk _ staging17 2018-02-26 12-41-51](https://user-images.githubusercontent.com/6951813/36668882-03f08d54-1af3-11e8-8176-e35987c3233a.png)
