### PR TITLE
PCHR-3411: Remove unnecesary relationship types

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -19,6 +19,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1009;
   use CRM_HRCore_Upgrader_Steps_1010;
   use CRM_HRCore_Upgrader_Steps_1011;
+  use CRM_HRCore_Upgrader_Steps_1012;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1012.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1012.php
@@ -18,7 +18,7 @@ trait CRM_HRCore_Upgrader_Steps_1012 {
   /**
    * Returns the Ids of the the relationship types to be disabled.
    *
-   * @return Array[int]
+   * @return int[]
    */
   private function up1012_getRelationshipTypesToBeDisabled() {
     $relationshipsToBeDeleted = [
@@ -38,7 +38,7 @@ trait CRM_HRCore_Upgrader_Steps_1012 {
   /**
    * Disables relationship types.
    *
-   * @param Array[int] $relationshipTypeIds
+   * @param int[] $relationshipTypeIds
    */
   private function up1012_disableRelationshipTypes($relationshipTypeIds) {
     foreach ($relationshipTypeIds as $relationshipTypeId) {
@@ -52,7 +52,7 @@ trait CRM_HRCore_Upgrader_Steps_1012 {
   /**
    * Removes relationships for the given relationship types.
    *
-   * @param Array[int] $relationshipTypeIds
+   * @param int[] $relationshipTypeIds
    */
   private function up1012_removeRelationshipsForTypes($relationshipTypeIds) {
     foreach ($relationshipTypeIds as $relationshipTypeId) {
@@ -64,9 +64,9 @@ trait CRM_HRCore_Upgrader_Steps_1012 {
   /**
    * Returns all the relationships associated with a given type.
    *
-   * @param Array[int] $relationshipTypeIds
+   * @param int $relationshipTypeId
    *
-   * @return Array
+   * @return array
    */
   private function up1012_getRelationshipsForType($relationshipTypeId) {
     $result = civicrm_api3('Relationship', 'get', [
@@ -79,7 +79,7 @@ trait CRM_HRCore_Upgrader_Steps_1012 {
   /**
    * Removes the relationships provided.
    *
-   * @param Array
+   * @param array $relationships
    */
   private function up1012_removeRelationships($relationships) {
     foreach ($relationships as $relationship) {
@@ -88,4 +88,5 @@ trait CRM_HRCore_Upgrader_Steps_1012 {
       ]);
     }
   }
+
 }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1012.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1012.php
@@ -1,0 +1,28 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1012 {
+
+  /**
+   * Removes relationship types that are not necessary for CiviHR.
+   */
+  public function upgrade_1012() {
+    $relationshipsToBeDeleted = [
+      'Case Coordinator is',
+      'Employee of',
+      'Head of Household for',
+      'Household member of'
+    ];
+
+    $result = civicrm_api3('RelationshipType', 'get', [
+      'name_a_b' => [ 'IN' => $relationshipsToBeDeleted ]
+    ]);
+
+    foreach($result['values'] as $relationship) {
+      civicrm_api3('RelationshipType', 'delete', [
+        'id' => $relationship['id']
+      ]);
+    }
+
+    return TRUE;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1012.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1012.php
@@ -3,9 +3,24 @@
 trait CRM_HRCore_Upgrader_Steps_1012 {
 
   /**
-   * Removes relationship types that are not necessary for CiviHR.
+   * Disables relationship types that are not necessary for CiviHR and
+   * removes existing relationships belonging to these types.
    */
   public function upgrade_1012() {
+    $relationshipTypesToBeDisabled = $this->up1012_getRelationshipTypesToBeDisabled();
+
+    $this->up1012_disableRelationshipTypes($relationshipTypesToBeDisabled);
+    $this->up1012_removeRelationshipsForTypes($relationshipTypesToBeDisabled);
+
+    return TRUE;
+  }
+
+  /**
+   * Returns the Ids of the the relationship types to be disabled.
+   *
+   * @return Array[int]
+   */
+  private function up1012_getRelationshipTypesToBeDisabled() {
     $relationshipsToBeDeleted = [
       'Case Coordinator is',
       'Employee of',
@@ -17,12 +32,60 @@ trait CRM_HRCore_Upgrader_Steps_1012 {
       'name_a_b' => [ 'IN' => $relationshipsToBeDeleted ]
     ]);
 
-    foreach($result['values'] as $relationship) {
-      civicrm_api3('RelationshipType', 'delete', [
+    return array_column($result['values'], 'id');
+  }
+
+  /**
+   * Disables relationship types.
+   *
+   * @param Array[int] $relationshipTypeIds
+   */
+  private function up1012_disableRelationshipTypes($relationshipTypeIds) {
+    foreach ($relationshipTypeIds as $relationshipTypeId) {
+      civicrm_api3('RelationshipType', 'create', [
+        'id' => $relationshipTypeId,
+        'is_active' => 0
+      ]);
+    }
+  }
+
+  /**
+   * Removes relationships for the given relationship types.
+   *
+   * @param Array[int] $relationshipTypeIds
+   */
+  private function up1012_removeRelationshipsForTypes($relationshipTypeIds) {
+    foreach ($relationshipTypeIds as $relationshipTypeId) {
+      $relationships = $this->up1012_getRelationshipsForType($relationshipTypeId);
+      $this->up1012_removeRelationships($relationships);
+    }
+  }
+
+  /**
+   * Returns all the relationships associated with a given type.
+   *
+   * @param Array[int] $relationshipTypeIds
+   *
+   * @return Array
+   */
+  private function up1012_getRelationshipsForType($relationshipTypeId) {
+    $result = civicrm_api3('Relationship', 'get', [
+      'relationship_type_id' => $relationshipTypeId
+    ]);
+
+    return $result['values'];
+  }
+
+  /**
+   * Removes the relationships provided.
+   *
+   * @param Array
+   */
+  private function up1012_removeRelationships($relationships) {
+    foreach ($relationships as $relationship) {
+      civicrm_api3('Relationship', 'delete', [
         'id' => $relationship['id']
       ]);
     }
-
-    return TRUE;
   }
 }


### PR DESCRIPTION
## Overview
This PR removes relationships type that are not needed by CiviHR. The relationships types are:
* Case Coordinator is
* Employee of
* Head of Household for
* Household member of

## Before
```json
{

    "is_error": 0,
    "version": 3,
    "count": 4,
    "values": [
        {
            "id": "9",
            "name_a_b": "Case Coordinator is"
        },
        {
            "id": "5",
            "name_a_b": "Employee of"
        },
        {
            "id": "7",
            "name_a_b": "Head of Household for"
        },
        {
            "id": "8",
            "name_a_b": "Household Member of"
        }
    ]
}
```

## After
```json
{
    "is_error": 0,
    "version": 3,
    "count": 0,
    "values": []
}
```

## Technical Details

A new upgrader was implemented for HRCore since this is a change that affects all extensions:

```php
<?php

trait CRM_HRCore_Upgrader_Steps_1012 {

  /**
   * Removes relationship types that are not necessary for CiviHR.
   */
  public function upgrade_1012() {
    $relationshipsToBeDeleted = [
      'Case Coordinator is',
      'Employee of',
      'Head of Household for',
      'Household member of'
    ];

    // finds the relationships by name
    $result = civicrm_api3('RelationshipType', 'get', [
      'name_a_b' => [ 'IN' => $relationshipsToBeDeleted ]
    ]);

    foreach($result['values'] as $relationship) {
      // deletes them one by one
      civicrm_api3('RelationshipType', 'delete', [
        'id' => $relationship['id']
      ]);
    }

    return TRUE;
  }
}
```

