### PR TITLE
PCHR-3372: Take Contact Work Pattern into Consideration when validating Max consecutive leave days

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -989,13 +989,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
       }
 
       $dayType = $leaveDateDayTypes[$date->format('Y-m-d')];
-      $publicHolidayLeaveRequestExists = $dayType == $leaveRequestDayTypes['public_holiday'];
 
-      if ($publicHolidayLeaveRequestExists) {
+      if ($dayType == $leaveRequestDayTypes['public_holiday']) {
         $amount = 0.0;
       }
-
-      if(!$publicHolidayLeaveRequestExists){
+      else {
         $amount = LeaveBalanceChange::calculateAmountForDate(
           $leaveRequest,
           $date,
@@ -1048,8 +1046,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
       if ($publicHolidayLeaveRequestExists) {
         $dayType = $leaveRequestDayTypes['public_holiday'];
       }
-
-      if(!$publicHolidayLeaveRequestExists) {
+      else {
         $type = ContactWorkPattern::getWorkDayType($contactID, $date);
         $dayType = self::getLeaveRequestDayTypeFromWorkDayType($type);
       }
@@ -1469,11 +1466,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
   }
 
   /**
-   * Get the number of working days for a leave request, Days with
-   * balance change of zero or that evaluates to false are either non
-   * working day, weekend or public holidays.
-   * The days for which the balance amounts are not zero are equal
-   * to the number of working days.
+   * Get the number of working days for a leave request, Leave dates
+   * with day types that are non working days(public holiday, weekend and
+   * non working day) are excluded from the results.
    *
    * @param array $params
    *

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -854,6 +854,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testNumberOfDaysOfLeaveRequestShouldNotBeGreaterMaxConsecutiveLeaveDaysForAbsenceType() {
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
+    $contactID = 1;
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contactID],
+      ['period_start_date' => '2017-01-01']
+    );
+
     $absenceType = AbsenceTypeFabricator::fabricate([
       'max_consecutive_leave_days' => 2.5
     ]);
@@ -865,11 +872,51 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     LeaveRequest::create([
       'type_id' => $absenceType->id,
-      'contact_id' => 1,
+      'contact_id' => $contactID,
       'status_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('now'),
       'from_date_type' => 1,
       'to_date' => CRM_Utils_Date::processDate('+4 days'),
+      'to_date_type' => 1,
+      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
+    ]);
+  }
+
+  public function testLeaveRequestCanbeCreatedWhenNumberOfLeaveWorkingDaysNotGreaterThanMaxConsecutiveDays() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2017-06-14'),
+    ]);
+
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
+    $contactID = 1;
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contactID],
+      ['period_start_date' => '2017-01-01']
+    );
+
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'max_consecutive_leave_days' => 4
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceType->id,
+      'contact_id' => $contactID,
+      'period_id' => $absencePeriod->id
+    ]);
+
+    $this->createLeaveBalanceChange($periodEntitlement->id, 10);
+
+    //The leave days are six days but in reality there are just 4 working days
+    //because 2017-01-07 and 2017-01-08 fall on weekends. So request should be allowed
+    //to be created.
+    LeaveRequest::create([
+      'type_id' => $absenceType->id,
+      'contact_id' => $contactID,
+      'status_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2017-01-05'),
+      'from_date_type' => 1,
+      'to_date' => CRM_Utils_Date::processDate('2017-01-10'),
       'to_date_type' => 1,
       'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
     ]);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -2767,6 +2767,13 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testLeaveRequestIsValidShouldReturnErrorWhenLeaveDaysIsGreaterThanAbsenceTypeMaxConsecutiveLeaveDays() {
+    WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
+    $contactID = 1;
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contactID],
+      ['period_start_date' => '2017-01-01']
+    );
+
     $maxConsecutiveLeaveDays = 2;
     $absenceType = AbsenceTypeFabricator::fabricate([
       'max_consecutive_leave_days' => $maxConsecutiveLeaveDays
@@ -2776,7 +2783,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $toDate = new DateTime('+4 days');
     $result = civicrm_api3('LeaveRequest', 'isvalid', [
       'type_id' => $absenceType->id,
-      'contact_id' => 1,
+      'contact_id' => $contactID,
       'status_id' => 1,
       'from_date' => $fromDate->format('YmdHis'),
       'from_date_type' => 1,


### PR DESCRIPTION
## Overview
When validating the maximum consecutive days that can be taken when a leave request is to be created, the validation does not consider actual working days in the leave request date range based on the contact work pattern, hence leave requests that should have been allowed to be created are not.

## Before
- Take for example a contact using the default work pattern having weekends as non working days for the contact. If a contact requests leave from Monday this week to Monday next week, thats 6 days of leave the the contact is requesting.
Assuming the max consecutive leave days allowed for the absence type the contact is requesting leave for is 6 days, these request should have been allowed but its not allowed currently.
The validation assumes that the contact is requesting for 8 days(weekend inclusive) and does not allow the leave request to be created.

## After
- The `validateLeaveDaysAgainstAbsenceTypeMaxConsecutiveLeaveDay` now actually considers the number of working days in the leave request date range and compares that against the max consecutive leave days allowed for the absence type the contact is requesting leave for. So days like weekends, public holidays and non-working days will not be included in the calculation for number of leave days requested.
- The` LeaveRequest::calculateBalanceChange` method was used to get the number of working days for a leave request date range.
