### PR TITLE
PCHR-3382: Modify Jobcontract.getContactsWithContractsInPeriod API And Reserve Work Location Type

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php
@@ -641,10 +641,11 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
    *  A date string in a format supported by strtotime
    * @param string|null $endDate
    *  A date string in a format supported by strtotime
+   * @param null|array $contactID
    *
    * @return array
    */
-  public static function getContactsWithContractsInPeriod($startDate = null, $endDate = null) {
+  public static function getContactsWithContractsInPeriod($startDate = null, $endDate = null, array $contactID = null) {
     if($startDate) {
       $startDate = CRM_Utils_Date::processDate($startDate, null, false, 'Y-m-d');
     } else {
@@ -655,6 +656,12 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
       $endDate = CRM_Utils_Date::processDate($endDate, null, false, 'Y-m-d');
     } else {
       $endDate = $startDate;
+    }
+
+    $whereContactID = '';
+    if (!empty($contactID)) {
+      array_walk($contactID, 'intval');
+      $whereContactID = ' AND contact.id IN('. implode(', ', $contactID) .')';
     }
 
     $query = "
@@ -694,6 +701,7 @@ class CRM_Hrjobcontract_BAO_HRJobContract extends CRM_Hrjobcontract_DAO_HRJobCon
             )
           )
         )
+        {$whereContactID}
       ORDER BY contact.display_name ASC
     ";
 

--- a/hrjobcontract/api/v3/HRJobContract.php
+++ b/hrjobcontract/api/v3/HRJobContract.php
@@ -240,16 +240,23 @@ function _civicrm_api3_h_r_job_contract_get_contacts_from_params($params) {
  */
 function _civicrm_api3_h_r_job_contract_getcontactswithcontractsinperiod_spec(&$spec) {
   $spec['start_date'] = array(
-    'name'         => 'start_date',
-    'title'        => 'Start Date',
-    'type'         => CRM_Utils_Type::T_DATE,
+    'name' => 'start_date',
+    'title' => 'Start Date',
+    'type' => CRM_Utils_Type::T_DATE,
     'api.required' => 0,
   );
 
   $spec['end_date'] = array(
-    'name'         => 'end_date',
-    'title'        => 'End Date',
-    'type'         => CRM_Utils_Type::T_DATE,
+    'name' => 'end_date',
+    'title' => 'End Date',
+    'type' => CRM_Utils_Type::T_DATE,
+    'api.required' => 0,
+  );
+
+  $spec['contact_id'] = array(
+    'name' => 'contact_id',
+    'title' => 'Contact ID',
+    'type' => CRM_Utils_Type::T_INT,
     'api.required' => 0,
   );
 }
@@ -265,6 +272,7 @@ function _civicrm_api3_h_r_job_contract_getcontactswithcontractsinperiod_spec(&$
 function civicrm_api3_h_r_job_contract_getcontactswithcontractsinperiod($params) {
   $startDate = null;
   $endDate = null;
+  $contactID = null;
 
   if(!empty($params['start_date'])) {
     if(is_array($params['start_date'])) {
@@ -280,7 +288,11 @@ function civicrm_api3_h_r_job_contract_getcontactswithcontractsinperiod($params)
     $endDate = $params['end_date'];
   }
 
-  $result = CRM_Hrjobcontract_BAO_HRJobContract::getContactsWithContractsInPeriod($startDate, $endDate);
+  if(!empty($params['contact_id'])) {
+    $contactID = _civicrm_api3_h_r_job_contract_get_contacts_from_params($params);
+  }
+
+  $result = CRM_Hrjobcontract_BAO_HRJobContract::getContactsWithContractsInPeriod($startDate, $endDate, $contactID);
   return civicrm_api3_create_success($result, $params);
 }
 

--- a/hrjobcontract/tests/phpunit/CRM/Hrjobcontract/BAO/HRJobContractTest.php
+++ b/hrjobcontract/tests/phpunit/CRM/Hrjobcontract/BAO/HRJobContractTest.php
@@ -280,6 +280,41 @@ class CRM_Hrjobcontract_BAO_HRJobContractTest extends CRM_Hrjobcontract_Test_Bas
     $this->assertEquals($this->contacts[1]['display_name'], $contacts[1]['display_name']);
   }
 
+  public function testGetContactsWithContractsInPeriodCanFilterContacts() {
+    $this->createContacts(3);
+    $startDate = date('Y-m-d', strtotime('-2 days'));
+    $endDate = date('Y-m-d', strtotime('+2 days'));
+
+    $this->createJobContract(
+      $this->contacts[0]['id'],
+      $startDate,
+      $endDate
+    );
+
+    $this->createJobContract(
+      $this->contacts[1]['id'],
+      $startDate,
+      $endDate
+    );
+
+    $this->createJobContract(
+      $this->contacts[2]['id'],
+      $startDate,
+      $endDate
+    );
+
+    //We want results only to be returned for the first and last contact.
+    $contactID = [$this->contacts[0]['id'], $this->contacts[2]['id']];
+    $contacts = CRM_Hrjobcontract_BAO_HRJobContract::getContactsWithContractsInPeriod($startDate, $endDate, $contactID);
+    $this->assertCount(2, $contacts);
+    // Since the results are ordered by display_name, it's reliable to
+    // assert the order like this
+    $this->assertEquals($this->contacts[0]['id'], $contacts[0]['id']);
+    $this->assertEquals($this->contacts[0]['display_name'], $contacts[0]['display_name']);
+    $this->assertEquals($this->contacts[2]['id'], $contacts[1]['id']);
+    $this->assertEquals($this->contacts[2]['display_name'], $contacts[1]['display_name']);
+  }
+
   public function testGetContactsWithContractsInPeriodShouldNotIncludeContactsWithDeletedContracts() {
     $this->createContacts(1);
 

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -18,6 +18,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1008;
   use CRM_HRCore_Upgrader_Steps_1009;
   use CRM_HRCore_Upgrader_Steps_1010;
+  use CRM_HRCore_Upgrader_Steps_1011;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1011.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1011.php
@@ -1,0 +1,26 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1011 {
+
+  /**
+   * Sets the 'Work' Location type to reserved if its not
+   * already reserved.
+   *
+   * @return bool
+   */
+  public function upgrade_1011() {
+    $result = civicrm_api3('LocationType', 'get', [
+      'name' => 'Work',
+      'is_reserved' => 0,
+    ]);
+
+    if ($result['count'] > 0) {
+      civicrm_api3('LocationType', 'create', [
+        'id' => $result['id'],
+        'is_reserved' => 1,
+      ]);
+    }
+
+    return TRUE;
+  }
+}


### PR DESCRIPTION
## Problem
This PR makes some changes needed by [#324](https://github.com/compucorp/civihr-tasks-assignments/pull/324). 
- To send the daily reminder email, we need to ensure that the recipients have an active contract, the  
`Jobcontract.getContactsWithContractsInPeriod` provides this information but does not accept a list of contact ID's to check for. The `Jobcontract.getContractsWithDetailsInPeriod` accepts a list of contacts to check for but the information returned is far too much than what we need.
- Daily reminder emails are now to be sent to the primary work emails of a recipient with an active contract. The Work location type is not reserved in the database and as such the name can be changed which may affect the sql query in code where we have asked that the email be of the Work type.

![location types home work _ staging17 2018-03-07 18-32-05](https://user-images.githubusercontent.com/6951813/37204116-2a7688d4-2390-11e8-9985-cb63fa8e950a.png)


## Solution
- The `Jobcontract.getContactsWithContractsInPeriod` API was modified to accept a list of contacts to check for.
- The Work location type was reserved in the database via an upgrader in HRCore extension so that the name can not be edited via the UI.

![location types home work _ staging17 2018-03-09 11-50-19](https://user-images.githubusercontent.com/6951813/37204083-2307a4ca-2390-11e8-964c-bcc3b8958969.png)


