### PR TITLE
PCHR-3474: Add TOIL times in reports

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/manage-leave-requests.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/manage-leave-requests.html
@@ -184,17 +184,8 @@
                       {{request.balance_change > 0 ? "+" : ""}}{{request.balance_change |
                         timeUnitApplier : absenceType.calculation_unit_name}}
                     </td>
-                    <td ng-init="unit = absenceType.calculation_unit_name">
-                      {{request.from_date | formatDate : null : request.request_type !== 'toil' ? unit : null}}
-                      <span ng-if="request.dates.length > 1">
-                        -
-                        {{request.to_date | formatDate : null : request.request_type !== 'toil' ? unit : null}}
-                      </span>
-                      <span ng-if="request.dates.length === 1 && unit === 'hours' && request_type !== 'toil'">
-                        -
-                        {{request.to_date.slice(11, 16)}}
-                      </span>
-                    </td>
+                    <td ng-init="unit = absenceType.calculation_unit_name"
+                      ng-include="$root.sharedPathTpl + 'components/partials/leave-request-dates.html'"></td>
                     <td>{{vm.getLeaveStatusByValue(request.status_id)}}</td>
                     <td class="text-center">
                       <leave-request-actions

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/partials/leave-request-dates.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/partials/leave-request-dates.html
@@ -1,0 +1,9 @@
+{{request.from_date | formatDate : null : (request.request_type === 'toil' ? 'hours' : unit)}}
+<span ng-if="request.dates.length > 1">
+  -
+  {{request.to_date | formatDate : null : (request.request_type === 'toil' ? 'hours' : unit)}}
+</span>
+<span ng-if="request.dates.length === 1 && (unit === 'hours' || request.request_type === 'toil')">
+  -
+  {{request.to_date.slice(11, 16)}}
+</span>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/partials/staff-leave-report-requests-rows.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/partials/staff-leave-report-requests-rows.html
@@ -7,17 +7,8 @@
       (expires {{request.toil_expiry_date | formatDate}})
     </span>
   </td>
-  <td ng-init="unit = absenceType.calculation_unit_name">
-    {{request.from_date | formatDate : null : request.request_type !== 'toil' ? unit : null}}
-    <span ng-if="request.dates.length > 1">
-      -
-      {{request.to_date | formatDate : null : request.request_type !== 'toil' ? unit : null}}
-    </span>
-    <span ng-if="request.dates.length === 1 && unit === 'hours' && request_type !== 'toil'">
-      -
-      {{request.to_date.slice(11, 16)}}
-    </span>
-  </td>
+  <td ng-init="unit = absenceType.calculation_unit_name"
+    ng-include="$root.sharedPathTpl + 'components/partials/leave-request-dates.html'"></td>
   <td>{{report.leaveRequestStatuses[request.status_id].label}}</td>
   <td ng-repeat="absenceType in report.absenceTypesFiltered track by $index"
     title="({{ absenceType.calculation_unit_label | lowercase }})">


### PR DESCRIPTION
## Overview

This PR adds times for TOIL requests in Staff Leave Report and Manage Leave Report.

## Before

![image](https://user-images.githubusercontent.com/3973243/37673557-6b67147c-2c68-11e8-8cd9-20fc11eed9d4.png)

![image](https://user-images.githubusercontent.com/3973243/37673593-88f372b0-2c68-11e8-8dfd-9695f9499af3.png)

## After

![image](https://user-images.githubusercontent.com/3973243/37673085-4309393e-2c67-11e8-8f0a-35e4ceb89ee0.png)

![image](https://user-images.githubusercontent.com/3973243/37673131-62aff67e-2c67-11e8-9c8c-f7426c0c68d5.png)

## Technical Details

1. Create a shared partial for request dates/times:

```html
<!-- only conditions changed -->
{{request.from_date | formatDate : null : (request.request_type === 'toil' ? 'hours' : unit)}}
<span ng-if="request.dates.length > 1">
  -
  {{request.to_date | formatDate : null : (request.request_type === 'toil' ? 'hours' : unit)}}
</span>
<span ng-if="request.dates.length === 1 && (unit === 'hours' || request.request_type === 'toil')">
  -
  {{request.to_date.slice(11, 16)}}
</span>
```

2. Then replace the dup code with a new partial in reports.

```html
<td ng-init="unit = absenceType.calculation_unit_name"
  ng-include="$root.sharedPathTpl + 'components/partials/leave-request-dates.html'"></td>
```

----

Only manual tests were performed.