### PR TITLE
PCHR-3318: Bump version to 1.7.4

### DIFF
--- a/bin/git-release.sh
+++ b/bin/git-release.sh
@@ -2,8 +2,7 @@
 ##################################
 fileName=""
 ## List of extensions
-ENTITY_EXTS=( hrabsence \
-hrbank \
+ENTITY_EXTS=( hrbank \
 hrcareer \
 hrcase \
 hrdemog \
@@ -24,7 +23,6 @@ org.civicrm.hremergency \
 com.civicrm.hrjobroles \
 hrjobcontract \
 org.civicrm.reqangular \
-uk.co.compucorp.civicrm.appraisals \
 uk.co.compucorp.civicrm.hrcore \
 uk.co.compucorp.civicrm.hremails \
 uk.co.compucorp.civicrm.hrleaveandabsences \

--- a/com.civicrm.hrjobroles/info.xml
+++ b/com.civicrm.hrjobroles/info.xml
@@ -8,8 +8,8 @@
     <author>gregmeszaros</author>
     <email>meszaros275@gmail.com</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/contactaccessrights/info.xml
+++ b/contactaccessrights/info.xml
@@ -8,8 +8,8 @@
     <author>Robin Mitra</author>
     <email>robinmitra1@gmail.com</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/contactsummary/info.xml
+++ b/contactsummary/info.xml
@@ -8,8 +8,8 @@
     <author>Robin Mitra</author>
     <email>robinmitra1@gmail.com</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrbank/info.xml
+++ b/hrbank/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrcareer/info.xml
+++ b/hrcareer/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrcase/info.xml
+++ b/hrcase/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrdemog/info.xml
+++ b/hrdemog/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrim/info.xml
+++ b/hrim/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrjobcontract/info.xml
+++ b/hrjobcontract/info.xml
@@ -8,8 +8,8 @@
     <author>Mateusz Cieplinski</author>
     <email>mateusz@coldrun.pl</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrmed/info.xml
+++ b/hrmed/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrprofile/info.xml
+++ b/hrprofile/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrqual/info.xml
+++ b/hrqual/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrrecruitment/info.xml
+++ b/hrrecruitment/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrreport/info.xml
+++ b/hrreport/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrstaffdir/info.xml
+++ b/hrstaffdir/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/hrui/info.xml
+++ b/hrui/info.xml
@@ -8,8 +8,8 @@
     <author>CiviCRM LLC</author>
     <email>info@civicrm.org</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/org.civicrm.bootstrapcivihr/info.xml
+++ b/org.civicrm.bootstrapcivihr/info.xml
@@ -8,8 +8,8 @@
     <author>Alessandro Verdura</author>
     <email>alessandro@compucorp.co.uk</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/org.civicrm.hremergency/info.xml
+++ b/org.civicrm.hremergency/info.xml
@@ -8,8 +8,8 @@
     <author>gregmeszaros</author>
     <email>meszaros275@gmail.com</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/org.civicrm.reqangular/info.xml
+++ b/org.civicrm.reqangular/info.xml
@@ -10,8 +10,8 @@
     <author>Mateusz Cieplinski</author>
     <email>mateusz@coldrun.pl</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/uk.co.compucorp.civicrm.hrcomments/info.xml
+++ b/uk.co.compucorp.civicrm.hrcomments/info.xml
@@ -8,8 +8,8 @@
     <author>Compucorp Ltd</author>
     <email>info@compucorp.co.uk</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.2</ver>

--- a/uk.co.compucorp.civicrm.hrcore/info.xml
+++ b/uk.co.compucorp.civicrm.hrcore/info.xml
@@ -8,8 +8,8 @@
     <author>Compucorp Ltd</author>
     <email>info@compucorp.co.uk</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/uk.co.compucorp.civicrm.hremails/info.xml
+++ b/uk.co.compucorp.civicrm.hremails/info.xml
@@ -8,8 +8,8 @@
     <author>Compucorp Ltd</author>
     <email>info@compucorp.co.uk</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/info.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/info.xml
@@ -8,8 +8,8 @@
     <author>Compucorp Ltd</author>
     <email>info@compucorp.co.uk</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/uk.co.compucorp.civicrm.hrsampledata/info.xml
+++ b/uk.co.compucorp.civicrm.hrsampledata/info.xml
@@ -8,8 +8,8 @@
     <author>Compucorp</author>
     <email>info@compucorp.com</email>
   </maintainer>
-  <releaseDate>2018-01-29</releaseDate>
-  <version>1.7.3</version>
+  <releaseDate>2018-02-26</releaseDate>
+  <version>1.7.4</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>


### PR DESCRIPTION
Bumping extension versions to 1.7.4 in preparation for this month's release.

The `git-release.sh` script was also updated to remove references to old extensions, that are not being updated anymore and will be soon removed