### PR TITLE
PCHR-3365: Change Permission for "CiviHR Website" Link

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -367,7 +367,7 @@ function _hrcore_createHelpMenu(&$menu) {
     'name' => ts('CiviHR website'),
     'url' => 'https://www.civihr.org/',
     'target' => '_blank',
-    'permission' => 'access CiviCRM'
+    'permission' => 'access root menu items and configurations'
   ]);
 
   _hrcore_civix_insert_navigation_menu($menu, 'Help', [


### PR DESCRIPTION
## Overview

The "CiviHR Website" link should only be accessible to users with the "CiviHR - Access root menu items and configurations" permission.

## Before

The "CiviHR Website" link was accessible to users with the "Administer CiviCRM" permission.

![image](https://user-images.githubusercontent.com/6374064/36676381-739301ea-1b03-11e8-92a6-9800e6c20df5.png)

## After

The "CiviHR Website" link is only accessible to users with the "CiviHR - Access root menu items and configurations" permission.

![image](https://user-images.githubusercontent.com/6374064/36676411-81e9d23c-1b03-11e8-990e-63d7b2786c7e.png)