### PR TITLE
PCHR-3376: Update Permissions

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
@@ -55,7 +55,7 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
     $params = ['return' => 'id', 'name' => 'Administer', 'domain_id' => $domain];
     $administerId = (int) civicrm_api3('Navigation', 'getvalue', $params);
 
-    $permission = 'Access CiviCRM';
+    $permission = 'access CiviCRM';
     $parent = $this->createNavItem('Job Roles', $permission, $administerId);
     $parentId = $parent['id'];
 

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1218,7 +1218,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     $params = ['return' => 'id', 'name' => 'Administer', 'domain_id' => $domain];
     $administerId = (int) civicrm_api3('Navigation', 'getvalue', $params);
 
-    $permission = 'Access CiviCRM';
+    $permission = 'access CiviCRM';
     $parent = $this->createNavItem('Job Contract', $permission, $administerId);
     $parentId = $parent['id'];
 

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1228,20 +1228,24 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     // If we don't flush it will not recognize newly created parent_id
     CRM_Core_PseudoConstant::flush();
 
-    $optionGroupLinks = [
-      'Contract Types' => 'hrjc_contract_type',
-      'Normal Place of Work' => 'hrjc_location',
-      'Contract End Reasons' => 'hrjc_contract_end_reason',
-      'Contract Revision Reasons' => 'hrjc_revision_change_reason',
-      'Standard Full Time Hours' => 'hrjc_hours_type',
-      'Pay Scales' => 'hrjc_pay_grade',
-      'Benefits' => 'hrjc_benefit_type',
-      'Deductions' => 'hrjc_deduction_type',
-      'Insurance Plan Types' => 'hrjc_insurance_plantype',
+    // returns the link to an option group edit page
+    $optGroupLinker = function ($groupName) {
+      return 'civicrm/admin/options/' . $groupName . '?reset=1';
+    };
+
+    $childLinks = [
+      'Contract Types' => $optGroupLinker('hrjc_contract_type'),
+      'Normal Place of Work' => $optGroupLinker('hrjc_location'),
+      'Contract End Reasons' => $optGroupLinker('hrjc_contract_end_reason'),
+      'Contract Revision Reasons' => $optGroupLinker('hrjc_revision_change_reason'),
+      'Standard Full Time Hours' => 'civicrm/hours_location',
+      'Pay Scales' => 'civicrm/pay_scale',
+      'Benefits' => $optGroupLinker('hrjc_benefit_name'),
+      'Deductions' => $optGroupLinker('hrjc_deduction_name'),
+      'Insurance Plan Types' => $optGroupLinker('hrjc_insurance_plantype'),
     ];
 
-    foreach ($optionGroupLinks as $itemName => $optionGroup) {
-      $link = 'civicrm/admin/options/' . $optionGroup . '?reset=1';
+    foreach ($childLinks as $itemName => $link) {
       $this->createNavItem($itemName, $permission, $parentId, ['url' => $link]);
     }
 

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -20,6 +20,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1010;
   use CRM_HRCore_Upgrader_Steps_1011;
   use CRM_HRCore_Upgrader_Steps_1012;
+  use CRM_HRCore_Upgrader_Steps_1013;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1012.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1012.php
@@ -24,7 +24,7 @@ trait CRM_HRCore_Upgrader_Steps_1012 {
    * @throws CiviCRM_API3_Exception
    */
   private function up1012_addOtherStaffDetailsSubmenu($administerId) {
-    $permission = 'Access CiviCRM';
+    $permission = 'access CiviCRM';
     $parentName = 'Other Staff Details';
     $parent = $this->up1012_createNavItem($parentName, $permission, $administerId);
     $parentId = $parent['id'];

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1012.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1012.php
@@ -13,10 +13,29 @@ trait CRM_HRCore_Upgrader_Steps_1012 {
     $params = ['return' => 'id', 'name' => 'Administer', 'domain_id' => $domain];
     $administerId = (int) civicrm_api3('Navigation', 'getvalue', $params);
 
+    $this->up1012_addLocalisationShortcut($administerId);
     $this->up1012_addOtherStaffDetailsSubmenu($administerId);
     $this->up1012_addCustomFieldsShortcut($administerId);
 
     return TRUE;
+  }
+
+  /**
+   * Adds a shortcut to the localization page
+   *
+   * @param int $administerId
+   */
+  private function up1012_addLocalisationShortcut($administerId) {
+    $result = $this->up1012_createNavItem(
+      'Localise CiviCRM',
+      'access CiviCRM',
+      $administerId,
+      ['url' => 'civicrm/admin/setting/localization?reset=1']
+    );
+
+    // weight cannot be set when you're creating first time
+    $id = $result['id'];
+    civicrm_api3('Navigation', 'create', ['id' => $id, 'weight' => -101]);
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1013.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1013.php
@@ -1,0 +1,60 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1013 {
+
+  /**
+   * Updates permissions on the items in the "Administer" submenu
+   *
+   * @return bool
+   */
+  public function upgrade_1013() {
+    $domain = CRM_Core_Config::domainID();
+    $params = ['return' => 'id', 'name' => 'Administer', 'domain_id' => $domain];
+    $administerId = (int) civicrm_api3('Navigation', 'getvalue', $params);
+
+    $this->up1013_replaceExistingAdministerItemsPermission($administerId);
+
+    return TRUE;
+  }
+
+  /**
+   * @param $administerId
+   * @throws CiviCRM_API3_Exception
+   */
+  private function up1013_replaceExistingAdministerItemsPermission($administerId) {
+    $allChildren = [];
+    $this->up1013_findAllChildElements($administerId, $allChildren);
+    $replacement = 'access root menu items and configurations';
+    $original = 'administer CiviCRM';
+
+    $exceptions = ['Custom Fields'];
+
+    foreach ($allChildren as $child) {
+      if (in_array($child['name'], $exceptions)) {
+        continue;
+      }
+
+      $permissions = CRM_Utils_Array::value('permission', $child);
+      $permissions = str_replace($original, $replacement, $permissions);
+      $params = ['id' => $child['id'], 'permission' => $permissions];
+      civicrm_api3('Navigation', 'create', $params);
+    }
+  }
+
+  /**
+   * Recursively search for all children of a given parent ID
+   *
+   * @param int $parentId
+   * @param array $allChildren
+   */
+  private function up1013_findAllChildElements($parentId, &$allChildren) {
+    $params = ['parent_id' => $parentId];
+    $children = civicrm_api3('Navigation', 'get', $params)['values'];
+    $allChildren = array_merge($allChildren, $children);
+
+    foreach ($children as $child) {
+      $this->up1013_findAllChildElements($child['id'], $allChildren);
+    }
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1013.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1013.php
@@ -12,6 +12,9 @@ trait CRM_HRCore_Upgrader_Steps_1013 {
     $params = ['return' => 'id', 'name' => 'Administer', 'domain_id' => $domain];
     $administerId = (int) civicrm_api3('Navigation', 'getvalue', $params);
 
+    // If running two consecutive upgraders, items from first are not found
+    CRM_Core_PseudoConstant::flush();
+
     $this->up1013_replaceExistingAdministerItemsPermission($administerId);
 
     return TRUE;

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1013.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1013.php
@@ -18,8 +18,10 @@ trait CRM_HRCore_Upgrader_Steps_1013 {
   }
 
   /**
-   * @param $administerId
-   * @throws CiviCRM_API3_Exception
+   * Replaces all existing 'administer CiviCRM' permissions in the
+   * 'Administer' submenu with 'access root menu items and configurations'
+   *
+   * @param int $administerId
    */
   private function up1013_replaceExistingAdministerItemsPermission($administerId) {
     $allChildren = [];


### PR DESCRIPTION
## Overview

The PR updates permissions on menu items in the "Configure" submenu. It also fixes some links and adds a link to "Localise CiviHR" which was missing.

## Before

![image](https://user-images.githubusercontent.com/6374064/37349499-79bc5414-26ce-11e8-9fb0-2aa6e2d9ccfd.png)

- Many of the permissions on the "Configure" submenu item used `administer CiviCRM`
- Some of the links were broken
- The case of the permission for some links was incorrect
- The "Localise CiviHR" menu item did not exist

## After

![image](https://user-images.githubusercontent.com/6374064/37349583-b14b28d8-26ce-11e8-9918-f1a3a9e525a6.png)


- Permission for the items that should not be viewable by non-root users has been changed to `access root menu items and configurations`
- Some of the links for menu items created in other PRs have been fixed
- Fixed a mistake in the permission case, `Access CiviCRM` => `access CiviCRM`
- Create the "Localise CiviHR" menu item

## Notes

- 'Custom Fields' is an exception for the permissions update, it was added as part of this epic and `administer CiviCRM` is the correct permission for it.