### PR TITLE
PCHR-3487: Escape user entered data

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/UserMenuMarkup.tpl
+++ b/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/UserMenuMarkup.tpl
@@ -10,7 +10,7 @@
   <nav class="chr_user-menu__dropdown">
     <ul>
       <li class="chr_user-menu__dropdown__username">
-        <span>Signed in as <strong>{$username}</strong></span>
+        <span>Signed in as <strong>{$username|escape}</strong></span>
       </li>
       <li>
         <a href="{$editLink}">

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/ManageEntitlements.tpl
@@ -35,7 +35,7 @@
             <div class="col-md-9">
               <select name="absence-type-filter" id="absence_type_filter" class="crm-select2 form-control absence-type-filter" multiple="multiple" data-placeholder="{ts}Leave Type{/ts}">
                 {foreach from=$enabledAbsenceTypes item=absenceType}
-                  <option value="{$absenceType->id}">{$absenceType->title}</option>
+                  <option value="{$absenceType->id}">{$absenceType->title|escape}</option>
                 {/foreach}
               </select>
             </div>
@@ -94,10 +94,10 @@
             {/if}
             <tr data-contact="{$contact.id}" data-absence-type="{$absenceTypeID}" data-absence-period="{$absencePeriodID}">
               <td>{$contact.id}</td>
-              <td>{$contact.display_name}</td>
+              <td>{$contact.display_name|escape}</td>
               <td>
                 <span class="absence-type" style="background-color: {$absenceType->color};">
-                  {$absenceType->title}
+                  {$absenceType->title|escape}
                 </span>
               </td>
               <td>{$calculation->getPreviousPeriodProposedEntitlement()|timeUnitApplier:$calculationUnit}</td>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsencePeriod.tpl
@@ -15,7 +15,7 @@
             </thead>
             {foreach from=$rows item=row}
               <tr id="AbsencePeriod-{$row.id}" class="crm-entity {$row.class}{if NOT $row.is_active} disabled{/if}">
-                <td data-field="title">{$row.title}</td>
+                <td data-field="title">{$row.title|escape}</td>
                 <td>{$row.start_date|crmDate}</td>
                 <td>{$row.end_date|crmDate}</td>
                 <td>{$row.weight}</td>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsenceType.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsenceType.tpl
@@ -21,7 +21,7 @@
             </thead>
             {foreach from=$rows item=row}
               <tr id="AbsenceType-{$row.id}" class="crm-entity {if NOT $row.is_active} disabled{/if}">
-                <td data-field="title">{$row.title}</td>
+                <td data-field="title">{$row.title|escape}</td>
                 <td>{if $row.allow_accruals_request eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
                 <td>{if $row.is_default eq 1}<i class="fa fa-check"></i>{/if}</td>
                 <td>{$row.weight}</td>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/PublicHoliday.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/PublicHoliday.tpl
@@ -16,7 +16,7 @@
           </thead>
           {foreach from=$rows item=row}
             <tr id="PublicHoliday-{$row.id}" class="crm-entity {$row.class}{if NOT $row.is_active} disabled{/if}">
-              <td data-field="title">{$row.title}</td>
+              <td data-field="title">{$row.title|escape}</td>
               <td>{$row.date|crmDate}</td>
               <td>{if $row.is_active eq 1} {ts}Enabled{/ts} {else} {ts}Disabled{/ts} {/if}</td>
               <td>{$row.action|replace:'xx':$row.id}</td>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/WorkPattern.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/WorkPattern.tpl
@@ -20,8 +20,8 @@
           </thead>
           {foreach from=$rows item=row}
             <tr id="WorkPattern-{$row.id}" class="crm-entity {$row.class}{if NOT $row.is_active} disabled{/if}">
-              <td data-field="title">{$row.label}</td>
-              <td>{$row.description}</td>
+              <td data-field="title">{$row.label|escape}</td>
+              <td>{$row.description|escape}</td>
               <td>{$row.number_of_weeks}</td>
               <td>{$row.number_of_hours}</td>
               <td>


### PR DESCRIPTION
## Overview

Some templates of our customized CiviHR pages were susceptible to XSS attacks. Mainly these are templates that render the contents of text fields without escaping them.

## Before

The contents were printed on the page as they were entered by the user, without any filtering or escaping. On this example, look at what would happen if a user would create a new Absence Period with the title  `<script>alert(1);</script>`:

![with_xss](https://user-images.githubusercontent.com/388373/37825201-bf5518b6-2e6d-11e8-874e-6f1e46e9b40d.gif)

When the page is rendered, the title is printed, which ends up adding a new script tag to the markup and the Javascript in that tag is executed when the page loads. Note also that, because the title renders as an HTML tag without any text in it, the Absence Period is not displayed on the page.

## After

The field contents are now escape using the `escape` filter from Smarty. This filter works in a way very similar to the `htmlspecialchars` function in PHP, where it converts special characters in the given string to their equivalent HTML entities. This way, when the field content is rendered to the page, it will be considered just a normal string instead of an HTML tag. Here is the same page from before, but now with the escape filter in use:

![without_xss](https://user-images.githubusercontent.com/388373/37825403-7573d830-2e6e-11e8-947d-7b59d66a3e29.gif)

Note that the JS alert is gone. Also, note that now the Absence Period title is displayed, because now it's not treated as a script tag anymore.

## Technical Details

There's some protection against XSS in CiviCRM, but it's not very consistent and there are ways to bypass it if you're not careful.

When you create a new record using a form (QuickForm), the form validation will take care of checking for potential insecure values:

![captura de tela de 2018-03-23 07-50-21](https://user-images.githubusercontent.com/388373/37825589-254e0ab4-2e6f-11e8-8793-3ea9eeae338c.png)

However, if you create a new record using the BAO, but without going through the form (think about a job that imports records in batch from a file, for example), the value given to the BAO is what will be stored in the database, without any filtering or validation for XSS. The AbsencePeriod used in the before and after screenshots were created that way.

When using the API, things get a bit weirder. The API does not validate the data, but it does encode it. This means that an API call like this will work without any errors:

```php
civicrm_api3('AbsencePeriod', 'create' [
  'title' => '<script>alert(1);</script>',
  'start_date' => '2017-01-01',
  'end_date' => '2017-12-31'
]);
```

However, in the database, the `title` will be stored like this: `&lt;script&gt;alert(1);&lt;/script&gt;`.

Later, if we fetch this value using the API, it will be decoded and the API will return the original value: `<script>alert(1);</script>`. So, if we just print it directly to a page it will be rendered as an HTML tag page and the injection will work.

Given there's no way to guarantee how the data will be stored and retrieved, the templates were updated to always escape the values of text fields.

You might have noticed that this PR only updates Smarty templates. The reason is in Angular templates the strings are escaped automatically, so there's no need to update anything there.

## Comments

This is, by no means, a complete solution for XSS fixes in CiviHR. It is just a quick solution mainly focusing on data that can be entered/seen by users in the SSP and some other obvious points that could be open for exploitation. A complete solution will be implemented soon.
