### PR TITLE
PCHR-3379: Fix Error When Creating a New Site With Buildkit

### DIFF
--- a/bin/drush-install.sh
+++ b/bin/drush-install.sh
@@ -45,7 +45,11 @@ CIVI_PATH=$1
 shift
 
 set -ex
-drush "$@" cvapi extension.install keys=$CORE_EXTS,$ENTITY_EXTS,$APP_EXTS
+drush "$@" cvapi extension.install keys=$CORE_EXTS
+drush cvapi Extension.refresh
+drush "$@" cvapi extension.install keys=$ENTITY_EXTS
+drush cvapi Extension.refresh
+drush "$@" cvapi extension.install keys=$APP_EXTS
 set +ex
 
 if [ "$WITH_HR_SAMPLE" == "1" ]; then


### PR DESCRIPTION
## Problem
After this #2496 was merged, when creating a new site with buildkit, it fails with some errors:
```php
WD php: CRM_Core_Exception: Invalid Entity Filter in CRM_Core_BAO_CustomGroup::validateSubTypeByEntity() (line 692 of                                                                      [error]
/vagrant/hr17/sites/all/modules/civicrm/CRM/Core/BAO/CustomGroup.php).
Cannot modify header information - headers already sent by (output started at /vagrant/buildkit/vendor/drush/drush/includes/output.inc:38) bootstrap.inc:1486                              [warning]
CRM_Core_Exception: Invalid Entity Filter in CRM_Core_BAO_CustomGroup::validateSubTypeByEntity() (line 692 of /vagrant/hr17/sites/all/modules/civicrm/CRM/Core/BAO/CustomGroup.php).
Drush command terminated abnormally due to an unrecoverable error.                                                                                                                         [error]
```
Upon investigations, the error was due to an API error that was thrown earlier in the installation process when trying to install the contactactions menu extension. The HRCore extension installs the extension via an upgrader [Here](https://github.com/civicrm/civihr/blob/f4e78101a8265f72800fd4891a8957ddf7daf413/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1010.php#L13). 
Civibuild also tries to install the extension again after it has been installed by HRCore, See [Here](https://github.com/civicrm/civihr/blob/ce8560deaae5f97ec92d328227d94b061fbeccbc/bin/drush-install.sh#L38), causing an error:
```php

Feb 27 19:05:47  [info] $Fatal Error Details = Array
(
    [callback] => Array
        (
            [0] => CRM_Core_Error
            [1] => exceptionHandler
        )

    [code] => -5
    [message] => DB Error: already exists
    [mode] => 16
    [debug_info] => INSERT INTO civicrm_extension (type , full_name , name , label , file , is_active ) VALUES ('module' , 'uk.co.compucorp.civicrm.hrcontactactionsmenu' , 'Contact Actions Menu' , 'Contact Actions Menu' , 'hrcontactactionsmenu' ,  1 )  [nativecode=1062 ** Duplicate entry 'uk.co.compucorp.civicrm.hrcontactactionsmenu' for key 'UI_extension_full_name']
    [type] => DB_Error
    [user_info] => INSERT INTO civicrm_extension (type , full_name , name , label , file , is_active ) VALUES ('module' , 'uk.co.compucorp.civicrm.hrcontactactionsmenu' , 'Contact Actions Menu' , 'Contact Actions Menu' , 'hrcontactactionsmenu' ,  1 )  [nativecode=1062 ** Duplicate entry 'uk.co.compucorp.civicrm.hrcontactactionsmenu' for key 'UI_extension_full_name']
    [to_string] => [db_error: message="DB Error: already exists" code=-5 mode=callback callback=CRM_Core_Error::exceptionHandler prefix="" info="INSERT INTO civicrm_extension (type , full_name , name , label , file , is_active ) VALUES ('module' , 'uk.co.compucorp.civicrm.hrcontactactionsmenu' , 'Contact Actions Menu' , 'Contact Actions Menu' , 'hrcontactactionsmenu' ,  1 )  [nativecode=1062 ** Duplicate entry 'uk.co.compucorp.civicrm.hrcontactactionsmenu' for key 'UI_extension_full_name']"]
)
```

## Solution
Normally the Civi Extension.install API will not try to re-install an already installed extension because it checks for the extension status to determine what to do. However it seems that the function for getting the list of extension and statuses [Here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Extension/Manager.php#L207) is cached and needs to be refreshed for Civi to know that the extension has been earlier installed.
To solve the problem, in the CiviHR drush install file, the Extensions list is refreshed after each category of extension was installed.
