### PR TITLE
PCHR-3367: Rename View Entitlements button Label.

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Helper/ContactActionsMenu/LeaveActionGroup.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Helper/ContactActionsMenu/LeaveActionGroup.php
@@ -47,7 +47,7 @@ class CRM_HRLeaveAndAbsences_Helper_ContactActionsMenu_LeaveActionGroup {
     $actionsGroup->addItem($this->getRecordSicknessButton());
     $actionsGroup->addItem($this->getRecordOvertimeButton());
     $actionsGroup->addItem(new GroupSeparatorItem());
-    $actionsGroup->addItem($this->getViewEntitlementsButton());
+    $actionsGroup->addItem($this->getViewReportButton());
     $actionsGroup->addItem(new GroupSeparatorItem());
 
     $leaveApprovers = $this->getLeaveApprovers();
@@ -67,13 +67,13 @@ class CRM_HRLeaveAndAbsences_Helper_ContactActionsMenu_LeaveActionGroup {
   }
 
   /**
-   * Gets the View Entitlement button
+   * Gets the View Report button
    *
    * @return ActionsGroupButtonItem
    */
-  private function getViewEntitlementsButton() {
+  private function getViewReportButton() {
     $params = [
-      'label' => 'View Entitlements',
+      'label' => 'View Report',
       'class' => 'btn-primary-outline',
       'icon' => 'fa-search',
       'url' => $this->getLeaveTabUrl()


### PR DESCRIPTION
## Overview
This PR updates the Label of the View Entitlements Button from `View Entitlements` to `View Report`

## Before
The label was `View Entitlements`

![civihr_staff compucorp co uk _ staging17 2018-02-26 15-46-14](https://user-images.githubusercontent.com/6951813/36676808-eb6eed88-1b0c-11e8-9fc7-01c78fd25fdc.png)


## After
The label is now `View Report`

![civihr_staff compucorp co uk _ staging17 2018-02-26 15-47-45](https://user-images.githubusercontent.com/6951813/36676828-f6b4828e-1b0c-11e8-8d86-a6aae85db88f.png)

