### PR TITLE
PCHR-3420: Hide Options on Localisation Page

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/LocalisationPageFilter.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/LocalisationPageFilter.php
@@ -1,6 +1,19 @@
 <?php
 
 class CRM_HRCore_Hook_BuildForm_LocalisationPageFilter {
+
+  private $restrictedSettings = [
+    'customTranslateFunction',
+    'contact_default_language',
+    'fieldSeparator',
+    'inheritLocale',
+    'lcMessages',
+    'legacyEncoding',
+    'monetaryThousandSeparator',
+    'monetaryDecimalPoint',
+    'moneyformat',
+    'moneyvalueformat'
+  ];
   /**
    * Hides options on the localisation page
    *
@@ -23,7 +36,7 @@ class CRM_HRCore_Hook_BuildForm_LocalisationPageFilter {
    * @return bool
    */
   private function shouldHandle($formName) {
-    if ($formName == CRM_Admin_Form_Setting_Localization::class) {
+    if ($formName === CRM_Admin_Form_Setting_Localization::class) {
       return TRUE;
     }
     
@@ -37,45 +50,20 @@ class CRM_HRCore_Hook_BuildForm_LocalisationPageFilter {
    */
   private function filterLocalisationOptions($form) {
     $canViewAllFields = CRM_Core_Permission::check('access root menu items and configurations ');
-    $settings = [
-      'customTranslateFunction',
-      'contact_default_language',
-      'fieldSeparator',
-      'inheritLocale',
-      'lcMessages',
-      'legacyEncoding',
-      'monetaryThousandSeparator',
-      'monetaryDecimalPoint',
-      'moneyformat',
-      'moneyvalueformat'
-    ];
     
     if (! $canViewAllFields) {
-      $this->hideOptionLabels();
-      foreach ($settings as $setting) {
+      $hiddenOptionsStyle = "tr.crm-localization-form-contact_default_language";
+      
+      foreach ($this->restrictedSettings as $setting) {
         if ($form->elementExists($setting)) {
+          $hiddenOptionsStyle .= ", tr.crm-localization-form-block-$setting";
           $form->freeze($setting);
         }
       }
-    }
-  }
   
-  /**
-   * Hide labels for frozen elements
-   */
-  private function hideOptionLabels() {
-    CRM_Core_Resources::singleton()->addStyle(
-      'tr.crm-localization-form-block-lcMessages,
-      tr.crm-localization-form-block-inheritLocale,
-      tr.crm-localization-form-contact_default_language,
-      tr.crm-localization-form-block-monetaryThousandSeparator,
-      tr.crm-localization-form-block-monetaryDecimalPoint,
-      tr.crm-localization-form-block-moneyformat,
-      tr.crm-localization-form-block-moneyvalueformat,
-      tr.crm-localization-form-block-customTranslateFunction,
-      tr.crm-localization-form-block-legacyEncoding,
-      tr.crm-localization-form-block-fieldSeparator { display: none; }'
-    );
+      $hiddenOptionsStyle .= ' { display: none; }';
+      CRM_Core_Resources::singleton()->addStyle($hiddenOptionsStyle);
+    }
   }
   
 }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/LocalisationPageFilter.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/LocalisationPageFilter.php
@@ -1,0 +1,81 @@
+<?php
+
+class CRM_HRCore_Hook_BuildForm_LocalisationPageFilter {
+  /**
+   * Hides options on the localisation page
+   *
+   * @param string $formName
+   * @param CRM_Core_Form $form
+   */
+  public function handle($formName, &$form) {
+    if (!$this->shouldHandle($formName)) {
+      return;
+    }
+    
+    $this->filterLocalisationOptions($form);
+  }
+  
+  /**
+   * Checks if the hook should be handled.
+   *
+   * @param string $formName
+   *
+   * @return bool
+   */
+  private function shouldHandle($formName) {
+    if ($formName == CRM_Admin_Form_Setting_Localization::class) {
+      return TRUE;
+    }
+    
+    return FALSE;
+  }
+  
+  /**
+   * Hide options on localisation page if user does not have required permission
+   *
+   * @param CRM_Core_Form $form
+   */
+  private function filterLocalisationOptions($form) {
+    $canViewAllFields = CRM_Core_Permission::check('access root menu items and configurations ');
+    $settings = [
+      'customTranslateFunction',
+      'contact_default_language',
+      'fieldSeparator',
+      'inheritLocale',
+      'lcMessages',
+      'legacyEncoding',
+      'monetaryThousandSeparator',
+      'monetaryDecimalPoint',
+      'moneyformat',
+      'moneyvalueformat'
+    ];
+    
+    if (! $canViewAllFields) {
+      $this->hideOptionLabels();
+      foreach ($settings as $setting) {
+        if ($form->elementExists($setting)) {
+          $form->freeze($setting);
+        }
+      }
+    }
+  }
+  
+  /**
+   * Hide labels for frozen elements
+   */
+  private function hideOptionLabels() {
+    CRM_Core_Resources::singleton()->addStyle(
+      'tr.crm-localization-form-block-lcMessages,
+      tr.crm-localization-form-block-inheritLocale,
+      tr.crm-localization-form-contact_default_language,
+      tr.crm-localization-form-block-monetaryThousandSeparator,
+      tr.crm-localization-form-block-monetaryDecimalPoint,
+      tr.crm-localization-form-block-moneyformat,
+      tr.crm-localization-form-block-moneyvalueformat,
+      tr.crm-localization-form-block-customTranslateFunction,
+      tr.crm-localization-form-block-legacyEncoding,
+      tr.crm-localization-form-block-fieldSeparator { display: none; }'
+    );
+  }
+  
+}

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -110,12 +110,13 @@ function hrcore_civicrm_container($container) {
  * Implements hook_civicrm_buildForm
  *
  * @param string $formName
- * @param object $form
+ * @param CRM_Core_Form $form
  */
 function hrcore_civicrm_buildForm($formName, &$form) {
   $listeners = [
     new CRM_HRCore_Hook_BuildForm_ActivityFilterSelectFieldsModifier(),
     new CRM_HRCore_Hook_BuildForm_ActivityLinksFilter(),
+    new CRM_HRCore_Hook_BuildForm_LocalisationPageFilter(),
   ];
 
   foreach ($listeners as $currentListener) {


### PR DESCRIPTION
## Overview
A new permission called `access root menu items and configurations` has been added. The implication of this on Localisation Page is that some fields will not be available for editing by users that do not have such permission.

## Before
<img width="1377" alt="before" src="https://user-images.githubusercontent.com/1507645/37142984-024519e2-22ba-11e8-9931-7d15f07ce596.png">


## After
![after](https://user-images.githubusercontent.com/1507645/37143003-1186df26-22ba-11e8-9138-7112cd4e9357.png)
