### PR TITLE
PCHR-3034: Fix Issue When Overriding Entitlement With Zero Value

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php
@@ -199,12 +199,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement extends CRM_HRLeaveAndAb
     $absenceTypeID = $calculation->getAbsenceType()->id;
     $contactID = $calculation->getContact()['id'];
     $absencePeriodID = $calculation->getAbsencePeriod()->id;
+    $entitlementOverridden = isset($overriddenEntitlement) && trim($overriddenEntitlement) != '';
 
     $params = [
       'type_id' => $absenceTypeID,
       'contact_id' => $contactID,
       'period_id' => $absencePeriodID,
-      'overridden' => (boolean)$overriddenEntitlement,
+      'overridden' => $entitlementOverridden,
       'created_date' => $createdDate->format('YmdHis'),
       'comment' => $calculationComment ?: ''
     ];


### PR DESCRIPTION
## Overview
Currently when overriding a contact's  entitlement for an absence period with a value of **0** on the manage entitlements page, the form gets submitted successfully but the change is not reflected instead of displaying the Overridden entitlement of **0**, it reverts back to the default entitlement for the contact without being overridden.

## Before
- When overriding a contact's  entitlement for an absence period with a value of **0**, it reverts back to the default entitlement for the contact without being overridden.

The issue was traced to [Here](https://github.com/civicrm/civihr/blob/a893ab83690c59c81b10671bf85e59341531600d/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php#L207).
The `$overriddenEntitlement` gets type casted to a boolean here which means that if the value of 
`$overriddenEntitlement` is 0, it will be casted to false and the Period entitlement will be seen as not overridden. 
Eventually when the Overridden balance change is to be created [Here](https://github.com/civicrm/civihr/blob/a893ab83690c59c81b10671bf85e59341531600d/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlement.php#L240),
Based on the condition
```php
 if($periodEntitlement->overridden && !is_null($overriddenEntitlement)) {
//create overridden entitlement
}
```
Because the Period entitlement is seen as not being overridden, the Overridden entitlement does not get created and the contact has an entitlement that is the default without being overridden.

## After
The condition to determine if the Period Entitlement was Overridden was modified to:
```php
$entitlementOverridden = isset($overriddenEntitlement) && trim($overriddenEntitlement) != '';
``` 
The overridden entitlement field has a value of an empty string `''` when the entitlement is not being overridden.