### PR TITLE
PCHR-2576: Fix Issue with Admin Not Being able to Cancel TOIL with Past Dates

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -354,7 +354,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    */
   public static function isTOILWithPastDates($params) {
     if($params['request_type'] !== LeaveRequest::REQUEST_TYPE_TOIL) {
-      return false;
+      return FALSE;
     }
 
     $fromDate = new DateTime($params['from_date']);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -336,8 +336,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     $toDate = new DateTime($params['to_date']);
     $todayDate = new DateTime('today');
     $leaveDatesHasPastDates = $fromDate < $todayDate || $toDate < $todayDate;
+    $isACancellationRequest = in_array($params['status_id'], LeaveRequest::getCancelledStatuses());
 
-    if ($leaveDatesHasPastDates && !$absenceType->allow_accrue_in_the_past) {
+    if ($leaveDatesHasPastDates && !$absenceType->allow_accrue_in_the_past && !$isACancellationRequest) {
       throw new InvalidLeaveRequestException(
         'You may only request TOIL for overtime to be worked in the future. Please modify the date of this request',
         'leave_request_toil_cannot_be_requested_for_past_days',

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -332,10 +332,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException
    */
   private static function validateTOILPastDays($params, $absenceType) {
-    $fromDate = new DateTime($params['from_date']);
-    $toDate = new DateTime($params['to_date']);
-    $todayDate = new DateTime('today');
-    $leaveDatesHasPastDates = $fromDate < $todayDate || $toDate < $todayDate;
+    $leaveDatesHasPastDates = self::isTOILWithPastDates($params);
     $isACancellationRequest = in_array($params['status_id'], LeaveRequest::getCancelledStatuses());
 
     if ($leaveDatesHasPastDates && !$absenceType->allow_accrue_in_the_past && !$isACancellationRequest) {
@@ -345,6 +342,26 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
         'from_date'
       );
     }
+  }
+
+  /**
+   * Checks whether the leave request is of type TOIL and has dates in the
+   * past.
+   *
+   * @param array $params
+   *
+   * @return bool
+   */
+  public static function isTOILWithPastDates($params) {
+    if($params['request_type'] !== LeaveRequest::REQUEST_TYPE_TOIL) {
+      return false;
+    }
+
+    $fromDate = new DateTime($params['from_date']);
+    $toDate = new DateTime($params['to_date']);
+    $todayDate = new DateTime('today');
+
+    return $fromDate < $todayDate || $toDate < $todayDate;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -117,6 +117,14 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
       );
     }
 
+    if ($this->isTOILWithPastDates($params) && $this->isCancelledStatus($params)) {
+      if (!$this->canCanCancelTOILWithPastDates($params)) {
+        throw new RuntimeException(
+          'You may only cancel TOIL with dates in the future.'
+        );
+      }
+    }
+
     return $this->createRequestWithBalanceChanges($params);
   }
 
@@ -374,5 +382,47 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
     $updateBalanceChange = !empty($params['change_balance']);
 
     return ($leaveRequestDatesNotChanged || $toilDatesAndToAccrueNotChanged) && !$updateBalanceChange;
+  }
+
+  /**
+   * Checks If the current user can cancel a TOIL request type that has past dates.
+   *
+   * @param array $params
+   *
+   * @return bool
+   */
+  private function canCanCancelTOILWithPastDates($params) {
+    return $this->leaveRequestRightsService->canCancelToilWithPastDates($params['contact_id'], $params['type_id']);
+  }
+
+  /**
+   * Checks whether the leave request is of type TOIL and has dates in the
+   * past.
+   *
+   * @param array $params
+   *
+   * @return bool
+   */
+  private function isTOILWithPastDates($params) {
+    if($params['request_type'] !== LeaveRequest::REQUEST_TYPE_TOIL) {
+      return false;
+    }
+
+    $fromDate = new DateTime($params['from_date']);
+    $toDate = new DateTime($params['to_date']);
+    $todayDate = new DateTime('today');
+
+    return $fromDate < $todayDate || $toDate < $todayDate;
+  }
+
+  /**
+   * Checks whether the Leave is to be updated to cancelled.
+   *
+   * @param array $params
+   *
+   * @return bool
+   */
+  private function isCancelledStatus($params) {
+    return in_array($params['status_id'], LeaveRequest::getCancelledStatuses());
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -117,12 +117,14 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
       );
     }
 
-    if ($this->isTOILWithPastDates($params) && $this->isCancelledStatus($params)) {
-      if (!$this->canCanCancelTOILWithPastDates($params)) {
-        throw new RuntimeException(
-          'You may only cancel TOIL with dates in the future.'
-        );
-      }
+    $isTOILWithPastDates = LeaveRequest::isTOILWithPastDates($params);
+    $isCancelledStatus = $this->isCancelledStatus($params);
+    $canCanCancelTOILWithPastDates = $this->canCanCancelTOILWithPastDates($params);
+
+    if ($isTOILWithPastDates && $isCancelledStatus && !$canCanCancelTOILWithPastDates) {
+      throw new RuntimeException(
+        'You may only cancel TOIL with dates in the future.'
+      );
     }
 
     return $this->createRequestWithBalanceChanges($params);
@@ -392,27 +394,10 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    * @return bool
    */
   private function canCanCancelTOILWithPastDates($params) {
-    return $this->leaveRequestRightsService->canCancelToilWithPastDates($params['contact_id'], $params['type_id']);
-  }
-
-  /**
-   * Checks whether the leave request is of type TOIL and has dates in the
-   * past.
-   *
-   * @param array $params
-   *
-   * @return bool
-   */
-  private function isTOILWithPastDates($params) {
-    if($params['request_type'] !== LeaveRequest::REQUEST_TYPE_TOIL) {
-      return false;
-    }
-
-    $fromDate = new DateTime($params['from_date']);
-    $toDate = new DateTime($params['to_date']);
-    $todayDate = new DateTime('today');
-
-    return $fromDate < $todayDate || $toDate < $todayDate;
+    return $this->leaveRequestRightsService->canCancelToilWithPastDates(
+      $params['contact_id'],
+      $params['type_id']
+    );
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
@@ -2,6 +2,7 @@
 
 use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 
 class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
 
@@ -150,5 +151,26 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
     }
 
     return self::$leaveStatuses;
+  }
+
+  /**
+   * Checks whether the current user can cancel the TOIL Request with
+   * past dates or not.
+   *
+   * @param int $contactID
+   *   The contactID of the leave request
+   * @param int $absenceTypeID
+   *   The absence Type ID of the leave request
+   *
+   * @return bool
+   */
+  public function canCancelToilWithPastDates($contactID, $absenceTypeID) {
+    $absenceType = AbsenceType::findById($absenceTypeID);
+
+    if(!$absenceType->allow_accrue_in_the_past) {
+      return $this->currentUserIsManagerOrAdmin($contactID);
+    }
+
+    return TRUE;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -4598,4 +4598,44 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals($leaveRequestParams['from_date_type'], $leaveRequest->from_date_type);
     $this->assertEquals($leaveRequestParams['to_date_type'], $leaveRequest->to_date_type);
   }
+
+  public function testisTOILWithPastDatesReturnsFalseWhenRequestTypeIsNotTOIL() {
+    $params = [
+      'from_date' => '2020-01-01',
+      'to_date' => '2025-01-02',
+      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
+    ];
+
+    $this->assertFalse(LeaveRequest::isTOILWithPastDates($params));
+  }
+
+  public function testisTOILWithPastDatesReturnsTrueWhenFromDateIsLessThanToday() {
+    $params = [
+      'from_date' => '2017-01-01',
+      'to_date' => '2025-01-02',
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
+    ];
+
+    $this->assertTrue(LeaveRequest::isTOILWithPastDates($params));
+  }
+
+  public function testisTOILWithPastDatesReturnsTrueWhenToDateIsLessThanToday() {
+    $params = [
+      'from_date' => '2025-01-01',
+      'to_date' => '2017-01-02',
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
+    ];
+
+    $this->assertTrue(LeaveRequest::isTOILWithPastDates($params));
+  }
+
+  public function testisTOILWithPastDatesReturnsFalseWhenToDateAndFromDateIsGreaterThanToday() {
+    $params = [
+      'from_date' => '2025-01-01',
+      'to_date' => '2025-01-02',
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
+    ];
+
+    $this->assertFalse(LeaveRequest::isTOILWithPastDates($params));
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -223,8 +223,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
 
   public function testCanCancelToilWithPastDatesReturnsTrueWhenCurrentUserIsManagerAndAbsenceTypeDoesNotAllowPastAccrual() {
     $absenceType = AbsenceTypeFabricator::fabricate([
-      'allow_accruals_request' => true,
-      'allow_accrue_in_the_past' => false
+      'allow_accruals_request' => TRUE,
+      'allow_accrue_in_the_past' => FALSE
     ]);
 
     $leaveRightsService = $this->getLeaveRequestRightsForLeaveManagerAsCurrentUser();
@@ -233,8 +233,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
 
   public function testCanCancelToilWithPastDatesReturnsTrueWhenCurrentUserIsAdminAndAbsenceTypeDoesNotAllowPastAccrual() {
     $absenceType = AbsenceTypeFabricator::fabricate([
-      'allow_accruals_request' => true,
-      'allow_accrue_in_the_past' => false
+      'allow_accruals_request' => TRUE,
+      'allow_accrue_in_the_past' => FALSE
     ]);
 
     $leaveRightsService = $this->getLeaveRequestRightsForAdminAsCurrentUser();
@@ -243,8 +243,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
 
   public function testCanCancelToilWithPastDatesReturnsFalseWhenCurrentUserIsLeaveContactAndAbsenceTypeDoesNotAllowPastAccrual() {
     $absenceType = AbsenceTypeFabricator::fabricate([
-      'allow_accruals_request' => true,
-      'allow_accrue_in_the_past' => false
+      'allow_accruals_request' => TRUE,
+      'allow_accrue_in_the_past' => FALSE
     ]);
 
     $leaveRightsService = $this->getLeaveRightsService();
@@ -253,8 +253,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
 
   public function testCanCancelToilWithPastDatesReturnsTrueWhenAbsenceTypeAllowsPastAccrualForLeaveContact() {
     $absenceType = AbsenceTypeFabricator::fabricate([
-      'allow_accruals_request' => true,
-      'allow_accrue_in_the_past' => true
+      'allow_accruals_request' => TRUE,
+      'allow_accrue_in_the_past' => TRUE
     ]);
 
     $leaveRightsService = $this->getLeaveRightsService();
@@ -263,8 +263,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
 
   public function testCanCancelToilWithPastDatesReturnsTrueWhenAbsenceTypeAllowsPastAccrualForAdmin() {
     $absenceType = AbsenceTypeFabricator::fabricate([
-      'allow_accruals_request' => true,
-      'allow_accrue_in_the_past' => true
+      'allow_accruals_request' => TRUE,
+      'allow_accrue_in_the_past' => TRUE
     ]);
 
     $leaveRightsService = $this->getLeaveRequestRightsForAdminAsCurrentUser();
@@ -273,25 +273,25 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
 
   public function testCanCancelToilWithPastDatesReturnsTrueWhenAbsenceTypeAllowsPastAccrualForManager() {
     $absenceType = AbsenceTypeFabricator::fabricate([
-      'allow_accruals_request' => true,
-      'allow_accrue_in_the_past' => true
+      'allow_accruals_request' => TRUE,
+      'allow_accrue_in_the_past' => TRUE
     ]);
 
     $leaveRightsService = $this->getLeaveRequestRightsForLeaveManagerAsCurrentUser();
     $this->assertTrue($leaveRightsService->canCancelToilWithPastDates($this->leaveContact, $absenceType->id));
   }
 
-  private function getLeaveRightsService($isAdmin = false, $isManager = false) {
+  private function getLeaveRightsService($isAdmin = FALSE, $isManager = FALSE) {
     $leaveManagerService = $this->createLeaveManagerServiceMock($isAdmin, $isManager);
     return new LeaveRequestRightsService($leaveManagerService);
   }
 
   private function getLeaveRequestRightsForAdminAsCurrentUser() {
-    return $this->getLeaveRightsService(true, false);
+    return $this->getLeaveRightsService(TRUE, FALSE);
   }
 
   private function getLeaveRequestRightsForLeaveManagerAsCurrentUser() {
-    return $this->getLeaveRightsService(false, true);
+    return $this->getLeaveRightsService(FALSE, TRUE);
   }
 
   public function leaveRequestStatusesDataProvider() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -2,6 +2,7 @@
 
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
 
 /**
  * Class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest
@@ -218,6 +219,66 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
         $status
       )
     );
+  }
+
+  public function testCanCancelToilWithPastDatesReturnsTrueWhenCurrentUserIsManagerAndAbsenceTypeDoesNotAllowPastAccrual() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'allow_accrue_in_the_past' => false
+    ]);
+
+    $leaveRightsService = $this->getLeaveRequestRightsForLeaveManagerAsCurrentUser();
+    $this->assertTrue($leaveRightsService->canCancelToilWithPastDates($this->leaveContact, $absenceType->id));
+  }
+
+  public function testCanCancelToilWithPastDatesReturnsTrueWhenCurrentUserIsAdminAndAbsenceTypeDoesNotAllowPastAccrual() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'allow_accrue_in_the_past' => false
+    ]);
+
+    $leaveRightsService = $this->getLeaveRequestRightsForAdminAsCurrentUser();
+    $this->assertTrue($leaveRightsService->canCancelToilWithPastDates($this->leaveContact, $absenceType->id));
+  }
+
+  public function testCanCancelToilWithPastDatesReturnsFalseWhenCurrentUserIsLeaveContactAndAbsenceTypeDoesNotAllowPastAccrual() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'allow_accrue_in_the_past' => false
+    ]);
+
+    $leaveRightsService = $this->getLeaveRightsService();
+    $this->assertFalse($leaveRightsService->canCancelToilWithPastDates($this->leaveContact, $absenceType->id));
+  }
+
+  public function testCanCancelToilWithPastDatesReturnsTrueWhenAbsenceTypeAllowsPastAccrualForLeaveContact() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'allow_accrue_in_the_past' => true
+    ]);
+
+    $leaveRightsService = $this->getLeaveRightsService();
+    $this->assertTrue($leaveRightsService->canCancelToilWithPastDates($this->leaveContact, $absenceType->id));
+  }
+
+  public function testCanCancelToilWithPastDatesReturnsTrueWhenAbsenceTypeAllowsPastAccrualForAdmin() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'allow_accrue_in_the_past' => true
+    ]);
+
+    $leaveRightsService = $this->getLeaveRequestRightsForAdminAsCurrentUser();
+    $this->assertTrue($leaveRightsService->canCancelToilWithPastDates($this->leaveContact, $absenceType->id));
+  }
+
+  public function testCanCancelToilWithPastDatesReturnsTrueWhenAbsenceTypeAllowsPastAccrualForManager() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'allow_accrue_in_the_past' => true
+    ]);
+
+    $leaveRightsService = $this->getLeaveRequestRightsForLeaveManagerAsCurrentUser();
+    $this->assertTrue($leaveRightsService->canCancelToilWithPastDates($this->leaveContact, $absenceType->id));
   }
 
   private function getLeaveRightsService($isAdmin = false, $isManager = false) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -1122,10 +1122,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     $params['id'] = $toilRequest->id;
 
     $this->setExpectedException('RuntimeException', 'You may only cancel TOIL with dates in the future.');
-    $this->getLeaveRequestService()->create(
-      $params,
-      false
-    );
+    $this->getLeaveRequestService()->create($params, false);
   }
 
   public function testToilRequestWithPastDatesCanBeCancelledWhenUserIsAdminAndAbsenceTypeDoesNotAllowPastAccrual() {
@@ -1151,10 +1148,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     $params['status_id'] = $leaveStatuses['cancelled'];
     $params['id'] = $toilRequest->id;
 
-    $toilRequest = $this->getLeaveRequestServiceWhenCurrentUserIsAdmin()->create(
-      $params,
-      false
-    );
+    $toilRequest = $this->getLeaveRequestServiceWhenCurrentUserIsAdmin()->create($params, false);
 
     $this->assertNotNull($toilRequest->id);
     $this->assertEquals($toilRequest->status_id, $leaveStatuses['cancelled']);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -1098,6 +1098,132 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals($expectedBreakdown, $breakdown);
   }
 
+  public function testToilRequestWithPastDatesCanNotBeCancelledWhenUserIsLeaveContactAndAbsenceTypeDoesNotAllowPastAccrual() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'allow_accrue_in_the_past' => false
+    ]);
+
+    $leaveStatuses = LeaveRequest::getStatuses();
+    $toilParams = [
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-07'),
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL,
+      'toil_to_accrue' => 1,
+      'type_id' => $absenceType->id,
+      'status_id' => $leaveStatuses['approved']
+    ];
+
+    $params = $this->getDefaultParams($toilParams);
+    $toilRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    //Update the toil status to cancelled.
+    $params['status_id'] = $leaveStatuses['cancelled'];
+    $params['id'] = $toilRequest->id;
+
+    $this->setExpectedException('RuntimeException', 'You may only cancel TOIL with dates in the future.');
+    $this->getLeaveRequestService()->create(
+      $params,
+      false
+    );
+  }
+
+  public function testToilRequestWithPastDatesCanBeCancelledWhenUserIsAdminAndAbsenceTypeDoesNotAllowPastAccrual() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'allow_accrue_in_the_past' => false
+    ]);
+
+    $leaveStatuses = LeaveRequest::getStatuses();
+    $toilParams = [
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-07'),
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL,
+      'toil_to_accrue' => 1,
+      'type_id' => $absenceType->id,
+      'status_id' => $leaveStatuses['approved']
+    ];
+
+    $params = $this->getDefaultParams($toilParams);
+    $toilRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    //Update the toil status to cancelled.
+    $params['status_id'] = $leaveStatuses['cancelled'];
+    $params['id'] = $toilRequest->id;
+
+    $toilRequest = $this->getLeaveRequestServiceWhenCurrentUserIsAdmin()->create(
+      $params,
+      false
+    );
+
+    $this->assertNotNull($toilRequest->id);
+    $this->assertEquals($toilRequest->status_id, $leaveStatuses['cancelled']);
+  }
+
+  public function testToilRequestWithPastDatesCanBeCancelledWhenUserIsManagerAndAbsenceTypeDoesNotAllowPastAccrual() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'allow_accrue_in_the_past' => false
+    ]);
+
+    $leaveStatuses = LeaveRequest::getStatuses();
+    $toilParams = [
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-07'),
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL,
+      'toil_to_accrue' => 1,
+      'type_id' => $absenceType->id,
+      'status_id' => $leaveStatuses['approved']
+    ];
+
+    $params = $this->getDefaultParams($toilParams);
+    $toilRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    //Update the toil status to cancelled.
+    $params['status_id'] = $leaveStatuses['cancelled'];
+    $params['id'] = $toilRequest->id;
+
+    $toilRequest = $this->getLeaveRequestServiceWhenCurrentUserIsLeaveManager()->create(
+      $params,
+      false
+    );
+
+    $this->assertNotNull($toilRequest->id);
+    $this->assertEquals($toilRequest->status_id, $leaveStatuses['cancelled']);
+  }
+
+  public function testToilRequestWithPastDatesCanBeCancelledWhenAbsenceTypeAllowsPastAccrual() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'allow_accrue_in_the_past' => true
+    ]);
+
+    $leaveStatuses = LeaveRequest::getStatuses();
+    $toilParams = [
+      'from_date' => CRM_Utils_Date::processDate('2016-01-04'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-07'),
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL,
+      'toil_to_accrue' => 1,
+      'type_id' => $absenceType->id,
+      'status_id' => $leaveStatuses['approved']
+    ];
+
+    $params = $this->getDefaultParams($toilParams);
+    $toilRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    //Update the toil status to cancelled.
+    $params['status_id'] = $leaveStatuses['cancelled'];
+    $params['id'] = $toilRequest->id;
+
+    $toilRequest = $this->getLeaveRequestService()->create(
+      $params,
+      false
+    );
+
+    $this->assertNotNull($toilRequest->id);
+    $this->assertEquals($toilRequest->status_id, $leaveStatuses['cancelled']);
+  }
+
   private function getExpectedBreakdownForLeaveRequest(LeaveRequest $leaveRequest, $amount = false) {
     $leaveRequestDayTypes = LeaveRequest::buildOptions('from_date_type');
 


### PR DESCRIPTION
## Overview
When a TOIL was requested and the TOIL days are now past and the Absence Type does not allow past accrual, neither Admin nor Staff is able to cancel such request. An error message `You may only request TOIL for overtime to be worked in the future` is displayed on trying to cancel such a TOIL request.
We want the only the Admin and Leave Managers to be able to cancel such TOIL requests. This PR makes changes to make this happen.

## Before
- The Administrator and Leave manager can not cancel a TOIL request with past dates if the Absence type does not allow past accrual.
- The staff can not cancel  a TOIL request with past dates when absence type does not allow past accrual.

## After
- The Administrator and Leave manager can now cancel a TOIL request with past dates even if the Absence type does not allow past accrual.
- The staff can still not cancel  a TOIL request with past dates when absence type does not allow past accrual according to the Ticket acceptance criteria.
- Note that the implementation is still subject to the existing validation for the `allow_request_cancelation` property of the Absence type. i.e if the Absence type does not allow request cancellation, the Leave request validation will still not allow such request to be cancelled by Admin or Leave Manager even though they can cancel TOIL with past dates.

A new method was added to the Leave Request rights Service and used in a validation method in the LeaveRequest Service. 
The validation was done at the LeaveRequest Service rather than at the LeaveRequest BAO since the LeaveRequest BAO validations are not aware of current user and user roles.

```php
  public function canCancelToilWithPastDates($contactID, $absenceTypeID) {
    $absenceType = AbsenceType::findById($absenceTypeID);

    if(!$absenceType->allow_accrue_in_the_past) {
      return $this->currentUserIsManagerOrAdmin($contactID);
    }

    return TRUE;
  }
```

