### PR TITLE
PCHR-3392: Moved HRIdent Upgrade to HRCore

### DIFF
--- a/hrident/CRM/HRIdent/Upgrader.php
+++ b/hrident/CRM/HRIdent/Upgrader.php
@@ -136,26 +136,4 @@ class CRM_HRIdent_Upgrader extends CRM_HRIdent_Upgrader_Base {
     return true;
   }
   
-  /**
-   * Upgrade CustomGroup, setting Identify is_reserved value to Yes
-   * if it existing.
-   *
-   * @return bool
-   */
-  public function upgrade_1502() {
-    $result = civicrm_api3('CustomGroup', 'get', [
-      'return' => ['id'],
-      'name' => 'Identify',
-    ]);
-  
-    if ($result['id']) {
-      civicrm_api3('CustomGroup', 'create', [
-        'id' => $result['id'],
-        'is_reserved' => 1,
-      ]);
-    }
-  
-    return TRUE;
-  }
-  
 }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -18,6 +18,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1008;
   use CRM_HRCore_Upgrader_Steps_1009;
   use CRM_HRCore_Upgrader_Steps_1010;
+  use CRM_HRCore_Upgrader_Steps_1011;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1011.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1011.php
@@ -1,14 +1,11 @@
 <?php
 
-/**
- * Trait CRM_HRCore_Upgrader_Steps_1011
- */
 trait CRM_HRCore_Upgrader_Steps_1011 {
   
   /**
    * Upgrade CustomGroup, setting Identify is_reserved value to Yes
-   * if it existing. This implementation was made in HRCore instead of 
-   * HRIdent extension because HRIdent is currently disabled in some setup.
+   * if it exists. This implementation was made in HRCore instead of
+   * HRIdent extension because HRIdent is currently disabled in some setups.
    *
    * @return bool
    */

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1011.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1011.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Trait CRM_HRCore_Upgrader_Steps_1011
+ */
+trait CRM_HRCore_Upgrader_Steps_1011 {
+  
+  /**
+   * Upgrade CustomGroup, setting Identify is_reserved value to Yes
+   * if it existing. This implementation was made in HRCore instead of 
+   * HRIdent extension because HRIdent is currently disabled in some setup.
+   *
+   * @return bool
+   */
+  public function upgrade_1011() {
+    $result = civicrm_api3('CustomGroup', 'get', [
+      'return' => ['id'],
+      'name' => 'Identify',
+    ]);
+
+    if ($result['id']) {
+      civicrm_api3('CustomGroup', 'create', [
+        'id' => $result['id'],
+        'is_reserved' => 1,
+      ]);
+    }
+
+    return TRUE;
+  }
+}


### PR DESCRIPTION

## Overview
An upgrade was required to move Custom Group Identify to is_reserved yes. Due to the fact that HRIdent extension have been disabled on some installation, the implementation was migrated to HRCore. This ensures consistency across systems.

## Before
<img width="1347" alt="before" src="https://user-images.githubusercontent.com/1507645/37029152-ad188b90-2136-11e8-9d27-50fc9a05d602.png">


## After
<img width="1357" alt="after" src="https://user-images.githubusercontent.com/1507645/37029161-b709c8e4-2136-11e8-8398-134fdb39879c.png">
