### PR TITLE
PCHR-3353: Quickfix for "is_multiple" Bug

### DIFF
--- a/org.civicrm.hremergency/CRM/Hremergency/Upgrader/Steps/1004.php
+++ b/org.civicrm.hremergency/CRM/Hremergency/Upgrader/Steps/1004.php
@@ -4,8 +4,12 @@ trait CRM_Hremergency_Upgrader_Steps_1004 {
 
   /**
    * Upgrade CustomGroup, setting Emergency_Contacts is_reserved to Yes.
+   *
    * Title was included here because of an issue with webform_civicrm
    * @see https://www.drupal.org/project/webform_civicrm/issues/2947922
+   *
+   * is_multiple was included because of an issue with CiviCRM core
+   * @see https://issues.civicrm.org/jira/browse/CRM-21853
    *
    * @return bool
    */
@@ -15,10 +19,11 @@ trait CRM_Hremergency_Upgrader_Steps_1004 {
       'return' => ['id'],
       'name' => 'Emergency_Contacts',
     ]);
-  
+
     civicrm_api3('CustomGroup', 'create', [
       'id' => $result['id'],
       'is_reserved' => 1,
+      'is_multiple' => 1,
       'title' => 'Emergency Contacts'
     ]);
 


### PR DESCRIPTION
## Overview

This ticket originally made some custom groups reserved. However because of a [bug in the CiviCRM Core](https://issues.civicrm.org/jira/browse/CRM-21853) the `is_multiple` value was set to `false` if it wasn't included in the params. This ticket fixed that problem, instead of waiting for the [Core PR](https://github.com/civicrm/civicrm-core/pull/11877).

The list of Custom Groups that were updated in the original ticket are:

- Extended demographics
- Probation
- Activity custom fields
- Contact length of service
- Application
- Vacancy
- Evaluation field
- Emergency contact
- Inline custom data

Looking at the custom groups on staging there is only one of those, "Emergency Contact" where `is_multiple` is true. Since the value will be set to `false` if it isn't included we don't need to fix the other groups where `is_multiple` should be `false` anyway.

## Before

The upgrader would set `is_multiple` to `false` for the Emergency Contacts custom group.

## After

The upgrader does not change `is_multiple` for the Emergency Contacts custom group.

## Comments

I kept the changes in the original upgrader since this hasn't been released yet.
