### PR TITLE
PCHR-3433: Rename Inline Custom Field Data

### DIFF
--- a/hrui/CRM/HRUI/Upgrader.php
+++ b/hrui/CRM/HRUI/Upgrader.php
@@ -40,6 +40,7 @@ class CRM_HRUI_Upgrader extends CRM_HRUI_Upgrader_Base {
   use CRM_HRUI_Upgrader_Steps_4707;
   use CRM_HRUI_Upgrader_Steps_4708;
   use CRM_HRUI_Upgrader_Steps_4709;
+  use CRM_HRUI_Upgrader_Steps_4710;
 
   public function install() {
     $this->runAllUpgraders();

--- a/hrui/CRM/HRUI/Upgrader/Steps/4710.php
+++ b/hrui/CRM/HRUI/Upgrader/Steps/4710.php
@@ -1,0 +1,23 @@
+<?php
+
+trait CRM_HRUI_Upgrader_Steps_4710 {
+  /**
+   * Upgrade CustomGroup, set Inline_Custom_Data title to NI/SSN Number
+   *
+   * @return bool
+   */
+  public function upgrade_4710() {
+    $result = civicrm_api3('CustomGroup', 'get', [
+      'return' => ['id'],
+      'name' => 'Inline_Custom_Data',
+    ]);
+    
+    civicrm_api3('CustomGroup', 'create', [
+      'id' => $result['id'],
+      'title' => 'NI/SSN Number',
+    ]);
+    
+    return TRUE;
+  }
+  
+}


### PR DESCRIPTION
## Overview
Custom group field called `Inline Custom Field` is currently titled `Inline Custom Data`. There is need to change the title to `NI/SSN Number`, whether it is reserved or not in any setup.

## Before
![before](https://user-images.githubusercontent.com/1507645/37082740-a05c4b5a-21ed-11e8-9c31-8cfc49f5a46f.png)

## After
![after](https://user-images.githubusercontent.com/1507645/37082758-aa0a66fa-21ed-11e8-8288-c6c3aa335951.png)
