### PR TITLE
PCHR-3510: Fix Limit On Leave Request getcount

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -161,7 +161,7 @@ function civicrm_api3_leave_request_get($params) {
  * @throws CiviCRM_API3_Exception
  */
 function civicrm_api3_leave_request_getcount($params) {
-  return civicrm_api3_leave_request_get($params)['count'];
+  return civicrm_api3('LeaveRequest', 'get', $params)['count'];
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Wrapper/LeaveRequestDatesTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Wrapper/LeaveRequestDatesTest.php
@@ -99,10 +99,32 @@ class CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestDatesTest extends BaseHeadl
     $this->assertEquals($result, $wrappedResult);
   }
 
+  public function testDateRangesAreAdjusted() {
+    $apiRequest = [
+      'entity' => 'LeaveRequest',
+      'action' => 'get',
+      'params' => [
+        'from_date' => ['BETWEEN' => ['2016-02-01', '2016-03-01']],
+        'to_date' => ['NOT IN' => ['2016-04-01', '2016-04-21', '2016-04-30']],
+      ]
+    ];
+
+    $wrappedRequest = $this->wrapper->fromApiInput($apiRequest);
+
+    $fromDate = $wrappedRequest['params']['from_date'];
+    $expectedFromDate = ['2016-02-01 00:00:00', '2016-03-01 00:00:00'];
+    $this->assertEquals($expectedFromDate, $fromDate['BETWEEN']);
+
+    $toDate = $wrappedRequest['params']['to_date'];
+    $expectedToDate = ['2016-04-01 23:59:59', '2016-04-21 23:59:59', '2016-04-30 23:59:59'];
+    $this->assertEquals($expectedToDate, $toDate['NOT IN']);
+  }
+
   public function supportedActions() {
     return [
       ['get'],
       ['getfull']
     ];
   }
+
 }


### PR DESCRIPTION
## Overview

API calls to LeaveRequest.getcount are limited to 25. This is because an API wrapper that sets the default limit to 0 (no limit) is not applied

## Before

If you have more than 25 leave requests and call LeaveRequest.getcount it will always return 25

## After

If you have more than 25 leave requests and call LeaveRequest.getcount it will always return the correct count

## Technical Details

The problem was that the function for the API request was called directly. This means that the request lifecycle was not called. The request lifecycle calls the `CRM_HRCore_APIWrapper_DefaultLimitRemover` but [only](https://github.com/civicrm/civihr/blob/94deaa003f590b7a3e07e0027606ae45c7da9660/uk.co.compucorp.civicrm.hrcore/hrcore.php#L243
) if it's a `GET` request. By changing to a `civicrm_api3` call we go through the request lifecycle and the default limit remover is applied.

## Notes

As mentioned in "Technical Details", this request was previously not using the full internal request lifecycle wrappers were not applied. Another side effect of changing to use the full request lifecycle is that `CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestDates` is now also applied. 

This adapter tries to modify the dates in `BETWEEN`. However this adapter cannot handle `BETWEEN` type ranges. It will fail with a warning when an array is passed to `date_parse`.

```
private function dateIsValid($date) {
  // $date will be like ['BETWEEN' => [201801010000, 201802010000]]
  $date = date_parse($date);
  
  return $date['error_count'] === 0 && $date['warning_count'] === 0;
}
```

 In production this isn't a big problem because it's just a warning, but for PHPUnit tests the warning gets upgraded to an exception causing the tests to fail (see [Jenkins](https://jenkins.compucorp.co.uk/blue/organizations/jenkins/civihr/detail/PR-2560/1/pipeline))