### PR TITLE
PCHR-3489: Fix entitlements override filter

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
@@ -23,8 +23,8 @@
               <input type="radio" name="overridde" class="override-filter" value="2">
               <span>Not Overridden</span>
             </label>
-            <label class="btn btn-default">
-              <input type="radio" name="overridde" class="override-filter" value="3">
+            <label class="btn btn-default active">
+              <input type="radio" name="overridde" class="override-filter" value="3" checked>
               <span>Both</span>
             </label>
           </div>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
@@ -16,15 +16,15 @@
         <div class="col-sm-4 col-sm-offset-4">
           <div class="btn-group btn-group-sm" data-toggle="buttons">
             <label class="btn btn-default">
-              <input type="radio" class="override-filter" value="1">
+              <input type="radio" name="overridde" class="override-filter" value="1">
               <span>Overriden</span>
             </label>
             <label class="btn btn-default">
-              <input type="radio" class="override-filter" value="2">
+              <input type="radio" name="overridde" class="override-filter" value="2">
               <span>Not Overridden</span>
             </label>
             <label class="btn btn-default">
-              <input type="radio" class="override-filter" value="3">
+              <input type="radio" name="overridde" class="override-filter" value="3">
               <span>Both</span>
             </label>
           </div>


### PR DESCRIPTION
## Overview
In the "Manage Leave Entitlements" page, the controls that filtered the list by the overridden status apparently got stuck after a couple of interactions, and the list didn't update anymore. Also none of the filters were selected by default, although these are radio-like filters, when one should always be selected.

## Before
![before](https://user-images.githubusercontent.com/6400898/37765856-a27e8590-2dc5-11e8-99f2-a9ab7c698175.gif)

## After
![after](https://user-images.githubusercontent.com/6400898/37765868-aa1a1c4c-2dc5-11e8-917f-f4395f3140d0.gif)

## Technical Details
The problem was that the filters are a set of radio buttons (the buttons themselves are hidden via css), but the buttons did not share the same `[name]` attribute, meaning that when one was selected, the others were not automatically de-selected
```html
<input type="radio" class="override-filter" value="1">
<input type="radio" class="override-filter" value="2">
<input type="radio" class="override-filter" value="3">
```
Here are the buttons in action, made visible
![before-visible](https://user-images.githubusercontent.com/6400898/37766046-1847bab2-2dc6-11e8-8fac-9a2e16721752.gif)

Simply adding a `[name]` property fixed the issue
```html
<input type="radio" name="overridde" class="override-filter" value="1">
<input type="radio" name="overridde" class="override-filter" value="2">
<input type="radio" name="overridde" class="override-filter" value="3">
```
![after-visible](https://user-images.githubusercontent.com/6400898/37766102-385a902c-2dc6-11e8-9c01-7862b973cd5c.gif)
