### PR TITLE
PCHR-3392: Quickfix for 'is_multiple' bug

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1192,16 +1192,23 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     ];
     
     $result = civicrm_api3('CustomGroup', 'get', [
-      'return' => ['id'],
+      'return' => ['id', 'name'],
       'name' => ['IN' => $customGroups],
     ]);
 
     if ($result['count'] > 0) {
       foreach ($result['values'] as $value) {
-        civicrm_api3('CustomGroup', 'create', [
-          'id' => $value['id'],
-          'is_reserved' => 1,
-        ]);
+        $params = ['id' => $value['id'], 'is_reserved' => 1];
+
+        /**
+         * 'is_multiple' is added to prevent bug that changes it to false
+         * @see https://issues.civicrm.org/jira/browse/CRM-21853
+         */
+        if ($value['name'] === 'HRJobContract_Dates') {
+          $params['is_multiple'] = 1;
+        }
+
+        civicrm_api3('CustomGroup', 'create', $params);
       }
     }
 

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1014.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1014.php
@@ -16,10 +16,15 @@ trait CRM_HRCore_Upgrader_Steps_1014 {
       'name' => 'Identify',
     ]);
 
+    /**
+     * 'is_multiple' is added to prevent bug that changes it to false
+     * @see https://issues.civicrm.org/jira/browse/CRM-21853
+     */
     if ($result['id']) {
       civicrm_api3('CustomGroup', 'create', [
         'id' => $result['id'],
         'is_reserved' => 1,
+        'is_multiple' => 1,
       ]);
     }
 


### PR DESCRIPTION
## Overview

In #2553 I fixed one of the updated groups as part of this epic. I missed some custom groups updated in a separate ticket though #2513. This PR fixes those groups.

To be sure this PR fixes all of them I checked the groups changed in #2513 or #2502 to make a list and compared them against groups on staging where `is_multiple` is 1

##### A) Groups Set to Reserved In #2513 or #2502

- Extended_Demographics
- Contact_Length_Of_Service
- Application
- application_case
- Evaluation_fields
- Emergency_Contacts
- Inline_Custom_Data
- Identify
- HRJobContract_Dates
- HRJobContract_Summary
- HRJob_Summary

##### B) Staging Groups where is_multiple is true

- Identify
- HRJobContract_Dates
- Medical_Disability
- Qualifications
- Immigration
- Career
- Emergency_Contacts

##### C) Groups that were changed where is_multiple should remain a true ( A ∩ B)

- Emergency_Contacts
- Identify
- HRJobContract_Dates

Emergency Contacts was fixed in #2553 so this PR will fix the other two.

## Before

After upgraders were run "Identify" (if it exists) and "HRJobContract_Dates" were set to `is_multiple` = 0

## After

`is_multiple` is not changed for any updated custom groups