### PR TITLE
PCHR-3506: Move Leave Request Template to System Workflow Message

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
@@ -29,6 +29,7 @@ class CRM_HRLeaveAndAbsences_Upgrader extends CRM_HRLeaveAndAbsences_Upgrader_Ba
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1021;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1022;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1023;
+  use CRM_HRLeaveAndAbsences_Upgrader_Step_1024;
 
   /**
    * A list of directories to be scanned for XML installation files

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1024.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1024.php
@@ -8,7 +8,8 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1024 {
    * @return bool
    */
   public function upgrade_1024() {
-    $result = $this->up1024_createLeaveWorkflowOptionGroup();
+    $templateName = 'msg_tpl_workflow_leave';
+    $result = $this->up1024_createLeaveWorkflowOptionGroup($templateName);
     
     if ($result['count'] > 0) {
       $this->up1024_createLeaveWorkflowOptionValue($result['id']);
@@ -20,37 +21,42 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1024 {
   /**
    * Create Leave Message Template Workflow Option Group.
    *
+   * @param $templateName
+   *
    * @return array
    */
-  public function up1024_createLeaveWorkflowOptionGroup() {
+  public function up1024_createLeaveWorkflowOptionGroup($templateName) {
     $workflow = 'Message Template Workflow for Leave';
     
-    return civicrm_api3('OptionGroup', 'create', [
-      'name' => 'msg_tpl_workflow_leave',
+    $result = civicrm_api3('OptionGroup', 'create', [
+      'name' => $templateName,
       'title' => $workflow,
       'description' => $workflow,
     ]);
+    CRM_Core_PseudoConstant::flush();
+    
+    return $result;
   }
   
   /**
    * Create Leave Message Template Workflow Option Values.
    *
-   * @param $id
+   * @param $templateName
    */
-  public function up1024_createLeaveWorkflowOptionValue($id) {
+  public function up1024_createLeaveWorkflowOptionValue($templateName) {
     $optionValues = [
       [
-        'option_group_id' => $id,
+        'option_group_id' => $templateName,
         'label' => 'CiviHR Leave Request Notification',
         'name' => 'civihr_leave_request',
       ],
       [
-        'option_group_id' => $id,
+        'option_group_id' => $templateName,
         'label' => 'CiviHR TOIL Request Notification',
         'name' => 'civihr_toil_request',
       ],
       [
-        'option_group_id' => $id,
+        'option_group_id' => $templateName,
         'label' => 'CiviHR Sickness Record Notification',
         'name' => 'civihr_sickness_record',
       ]
@@ -79,7 +85,7 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1024 {
       'msg_title' => $msgLabel,
       'api.MessageTemplate.create' => [
         'workflow_id' => $workflowId,
-        'id' => "\$values['id']"
+        'id' => '$value.id'
       ],
     ));
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1024.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1024.php
@@ -1,0 +1,86 @@
+<?php
+
+trait CRM_HRLeaveAndAbsences_Upgrader_Step_1024 {
+  
+  /**
+   * Update leave request templates to system workflow message
+   *
+   * @return bool
+   */
+  public function upgrade_1024() {
+    $result = $this->up1024_createLeaveWorkflowOptionGroup();
+    
+    if ($result['count'] > 0) {
+      $this->up1024_createLeaveWorkflowOptionValue($result['id']);
+    }
+    
+    return TRUE;
+  }
+  
+  /**
+   * Create Leave Message Template Workflow Option Group.
+   *
+   * @return array
+   */
+  public function up1024_createLeaveWorkflowOptionGroup() {
+    $workflow = 'Message Template Workflow for Leave';
+    
+    return civicrm_api3('OptionGroup', 'create', [
+      'name' => 'msg_tpl_workflow_leave',
+      'title' => $workflow,
+      'description' => $workflow,
+    ]);
+  }
+  
+  /**
+   * Create Leave Message Template Workflow Option Values.
+   *
+   * @param $id
+   */
+  public function up1024_createLeaveWorkflowOptionValue($id) {
+    $optionValues = [
+      [
+        'option_group_id' => $id,
+        'label' => 'CiviHR Leave Request Notification',
+        'name' => 'civihr_leave_request',
+      ],
+      [
+        'option_group_id' => $id,
+        'label' => 'CiviHR TOIL Request Notification',
+        'name' => 'civihr_toil_request',
+      ],
+      [
+        'option_group_id' => $id,
+        'label' => 'CiviHR Sickness Record Notification',
+        'name' => 'civihr_sickness_record',
+      ]
+    ];
+  
+    foreach ($optionValues as $optionValue) {
+      $result = civicrm_api3('OptionValue', 'create', $optionValue);
+      if ($result['count'] > 0) {
+        $this->up1024_updateLeaveMsgTemplate(
+          $result['id'],
+          $optionValue['label']
+        );
+      }
+    }
+  }
+  
+  /**
+   * Update message template workflow id for option group msg_tpl_workflow_leave
+   *
+   * @param $workflowId
+   * @param $msgLabel
+   */
+  public function up1024_updateLeaveMsgTemplate($workflowId, $msgLabel) {
+    civicrm_api3('MessageTemplate', 'get', array(
+      'return' => ['id'],
+      'msg_title' => $msgLabel,
+      'api.MessageTemplate.create' => [
+        'workflow_id' => $workflowId,
+        'id' => "\$values['id']"
+      ],
+    ));
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1024.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1024.php
@@ -1,7 +1,6 @@
 <?php
 
 trait CRM_HRLeaveAndAbsences_Upgrader_Step_1024 {
-  
   /**
    * Update leave request templates to system workflow message
    *
@@ -10,9 +9,9 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1024 {
   public function upgrade_1024() {
     $templateName = 'msg_tpl_workflow_leave';
     $result = $this->up1024_createLeaveWorkflowOptionGroup($templateName);
-    
+
     if ($result['count'] > 0) {
-      $this->up1024_createLeaveWorkflowOptionValue($result['id']);
+      $this->up1024_createLeaveWorkflowOptionValue($templateName);
     }
     
     return TRUE;
@@ -21,7 +20,7 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1024 {
   /**
    * Create Leave Message Template Workflow Option Group.
    *
-   * @param $templateName
+   * @param string $templateName
    *
    * @return array
    */
@@ -32,7 +31,12 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1024 {
       'name' => $templateName,
       'title' => $workflow,
       'description' => $workflow,
+      'is_locked' => 1,
+      'is_reserved' => 1
     ]);
+    
+    // Flush constant because the option group id is cached and will not be
+    // available for linking newly created option group value
     CRM_Core_PseudoConstant::flush();
     
     return $result;
@@ -41,24 +45,24 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1024 {
   /**
    * Create Leave Message Template Workflow Option Values.
    *
-   * @param $templateName
+   * @param string $templateName
    */
   public function up1024_createLeaveWorkflowOptionValue($templateName) {
     $optionValues = [
       [
         'option_group_id' => $templateName,
         'label' => 'CiviHR Leave Request Notification',
-        'name' => 'civihr_leave_request',
+        'name' => 'civihr_leave_request_notification',
       ],
       [
         'option_group_id' => $templateName,
         'label' => 'CiviHR TOIL Request Notification',
-        'name' => 'civihr_toil_request',
+        'name' => 'civihr_toil_request_notification',
       ],
       [
         'option_group_id' => $templateName,
         'label' => 'CiviHR Sickness Record Notification',
-        'name' => 'civihr_sickness_record',
+        'name' => 'civihr_sickness_record_notification',
       ]
     ];
   
@@ -76,17 +80,53 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1024 {
   /**
    * Update message template workflow id for option group msg_tpl_workflow_leave
    *
-   * @param $workflowId
-   * @param $msgLabel
+   * @param int $workflowId
+   * @param string $msgLabel
    */
   public function up1024_updateLeaveMsgTemplate($workflowId, $msgLabel) {
-    civicrm_api3('MessageTemplate', 'get', array(
-      'return' => ['id'],
+    $result = civicrm_api3('MessageTemplate', 'get', [
+      'sequential' => 1,
+      'return' => ['id', 'msg_title', 'msg_subject', 'msg_text', 'msg_html'],
       'msg_title' => $msgLabel,
-      'api.MessageTemplate.create' => [
+    ]);
+    if ($result['count'] == 1) {
+      // update existing record as default with new workflow id
+      civicrm_api3('MessageTemplate', 'create', [
         'workflow_id' => $workflowId,
-        'id' => '$value.id'
-      ],
-    ));
+        'is_default' => 1,
+        'is_reserved' => 0,
+        'id' => $result['id'],
+      ]);
+      
+      // create the reserved version of template
+      $this->duplicateTemplateAsReserved($result['values'][0], $workflowId);
+    } else {
+      foreach ($result['values'] as $value) {
+        civicrm_api3('MessageTemplate', 'create', [
+          'workflow_id' => $workflowId,
+          'id' => $value['id'],
+        ]);
+      }
+    }
+  }
+  
+  /**
+   * Duplicate an existing template and set is_reserved true
+   *
+   * @param array $template
+   * @param int $workflowId
+   */
+  public function duplicateTemplateAsReserved($template, $workflowId) {
+    $newTemplate = [
+      'msg_title' => $template['msg_title'],
+      'msg_subject' => $template['msg_subject'],
+      'msg_text' => $template['msg_text'],
+      'msg_html' => $template['msg_html'],
+      'workflow_id' => $workflowId,
+      'is_default' => 0,
+      'is_reserved' => 1
+    ];
+  
+    civicrm_api3('MessageTemplate', 'create', $newTemplate);
   }
 }


### PR DESCRIPTION
## Overview
When creating PDF Letter or sending email from contact page action button, some templates which are meant to be part of System Workflow Message Templates show as part of User-driven Message templates. These are `CiviHR Leave Request Notification`, `CiviHR TOIL Request Notification` and `CiviHR Sickness Record Notification`. This PR fixes that by moving them as appropriate.

## Before
![before](https://user-images.githubusercontent.com/1507645/38144098-57382efc-343b-11e8-8dc7-b61b125e03a9.gif)

##### Message Templates
![before](https://user-images.githubusercontent.com/1507645/38250073-b93c4ef0-3745-11e8-96a6-d273148c9483.gif)


## After
![after](https://user-images.githubusercontent.com/1507645/38144103-60f2652a-343b-11e8-83fb-20659813be40.gif)

##### Message Templates
![after](https://user-images.githubusercontent.com/1507645/38250103-d112dcb0-3745-11e8-9f76-9c07819477db.gif)

##### Sent Email Sample
![civihr sickness request 2018-04-04 10-29-09](https://user-images.githubusercontent.com/1507645/38300138-ec3df4d0-37f3-11e8-9bf8-41f67d971137.png)



## Technical Details
The affected records do not belong to any workflow, making them show up as user-driven message. This was fixed by ensuring each of those templates belong to a workflow. For this purpose, new option group and option values were created. This is because the template `workflow_id` is a pseudo reference to `option value id`, which also have a reference to `option group` by `option_group_id`.

After setting up the option group and values respectively, message template was updated with newly created option value id for templates to be moved. The templates were also duplicated in order to provide for `default` and `reserved` templates as required by CiviCRM.

```php
public function up1024_updateLeaveMsgTemplate($workflowId, $msgLabel) {
    civicrm_api3('MessageTemplate', 'get', array(
      'return' => ['id'],
      'msg_title' => $msgLabel,
      'api.MessageTemplate.create' => [
        'workflow_id' => $workflowId,
        'id' => "\$values['id']"
      ],
    ));
  }
```



