### PR TITLE
PCHR-3423: Do not allow deleted Public holiday Leave Request for Contact to be re-created

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -803,25 +803,43 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    *
    * @param int $contactID
    * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
-   * @param boolean $nonDeletedOnly
-   *   When true will only return result if the given public
-   *   holiday request is not yet deleted.
    *
    * @return \CRM_HRLeaveAndAbsences_BAO_LeaveRequest|null
    */
-  public static function findPublicHolidayLeaveRequest($contactID, PublicHoliday $publicHoliday, $nonDeletedOnly = TRUE) {
+  public static function findPublicHolidayLeaveRequest($contactID, PublicHoliday $publicHoliday) {
     $leaveRequest = new self();
     $leaveRequest->contact_id = (int)$contactID;
     $leaveRequest->from_date = date('Ymd', strtotime($publicHoliday->date));
     $leaveRequest->request_type = self::REQUEST_TYPE_PUBLIC_HOLIDAY;
-    if ($nonDeletedOnly) {
-      $leaveRequest->is_deleted = 0;
-    }
+    $leaveRequest->is_deleted = 0;
 
     $leaveRequest->find(true);
     if($leaveRequest->id) {
-      $leaveRequest->fetch();
+      return $leaveRequest;
+    }
 
+    return null;
+  }
+
+  /**
+   * Returns a LeaveRequest instance representing the Public Holiday Leave Request
+   * for the given $publicHoliday and assigned to the Contact with the given
+   * $contactID, the leave request is returned as long as it exists in the database
+   * either soft deleted or not.
+   *
+   * @param int $contactID
+   * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
+   *
+   * @return \CRM_HRLeaveAndAbsences_BAO_LeaveRequest|null
+   */
+  public static function findPublicHolidayLeaveRequestEvenIfDeleted($contactID, PublicHoliday $publicHoliday) {
+    $leaveRequest = new self();
+    $leaveRequest->contact_id = (int)$contactID;
+    $leaveRequest->from_date = date('Ymd', strtotime($publicHoliday->date));
+    $leaveRequest->request_type = self::REQUEST_TYPE_PUBLIC_HOLIDAY;
+
+    $leaveRequest->find(true);
+    if($leaveRequest->id) {
       return $leaveRequest;
     }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -803,15 +803,20 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    *
    * @param int $contactID
    * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
+   * @param boolean $nonDeletedOnly
+   *   When true will only return result if the given public
+   *   holiday request is not yet deleted.
    *
    * @return \CRM_HRLeaveAndAbsences_BAO_LeaveRequest|null
    */
-  public static function findPublicHolidayLeaveRequest($contactID, PublicHoliday $publicHoliday) {
+  public static function findPublicHolidayLeaveRequest($contactID, PublicHoliday $publicHoliday, $nonDeletedOnly = TRUE) {
     $leaveRequest = new self();
     $leaveRequest->contact_id = (int)$contactID;
     $leaveRequest->from_date = date('Ymd', strtotime($publicHoliday->date));
     $leaveRequest->request_type = self::REQUEST_TYPE_PUBLIC_HOLIDAY;
-    $leaveRequest->is_deleted = 0;
+    if ($nonDeletedOnly) {
+      $leaveRequest->is_deleted = 0;
+    }
 
     $leaveRequest->find(true);
     if($leaveRequest->id) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -135,7 +135,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
     if($leaveRequest->request_type == LeaveRequest::REQUEST_TYPE_PUBLIC_HOLIDAY) {
       $publicHoliday = new PublicHoliday();
       $publicHoliday->date = $leaveRequest->from_date;
-      $this->publicHolidayLeaveRequestDeletionService->deleteForContact($leaveRequest->contact_id, $publicHoliday, TRUE);
+      $this->publicHolidayLeaveRequestDeletionService->softDeleteForContact($leaveRequest->contact_id, $publicHoliday);
     }
     else {
       LeaveRequest::softDelete($leaveRequestID);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -135,7 +135,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
     if($leaveRequest->request_type == LeaveRequest::REQUEST_TYPE_PUBLIC_HOLIDAY) {
       $publicHoliday = new PublicHoliday();
       $publicHoliday->date = $leaveRequest->from_date;
-      $this->publicHolidayLeaveRequestDeletionService->deleteForContact($leaveRequest->contact_id, $publicHoliday);
+      $this->publicHolidayLeaveRequestDeletionService->deleteForContact($leaveRequest->contact_id, $publicHoliday, TRUE);
     }
     else {
       LeaveRequest::softDelete($leaveRequestID);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -181,6 +181,8 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
    *
    * @param int $contactID
    * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
+   *
+   * @return LeaveRequest|null
    */
   public function createForContact($contactID, PublicHoliday $publicHoliday) {
     if (!$this->absenceType) {
@@ -195,6 +197,8 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
     $leaveRequest = $this->createLeaveRequest($contactID, $this->absenceType, $publicHoliday);
     $this->createLeaveBalanceChangeRecord($leaveRequest);
     $this->recalculateExpiredBalanceChange($leaveRequest);
+
+    return $leaveRequest;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -189,7 +189,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
       return;
     }
 
-    $existingLeaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
+    $existingLeaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday, FALSE);
     if($existingLeaveRequest) {
       return;
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -189,7 +189,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
       return;
     }
 
-    $existingLeaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday, FALSE);
+    $existingLeaveRequest = LeaveRequest::findPublicHolidayLeaveRequestEvenIfDeleted($contactID, $publicHoliday);
     if($existingLeaveRequest) {
       return;
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
@@ -73,8 +73,11 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion {
     if(!$leaveRequest) {
       return;
     }
-    
+
     LeaveRequest::softDelete($leaveRequest->id);
+    foreach($leaveRequest->getDates() as $date) {
+      $this->recalculateDeductionForOverlappingLeaveRequestDate($leaveRequest, new DateTime($date->date));
+    }
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
@@ -56,7 +56,6 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion {
 
     $this->deleteDatesWithBalanceChanges($leaveRequest);
     $leaveRequest->delete();
-
   }
 
   /**
@@ -74,8 +73,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion {
     if(!$leaveRequest) {
       return;
     }
-
-    $this->deleteDatesWithBalanceChanges($leaveRequest);
+    
     LeaveRequest::softDelete($leaveRequest->id);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
@@ -46,8 +46,10 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion {
    *
    * @param int $contactID
    * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
+   * @param boolean $softDelete
+   *   If true, the public holiday request will be soft deleted
    */
-  public function deleteForContact($contactID, PublicHoliday $publicHoliday) {
+  public function deleteForContact($contactID, PublicHoliday $publicHoliday, $softDelete = FALSE) {
     $leaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
 
     if(!$leaveRequest) {
@@ -60,7 +62,13 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion {
       $date->delete();
     }
 
-    $leaveRequest->delete();
+    if ($softDelete) {
+      LeaveRequest::softDelete($leaveRequest->id);
+    }
+    else {
+      $leaveRequest->delete();
+    }
+
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/PublicHolidayLeaveRequest.php
@@ -33,6 +33,7 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest {
       $leaveBalanceChangeService,
       $leavePeriodEntitlementService
     );
-    $creationLogic->createForContact($contactID, $publicHoliday);
+
+    return $creationLogic->createForContact($contactID, $publicHoliday);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -29,6 +29,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   use CRM_HRLeaveAndAbsences_SessionHelpersTrait;
   use CRM_HRLeaveAndAbsences_LeaveManagerHelpersTrait;
   use CRM_HRLeaveAndAbsences_MailHelpersTrait;
+  use CRM_HRLeaveAndAbsences_PublicHolidayHelpersTrait;
 
   /**
    * @var CRM_HRLeaveAndAbsences_BAO_AbsenceType
@@ -224,15 +225,14 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     $contactID = 2;
 
-    $publicHoliday = new PublicHoliday();
-    $publicHoliday->date = '2017-01-01';
+    $publicHoliday = $this->instantiatePublicHoliday('2017-01-01');
 
     $publicHolidayRequest = PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
     LeaveRequest::softDelete($publicHolidayRequest->id);
 
-    $publicHolidayRequest = LeaveRequest::findPublicHolidayLeaveRequestEvenIfDeleted($contactID, $publicHoliday);
-    $this->assertNotNull($publicHolidayRequest->id);
-    $this->assertEquals(1, $publicHolidayRequest->is_deleted);
+    $publicHolidayRequestDeleted = LeaveRequest::findPublicHolidayLeaveRequestEvenIfDeleted($contactID, $publicHoliday);
+    $this->assertEquals($publicHolidayRequest->id, $publicHolidayRequestDeleted->id);
+    $this->assertEquals(1, $publicHolidayRequestDeleted->is_deleted);
   }
 
   public function testFindPublicHolidayLeaveRequestEvenIfDeletedReturnsResultForANonDeletedPublicHolidayRequest() {
@@ -243,14 +243,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     $contactID = 2;
 
-    $publicHoliday = new PublicHoliday();
-    $publicHoliday->date = '2017-01-01';
+    $publicHoliday = $this->instantiatePublicHoliday('2017-01-01');
 
-    PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
+    $publicHolidayRequest = PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
 
-    $publicHolidayRequest = LeaveRequest::findPublicHolidayLeaveRequestEvenIfDeleted($contactID, $publicHoliday);
-    $this->assertNotNull($publicHolidayRequest->id);
-    $this->assertEquals(0, $publicHolidayRequest->is_deleted);
+    $publicHolidayRequestNonDeleted = LeaveRequest::findPublicHolidayLeaveRequestEvenIfDeleted($contactID, $publicHoliday);
+    $this->assertEquals($publicHolidayRequest->id, $publicHolidayRequestNonDeleted->id);
+    $this->assertEquals(0, $publicHolidayRequestNonDeleted->is_deleted);
   }
 
   public function testFindPublicHolidayLeaveRequestEvenIfDeletedReturnsNullForANonExistentPublicHolidayRequest() {
@@ -261,9 +260,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     $contactID = 2;
 
-    $publicHoliday = new PublicHoliday();
-    $publicHoliday->date = '2017-01-01';
-
+    $publicHoliday = $this->instantiatePublicHoliday('2017-01-01');
     $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequestEvenIfDeleted($contactID, $publicHoliday));
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -216,6 +216,56 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest(3, $publicHoliday));
   }
 
+  public function testCanFindAPublicHolidayLeaveRequestReturnsResultWhenNonDeletedIsFalseAndPublicHolidayRequestIsDeleted() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2017-12-01')
+    ]);
+
+    $contactID = 2;
+
+    $publicHoliday = new PublicHoliday();
+    $publicHoliday->date = '2017-01-01';
+
+    $publicHolidayRequest = PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
+    LeaveRequest::softDelete($publicHolidayRequest->id);
+
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday, FALSE));
+  }
+
+  public function testCanFindAPublicHolidayLeaveRequestReturnsResultWhenNonDeletedIsFalseAndPublicHolidayRequestIsNotDeleted() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2017-12-01')
+    ]);
+
+    $contactID = 2;
+
+    $publicHoliday = new PublicHoliday();
+    $publicHoliday->date = '2017-01-01';
+
+    PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
+
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday, FALSE));
+  }
+
+  public function testCanFindAPublicHolidayLeaveRequestReturnsNullWhenNotDeletedIsTrueAndPublicHolidayRequestIsDeleted() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2017-12-01')
+    ]);
+
+    $contactID = 2;
+
+    $publicHoliday = new PublicHoliday();
+    $publicHoliday->date = '2017-01-01';
+
+    $publicHolidayRequest = PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
+    LeaveRequest::softDelete($publicHolidayRequest->id);
+
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday, TRUE));
+  }
+
   public function testCalculateBalanceChangeForALeaveRequestForAContact() {
     $periodStartDate = date('Y-01-01');
     $absenceType = AbsenceTypeFabricator::fabricate();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -216,7 +216,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest(3, $publicHoliday));
   }
 
-  public function testCanFindAPublicHolidayLeaveRequestReturnsResultWhenNonDeletedIsFalseAndPublicHolidayRequestIsDeleted() {
+  public function testFindPublicHolidayLeaveRequestEvenIfDeletedReturnsResultForADeletedPublicHolidayRequest() {
     AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
       'end_date' => CRM_Utils_Date::processDate('2017-12-01')
@@ -230,10 +230,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $publicHolidayRequest = PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
     LeaveRequest::softDelete($publicHolidayRequest->id);
 
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday, FALSE));
+    $publicHolidayRequest = LeaveRequest::findPublicHolidayLeaveRequestEvenIfDeleted($contactID, $publicHoliday);
+    $this->assertNotNull($publicHolidayRequest->id);
+    $this->assertEquals(1, $publicHolidayRequest->is_deleted);
   }
 
-  public function testCanFindAPublicHolidayLeaveRequestReturnsResultWhenNonDeletedIsFalseAndPublicHolidayRequestIsNotDeleted() {
+  public function testFindPublicHolidayLeaveRequestEvenIfDeletedReturnsResultForANonDeletedPublicHolidayRequest() {
     AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
       'end_date' => CRM_Utils_Date::processDate('2017-12-01')
@@ -246,10 +248,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
 
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday, FALSE));
+    $publicHolidayRequest = LeaveRequest::findPublicHolidayLeaveRequestEvenIfDeleted($contactID, $publicHoliday);
+    $this->assertNotNull($publicHolidayRequest->id);
+    $this->assertEquals(0, $publicHolidayRequest->is_deleted);
   }
 
-  public function testCanFindAPublicHolidayLeaveRequestReturnsNullWhenNotDeletedIsTrueAndPublicHolidayRequestIsDeleted() {
+  public function testFindPublicHolidayLeaveRequestEvenIfDeletedReturnsNullForANonExistentPublicHolidayRequest() {
     AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
       'end_date' => CRM_Utils_Date::processDate('2017-12-01')
@@ -260,10 +264,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = '2017-01-01';
 
-    $publicHolidayRequest = PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
-    LeaveRequest::softDelete($publicHolidayRequest->id);
-
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday, TRUE));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequestEvenIfDeleted($contactID, $publicHoliday));
   }
 
   public function testCalculateBalanceChangeForALeaveRequestForAContact() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -235,6 +235,24 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals(1, $leaveRequestRecord->is_deleted);
   }
 
+  public function testDeleteSoftDeletesAPublicHolidayLeaveRequest() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2017-12-31')
+    ]);
+
+    $publicHoliday = new PublicHoliday();
+    $publicHoliday->date = CRM_Utils_Date::processDate('2017-10-10');
+
+    $publicHolidayLeaveRequest = PublicHolidayLeaveRequestFabricator::fabricate($this->leaveContact, $publicHoliday);
+    $this->getLeaveRequestServiceWhenCurrentUserIsAdmin()->delete($publicHolidayLeaveRequest->id);
+
+    $publicHolidayLeaveRequestRecord = new LeaveRequest();
+    $publicHolidayLeaveRequestRecord->id = $publicHolidayLeaveRequest->id;
+    $publicHolidayLeaveRequestRecord->find(true);
+    $this->assertEquals(1, $publicHolidayLeaveRequestRecord->is_deleted);
+  }
+
   public function testPublicHolidayLeaveRequestIsDeletedAndBalanceRecalculatedForOverlappingLeaveRequestDate() {
     AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -27,6 +27,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
   use CRM_HRLeaveAndAbsences_LeaveManagerHelpersTrait;
   use CRM_HRLeaveAndAbsences_LeaveRequestStatusMatrixHelpersTrait;
   use CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait;
+  use CRM_HRLeaveAndAbsences_PublicHolidayHelpersTrait;
 
 
   private $leaveBalanceChangeService;
@@ -241,9 +242,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
       'end_date' => CRM_Utils_Date::processDate('2017-12-31')
     ]);
 
-    $publicHoliday = new PublicHoliday();
-    $publicHoliday->date = CRM_Utils_Date::processDate('2017-10-10');
-
+    $publicHoliday = $this->instantiatePublicHoliday('2017-10-10');
     $publicHolidayLeaveRequest = PublicHolidayLeaveRequestFabricator::fabricate($this->leaveContact, $publicHoliday);
     $this->getLeaveRequestServiceWhenCurrentUserIsAdmin()->delete($publicHolidayLeaveRequest->id);
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -26,6 +26,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
 
   use CRM_HRLeaveAndAbsences_LeavePeriodEntitlementHelpersTrait;
   use CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait;
+  use CRM_HRLeaveAndAbsences_PublicHolidayHelpersTrait;
 
   /**
    * @var CRM_HRLeaveAndAbsences_BAO_AbsenceType
@@ -102,8 +103,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $periodEntitlement->type_id = $this->absenceType->id;
 
     $date = new DateTime('first monday of this year');
-    $publicHoliday = new PublicHoliday();
-    $publicHoliday->date = $date->format('YmdHis');
+    $publicHoliday = $this->instantiatePublicHoliday($date->format('Ymd'));
 
     $publicHolidayRequest = $this->getCreationLogic()->createForContact($periodEntitlement->contact_id, $publicHoliday);
     $this->assertEquals(1, $this->countNumberOfLeaveRequests($periodEntitlement->contact_id, $date->format('Ymd')));

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -91,6 +91,41 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $this->assertEquals(1, $this->countNumberOfLeaveRequests($periodEntitlement->contact_id, $date->format('Ymd')));
   }
 
+  public function testItDoesNotCreateALeaveRequestIfThereIsAlreadyASoftDeletedLeaveRequestForTheGivenPublicHolidayAndContact() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('first day of this year'),
+      'end_date' => CRM_Utils_Date::processDate('last day of this year')
+    ]);
+
+    $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests();
+    $periodEntitlement->contact_id = 2;
+    $periodEntitlement->type_id = $this->absenceType->id;
+
+    $date = new DateTime('first monday of this year');
+    $publicHoliday = new PublicHoliday();
+    $publicHoliday->date = $date->format('YmdHis');
+
+    $publicHolidayRequest = $this->getCreationLogic()->createForContact($periodEntitlement->contact_id, $publicHoliday);
+    $this->assertEquals(1, $this->countNumberOfLeaveRequests($periodEntitlement->contact_id, $date->format('Ymd')));
+    //soft delete the public holiday leave request
+    LeaveRequest::softDelete($publicHolidayRequest->id);
+
+    $numberOfDeletedRequests = $this->countNumberOfLeaveRequests($periodEntitlement->contact_id, $date->format('Ymd'), FALSE);
+    $numberOfNonDeletedRequests = $this->countNumberOfLeaveRequests($periodEntitlement->contact_id, $date->format('Ymd'));
+    $this->assertEquals(1, $numberOfDeletedRequests);
+    $this->assertEquals(0, $numberOfNonDeletedRequests);
+
+    //Try to create a public holiday leave request for same date
+    //Null will be returned because a soft deleted request is found for same date.
+    //Also the number of deleted request stays same and no new public holiday request is created.
+    $publicHolidayRequest = $this->getCreationLogic()->createForContact($periodEntitlement->contact_id, $publicHoliday);
+    $this->assertNull($publicHolidayRequest);
+    $numberOfDeletedRequests = $this->countNumberOfLeaveRequests($periodEntitlement->contact_id, $date->format('Ymd'), FALSE);
+    $numberOfNonDeletedRequests = $this->countNumberOfLeaveRequests($periodEntitlement->contact_id, $date->format('Ymd'));
+    $this->assertEquals(1, $numberOfDeletedRequests);
+    $this->assertEquals(0, $numberOfNonDeletedRequests);
+  }
+
   public function testItUpdatesTheBalanceChangeForOverlappingLeaveRequestDayToZero() {
     AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
@@ -467,10 +502,14 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     return $bao->count();
   }
 
-  private function countNumberOfLeaveRequests($contactID, $date) {
+  private function countNumberOfLeaveRequests($contactID, $date, $nonDeletedOnly = TRUE) {
     $bao = new LeaveRequest();
     $bao->contact_id = $contactID;
     $bao->from_date = $date;
+
+    if($nonDeletedOnly) {
+      $bao->is_deleted = 0;
+    }
 
     return $bao->count();
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
 use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_Service_JobContract as JobContractService;
@@ -25,6 +24,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
   use CRM_HRLeaveAndAbsences_ContractHelpersTrait;
   use CRM_HRLeaveAndAbsences_LeavePeriodEntitlementHelpersTrait;
   use CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait;
+  use CRM_HRLeaveAndAbsences_PublicHolidayHelpersTrait;
 
   /**
    * @var CRM_HRLeaveAndAbsences_BAO_AbsenceType
@@ -363,13 +363,6 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday));
     $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));
-  }
-
-  private function instantiatePublicHoliday($date) {
-    $publicHoliday = new PublicHoliday();
-    $publicHoliday->date = CRM_Utils_Date::processDate($date);
-
-    return $publicHoliday;
   }
 
   private function countNumberOfPublicHolidayBalanceChanges() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
@@ -71,7 +71,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
   }
 
-  public function testDeleteForContactWithSoftDeleteAsTrue() {
+  public function testSoftDeleteForContactSoftDeletesThePublicHolidayRequest() {
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
       'end_date' => CRM_Utils_Date::processDate('2017-12-31')
@@ -95,7 +95,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     $this->assertEquals(-1, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
 
     $deletionLogic = new PublicHolidayLeaveRequestDeletion(new JobContractService());
-    $deletionLogic->deleteForContact($periodEntitlement->contact_id, $publicHoliday, TRUE);
+    $deletionLogic->softDeleteForContact($periodEntitlement->contact_id, $publicHoliday);
 
     $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
     //Check that the public holiday leave request is soft deleted.

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/bootstrap.php
@@ -25,6 +25,7 @@ require_once 'helpers/LeaveRequestStatusMatrixHelpersTrait.php';
 require_once 'helpers/ApiHelpersTrait.php';
 require_once 'helpers/MailHelpersTrait.php';
 require_once 'helpers/WorkDayHelpersTest.php';
+require_once 'helpers/PublicHolidayHelpersTrait.php';
 
 /**
  * Call the "cv" command.

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/LeaveBalanceChangeHelpersTrait.php
@@ -252,10 +252,13 @@ trait CRM_HRLeaveAndAbsences_LeaveBalanceChangeHelpersTrait {
    *
    * @param int $contactID
    * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
+   *
+   * @return LeaveRequest
    */
   public function fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contactID, PublicHoliday $publicHoliday) {
     $balanceChangeServiceMock = $this->createLeaveBalanceChangeServiceForPublicHolidayLeaveRequestMock();
-    PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday, $balanceChangeServiceMock);
+
+    return PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday, $balanceChangeServiceMock);
   }
 
   public function createLeaveDateAmountDeductionServiceMock($amount) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/PublicHolidayHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/PublicHolidayHelpersTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
+
+trait CRM_HRLeaveAndAbsences_PublicHolidayHelpersTrait {
+  
+  private function instantiatePublicHoliday($date) {
+    $publicHoliday = new PublicHoliday();
+    $publicHoliday->date = CRM_Utils_Date::processDate($date);
+
+    return $publicHoliday;
+  }
+}


### PR DESCRIPTION
## Overview
Currently when a public holiday leave request is deleted by the Admin for a contact, If a condition that triggers the creation of public holiday leave requests occurs e.g change in Work Pattern, the public holiday leave request is created for the contact again.

## Before
When a public holiday leave request is deleted by the Admin for a contact, it gets created again when a condition that triggers public holiday creation happens.

## After
When a public holiday leave request is deleted by the Admin for a contact, it does not get created again when a condition that triggers public holiday creation happens.

- The Admin deletes public holiday leave requests via the `LeaveRequestService.delete` function, rather than hard delete the requests, the function was modified to now soft delete public holiday leave requests.
```php
if ($leaveRequest->request_type == LeaveRequest::REQUEST_TYPE_PUBLIC_HOLIDAY) {
       $publicHoliday = new PublicHoliday();
       $publicHoliday->date = $leaveRequest->from_date;
       $this->publicHolidayLeaveRequestDeletionService->deleteForContact($leaveRequest->contact_id, $publicHoliday, TRUE);
}
```
Note the TRUE passed as the last parameter to `publicHolidayLeaveRequestDeletionService.deleteForContact` method. This method was modified to accept an optional parameter to specify whether to soft delete or hard delete a public holiday leave request.
It is still necessary to hard delete some public holiday leave requests for example when a Work pattern changes, all future public holiday leave requests are hard deleted and then created again with the new respective balance changes.

- The logic for creating public holiday leave requests was modified to check not only for the existence of a public holiday request before attempting to create a public holiday request. The logic now checks for existence of both soft deleted and non deleted public holiday leave requests, if such public holiday requests exists for the given date for the contact, the request does not get created.

```php
  public function createForContact($contactID, PublicHoliday $publicHoliday) {
    if (!$this->absenceType) {
      return;
    }

    $existingLeaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday, FALSE);
    if($existingLeaveRequest) {
      return;
    }

    $leaveRequest = $this->createLeaveRequest($contactID, $this->absenceType, $publicHoliday);
    $this->createLeaveBalanceChangeRecord($leaveRequest);
    $this->recalculateExpiredBalanceChange($leaveRequest);

    return $leaveRequest;
  }
```
Note the last parameter passed to the `LeaveRequest::findPublicHolidayLeaveRequest` function. The method was modified to either find all  public holiday requests or only non deleted public holiday requests via the optional parameter `nonDeletedOnly`.
