### PR TITLE
PCHR-3353: Set Custom Groups to Reserved

### DIFF
--- a/hrdemog/CRM/HRDemog/Upgrader.php
+++ b/hrdemog/CRM/HRDemog/Upgrader.php
@@ -161,4 +161,18 @@ class CRM_HRDemog_Upgrader extends CRM_HRDemog_Upgrader_Base {
     CRM_Core_DAO::executeQuery("UPDATE civicrm_custom_group SET is_reserved = 0, collapse_display = 1 where name = 'Extended_Demographics'");
     return TRUE;
   }
+
+    /**
+     * Upgrade CustomGroup, setting Extended_Demographics is_reserved value to YES
+     */
+  public function upgrade_1401() {
+      $result = civicrm_api3('CustomGroup', 'get', [
+          'sequential' => 1,
+          'return' => ["id"],
+          'name' => "Extended_Demographics",
+          'api.CustomGroup.create' => ['id' => "\$value.id", 'is_reserved' => 0],
+      ]);
+
+      return true;
+  }
 }

--- a/hrdemog/CRM/HRDemog/Upgrader.php
+++ b/hrdemog/CRM/HRDemog/Upgrader.php
@@ -162,17 +162,20 @@ class CRM_HRDemog_Upgrader extends CRM_HRDemog_Upgrader_Base {
     return TRUE;
   }
 
-    /**
-     * Upgrade CustomGroup, setting Extended_Demographics is_reserved value to YES
-     */
+  /**
+   * Upgrade CustomGroup, setting Extended_Demographics is_reserved value to YES
+   *
+   * @return bool
+   */
   public function upgrade_1401() {
-      $result = civicrm_api3('CustomGroup', 'get', [
-          'sequential' => 1,
-          'return' => ["id"],
-          'name' => "Extended_Demographics",
-          'api.CustomGroup.create' => ['id' => "\$value.id", 'is_reserved' => 0],
-      ]);
+    civicrm_api3('CustomGroup', 'get', [
+      'sequential' => 1,
+      'return' => ['id'],
+      'name' => 'Extended_Demographics',
+      'api.CustomGroup.create' => ['id' => '\$value.id', 'is_reserved' => 1],
+    ]);
 
-      return true;
+    return TRUE;
   }
+
 }

--- a/hrdemog/CRM/HRDemog/Upgrader.php
+++ b/hrdemog/CRM/HRDemog/Upgrader.php
@@ -168,11 +168,15 @@ class CRM_HRDemog_Upgrader extends CRM_HRDemog_Upgrader_Base {
    * @return bool
    */
   public function upgrade_1401() {
-    civicrm_api3('CustomGroup', 'get', [
+    $result = civicrm_api3('CustomGroup', 'get', [
       'sequential' => 1,
       'return' => ['id'],
       'name' => 'Extended_Demographics',
-      'api.CustomGroup.create' => ['id' => '\$value.id', 'is_reserved' => 1],
+    ]);
+  
+    civicrm_api3('CustomGroup', 'create', [
+      'id' => $result['id'],
+      'is_reserved' => 1,
     ]);
 
     return TRUE;

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -165,7 +165,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
       ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 AUTO_INCREMENT=1
     ");
     CRM_Core_DAO::executeQuery("
-      INSERT INTO `civicrm_hrhours_location` (`id`, `location`, `standard_hours`, `periodicity`, `is_active`) 
+      INSERT INTO `civicrm_hrhours_location` (`id`, `location`, `standard_hours`, `periodicity`, `is_active`)
       VALUES (1, 'Head office', 40, 'Week', 1)
     ");
 
@@ -925,7 +925,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
 
     if (empty($data)) {
       CRM_Core_DAO::executeQuery("
-        INSERT INTO `civicrm_hrpay_scale` (`pay_scale`, `pay_grade`, `currency`, `amount`, `periodicity`, `is_active`) 
+        INSERT INTO `civicrm_hrpay_scale` (`pay_scale`, `pay_grade`, `currency`, `amount`, `periodicity`, `is_active`)
         VALUES ('Not Applicable', NULL, NULL, NULL, NULL, 1)
     ");
     }
@@ -1007,8 +1007,8 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
    */
   public function upgrade_1026() {
     $query = "
-      ALTER TABLE `civicrm_hrjobcontract_hour` 
-      CHANGE `fte_num` `fte_num` INT(10) UNSIGNED NULL DEFAULT '0' COMMENT '.', 
+      ALTER TABLE `civicrm_hrjobcontract_hour`
+      CHANGE `fte_num` `fte_num` INT(10) UNSIGNED NULL DEFAULT '0' COMMENT '.',
       CHANGE `fte_denom` `fte_denom` INT(10) UNSIGNED NULL DEFAULT '0' COMMENT '.'
     ";
     CRM_Core_DAO::executeQuery($query);
@@ -1163,12 +1163,16 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
    * @return bool
    */
   public function upgrade_1034() {
-    civicrm_api3('CustomGroup', 'get', [
+    $result = civicrm_api3('CustomGroup', 'get', array(
       'sequential' => 1,
       'return' => ['id'],
       'name' => 'Contact_Length_Of_Service',
-      'api.CustomGroup.create' => ['id' => '\$value.id', 'is_reserved' => 1],
-    ]);
+    ));
+  
+    civicrm_api3('CustomGroup', 'create', array(
+      'id' => $result['id'],
+      'is_reserved' => 1,
+    ));
 
     return TRUE;
   }

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1157,19 +1157,20 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     return TRUE;
   }
 
-    /**
-     * Update CustomGroup, setting Contact_Length_Of_Service is_reserved to Yes
-     * @return bool
-     */
+  /**
+   * Update CustomGroup, setting Contact_Length_Of_Service is_reserved to Yes
+   *
+   * @return bool
+   */
   public function upgrade_1034() {
-      $result = civicrm_api3('CustomGroup', 'get', [
-          'sequential' => 1,
-          'return' => ["id"],
-          'name' => "Contact_Length_Of_Service",
-          'api.CustomGroup.create' => ['id' => "\$value.id", 'is_reserved' => 0],
-      ]);
+    civicrm_api3('CustomGroup', 'get', [
+      'sequential' => 1,
+      'return' => ['id'],
+      'name' => 'Contact_Length_Of_Service',
+      'api.CustomGroup.create' => ['id' => '\$value.id', 'is_reserved' => 1],
+    ]);
 
-      return true;
+    return TRUE;
   }
 
   /**

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1157,6 +1157,21 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     return TRUE;
   }
 
+    /**
+     * Update CustomGroup, setting Contact_Length_Of_Service is_reserved to Yes
+     * @return bool
+     */
+  public function upgrade_1034() {
+      $result = civicrm_api3('CustomGroup', 'get', [
+          'sequential' => 1,
+          'return' => ["id"],
+          'name' => "Contact_Length_Of_Service",
+          'api.CustomGroup.create' => ['id' => "\$value.id", 'is_reserved' => 0],
+      ]);
+
+      return true;
+  }
+
   /**
    * Removes the "Pension Type" item from the
    *  "Administer -> Customize Data and Screens -> Dropdowns" menu

--- a/hrrecruitment/CRM/HRRecruitment/Upgrader.php
+++ b/hrrecruitment/CRM/HRRecruitment/Upgrader.php
@@ -56,12 +56,18 @@ class CRM_HRRecruitment_Upgrader extends CRM_HRRecruitment_Upgrader_Base {
    * @return bool
    */
   public function upgrade_1403() {
-    civicrm_api3('CustomGroup', 'get', [
+    $result = civicrm_api3('CustomGroup', 'get', [
       'sequential' => 1,
       'return' => ['id'],
       'name' => ['IN' => ['Application', 'application_case', 'Evaluation_fields']],
-      'api.CustomGroup.create' => ['id' => '\$value.id', 'is_reserved' => 1],
     ]);
+  
+    foreach ($result['values'] as $value) {
+      civicrm_api3('CustomGroup', 'create', [
+        'id' => $value['id'],
+        'is_reserved' => 1,
+      ]);
+    }
 
     return TRUE;
   }

--- a/hrrecruitment/CRM/HRRecruitment/Upgrader.php
+++ b/hrrecruitment/CRM/HRRecruitment/Upgrader.php
@@ -49,4 +49,19 @@ class CRM_HRRecruitment_Upgrader extends CRM_HRRecruitment_Upgrader_Base {
 
     return TRUE;
   }
+
+    /**
+     * Upgrade CustomGroup, setting Application, application_case and Evaluation_fields names to is_reserved Yes
+     * @return bool
+     */
+  public function upgrade_1403() {
+      $result = civicrm_api3('CustomGroup', 'get', array(
+          'sequential' => 1,
+          'return' => array("id"),
+          'name' => array('IN' => array("Application", "application_case", "Evaluation_fields")),
+          'api.CustomGroup.create' => array('id' => "\$value.id", 'is_reserved' => 0),
+      ));
+
+      return true;
+  }
 }

--- a/hrrecruitment/CRM/HRRecruitment/Upgrader.php
+++ b/hrrecruitment/CRM/HRRecruitment/Upgrader.php
@@ -50,18 +50,20 @@ class CRM_HRRecruitment_Upgrader extends CRM_HRRecruitment_Upgrader_Base {
     return TRUE;
   }
 
-    /**
-     * Upgrade CustomGroup, setting Application, application_case and Evaluation_fields names to is_reserved Yes
-     * @return bool
-     */
+  /**
+   * Upgrade CustomGroup, setting Application, application_case and Evaluation_fields names to is_reserved Yes
+   *
+   * @return bool
+   */
   public function upgrade_1403() {
-      $result = civicrm_api3('CustomGroup', 'get', array(
-          'sequential' => 1,
-          'return' => array("id"),
-          'name' => array('IN' => array("Application", "application_case", "Evaluation_fields")),
-          'api.CustomGroup.create' => array('id' => "\$value.id", 'is_reserved' => 0),
-      ));
+    civicrm_api3('CustomGroup', 'get', [
+      'sequential' => 1,
+      'return' => ['id'],
+      'name' => ['IN' => ['Application', 'application_case', 'Evaluation_fields']],
+      'api.CustomGroup.create' => ['id' => '\$value.id', 'is_reserved' => 1],
+    ]);
 
-      return true;
+    return TRUE;
   }
+
 }

--- a/hrui/CRM/HRUI/Upgrader.php
+++ b/hrui/CRM/HRUI/Upgrader.php
@@ -38,6 +38,7 @@ class CRM_HRUI_Upgrader extends CRM_HRUI_Upgrader_Base {
   use CRM_HRUI_Upgrader_Steps_4705;
   use CRM_HRUI_Upgrader_Steps_4706;
   use CRM_HRUI_Upgrader_Steps_4707;
+  use CRM_HRUI_Upgrader_Steps_4708;
 
   public function install() {
     $this->runAllUpgraders();

--- a/hrui/CRM/HRUI/Upgrader/Steps/4708.php
+++ b/hrui/CRM/HRUI/Upgrader/Steps/4708.php
@@ -1,0 +1,20 @@
+<?php
+
+trait CRM_HRUI_Upgrader_Steps_4708 {
+
+    /**
+     * Upgrade CustomGroup, set Inline_Custom_Data is_reserved Yes
+     * @return bool
+     */
+    public function upgrade_4708() {
+        $result = civicrm_api3('CustomGroup', 'get', [
+            'sequential' => 1,
+            'return' => ["id"],
+            'name' => "Inline_Custom_Data",
+            'api.CustomGroup.create' => ['id' => "\$value.id", 'is_reserved' => 1],
+        ]);
+
+        return true;
+    }
+
+}

--- a/hrui/CRM/HRUI/Upgrader/Steps/4708.php
+++ b/hrui/CRM/HRUI/Upgrader/Steps/4708.php
@@ -8,13 +8,17 @@ trait CRM_HRUI_Upgrader_Steps_4708 {
    * @return bool
    */
   public function upgrade_4708() {
-    civicrm_api3('CustomGroup', 'get', [
+    $result = civicrm_api3('CustomGroup', 'get', [
       'sequential' => 1,
       'return' => ['id'],
       'name' => 'Inline_Custom_Data',
-      'api.CustomGroup.create' => ['id' => '\$value.id', 'is_reserved' => 1],
     ]);
-
+  
+    civicrm_api3('CustomGroup', 'create', [
+      'id' => $result['id'],
+      'is_reserved' => 1,
+    ]);
+    
     return TRUE;
   }
 

--- a/hrui/CRM/HRUI/Upgrader/Steps/4708.php
+++ b/hrui/CRM/HRUI/Upgrader/Steps/4708.php
@@ -2,19 +2,20 @@
 
 trait CRM_HRUI_Upgrader_Steps_4708 {
 
-    /**
-     * Upgrade CustomGroup, set Inline_Custom_Data is_reserved Yes
-     * @return bool
-     */
-    public function upgrade_4708() {
-        $result = civicrm_api3('CustomGroup', 'get', [
-            'sequential' => 1,
-            'return' => ["id"],
-            'name' => "Inline_Custom_Data",
-            'api.CustomGroup.create' => ['id' => "\$value.id", 'is_reserved' => 1],
-        ]);
+  /**
+   * Upgrade CustomGroup, set Inline_Custom_Data is_reserved Yes
+   *
+   * @return bool
+   */
+  public function upgrade_4708() {
+    civicrm_api3('CustomGroup', 'get', [
+      'sequential' => 1,
+      'return' => ['id'],
+      'name' => 'Inline_Custom_Data',
+      'api.CustomGroup.create' => ['id' => '\$value.id', 'is_reserved' => 1],
+    ]);
 
-        return true;
-    }
+    return TRUE;
+  }
 
 }

--- a/org.civicrm.hremergency/CRM/Hremergency/Upgrader.php
+++ b/org.civicrm.hremergency/CRM/Hremergency/Upgrader.php
@@ -9,6 +9,7 @@ class CRM_Hremergency_Upgrader extends CRM_Hremergency_Upgrader_Base {
   use CRM_Hremergency_Upgrader_Steps_1001;
   use CRM_Hremergency_Upgrader_Steps_1002;
   use CRM_Hremergency_Upgrader_Steps_1003;
+  use CRM_Hremergency_Upgrader_Steps_1004;
 
   /**
    * Change the custom_group ID to 99999 as we have this exported through Drupal webforms so the ID needs to be always the same

--- a/org.civicrm.hremergency/CRM/Hremergency/Upgrader/Steps/1004.php
+++ b/org.civicrm.hremergency/CRM/Hremergency/Upgrader/Steps/1004.php
@@ -6,21 +6,20 @@ trait CRM_Hremergency_Upgrader_Steps_1004 {
    * Upgrade CustomGroup, setting Emergency_Contacts is_reserved to Yes.
    * Title was included here because of an issue with webform_civicrm
    * @see https://www.drupal.org/project/webform_civicrm/issues/2947922
-   * 
+   *
    * @return bool
    */
   public function upgrade_1004() {
-    $creationParams = [
-      'id' => '\$value.id',
-      'is_reserved' => 1,
-      'title' => 'Emergency Contacts'
-    ];
-    
-    civicrm_api3('CustomGroup', 'get', [
+    $result = civicrm_api3('CustomGroup', 'get', [
       'sequential' => 1,
       'return' => ['id'],
       'name' => 'Emergency_Contacts',
-      'api.CustomGroup.create' => $creationParams,
+    ]);
+  
+    civicrm_api3('CustomGroup', 'create', [
+      'id' => $result['id'],
+      'is_reserved' => 1,
+      'title' => 'Emergency Contacts'
     ]);
 
     return TRUE;

--- a/org.civicrm.hremergency/CRM/Hremergency/Upgrader/Steps/1004.php
+++ b/org.civicrm.hremergency/CRM/Hremergency/Upgrader/Steps/1004.php
@@ -2,21 +2,28 @@
 
 trait CRM_Hremergency_Upgrader_Steps_1004 {
 
-    /**
-     * Upgrade CustomGroup, setting Emergency_Contacts is_reserved to Yes
-     * title was included here because of an issue with webform_civicrm
-     * @see https://www.drupal.org/project/webform_civicrm/issues/2947922
-     * @return bool
-     */
-    public function upgrade_1004() {
-        $result = civicrm_api3('CustomGroup', 'get', [
-            'sequential' => 1,
-            'return' => ["id"],
-            'name' => "Emergency_Contacts",
-            'api.CustomGroup.create' => ['id' => "\$value.id", 'is_reserved' => 1, 'title' => "Emergency Contacts"],
-        ]);
+  /**
+   * Upgrade CustomGroup, setting Emergency_Contacts is_reserved to Yes.
+   * Title was included here because of an issue with webform_civicrm
+   * @see https://www.drupal.org/project/webform_civicrm/issues/2947922
+   * 
+   * @return bool
+   */
+  public function upgrade_1004() {
+    $creationParams = [
+      'id' => '\$value.id',
+      'is_reserved' => 1,
+      'title' => 'Emergency Contacts'
+    ];
+    
+    civicrm_api3('CustomGroup', 'get', [
+      'sequential' => 1,
+      'return' => ['id'],
+      'name' => 'Emergency_Contacts',
+      'api.CustomGroup.create' => $creationParams,
+    ]);
 
-        return true;
-    }
+    return TRUE;
+  }
 
 }

--- a/org.civicrm.hremergency/CRM/Hremergency/Upgrader/Steps/1004.php
+++ b/org.civicrm.hremergency/CRM/Hremergency/Upgrader/Steps/1004.php
@@ -1,0 +1,22 @@
+<?php
+
+trait CRM_Hremergency_Upgrader_Steps_1004 {
+
+    /**
+     * Upgrade CustomGroup, setting Emergency_Contacts is_reserved to Yes
+     * title was included here because of an issue with webform_civicrm
+     * @see https://www.drupal.org/project/webform_civicrm/issues/2947922
+     * @return bool
+     */
+    public function upgrade_1004() {
+        $result = civicrm_api3('CustomGroup', 'get', [
+            'sequential' => 1,
+            'return' => ["id"],
+            'name' => "Emergency_Contacts",
+            'api.CustomGroup.create' => ['id' => "\$value.id", 'is_reserved' => 1, 'title' => "Emergency Contacts"],
+        ]);
+
+        return true;
+    }
+
+}


### PR DESCRIPTION
## Overview
This PR sets custom field groups that should not be editable to "is_reserved"=yes for the following custom groups

   - Extended demographics
   - Contact length of service
   - Application
   - Vacancy
   - Evaluation field
   - Emergency contact
   - Inline custom data

## Before
![custom_group_before](https://user-images.githubusercontent.com/1507645/36676173-3cd656fe-1b0b-11e8-947d-02c69697c2af.png)

## After
![custom_group_after_1](https://user-images.githubusercontent.com/1507645/36717971-65310140-1ba0-11e8-8b61-eefc2571c409.png)
