### PR TITLE
PCHR-3392: Set some Installation Custom Field Group Reserved Yes

### DIFF
--- a/hrident/CRM/HRIdent/Upgrader.php
+++ b/hrident/CRM/HRIdent/Upgrader.php
@@ -135,4 +135,28 @@ class CRM_HRIdent_Upgrader extends CRM_HRIdent_Upgrader_Base {
 
     return true;
   }
+  
+  /**
+   * Upgrade CustomGroup, setting Identify is_reserved value to Yes
+   * if it existing.
+   *
+   * @return bool
+   */
+  public function upgrade_1502() {
+    $result = civicrm_api3('CustomGroup', 'get', [
+      'sequential' => 1,
+      'return' => ['id'],
+      'name' => 'Identify',
+    ]);
+  
+    if ($result['id']) {
+      civicrm_api3('CustomGroup', 'create', [
+        'id' => $result['id'],
+        'is_reserved' => 1,
+      ]);
+    }
+  
+    return TRUE;
+  }
+  
 }

--- a/hrident/CRM/HRIdent/Upgrader.php
+++ b/hrident/CRM/HRIdent/Upgrader.php
@@ -144,7 +144,6 @@ class CRM_HRIdent_Upgrader extends CRM_HRIdent_Upgrader_Base {
    */
   public function upgrade_1502() {
     $result = civicrm_api3('CustomGroup', 'get', [
-      'sequential' => 1,
       'return' => ['id'],
       'name' => 'Identify',
     ]);

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1163,16 +1163,47 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
    * @return bool
    */
   public function upgrade_1034() {
-    $result = civicrm_api3('CustomGroup', 'get', array(
+    $result = civicrm_api3('CustomGroup', 'get', [
       'sequential' => 1,
       'return' => ['id'],
       'name' => 'Contact_Length_Of_Service',
-    ));
-  
-    civicrm_api3('CustomGroup', 'create', array(
+    ]);
+
+    civicrm_api3('CustomGroup', 'create', [
       'id' => $result['id'],
       'is_reserved' => 1,
-    ));
+    ]);
+
+    return TRUE;
+  }
+
+  /**
+   * Upgrade CustomGroup, setting HRJobContract_Dates, HRJob_Summary and
+   * HRJobContract_Summary is_reserved value to Yes if it is existing.
+   *
+   * @return bool
+   */
+  public function upgrade_1035() {
+    $customGroups = [
+      'HRJobContract_Dates',
+      'HRJob_Summary',
+      'HRJobContract_Summary'
+    ];
+    
+    $result = civicrm_api3('CustomGroup', 'get', [
+      'sequential' => 1,
+      'return' => ['id'],
+      'name' => ['IN' => $customGroups],
+    ]);
+
+    if (count($result['values'])) {
+      foreach ($result['values'] as $value) {
+        civicrm_api3('CustomGroup', 'create', [
+          'id' => $value['id'],
+          'is_reserved' => 1,
+        ]);
+      }
+    }
 
     return TRUE;
   }

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1191,12 +1191,11 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     ];
     
     $result = civicrm_api3('CustomGroup', 'get', [
-      'sequential' => 1,
       'return' => ['id'],
       'name' => ['IN' => $customGroups],
     ]);
 
-    if (count($result['values'])) {
+    if ($result['count'] > 0) {
       foreach ($result['values'] as $value) {
         civicrm_api3('CustomGroup', 'create', [
           'id' => $value['id'],


### PR DESCRIPTION
## Overview
This PR ensure the following custom groups are reserved if they exist in any installations.

 * Identification
 * Job contract dates
 * Job contract summary
 * Job summary

## Before
![customer_group_installation_before](https://user-images.githubusercontent.com/1507645/36849620-c81da0cc-1d64-11e8-8e0e-c0f5129d009f.png)


## After
![customer_group_installation_after](https://user-images.githubusercontent.com/1507645/36849734-175a0374-1d65-11e8-9aa9-a7a60e2091aa.png)
