### PR TITLE
PCHR-2769: Remove the Zero Days TOIL amount option value.

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
@@ -25,6 +25,7 @@ class CRM_HRLeaveAndAbsences_Upgrader extends CRM_HRLeaveAndAbsences_Upgrader_Ba
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1017;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1018;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1019;
+  use CRM_HRLeaveAndAbsences_Upgrader_Step_1020;
 
   /**
    * A list of directories to be scanned for XML installation files

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1020.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1020.php
@@ -1,0 +1,27 @@
+<?php
+
+trait CRM_HRLeaveAndAbsences_Upgrader_Step_1020 {
+
+  /**
+   * Deletes the 'zero_days' option value of the toil amounts
+   * option group.
+   *
+   * @return bool
+   */
+  public function upgrade_1020() {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'hrleaveandabsences_toil_amounts',
+      'name' => 'zero_days',
+    ]);
+
+    if (empty($result['id'])) {
+      return TRUE;
+    }
+
+    civicrm_api3('OptionValue', 'delete', [
+      'id' => $result['id']
+    ]);
+
+    return TRUE;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/option_groups/toil_amounts_install.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/option_groups/toil_amounts_install.xml
@@ -15,18 +15,6 @@
   <OptionValues>
 
     <OptionValue>
-      <label>0 Days</label>
-      <value>0</value>
-      <name>zero_days</name>
-      <is_default>0</is_default>
-      <weight>1</weight>
-      <is_optgroup>0</is_optgroup>
-      <is_reserved>1</is_reserved>
-      <is_active>1</is_active>
-      <option_group_name>hrleaveandabsences_toil_amounts</option_group_name>
-    </OptionValue>
-
-    <OptionValue>
       <label>1/4 Days</label>
       <value>0.25</value>
       <name>quarter_day</name>


### PR DESCRIPTION
## Overview
This PR removes the Zero Days TOIL amount option value from the toil amounts option group.

## Before
- The Zero Days TOIL amount option value was present in the toil amounts option group.

![toil amounts options _ testbreak 2018-03-21 13-42-07](https://user-images.githubusercontent.com/6951813/37710385-c8ac4724-2d0d-11e8-829d-0baf0bff29e3.png)


## After
- The Zero Days TOIL amount option value is no longer present in the toil amounts option group.
 The option value was removed from the toil_amounts option group xml installation file for new sites and removed via an upgrader for existing sites.

![toil amounts options _ staging17 2018-03-21 13-42-36](https://user-images.githubusercontent.com/6951813/37710408-da87e46c-2d0d-11e8-8529-8cbb9fa44f41.png)

## Comments
- Part of the fixes for this ticket(PCHR-2769) was also to re-order the TOIL amounts options in the TOIL request modal but that has already been fixed as part of https://compucorp.atlassian.net/browse/PCHR-3427.
