### PR TITLE
PCHR-3476: Add an upgrader to amend existing toil requests end time to 23:45

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
@@ -25,6 +25,7 @@ class CRM_HRLeaveAndAbsences_Upgrader extends CRM_HRLeaveAndAbsences_Upgrader_Ba
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1017;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1018;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1019;
+  use CRM_HRLeaveAndAbsences_Upgrader_Step_1020;
 
   /**
    * A list of directories to be scanned for XML installation files

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1020.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1020.php
@@ -26,7 +26,7 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1020 {
   public function upgrade_1020 () {
     $leaveRequest = new LeaveRequest();
 
-    $leaveRequest->whereAdd('request_type = "toil"');
+    $leaveRequest->whereAdd('request_type = "' . LeaveRequest::REQUEST_TYPE_TOIL . '"');
     $leaveRequest->whereAdd('is_deleted = 0');
     $leaveRequest->find();
 
@@ -36,6 +36,6 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1020 {
       $leaveRequest->update();
     }
 
-    return true;
+    return TRUE;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1020.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1020.php
@@ -1,0 +1,41 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+
+trait CRM_HRLeaveAndAbsences_Upgrader_Step_1020 {
+
+  /**
+   * Sets "end" time for all existing TOIL (overtime) requests to 23:45.
+   *
+   * As per PCHR-3427 TOIL (overtime) requests have both "from" and "to" times now.
+   * Currently, TOIL requests in days have end time set as 23:59, TOIL requests in hours
+   * have end time set as 00:00. There are two problems that this upgrader solves:
+   *
+   * Problem 1. The interval for TOIL time as per PCHR-3427 is now 15 minutes, which means
+   * 23:59 is not a valid time anymore and must be amended.
+   *
+   * Problem 2. The timeframe of 00:00 - 00:00 does not make sense. If it is a
+   * single day TOIL, then the date will be the same, meaning the request timeframe
+   * duration equals to 0. If a request covers, for example, 2 days, then the
+   * difference between "end" and "start" date/times will be exactly 24 hours,
+   * which also does not make sense.
+   *
+   * @return boolean
+   */
+
+  public function upgrade_1020 () {
+    $leaveRequest = new LeaveRequest();
+
+    $leaveRequest->whereAdd('request_type = "toil"');
+    $leaveRequest->whereAdd('is_deleted = 0');
+    $leaveRequest->find();
+
+    while ($leaveRequest->fetch()) {
+      $leaveRequest->to_date = substr($leaveRequest->to_date, 0, 11) . '23:45:00';
+
+      $leaveRequest->update();
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
## Overview

Currently the end time for TOIL requests in **days** is stored as `23:59`. TOIL requests in **hours** store it as `00:00` instead of `23:59`.

Due to new requirements (https://github.com/civicrm/civihr/pull/2534), all TOIL requests now have both *start* and *end* times and the allowed time interval is 15 minutes starting from 00:00 - the time `23:59` becomes invalid. As a result, the time `23:59` will not be selected in the according selector in the Leave Request Modal and will also look odd in the Leave Report.

This PR adds an upgrader that transforms all TOIL requests end time into `23:45` (`23:45:00` if we consider the format on the server).

## Before

![1](https://user-images.githubusercontent.com/3973243/37719292-959f6190-2d1c-11e8-8447-669b4ea43802.gif)

## After

![2](https://user-images.githubusercontent.com/3973243/37719299-9a916806-2d1c-11e8-9203-5f87d5ddcf7e.gif)

## Technical Details

It gets all existing not deleted TOIL requests and transforms the end date/time by preserving the date and changing the time.

```php
// ...

$leaveRequest->whereAdd('request_type = "toil"'); // fetch only TOILs
$leaveRequest->whereAdd('is_deleted = 0'); // only not soft deleted
// ...

while ($leaveRequest->fetch()) { // loop
  $leaveRequest->to_date = substr($leaveRequest->to_date, 0, 11) . '23:45:00';
  //   2018-04-14 23:59:00
  //   |  substr |
  //   2018-04-14 23:45:00
  $leaveRequest->update();
}
```

---

✅Manual Tests - passed