### PR TITLE
PCHR-3451: Default Existing Work Pattern to As per contract

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
@@ -27,6 +27,7 @@ class CRM_HRLeaveAndAbsences_Upgrader extends CRM_HRLeaveAndAbsences_Upgrader_Ba
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1019;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1020;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1021;
+  use CRM_HRLeaveAndAbsences_Upgrader_Step_1022;
 
   /**
    * A list of directories to be scanned for XML installation files

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1022.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1022.php
@@ -1,0 +1,22 @@
+<?php
+
+trait CRM_HRLeaveAndAbsences_Upgrader_Step_1022 {
+  
+  /**
+   * Default existing work pattern to As per contract (new default)
+   *
+   * @return bool
+   */
+  public function upgrade_1022()
+  {
+    civicrm_api3('ContactWorkPattern', 'get', [
+      'return' => ['id'],
+      'api.ContactWorkPattern.update' => [
+        'change_reason' => 1,
+        'id' => "\$value.id"
+      ],
+    ]);
+    
+    return TRUE;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1022.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1022.php
@@ -9,13 +9,15 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1022 {
    */
   public function upgrade_1022()
   {
-    civicrm_api3('ContactWorkPattern', 'get', [
-      'return' => ['id'],
-      'api.ContactWorkPattern.update' => [
-        'change_reason' => 1,
-        'id' => "\$value.id"
-      ],
-    ]);
+    $query = 'UPDATE civicrm_hrleaveandabsences_contact_work_pattern SET change_reason =
+      (
+        SELECT cov.value FROM civicrm_option_value cov LEFT JOIN civicrm_option_group cog
+          ON (cog.id = cov.option_group_id)
+          WHERE cog.name = "hrleaveandabsences_work_pattern_change_reason"
+          AND cov.is_default = 1
+      )';
+    
+    CRM_Core_DAO::executeQuery($query);
     
     return TRUE;
   }


### PR DESCRIPTION
## Overview
Since new work pattern are being created, the need arose to update existing records to the new default value of `As per contract`. This PR caters for that.

## Before
![before](https://user-images.githubusercontent.com/1507645/37901399-01393992-30e9-11e8-85ab-361328a3eba7.gif)


## After
![after](https://user-images.githubusercontent.com/1507645/37901405-059f18d0-30e9-11e8-938a-442fd9d71b80.gif)


## Technical Details
All existing records are fetched and updated to the new default value using chained api call.

```php
civicrm_api3('ContactWorkPattern', 'get', [
      'return' => ['id'],
      'api.ContactWorkPattern.update' => [
        'change_reason' => 1,
        'id' => "\$value.id"
      ],
]);
```