### PR TITLE
PCHR-3221: Migrate BackstopJS test suite to Puppeteer

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/backstop.tpl.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/backstop.tpl.json
@@ -16,12 +16,13 @@
     "ci_report": "backstop_data/ci_report"
   },
   "report": ["browser"],
-  "engine": "chrome",
+  "engine": "puppet",
   "engineFlags": [],
   "engineOptions": {
-    "waitTimeout": 12000
+    "waitTimeout": 20000,
+    "ignoreHTTPSErrors": true
   },
-  "asyncCaptureLimit": 1,
+  "asyncCaptureLimit": 7,
   "asyncCompareLimit": 50,
   "debug": false,
   "debugWindow": false

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/backstop.tpl.json
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/backstop.tpl.json
@@ -19,10 +19,9 @@
   "engine": "puppet",
   "engineFlags": [],
   "engineOptions": {
-    "waitTimeout": 20000,
-    "ignoreHTTPSErrors": true
+    "waitTimeout": 20000
   },
-  "asyncCaptureLimit": 7,
+  "asyncCaptureLimit": 1,
   "asyncCompareLimit": 50,
   "debug": false,
   "debugWindow": false

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/clickAndHoverHelper.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/clickAndHoverHelper.js
@@ -1,24 +1,19 @@
-module.exports = function (chromy, scenario) {
+module.exports = async (puppet, scenario) => {
   var hoverSelector = scenario.hoverSelector;
   var clickSelector = scenario.clickSelector;
   var postInteractionWait = scenario.postInteractionWait; // selector [str] | ms [int]
 
   if (hoverSelector) {
-    chromy
-      .wait(hoverSelector)
-      .rect(hoverSelector)
-      .result(function (rect) {
-        chromy.mouseMoved(rect.left, rect.top);
-      });
+    await puppet.waitFor(hoverSelector);
+    await puppet.hover(hoverSelector);
   }
 
   if (clickSelector) {
-    chromy
-      .wait(clickSelector)
-      .click(clickSelector);
+    await puppet.waitFor(clickSelector);
+    await puppet.click(clickSelector);
   }
 
   if (postInteractionWait) {
-    chromy.wait(postInteractionWait);
+    await puppet.waitFor(postInteractionWait);
   }
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-access-rights/open-ui-select.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-access-rights/open-ui-select.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var page = require('../../page-objects/contact-summary');
+const pageObj = require('../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openManageRightsModal()
-    .then(function (modal) {
-      modal.openDropdown('locations');
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const modal = await page.openManageRightsModal();
+
+  await modal.openDropdown('locations');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-access-rights/show.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-access-rights/show.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../page-objects/contact-summary');
+const pageObj = require('../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openManageRightsModal();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.openManageRightsModal();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-access-rights/show.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-access-rights/show.js
@@ -4,5 +4,6 @@ const pageObj = require('../../page-objects/contact-summary');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.openManageRightsModal();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-calendar.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-calendar.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/tabs/absence');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.openSubTab('calendar');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-calendar.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-calendar.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/tabs/absence');
+const pageObj = require('../../../page-objects/tabs/absence');
 
-module.exports = function (engine) {
-  page.init(engine).openSubTab('calendar');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.openSubTab('calendar');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-entitlements.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-entitlements.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/tabs/absence');
+const pageObj = require('../../../page-objects/tabs/absence');
 
-module.exports = function (engine) {
-  page.init(engine).openSubTab('entitlements');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.openSubTab('entitlements');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-entitlements.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-entitlements.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/tabs/absence');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.openSubTab('entitlements');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-report-actions.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-report-actions.js
@@ -1,10 +1,11 @@
 'use strict';
 
-var page = require('../../../page-objects/tabs/absence');
+const pageObj = require('../../../page-objects/tabs/absence');
 
-module.exports = function (engine) {
-  page.init(engine).openSubTab('report')
-    .then(function (reportTab) {
-      reportTab.openSection('pending').showActions();
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openSubTab('report');
+
+  await tab.openSection('pending');
+  await tab.showActions();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-report-open-section.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-report-open-section.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var page = require('../../../page-objects/tabs/absence');
+const pageObj = require('../../../page-objects/tabs/absence');
 
-module.exports = function (engine) {
-  page.init(engine).openSubTab('report')
-    .then(function (reportTab) {
-      reportTab.openSection('pending');
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openSubTab('report');
+
+  await tab.openSection('pending');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-report.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-report.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/tabs/absence');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.openSubTab('report');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-report.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-report.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/tabs/absence');
+const pageObj = require('../../../page-objects/tabs/absence');
 
-module.exports = function (engine) {
-  page.init(engine).openSubTab('report');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.openSubTab('report');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-work-patterns-modal.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-work-patterns-modal.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var page = require('../../../page-objects/tabs/absence');
+const pageObj = require('../../../page-objects/tabs/absence');
 
-module.exports = function (engine) {
-  page.init(engine).openSubTab('work-patterns')
-    .then(function (workPatternsTab) {
-      workPatternsTab.showModal();
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openSubTab('work-patterns');
+
+  await tab.showModal();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-work-patterns.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-work-patterns.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/tabs/absence');
+const pageObj = require('../../../page-objects/tabs/absence');
 
-module.exports = function (engine) {
-  page.init(engine).openSubTab('work-patterns');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.openSubTab('work-patterns');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-work-patterns.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/absence/tab-work-patterns.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/tabs/absence');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.openSubTab('work-patterns');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/documents/show.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/documents/show.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('documents');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.openTab('documents');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/change-terms.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/change-terms.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-contract')
-    .then(function (tab) {
-      return tab.openContractModal('revision');
-    })
-    .then(function (modal) {
-      modal.selectTab('General');
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('job-contract');
+  const modal = await tab.openContractModal('revision');
+
+  await modal.selectTab('General');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/correct-error.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/correct-error.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-contract')
-    .then(function (tab) {
-      return tab.openContractModal('correct');
-    })
-    .then(function (modal) {
-      modal.selectTab('General');
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('job-contract');
+  const modal = await tab.openContractModal('correct');
+
+  await modal.selectTab('General');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/delete-dialog.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/delete-dialog.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-contract')
-    .then(function (tab) {
-      tab.attemptDelete();
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('job-contract');
+
+  await tab.attemptDelete();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/delete-dialog.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/delete-dialog.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/tabs/job-contract');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.attemptDelete();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/full-history.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/full-history.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-contract')
-    .then(function (tab) {
-      tab.showFullHistory();
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('job-contract');
+
+  await tab.showFullHistory();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/full-history.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/full-history.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/tabs/job-contract');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.showFullHistory();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/summary.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/summary.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-contract');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.openTab('job-contract');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/tab-funding.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/tab-funding.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-contract')
-    .then(function (tab) {
-      return tab.openNewContractModal();
-    })
-    .then(function (modal) {
-      modal.selectTab('Funding');
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('job-contract');
+  const modal = await tab.openNewContractModal();
+
+  await modal.selectTab('Funding');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/tab-general.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/tab-general.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-contract')
-    .then(function (tab) {
-      return tab.openNewContractModal();
-    })
-    .then(function (modal) {
-      modal.selectTab('General');
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('job-contract');
+  const modal = await tab.openNewContractModal();
+
+  await modal.selectTab('General');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/tab-hours.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/tab-hours.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-contract')
-    .then(function (tab) {
-      return tab.openNewContractModal();
-    })
-    .then(function (modal) {
-      modal.selectTab('Hours');
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('job-contract');
+  const modal = await tab.openNewContractModal();
+
+  await modal.selectTab('Hours');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/tab-insurance.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/tab-insurance.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-contract')
-    .then(function (tab) {
-      return tab.openNewContractModal();
-    })
-    .then(function (modal) {
-      modal.selectTab('Insurance');
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('job-contract');
+  const modal = await tab.openNewContractModal();
+
+  await modal.selectTab('Insurance');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/tab-leave.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/tab-leave.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-contract')
-    .then(function (tab) {
-      return tab.openNewContractModal();
-    })
-    .then(function (modal) {
-      modal.selectTab('Leave');
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('job-contract');
+  const modal = await tab.openNewContractModal();
+
+  await modal.selectTab('Leave');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/tab-pay.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/tab-pay.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-contract')
-    .then(function (tab) {
-      return tab.openNewContractModal();
-    })
-    .then(function (modal) {
-      modal.selectTab('Pay');
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('job-contract');
+  const modal = await tab.openNewContractModal();
+
+  await modal.selectTab('Pay');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/tab-pension.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-contract/tab-pension.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-contract')
-    .then(function (tab) {
-      return tab.openNewContractModal();
-    })
-    .then(function (modal) {
-      modal.selectTab('Pension');
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('job-contract');
+  const modal = await tab.openNewContractModal();
+
+  await modal.selectTab('Pension');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/add-new.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/add-new.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/tabs/job-roles');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.showAddNew();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/add-new.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/add-new.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-roles')
-    .then(function (tab) {
-      tab.showAddNew();
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('job-roles');
+
+  await tab.showAddNew();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/basic-details-edit.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/basic-details-edit.js
@@ -1,10 +1,11 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-roles')
-    .then(function (tab) {
-      tab.switchToTab('Basic Details').edit();
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('job-roles');
+
+  await tab.switchToTab('Basic Details');
+  await tab.edit();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/basic-details.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/basic-details.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-roles');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.openTab('job-roles');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/cost-centres-edit.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/cost-centres-edit.js
@@ -1,10 +1,11 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-roles')
-    .then(function (tab) {
-      tab.switchToTab('Cost Centres').edit();
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('job-roles');
+
+  await tab.switchToTab('Cost Centres');
+  await tab.edit();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/cost-centres.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/cost-centres.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/tabs/job-roles');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.switchToTab('Cost Centres');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/cost-centres.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/cost-centres.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-roles')
-    .then(function (tab) {
-      tab.switchToTab('Cost Centres');
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('job-roles');
+
+  await tab.switchToTab('Cost Centres');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/delete-dialog.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/delete-dialog.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/tabs/job-roles');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.attemptDelete();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/delete-dialog.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/delete-dialog.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-roles')
-    .then(function (tab) {
-      tab.attemptDelete();
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('job-roles');
+
+  await tab.attemptDelete();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/funding-edit.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/funding-edit.js
@@ -1,10 +1,11 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-roles')
-    .then(function (tab) {
-      tab.switchToTab('Funding').edit();
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('job-roles');
+
+  await tab.switchToTab('Funding');
+  await tab.edit();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/funding.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/funding.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-roles')
-    .then(function (tab) {
-      tab.switchToTab('Funding');
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('job-roles');
+
+  await tab.switchToTab('Funding');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/funding.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/funding.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/tabs/job-roles');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.switchToTab('Funding');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/open-ui-select.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/job-roles/open-ui-select.js
@@ -1,10 +1,12 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('job-roles')
-    .then(function (tab) {
-      tab.switchToTab('Basic Details').edit().openDropdown('department');
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('job-roles');
+
+  await tab.switchToTab('Basic Details');
+  await tab.edit();
+  await tab.openDropdown('department');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/show-actions.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/show-actions.js
@@ -4,5 +4,6 @@ const pageObj = require('../../page-objects/contact-summary');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.showActions();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/show-actions.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/show-actions.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../page-objects/contact-summary');
+const pageObj = require('../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).showActions();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.showActions();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/tasks/show.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/contact-summary/tasks/show.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/contact-summary');
+const pageObj = require('../../../page-objects/contact-summary');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('tasks');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.openTab('tasks');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/documents/advanced-filters.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/documents/advanced-filters.js
@@ -4,5 +4,6 @@ const pageObj = require('../../page-objects/documents');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.advancedFilters();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/documents/advanced-filters.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/documents/advanced-filters.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../page-objects/documents');
+const pageObj = require('../../page-objects/documents');
 
-module.exports = function (engine) {
-  page.init(engine).advancedFilters();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.advancedFilters();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/documents/document/add.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/documents/document/add.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/documents');
+const pageObj = require('../../../page-objects/documents');
 
-module.exports = function (engine) {
-  page.init(engine).addDocument();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.addDocument();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/documents/document/add.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/documents/document/add.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/documents');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.addDocument();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/documents/document/pick-due-date.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/documents/document/pick-due-date.js
@@ -1,9 +1,11 @@
 'use strict';
 
-var page = require('../../../page-objects/documents');
+const pageObj = require('../../../page-objects/documents');
 
-module.exports = function (engine) {
-  page.init(engine).addDocument().then(function (modal) {
-    modal.showTab('Assignments').pickDueDate();
-  });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const modal = await page.addDocument();
+
+  await modal.showTab('Assignments');
+  await modal.pickDueDate();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/documents/document/select-assignee.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/documents/document/select-assignee.js
@@ -1,9 +1,12 @@
 'use strict';
 
-var page = require('../../../page-objects/documents');
+const pageObj = require('../../../page-objects/documents');
 
-module.exports = function (engine) {
-  page.init(engine).addDocument().then(function (modal) {
-    modal.showTab('Assignments').showField('Assignee').selectAssignee();
-  });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const modal = await page.addDocument();
+
+  await modal.showTab('Assignments');
+  await modal.showField('Assignee');
+  await modal.selectAssignee();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/documents/document/select-type.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/documents/document/select-type.js
@@ -1,9 +1,10 @@
 'use strict';
 
-var page = require('../../../page-objects/documents');
+const pageObj = require('../../../page-objects/documents');
 
-module.exports = function (engine) {
-  page.init(engine).addDocument().then(function (modal) {
-    modal.selectType();
-  });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const modal = await page.addDocument();
+
+  await modal.selectType();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/documents/document/show-all-fields.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/documents/document/show-all-fields.js
@@ -1,9 +1,12 @@
 'use strict';
 
-var page = require('../../../page-objects/documents');
+const pageObj = require('../../../page-objects/documents');
 
-module.exports = function (engine) {
-  page.init(engine).addDocument().then(function (modal) {
-    modal.showTab('Assignments').showField('Assignee').showField('Assignment');
-  });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const modal = await page.addDocument();
+
+  await modal.showTab('Assignments');
+  await modal.showField('Assignee');
+  await modal.showField('Assignment');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/import/step-2.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/import/step-2.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/leave-absence-import');
+const pageObj = require('../../../page-objects/leave-absence-import');
 
-module.exports = function (engine) {
-  page.init(engine).showStep2();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.showStep2();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/import/step-2.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/import/step-2.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/leave-absence-import');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.showStep2();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/import/step-3.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/import/step-3.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/leave-absence-import');
+const pageObj = require('../../../page-objects/leave-absence-import');
 
-module.exports = function (engine) {
-  page.init(engine).showStep3();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.showStep3();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/import/step-3.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/import/step-3.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/leave-absence-import');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.showStep3();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/import/step-4.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/import/step-4.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/leave-absence-import');
+const pageObj = require('../../../page-objects/leave-absence-import');
 
-module.exports = function (engine) {
-  page.init(engine).showStep4();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.showStep4();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/import/step-4.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/import/step-4.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/leave-absence-import');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.showStep4();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/leave-balances/leave-balances.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/leave-balances/leave-balances.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/leave-absence-dashboard');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.openTab('leave-balances');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/leave-balances/leave-balances.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/leave-balances/leave-balances.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/leave-absence-dashboard');
+const pageObj = require('../../../page-objects/leave-absence-dashboard');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('leave-balances');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.openTab('leave-balances');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/leave-calendar/leave-calendar.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/leave-calendar/leave-calendar.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/leave-absence-dashboard');
+const pageObj = require('../../../page-objects/leave-absence-dashboard');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('leave-calendar');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.openTab('leave-calendar');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/leave-calendar/leave-calendar.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/leave-calendar/leave-calendar.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/leave-absence-dashboard');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.openTab('leave-calendar');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/leave-requests/leave-requests-with-filters.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/leave-requests/leave-requests-with-filters.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var page = require('../../../page-objects/leave-absence-dashboard');
+const pageObj = require('../../../page-objects/leave-absence-dashboard');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('leave-requests')
-    .then(function (requestTab) {
-      requestTab.showFilters();
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const tab = await page.openTab('leave-requests');
+
+  await tab.showFilters();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/leave-requests/leave-requests.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/leave-requests/leave-requests.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/leave-absence-dashboard');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.openTab('leave-requests');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/leave-requests/leave-requests.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/leave-absence-dashboard/leave-requests/leave-requests.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/leave-absence-dashboard');
+const pageObj = require('../../../page-objects/leave-absence-dashboard');
 
-module.exports = function (engine) {
-  page.init(engine).openTab('leave-requests');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.openTab('leave-requests');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/loadCookies.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/loadCookies.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 
-module.exports = function (chromy, scenario) {
+module.exports = async (puppet, scenario) => {
   var cookies = [];
   var cookiePath = scenario.cookiePath;
 
@@ -9,13 +9,21 @@ module.exports = function (chromy, scenario) {
     cookies = JSON.parse(fs.readFileSync(cookiePath));
   }
 
-  // MUNGE COOKIE DOMAIN FOR CHROMY USAGE
+  // MUNGE COOKIE DOMAIN
   cookies = cookies.map(cookie => {
     cookie.url = 'http://' + cookie.domain;
     delete cookie.domain;
     return cookie;
   });
 
-  // SET COOKIES VIA CHROMY
-  chromy.setCookie(cookies);
+  // SET COOKIES
+  const setCookies = async () => {
+    return Promise.all(
+      cookies.map(async (cookie) => {
+        await puppet.setCookie(cookie);
+      })
+    );
+  };
+
+  await setCookies();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onBefore.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onBefore.js
@@ -1,9 +1,6 @@
-module.exports = function (chromy, scenario, vp) {
+module.exports = async (puppet, scenario, vp) => {
   console.log('--------------------------------------------');
   console.log('Running Scenario "' + scenario.label + '" ' + scenario.count);
 
-  require('./loadCookies')(chromy, scenario);
-
-  // IGNORE ANY CERT WARNINGS
-  chromy.ignoreCertificateErrors();
+  await require('./loadCookies')(puppet, scenario);
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onReady.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onReady.js
@@ -1,7 +1,6 @@
 var page = require('../page-objects/page');
 
-module.exports = function (chromy, scenario, vp) {
-  require('./clickAndHoverHelper')(chromy, scenario);
-
-  page.init(chromy);
+module.exports = async (puppet, scenario, vp) => {
+  await require('./clickAndHoverHelper')(puppet, scenario);
+  await page.init(puppet);
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onReady.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onReady.js
@@ -1,4 +1,4 @@
-var page = require('../page-objects/page');
+const page = require('../page-objects/page');
 
 module.exports = async (puppet, scenario, vp) => {
   await require('./clickAndHoverHelper')(puppet, scenario);

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/address.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/address.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../page-objects/onboarding-wizard');
+const pageObj = require('../../page-objects/onboarding-wizard');
 
-module.exports = function (engine) {
-  page.init(engine).reachAddressPage();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.reachAddressPage();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/address.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/address.js
@@ -4,5 +4,6 @@ const pageObj = require('../../page-objects/onboarding-wizard');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.reachAddressPage();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/contact.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/contact.js
@@ -4,5 +4,6 @@ const pageObj = require('../../page-objects/onboarding-wizard');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.reachContactInfoPage();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/contact.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/contact.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../page-objects/onboarding-wizard');
+const pageObj = require('../../page-objects/onboarding-wizard');
 
-module.exports = function (engine) {
-  page.init(engine).reachContactInfoPage();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.reachContactInfoPage();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/dependents.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/dependents.js
@@ -4,5 +4,6 @@ const pageObj = require('../../page-objects/onboarding-wizard');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.reachDependentPage();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/dependents.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/dependents.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../page-objects/onboarding-wizard');
+const pageObj = require('../../page-objects/onboarding-wizard');
 
-module.exports = function (engine) {
-  page.init(engine).reachDependentPage();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.reachDependentPage();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/emergency_contact.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/emergency_contact.js
@@ -4,5 +4,6 @@ const pageObj = require('../../page-objects/onboarding-wizard');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.reachEmergencyContactPage();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/emergency_contact.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/emergency_contact.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../page-objects/onboarding-wizard');
+const pageObj = require('../../page-objects/onboarding-wizard');
 
-module.exports = function (engine) {
-  page.init(engine).reachEmergencyContactPage();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.reachEmergencyContactPage();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/payroll.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/payroll.js
@@ -4,5 +4,6 @@ const pageObj = require('../../page-objects/onboarding-wizard');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.reachPayrollPage();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/payroll.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/payroll.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../page-objects/onboarding-wizard');
+const pageObj = require('../../page-objects/onboarding-wizard');
 
-module.exports = function (engine) {
-  page.init(engine).reachPayrollPage();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.reachPayrollPage();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/profile_picture.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/profile_picture.js
@@ -4,5 +4,6 @@ const pageObj = require('../../page-objects/onboarding-wizard');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.reachProfilePicturePage();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/profile_picture.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/onboarding-wizard/profile_picture.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../page-objects/onboarding-wizard');
+const pageObj = require('../../page-objects/onboarding-wizard');
 
-module.exports = function (engine) {
-  page.init(engine).reachProfilePicturePage();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.reachProfilePicturePage();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/edit-my-details.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/edit-my-details.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../page-objects/ssp-my-details');
+const pageObj = require('../../page-objects/ssp-my-details');
 
-module.exports = function (engine) {
-  page.init(engine).showEditMyDetailsPopup();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.showEditMyDetailsPopup();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/edit-my-details.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/edit-my-details.js
@@ -4,5 +4,6 @@ const pageObj = require('../../page-objects/ssp-my-details');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.showEditMyDetailsPopup();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/hr-resources-see-resources.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/hr-resources-see-resources.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../page-objects/ssp-hr-resources');
+const pageObj = require('../../page-objects/ssp-hr-resources');
 
-module.exports = function (engine) {
-  page.init(engine).seeResources();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.seeResources();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/hr-resources-see-resources.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/hr-resources-see-resources.js
@@ -4,5 +4,6 @@ const pageObj = require('../../page-objects/ssp-hr-resources');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.seeResources();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/calendar-all-contacts.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/calendar-all-contacts.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-manager-leave-calendar');
+const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-calendar');
 
-module.exports = function (engine) {
-  page.init(engine).toggleContactsWithLeaves();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.toggleContactsWithLeaves();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/calendar-all-contacts.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/calendar-all-contacts.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.toggleContactsWithLeaves();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/calendar-current-month-visible.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/calendar-current-month-visible.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-manager-leave-calendar');
+const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-calendar');
 
-module.exports = function (engine) {
-  page.init(engine);
+module.exports = async engine => {
+  await pageObj.init(engine);
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/calendar-legend-expanded.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/calendar-legend-expanded.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-manager-leave-calendar');
+const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-calendar');
 
-module.exports = function (engine) {
-  page.init(engine).toggleLegend();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.toggleLegend();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/calendar-legend-expanded.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/calendar-legend-expanded.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.toggleLegend();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/leave-balances.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/leave-balances.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-manager-leave-balance-report');
+const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-balance-report');
 
-module.exports = function (engine) {
-  page.init(engine);
+module.exports = async engine => {
+  await pageObj.init(engine);
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/leave-requests-as-admin-all-requests.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/leave-requests-as-admin-all-requests.js
@@ -6,5 +6,6 @@ const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-
 // and have at least one leave request *assigned* to the Admin
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.changeFilterByAssignee('all');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/leave-requests-as-admin-all-requests.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/leave-requests-as-admin-all-requests.js
@@ -1,9 +1,10 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
+const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
 
 // precondition: need to have the login of Admin
 // and have at least one leave request *assigned* to the Admin
-module.exports = function (engine) {
-  page.init(engine).changeFilterByAssignee('all');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.changeFilterByAssignee('all');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/leave-requests-as-admin.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/leave-requests-as-admin.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
+const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
 
 // precondition: need to have the login of Admin
 // and have at least one leave request *assigned* to the Admin
-module.exports = function (engine) {
-  page.init(engine);
+module.exports = async engine => {
+  await pageObj.init(engine);
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/leave-requests-show-actions.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/leave-requests-show-actions.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
+const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
 
 // precondition: need to have the login of manager and have at least one leave request
-module.exports = function (engine) {
-  page.init(engine).openActionsForRow(1);
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.openActionsForRow(1);
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/leave-requests-show-actions.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/leave-requests-show-actions.js
@@ -5,5 +5,6 @@ const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-
 // precondition: need to have the login of manager and have at least one leave request
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.openActionsForRow(1);
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/leave-requests-with-filters.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/leave-requests-with-filters.js
@@ -5,5 +5,6 @@ const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-
 // precondition: need to have the login of manager and have at least one leave request
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.expandFilter();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/leave-requests-with-filters.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/leave-requests-with-filters.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
+const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
 
 // precondition: need to have the login of manager and have at least one leave request
-module.exports = function (engine) {
-  page.init(engine).expandFilter();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.expandFilter();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/leave-requests-without-filters.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/leave-requests-without-filters.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
+const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
 
 // precondition: need to have the login of manager and have at least one leave request
-module.exports = function (engine) {
-  page.init(engine);
+module.exports = async engine => {
+  await pageObj.init(engine);
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/modal-leave-on-behalf-of-staff.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/modal-leave-on-behalf-of-staff.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
+const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
 
 // precondition: need to have the login of manager
-module.exports = function (engine) {
-  page.init(engine).applyLeaveForStaff('leave');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.applyLeaveForStaff('leave');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/modal-leave-on-behalf-of-staff.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/modal-leave-on-behalf-of-staff.js
@@ -5,5 +5,6 @@ const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-
 // precondition: need to have the login of manager
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.applyLeaveForStaff('leave');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/modal-sick-edit.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/modal-sick-edit.js
@@ -1,11 +1,12 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
+var pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
 
 // precondition: need to have the login of manager and have at least one sickness request
-module.exports = function (engine) {
-  page.init(engine)
-    .openLeaveTypeFor(3)
-    .openActionsForRow(1)
-    .editRequest();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+
+  await page.openLeaveTypeFor(3);
+  await page.openActionsForRow(1);
+  await page.editRequest();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/modal-sick-on-behalf-of-staff.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/modal-sick-on-behalf-of-staff.js
@@ -5,5 +5,6 @@ const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-
 // precondition: need to have the login of manager
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.applyLeaveForStaff('sickness');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/modal-sick-on-behalf-of-staff.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/modal-sick-on-behalf-of-staff.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
+const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
 
 // precondition: need to have the login of manager
-module.exports = function (engine) {
-  page.init(engine).applyLeaveForStaff('sickness');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.applyLeaveForStaff('sickness');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/modal-toil-edit.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/modal-toil-edit.js
@@ -1,11 +1,12 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
+const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
 
 // precondition: need to have the login of manager and have at least one toil request
-module.exports = function (engine) {
-  page.init(engine)
-    .openLeaveTypeFor(2)
-    .openActionsForRow(1)
-    .editRequest();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+
+  await page.openLeaveTypeFor(2);
+  await page.openActionsForRow(1);
+  await page.editRequest();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/modal-toil-on-behalf-of-staff.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/modal-toil-on-behalf-of-staff.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
+const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-requests');
 
 // precondition: need to have the login of manager
-module.exports = function (engine) {
-  page.init(engine).applyLeaveForStaff('toil');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.applyLeaveForStaff('toil');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/modal-toil-on-behalf-of-staff.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/manager-leave/modal-toil-on-behalf-of-staff.js
@@ -5,5 +5,6 @@ const pageObj = require('../../../page-objects/ssp-leave-absences-manager-leave-
 // precondition: need to have the login of manager
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.applyLeaveForStaff('toil');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/my-leave/calendar-current-month-visible.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/my-leave/calendar-current-month-visible.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-my-leave-calendar');
+const pageObj = require('../../../page-objects/ssp-leave-absences-my-leave-calendar');
 
-module.exports = function (engine) {
-  page.init(engine);
+module.exports = async engine => {
+  await pageObj.init(engine);
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/my-leave/calendar-tooltip.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/my-leave/calendar-tooltip.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/ssp-leave-absences-my-leave-calen
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.showTooltip();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/my-leave/calendar-tooltip.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/my-leave/calendar-tooltip.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-my-leave-calendar');
+const pageObj = require('../../../page-objects/ssp-leave-absences-my-leave-calendar');
 
-module.exports = function (engine) {
-  page.init(engine).showTooltip();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.showTooltip();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/my-leave/modal-show-deduction-fields-expanded.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/my-leave/modal-show-deduction-fields-expanded.js
@@ -1,16 +1,17 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-my-leave-report');
+const pageObj = require('../../../page-objects/ssp-leave-absences-my-leave-report');
 
 // precondition: need to have a current absence period
-module.exports = function (engine) {
-  page.init(engine)
-    .newRequest('leave')
-    .selectRequestAbsenceType('Holiday in Hours')
-    .changeRequestDaysMode('multiple')
-    .selectRequestDate('from', 2, 1)
-    .selectRequestDate('to', 2, 2)
-    .waitUntilRequestBalanceIsCalculated()
-    .expandDeductionField('from')
-    .expandDeductionField('to');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+
+  await page.newRequest('leave');
+  await page.selectRequestAbsenceType('Holiday in Hours');
+  await page.changeRequestDaysMode('multiple');
+  await page.selectRequestDate('from', 2, 1);
+  await page.selectRequestDate('to', 2, 2);
+  await page.waitUntilRequestBalanceIsCalculated();
+  await page.expandDeductionField('from');
+  await page.expandDeductionField('to');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/my-leave/modal-show-deduction-fields.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/my-leave/modal-show-deduction-fields.js
@@ -1,14 +1,15 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-my-leave-report');
+const pageObj = require('../../../page-objects/ssp-leave-absences-my-leave-report');
 
 // precondition: need to have a current absence period
-module.exports = function (engine) {
-  page.init(engine)
-    .newRequest('leave')
-    .selectRequestAbsenceType('Holiday in Hours')
-    .changeRequestDaysMode('multiple')
-    .selectRequestDate('from', 2, 1)
-    .selectRequestDate('to', 2, 2)
-    .waitUntilRequestBalanceIsCalculated();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+
+  await page.newRequest('leave');
+  await page.selectRequestAbsenceType('Holiday in Hours');
+  await page.changeRequestDaysMode('multiple');
+  await page.selectRequestDate('from', 2, 1);
+  await page.selectRequestDate('to', 2, 2);
+  await page.waitUntilRequestBalanceIsCalculated();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/my-leave/report-pending-show-comments.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/my-leave/report-pending-show-comments.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-my-leave-report');
+const pageObj = require('../../../page-objects/ssp-leave-absences-my-leave-report');
 
 // precondition: need to have the first leave request on the pending list with at least a comment
-module.exports = function (engine) {
-  page.init(engine)
-    .openSection('pending')
-    .openActionsForRow()
-    .editRequest().then(function (modal) {
-      modal.selectTab('Comments');
-    });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.openSection('pending');
+  await page.openActionsForRow();
+
+  const modal = await page.editRequest();
+  await modal.selectTab('Comments');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/my-leave/report-show-absence-in-hours.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/my-leave/report-show-absence-in-hours.js
@@ -1,10 +1,11 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-my-leave-report');
+const pageObj = require('../../../page-objects/ssp-leave-absences-my-leave-report');
 
 // precondition: need to have the absence type in *hours* with a label "Holiday in Hours"
-module.exports = function (engine) {
-  page.init(engine)
-    .newRequest('leave')
-    .selectRequestAbsenceType('Holiday in Hours');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+
+  await page.newRequest('leave');
+  await page.selectRequestAbsenceType('Holiday in Hours');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/my-leave/report.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/my-leave/report.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var page = require('../../../page-objects/ssp-leave-absences-my-leave-report');
+const pageObj = require('../../../page-objects/ssp-leave-absences-my-leave-report');
 
 // precondition: need to have at least one pending leave request
-module.exports = function (engine) {
-  page.init(engine).openSection('pending');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.openSection('pending');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/my-leave/report.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/my-leave/report.js
@@ -5,5 +5,6 @@ const pageObj = require('../../../page-objects/ssp-leave-absences-my-leave-repor
 // precondition: need to have at least one pending leave request
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.openSection('pending');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/tasks-create-new-task.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/tasks-create-new-task.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../page-objects/ssp-tasks');
+const pageObj = require('../../page-objects/ssp-tasks');
 
-module.exports = function (engine) {
-  page.init(engine).openCreateNewTaskModal();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.openCreateNewTaskModal();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/tasks-create-new-task.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/tasks-create-new-task.js
@@ -4,5 +4,6 @@ const pageObj = require('../../page-objects/ssp-tasks');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.openCreateNewTaskModal();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/tasks-show-completed-tasks.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/tasks-show-completed-tasks.js
@@ -4,5 +4,6 @@ const pageObj = require('../../page-objects/ssp-tasks');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.openCompletedTasksModal();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/tasks-show-completed-tasks.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/tasks-show-completed-tasks.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../page-objects/ssp-tasks');
+const pageObj = require('../../page-objects/ssp-tasks');
 
-module.exports = function (engine) {
-  page.init(engine).openCompletedTasksModal();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.openCompletedTasksModal();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/vacancies-more-details.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/vacancies-more-details.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../page-objects/ssp-vacancies');
+const pageObj = require('../../page-objects/ssp-vacancies');
 
-module.exports = function (engine) {
-  page.init(engine).showMoreDetails();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.showMoreDetails();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/vacancies-more-details.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/ssp/vacancies-more-details.js
@@ -4,5 +4,6 @@ const pageObj = require('../../page-objects/ssp-vacancies');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.showMoreDetails();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/advanced-filters.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/advanced-filters.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../page-objects/tasks');
+const pageObj = require('../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine).advancedFilters();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.advancedFilters();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/advanced-filters.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/advanced-filters.js
@@ -4,5 +4,6 @@ const pageObj = require('../../page-objects/tasks');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.advancedFilters();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/assignment/add-document.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/assignment/add-document.js
@@ -1,9 +1,11 @@
 'use strict';
 
-var page = require('../../../page-objects/tasks');
+const pageObj = require('../../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine).addAssignment().then(function (modal) {
-    modal.selectType().addDocument();
-  });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const modal = await page.addAssignment();
+
+  await modal.selectType();
+  await modal.addDocument();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/assignment/add-task.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/assignment/add-task.js
@@ -1,9 +1,11 @@
 'use strict';
 
-var page = require('../../../page-objects/tasks');
+const pageObj = require('../../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine).addAssignment().then(function (modal) {
-    modal.selectType().addTask();
-  });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const modal = await page.addAssignment();
+
+  await modal.selectType();
+  await modal.addTask();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/assignment/add.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/assignment/add.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/tasks');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.addAssignment();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/assignment/add.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/assignment/add.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/tasks');
+const pageObj = require('../../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine).addAssignment();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.addAssignment();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/assignment/pick-date.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/assignment/pick-date.js
@@ -1,9 +1,10 @@
 'use strict';
 
-var page = require('../../../page-objects/tasks');
+const pageObj = require('../../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine).addAssignment().then(function (modal) {
-    modal.pickDate();
-  });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const modal = await page.addAssignment();
+
+  await modal.pickDate();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/assignment/select-type.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/assignment/select-type.js
@@ -1,9 +1,10 @@
 'use strict';
 
-var page = require('../../../page-objects/tasks');
+const pageObj = require('../../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine).addAssignment().then(function (modal) {
-    modal.selectType();
-  });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const modal = await page.addAssignment();
+
+  await modal.selectType();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/select-dates.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/select-dates.js
@@ -4,5 +4,6 @@ const pageObj = require('../../page-objects/tasks');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.selectDates();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/select-dates.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/select-dates.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../page-objects/tasks');
+const pageObj = require('../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine).selectDates();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.selectDates();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/actions.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/actions.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/tasks');
+const pageObj = require('../../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine).taskActions();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.taskActions();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/actions.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/actions.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/tasks');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.taskActions();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/add.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/add.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/tasks');
+const pageObj = require('../../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine).addTask();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.addTask();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/add.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/add.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/tasks');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.addTask();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/editable-assigned.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/editable-assigned.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/tasks');
+const pageObj = require('../../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine).inPlaceEdit('assigned');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.inPlaceEdit('assigned');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/editable-assigned.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/editable-assigned.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/tasks');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.inPlaceEdit('assigned');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/editable-date.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/editable-date.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/tasks');
+const pageObj = require('../../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine).inPlaceEdit('date');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.inPlaceEdit('date');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/editable-date.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/editable-date.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/tasks');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.inPlaceEdit('date');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/editable-subject.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/editable-subject.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/tasks');
+const pageObj = require('../../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine).inPlaceEdit('subject');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.inPlaceEdit('subject');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/editable-subject.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/editable-subject.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/tasks');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.inPlaceEdit('subject');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/editable-target.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/editable-target.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/tasks');
+const pageObj = require('../../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine).inPlaceEdit('target');
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.inPlaceEdit('target');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/editable-target.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/editable-target.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/tasks');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.inPlaceEdit('target');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/open.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/open.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/tasks');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.openTask();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/open.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/open.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/tasks');
+const pageObj = require('../../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine).openTask();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.openTask();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/pick-date.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/pick-date.js
@@ -1,9 +1,10 @@
 'use strict';
 
-var page = require('../../../page-objects/tasks');
+const pageObj = require('../../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine).addTask().then(function (modal) {
-    modal.pickDate();
-  });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const modal = await page.addTask();
+
+  await modal.pickDate();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/select-assignee.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/select-assignee.js
@@ -1,9 +1,11 @@
 'use strict';
 
-var page = require('../../../page-objects/tasks');
+const pageObj = require('../../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine).addTask().then(function (modal) {
-    modal.showField('Assignee').selectAssignee();
-  });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const modal = await page.addTask();
+
+  await modal.showField('Assignee');
+  await modal.selectAssignee();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/select-type.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/select-type.js
@@ -1,9 +1,10 @@
 'use strict';
 
-var page = require('../../../page-objects/tasks');
+const pageObj = require('../../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine).addTask().then(function (modal) {
-    modal.selectType();
-  });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const modal = await page.addTask();
+
+  await modal.selectType();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/show-all-fields.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/show-all-fields.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var page = require('../../../page-objects/tasks');
+const pageObj = require('../../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine).addTask().then(function (modal) {
-    modal
-      .showField('Subject')
-      .showField('Assignee')
-      .showField('Status')
-      .showField('Assignment');
-  });
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  const modal = await page.addTask();
+
+  await modal.showField('Subject');
+  await modal.showField('Assignee');
+  await modal.showField('Status');
+  await modal.showField('Assignment');
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/show-more.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/show-more.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../../page-objects/tasks');
+const pageObj = require('../../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine).showMore();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.showMore();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/show-more.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/show-more.js
@@ -4,5 +4,6 @@ const pageObj = require('../../../page-objects/tasks');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.showMore();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/task.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/tasks/task/task.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var page = require('../../../page-objects/tasks');
+const pageObj = require('../../../page-objects/tasks');
 
-module.exports = function (engine) {
-  page.init(engine);
+module.exports = async engine => {
+  await pageObj.init(engine);
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/work-patterns/show-calendar-form.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/work-patterns/show-calendar-form.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var page = require('../../page-objects/work-patterns-form');
+const pageObj = require('../../page-objects/work-patterns-form');
 
-module.exports = function (engine) {
-  page.init(engine).showCalendarForm();
+module.exports = async engine => {
+  const page = await pageObj.init(engine);
+  await page.showCalendarForm();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/work-patterns/show-calendar-form.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/engine_scripts/work-patterns/show-calendar-form.js
@@ -4,5 +4,6 @@ const pageObj = require('../../page-objects/work-patterns-form');
 
 module.exports = async engine => {
   const page = await pageObj.init(engine);
+
   await page.showCalendarForm();
 };

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/contact-summary.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/contact-summary.js
@@ -1,49 +1,37 @@
-var Promise = require('es6-promise').Promise;
-var page = require('./page');
+const page = require('./page');
 
 module.exports = page.extend({
   /**
    * Opens the "contact access rights" modal
    *
-   * @return {Promise} resolves with the modal page object
+   * @return {Object} the modal page object
    */
-  openManageRightsModal: function () {
-    var chromy = this.chromy;
+  async openManageRightsModal () {
+    await this.showActions();
+    await this.puppet.click('[data-contact-access-rights]');
+    await this.puppet.waitFor('.spinner', { hidden: true });
 
-    return new Promise(function (resolve) {
-      this.showActions();
-
-      chromy.click('[data-contact-access-rights]');
-      chromy.wait(function () {
-        var dom = document.querySelector('.spinner');
-
-        return dom === null || (dom.offsetWidth <= 0 && dom.offsetHeight <= 0);
-      });
-
-      resolve(this.waitForModal('contact-access-rights'));
-    }.bind(this));
+    return this.waitForModal('contact-access-rights');
   },
 
   /**
    * Opens one of the contact summary tabs
    *
-   * @param  {string} tabId
-   * @return {object} resolves with the tab page object
+   * @param  {String} tabId
+   * @return {Pbject} resolves with the tab page object
    */
-  openTab: function (tabId) {
-    return new Promise(function (resolve) {
-      var tab = require('./tabs/' + tabId);
-      this.chromy.click('[title="' + tab.tabTitle + '"]');
+  async openTab (tabId) {
+    const tabObj = require('./tabs/' + tabId);
+    await this.puppet.click('[title="' + tabObj.tabTitle + '"]');
 
-      resolve(tab.init(this.chromy, false));
-    }.bind(this));
+    return tabObj.init(this.puppet, false);
   },
 
   /**
    * Shows the dropdown of the "Actions" button in the contact summary page
    */
-  showActions: function () {
-    this.chromy.click('#crm-contact-actions-link');
-    this.chromy.wait('#crm-contact-actions-list');
+  async showActions () {
+    await this.puppet.click('#crm-contact-actions-link');
+    await this.puppet.waitFor('#crm-contact-actions-list');
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/contact-summary.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/contact-summary.js
@@ -22,6 +22,7 @@ module.exports = page.extend({
    */
   async openTab (tabId) {
     const tabObj = require('./tabs/' + tabId);
+
     await this.puppet.click('[title="' + tabObj.tabTitle + '"]');
 
     return tabObj.init(this.puppet, false);

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/documents.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/documents.js
@@ -1,70 +1,62 @@
-var Promise = require('es6-promise').Promise;
-var page = require('./page');
+const page = require('./page');
 
-var documentSelector = '.ct-table-documents > tbody > tr:nth-child(1)';
+const documentSelector = '.ct-table-documents > tbody > tr:nth-child(1)';
 
 module.exports = page.extend({
   /**
    * Opens the modal to add a documents
    *
-   * @return {Promise} resolves with the document modal page object
+   * @return {Object} the document modal page object
    */
-  addDocument: function () {
-    return new Promise(function (resolve) {
-      this.chromy.click('a[ng-click*="itemAdd"]');
-      resolve(this.waitForModal('document'));
-    }.bind(this));
+  async addDocument () {
+    await this.puppet.click('a[ng-click*="itemAdd"]');
+
+    return this.waitForModal('document');
   },
 
   /**
    * Shows the advanced filters
    *
-   * @return {object}
+   * @return {Object}
    */
-  advancedFilters: function () {
-    this.chromy.click('a[ng-click*="isCollapsed.filterAdvanced"]');
-    this.chromy.wait(500);
-
-    return this;
+  async advancedFilters () {
+    await this.puppet.click('a[ng-click*="isCollapsed.filterAdvanced"]');
+    await this.puppet.waitFor(500);
   },
 
   /**
    * Shows the dropdown of the actions available on any given document
    *
-   * @return {object}
+   * @return {Object}
    */
-  documentActions: function () {
-    this.chromy.click(documentSelector + ' .ct-context-menu-toggle');
-
-    return this;
+  async documentActions () {
+    await this.puppet.click(documentSelector + ' .ct-context-menu-toggle');
   },
 
   /**
    * Opens a document
    *
-   * @return {Promise} resolves with the document modal page object
+   * @return {Object} the document modal page object
    */
-  openDocument: function () {
-    return new Promise(function (resolve) {
-      this.documentActions();
+  async openDocument () {
+    await this.documentActions();
+    await this.puppet.click(documentSelector + ' .dropdown-menu a[ng-click*="modalDocument"]');
 
-      this.chromy.click(documentSelector + ' .dropdown-menu a[ng-click*="modalDocument"]');
-      resolve(this.waitForModal('document'));
-    }.bind(this));
+    return this.waitForModal('document');
   },
 
   /**
    * Shows the "select dates" filter
    */
-  selectDates: function () {
-    this.chromy.click('.ct-select-dates');
-    this.chromy.wait(500);
+  async selectDates () {
+    await this.puppet.click('.ct-select-dates');
+    await this.puppet.waitFor(500);
   },
 
   /**
    * Waits until the specified select is visible on the page
    */
-  waitForReady: function () {
-    this.chromy.waitUntilVisible('.ct-filter-date');
+  async waitForReady () {
+    await this.puppet.waitFor('.ct-filter-date', { visible: true });
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/leave-absence-dashboard.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/leave-absence-dashboard.js
@@ -1,5 +1,4 @@
-var Promise = require('es6-promise').Promise;
-var page = require('./page');
+const page = require('./page');
 
 module.exports = page.extend({
   /**
@@ -8,16 +7,13 @@ module.exports = page.extend({
    * @param  {string} tabId
    * @return {object} resolves with the tab page object
    */
-  openTab: function (tabId) {
-    var chromy = this.chromy;
-    var tab = require('./tabs/' + tabId).init(chromy, false);
+  async openTab (tabId) {
+    const tab = await require('./tabs/' + tabId).init(this.puppet, false);
 
-    return new Promise(function (resolve) {
-      chromy.click('[ui-sref="' + tab.tabUiSref + '"]');
-      chromy.waitUntilVisible(tab.readySelector);
-      chromy.wait(500);
+    await this.puppet.click('[ui-sref="' + tab.tabUiSref + '"]');
+    await this.puppet.waitFor(tab.readySelector, { visible: true });
+    await this.puppet.waitFor(500);
 
-      resolve(tab);
-    });
+    return tab;
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/leave-absence-import.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/leave-absence-import.js
@@ -1,5 +1,5 @@
-var path = require('path');
-var page = require('./page');
+const path = require('path');
+const page = require('./page');
 
 module.exports = page.extend({
   /**
@@ -8,14 +8,13 @@ module.exports = page.extend({
    *
    * @return Page instance.
    */
-  showStep2: function () {
-    var filePath = path.join(__dirname, '..', 'uploads/leave-and-absences-import-data.csv');
+  async showStep2 () {
+    const filePath = path.join(__dirname, '..', 'uploads/leave-and-absences-import-data.csv');
+    const fileInput = await this.puppet.$('input[name="uploadFile"]');
 
-    this.chromy.setFile('input[name="uploadFile"]', filePath);
-    this.chromy.check('#skipColumnHeader');
-    this.submitAndWait();
-
-    return this;
+    await fileInput.uploadFile(filePath);
+    await this.puppet.click('[name="skipColumnHeader"]');
+    await this.submitAndWait();
   },
 
   /**
@@ -24,11 +23,9 @@ module.exports = page.extend({
    *
    * @return Page instance.
    */
-  showStep3: function () {
-    this.showStep2();
-    this.submitAndWait();
-
-    return this;
+  async showStep3 () {
+    await this.showStep2();
+    await this.submitAndWait();
   },
 
   /**
@@ -37,25 +34,23 @@ module.exports = page.extend({
    *
    * @return page instance.
    */
-  showStep4: function () {
-    this.showStep3();
-    this.submitAndWait();
-
-    return this;
+  async showStep4 () {
+    await this.showStep3();
+    await this.submitAndWait();
   },
 
   /**
    * Clicks on next button (.validate) and waits for Step URL.
    */
-  submitAndWait: function () {
-    this.chromy.click('.crm-leave-and-balance-import .validate');
-    this.chromy.waitLoadEvent();
+  async submitAndWait () {
+    await this.puppet.click('.crm-leave-and-balance-import .validate');
+    await this.puppet.waitForNavigation({ waitUntil: 'domcontentloaded' });
   },
 
   /**
    * Waits until the import form is visible.
    */
-  waitForReady: function () {
-    this.chromy.wait('.crm-leave-and-balance-import');
+  async waitForReady () {
+    await this.puppet.waitFor('.crm-leave-and-balance-import');
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/leave-absence-import.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/leave-absence-import.js
@@ -14,7 +14,7 @@ module.exports = page.extend({
 
     await fileInput.uploadFile(filePath);
     await this.puppet.click('[name="skipColumnHeader"]');
-    await this.submitAndWait();
+    await this.submitAndWaitForStep(2);
   },
 
   /**
@@ -25,7 +25,7 @@ module.exports = page.extend({
    */
   async showStep3 () {
     await this.showStep2();
-    await this.submitAndWait();
+    await this.submitAndWaitForStep(3);
   },
 
   /**
@@ -36,15 +36,18 @@ module.exports = page.extend({
    */
   async showStep4 () {
     await this.showStep3();
-    await this.submitAndWait();
+    await this.submitAndWaitForStep(4);
   },
 
   /**
-   * Clicks on next button (.validate) and waits for Step URL.
+   * Clicks on "next" button and waits for the next step to be ready
+   * (a step is ready when its breadcrumb in the wizard is active)
+   *
+   * @param {Number} step
    */
-  async submitAndWait () {
+  async submitAndWaitForStep (step) {
     await this.puppet.click('.crm-leave-and-balance-import .validate');
-    await this.puppet.waitForNavigation({ waitUntil: 'domcontentloaded' });
+    await this.puppet.waitFor(`.crm_wizard__title .nav-pills li.active:nth-child(${step})`);
   },
 
   /**

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/assignment.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/assignment.js
@@ -1,57 +1,41 @@
 /* global jQuery */
 
-var modal = require('./modal');
+const modal = require('./modal');
 
 module.exports = modal.extend({
 
   /**
    * Clicks the "add document" button
-   *
-   * @return {object}
    */
-  addDocument: function () {
-    this.chromy.click(this.modalRoot + ' a[ng-click="addActivity(documentList)"]');
-
-    return this;
+  async addDocument () {
+    await this.puppet.click(this.modalRoot + ' a[ng-click="addActivity(documentList)"]');
   },
 
   /**
    * Clicks the "add task" button
-   *
-   * @return {object}
    */
-  addTask: function () {
-    this.chromy.click(this.modalRoot + ' a[ng-click="addActivity(taskList)"]');
-
-    return this;
+  async addTask () {
+    await this.puppet.click(this.modalRoot + ' a[ng-click="addActivity(taskList)"]');
   },
 
   /**
    * Opens a date picker
-   *
-   * @return {object}
    */
-  pickDate: function () {
-    this.chromy.click(this.modalRoot + ' [ng-model="assignment.dueDate"]');
-    this.chromy.waitUntilVisible('.uib-datepicker-popup');
-
-    return this;
+  async pickDate () {
+    await this.puppet.click(this.modalRoot + ' [ng-model="assignment.dueDate"]');
+    await this.puppet.waitFor('.uib-datepicker-popup', { visible: true });
   },
 
   /**
    * Selects an assignment type, so that the rest of the modal is shown
-   *
-   * @return {object}
    */
-  selectType: function () {
-    this.chromy.evaluate(function (modalRoot) {
-      var select = document.querySelector(modalRoot + ' select[name="assignment"]');
+  async selectType () {
+    await this.puppet.evaluate(function (modalRoot) {
+      const select = document.querySelector(modalRoot + ' select[name="assignment"]');
 
       select.selectedIndex = 2;
       jQuery(select).change();
-    }, [this.modalRoot]);
-    this.chromy.wait(500);
-
-    return this;
+    }, this.modalRoot);
+    await this.puppet.waitFor(500);
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/contact-access-rights.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/contact-access-rights.js
@@ -1,4 +1,4 @@
-var modal = require('./modal');
+const modal = require('./modal');
 
 module.exports = modal.extend({
   /**
@@ -6,12 +6,10 @@ module.exports = modal.extend({
    *
    * @return {object}
    */
-  openDropdown: function (name) {
-    var common = '[ng-model="modalCtrl.selectedData.%{name}"] input';
+  async openDropdown (name) {
+    const common = '[ng-model="modalCtrl.selectedData.%{name}"] input';
 
-    this.chromy.click(common.replace('%{name}', name));
-    this.chromy.wait(100);
-
-    return this;
+    await this.puppet.click(common.replace('%{name}', name));
+    await this.puppet.waitFor(100);
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/document.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/document.js
@@ -1,63 +1,44 @@
-var modal = require('./modal');
+const modal = require('./modal');
 
 module.exports = modal.extend({
   /**
    * Opens the "due date" datepicker
-   *
-   * @return {object}
    */
-  pickDueDate: function () {
-    this.chromy.click(this.modalRoot + ' [ng-model="documentModal.document.activity_date_time"]');
-    this.chromy.waitUntilVisible('.uib-datepicker-popup');
-
-    return this;
+  async pickDueDate () {
+    await this.puppet.click(this.modalRoot + ' [ng-model="documentModal.document.activity_date_time"]');
+    await this.puppet.waitFor('.uib-datepicker-popup', { visible: true });
   },
 
   /**
    * Shows the given field
    *
-   * @param  {string} fieldName
-   * @return {object}
+   * @param {String} fieldName
    */
-  showField: function (fieldName) {
-    this.chromy.click(this.modalRoot + ' a[ng-click*="show' + fieldName + 'Field"]');
-
-    return this;
+  async showField (fieldName) {
+    await this.puppet.click(this.modalRoot + ' a[ng-click*="show' + fieldName + 'Field"]');
   },
 
   /**
    * Selects an assignee for the document
-   *
-   * @return {object}
    */
-  selectAssignee: function () {
-    this.chromy.click(this.modalRoot + ' [ng-model="documentModal.document.assignee_contact"] .ui-select-match');
-    this.chromy.waitUntilVisible('.select2-with-searchbox:not(.select2-display-none)');
-
-    return this;
+  async selectAssignee () {
+    await this.puppet.click(this.modalRoot + ' [ng-model="documentModal.document.assignee_contact"] .ui-select-match');
+    await this.puppet.waitFor('.select2-with-searchbox:not(.select2-display-none)', { visible: true });
   },
 
   /**
    * Selects the type of document
-   *
-   * @return {object}
    */
-  selectType: function () {
-    this.chromy.click(this.modalRoot + ' [ng-model="documentModal.document.activity_type_id"] .ui-select-match');
-    this.chromy.waitUntilVisible('.select2-with-searchbox:not(.select2-display-none)');
-
-    return this;
+  async selectType () {
+    await this.puppet.click(this.modalRoot + ' [ng-model="documentModal.document.activity_type_id"] .ui-select-match');
+    await this.puppet.waitFor('.select2-with-searchbox:not(.select2-display-none)', { visible: true });
   },
 
   /**
    * Opens the given tab
-   *
-   * @return {object}
    */
-  showTab: function (tabName) {
-    this.chromy.click(this.modalRoot + ' a[data-target="#' + tabName.toLowerCase() + 'Tab"]');
-    this.chromy.wait(200);
-
-    return this;
+  async showTab (tabName) {
+    await this.puppet.click(this.modalRoot + ' a[data-target="#' + tabName.toLowerCase() + 'Tab"]');
+    await this.puppet.waitFor(200);
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/job-contract.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/job-contract.js
@@ -1,20 +1,18 @@
 /* global XPathResult */
 
-var modal = require('./modal');
+const modal = require('./modal');
 
 module.exports = modal.extend({
   /**
    * Selects the tab with the given title
-   *
-   * @param  {string} tabTitle
    */
-  selectTab: function (tabTitle) {
-    this.chromy.evaluate(function (tabTitle) {
+  async selectTab (tabTitle) {
+    await this.puppet.evaluate(function (tabTitle) {
       // = clickLabel
-      var xPath = './/a[text()="' + tabTitle + '"]';
-      var link = document.evaluate(xPath, document.body, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      const xPath = './/a[text()="' + tabTitle + '"]';
+      const link = document.evaluate(xPath, document.body, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
 
       link.click();
-    }, [tabTitle]);
+    }, tabTitle);
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/modal.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/modal.js
@@ -1,4 +1,4 @@
-var page = require('../page');
+const page = require('../page');
 
 module.exports = page.extend({
   modalRoot: '.modal'

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/ssp-leave-request.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/ssp-leave-request.js
@@ -1,14 +1,12 @@
-var modal = require('./modal');
+const modal = require('./modal');
 
 module.exports = modal.extend({
   /**
    * Selects tabs like comments or attachments
+   *
    * @param {String} tabName like comments or attachments
-   * @return {Object} this object
    */
-  selectTab: function (tabName) {
-    this.chromy.click('div.chr_leave-request-modal__tab li[heading=\'' + tabName + '\'] a');
-
-    return this;
+  async selectTab (tabName) {
+    await this.puppet.click('div.chr_leave-request-modal__tab li[heading=\'' + tabName + '\'] a');
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/task.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/modals/task.js
@@ -1,51 +1,36 @@
-var modal = require('./modal');
+const modal = require('./modal');
 
 module.exports = modal.extend({
   /**
    * Opens a date picker
-   *
-   * @return {object}
    */
-  pickDate: function () {
-    this.chromy.click(this.modalRoot + ' [ng-model="task.activity_date_time"]');
-    this.chromy.waitUntilVisible('.uib-datepicker-popup');
-
-    return this;
+  async pickDate () {
+    await this.puppet.click(this.modalRoot + ' [ng-model="task.activity_date_time"]');
+    await this.puppet.waitFor('.uib-datepicker-popup', { visible: true });
   },
 
   /**
    * Shows a given field
    *
-   * @param  {string} fieldName
-   * @return {object}
+   * @param {String} fieldName
    */
-  showField: function (fieldName) {
-    this.chromy.click(this.modalRoot + ' a[ng-click*="showField' + fieldName + '"]');
-
-    return this;
+  async showField (fieldName) {
+    await this.puppet.click(this.modalRoot + ' a[ng-click*="showField' + fieldName + '"]');
   },
 
   /**
    * Selects the task's assignee
-   *
-   * @return {object}
    */
-  selectAssignee: function () {
-    this.chromy.click(this.modalRoot + ' [ng-model="task.assignee_contact_id[0]"] .ui-select-match');
-    this.chromy.waitUntilVisible('.select2-with-searchbox:not(.select2-display-none)');
-
-    return this;
+  async selectAssignee () {
+    await this.puppet.click(this.modalRoot + ' [ng-model="task.assignee_contact_id[0]"] .ui-select-match');
+    await this.puppet.waitFor('.select2-with-searchbox:not(.select2-display-none)', { visible: true });
   },
 
   /**
    * Select the task type
-   *
-   * @return {object}
    */
-  selectType: function () {
-    this.chromy.click(this.modalRoot + ' [ng-model="task.activity_type_id"] .ui-select-match');
-    this.chromy.waitUntilVisible('.select2-with-searchbox:not(.select2-display-none)');
-
-    return this;
+  async selectType () {
+    await this.puppet.click(this.modalRoot + ' [ng-model="task.activity_type_id"] .ui-select-match');
+    await this.puppet.waitFor('.select2-with-searchbox:not(.select2-display-none)', { visible: true });
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/onboarding-wizard.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/onboarding-wizard.js
@@ -1,4 +1,4 @@
-var page = require('./page');
+const page = require('./page');
 
 module.exports = page.extend({
   /**
@@ -6,9 +6,9 @@ module.exports = page.extend({
    *
    * @return {*}
    */
-  reachAddressPage: function () {
-    this.chromy.click('.webform-next');
-    this.chromy.wait('input[value="Address"]');
+  async reachAddressPage () {
+    await this.puppet.click('.webform-next');
+    await this.puppet.waitFor('input[value="Address"]');
   },
 
   /**
@@ -16,10 +16,10 @@ module.exports = page.extend({
    *
    * @return {*}
    */
-  reachContactInfoPage: function () {
-    this.reachAddressPage();
-    this.chromy.click('.webform-next');
-    this.chromy.wait('input[value="Contact Info"]');
+  async reachContactInfoPage () {
+    await this.reachAddressPage();
+    await this.puppet.click('.webform-next');
+    await this.puppet.waitFor('input[value="Contact Info"]');
   },
 
   /**
@@ -27,10 +27,10 @@ module.exports = page.extend({
    *
    * @return {*}
    */
-  reachPayrollPage: function () {
-    this.reachContactInfoPage();
-    this.chromy.click('.webform-next');
-    this.chromy.wait('input[value="Payroll"]');
+  async reachPayrollPage () {
+    await this.reachContactInfoPage();
+    await this.puppet.click('.webform-next');
+    await this.puppet.waitFor('input[value="Payroll"]');
   },
 
   /**
@@ -38,10 +38,10 @@ module.exports = page.extend({
    *
    * @return {*}
    */
-  reachEmergencyContactPage: function () {
-    this.reachPayrollPage();
-    this.chromy.click('.webform-next');
-    this.chromy.wait('input[value="Emergency Contact"]');
+  async reachEmergencyContactPage () {
+    await this.reachPayrollPage();
+    await this.puppet.click('.webform-next');
+    await this.puppet.waitFor('input[value="Emergency Contact"]');
   },
 
   /**
@@ -49,11 +49,11 @@ module.exports = page.extend({
    *
    * @return {*}
    */
-  reachDependentPage: function () {
-    this.reachEmergencyContactPage();
-    this.chromy.click('.webform-next');
-    this.chromy.wait('input[value="Dependants"]');
-    this.chromy.click('#edit-submitted-do-you-have-dependants-1');
+  async reachDependentPage () {
+    await this.reachEmergencyContactPage();
+    await this.puppet.click('.webform-next');
+    await this.puppet.waitFor('input[value="Dependants"]');
+    await this.puppet.click('#edit-submitted-do-you-have-dependants-1');
   },
 
   /**
@@ -61,13 +61,13 @@ module.exports = page.extend({
    *
    * @return {*}
    */
-  reachProfilePicturePage: function () {
-    this.reachDependentPage();
-    this.chromy.waitUntilVisible('.webform-component-fieldset');
-    this.chromy.type('#edit-submitted-first-dependant-civicrm-1-contact-3-cg99999-custom-100000', 'Duke');
-    this.chromy.type('#edit-submitted-first-dependant-civicrm-1-contact-3-cg99999-custom-100001', '1234');
-    this.chromy.type('#edit-submitted-first-dependant-civicrm-1-contact-3-cg99999-custom-100010', 'sibling');
-    this.chromy.click('.webform-next');
-    this.chromy.wait('input[value="Profile Picture"]');
+  async reachProfilePicturePage () {
+    await this.reachDependentPage();
+    await this.puppet.waitFor('.webform-component-fieldset', { visible: true });
+    await this.puppet.type('#edit-submitted-first-dependant-civicrm-1-contact-3-cg99999-custom-100000', 'Duke');
+    await this.puppet.type('#edit-submitted-first-dependant-civicrm-1-contact-3-cg99999-custom-100001', '1234');
+    await this.puppet.type('#edit-submitted-first-dependant-civicrm-1-contact-3-cg99999-custom-100010', 'sibling');
+    await this.puppet.click('.webform-next');
+    await this.puppet.waitFor('input[value="Profile Picture"]');
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/page.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/page.js
@@ -14,12 +14,12 @@ module.exports = {
     this.puppet = puppet;
     !!this.waitForReady && await this.waitForReady();
 
-    let href = await this.puppet.evaluate(() => document.location.href);
-    let isAdmin = href.indexOf('civicrm/') > 1;
+    const href = await this.puppet.evaluate(() => document.location.href);
+    const isAdmin = href.indexOf('civicrm/') > 1;
 
     await this.puppet.evaluate(function (isAdmin) {
-      let selector = isAdmin ? '#content > #console' : '#messages .alert';
-      let errorsWrapper = document.querySelector(selector);
+      const selector = isAdmin ? '#content > #console' : '#messages .alert';
+      const errorsWrapper = document.querySelector(selector);
 
       errorsWrapper && (errorsWrapper.style.display = 'none');
     }, isAdmin);
@@ -68,7 +68,7 @@ module.exports = {
 async function closeAnyModal () {
   const openModalSelector = '.modal.in';
 
-  let result = await this.puppet.$(openModalSelector);
+  const result = await this.puppet.$(openModalSelector);
 
   if (result) {
     await this.puppet.click(openModalSelector + ' .close[ng-click="cancel()"]');
@@ -82,7 +82,7 @@ async function closeAnyModal () {
 async function closeNotifications () {
   const notificationSelector = 'a.ui-notify-cross.ui-notify-close';
 
-  let result = await this.puppet.$(notificationSelector);
+  const result = await this.puppet.$(notificationSelector);
 
   if (result) {
     await this.puppet.click(notificationSelector);

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/page.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/page.js
@@ -1,5 +1,4 @@
 const _ = require('lodash');
-const Promise = require('es6-promise').Promise;
 
 module.exports = {
   /**
@@ -9,7 +8,7 @@ module.exports = {
    * @param  {Boolean} clearDialogs if true it will close modals and notifications
    * @return {Object}
    */
-  init: async (puppet, clearDialogs) => {
+  async init (puppet, clearDialogs) {
     clearDialogs = typeof clearDialogs !== 'undefined' ? !!clearDialogs : true;
 
     this.puppet = puppet;
@@ -45,7 +44,7 @@ module.exports = {
    *   a collection of methods and properties that will extend the main page
    * @return {Object}
    */
-  extend: (page) => {
+  extend (page) {
     return _.assign(Object.create(this), page);
   },
 
@@ -53,30 +52,23 @@ module.exports = {
    * Waits for the modal dialog to load. By default it waits for the .modal class
    * in dialog otherwise user can specify a custom waitSelector. Once model is
    * visible it loads the respective modalModule (if any)
+   *
    * @param {String} modalModule
    * @param {String} waitSelector
-   * @return {Promise}
+   * @return {Object} the modal
    */
-  waitForModal: async (modalModule, waitSelector) => {
-    return new Promise(async resolve => {
-      await this.puppet.waitFor(waitSelector || '.modal');
-      await this.puppet.wait(300);
+  async waitForModal (modalModule, waitSelector) {
+    await this.puppet.waitFor(waitSelector || '.modal', { visible: true });
+    await this.puppet.waitFor(300);
 
-      if (modalModule) {
-        let modal = await require('./modals/' + modalModule).init(this.puppet, false);
-
-        resolve(modal);
-      } else {
-        resolve();
-      }
-    });
+    if (modalModule) {
+      return require('./modals/' + modalModule).init(this.puppet, false);
+    }
   }
 };
 
 /**
  * Closes any modal currently open
- *
- * @return {Object}
  */
 async function closeAnyModal () {
   const openModalSelector = '.modal.in';
@@ -85,16 +77,12 @@ async function closeAnyModal () {
 
   if (result) {
     await this.puppet.click(openModalSelector + ' .close[ng-click="cancel()"]');
-    await this.puppet.wait(300);
+    await this.puppet.waitFor(300);
   }
-
-  return this;
 }
 
 /**
  * Closes any notification currently open
- *
- * @return {Object}
  */
 async function closeNotifications () {
   const notificationSelector = 'a.ui-notify-cross.ui-notify-close';
@@ -103,8 +91,6 @@ async function closeNotifications () {
 
   if (result) {
     await this.puppet.click(notificationSelector);
-    await this.puppet.wait(500);
+    await this.puppet.waitFor(500);
   }
-
-  return this;
 }

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-hr-resources.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-hr-resources.js
@@ -1,4 +1,4 @@
-var modal = require('./page');
+const modal = require('./page');
 
 module.exports = modal.extend({
   /**
@@ -6,10 +6,8 @@ module.exports = modal.extend({
    *
    * @return {object}
    */
-  seeResources: function () {
-    this.chromy.click('.fieldset-title');
-    this.chromy.wait(2000); // wait for animation to complete
-
-    return this;
+  async seeResources () {
+    await this.puppet.click('.fieldset-title');
+    await this.puppet.waitFor(2000); // wait for animation to complete
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-manager-leave-balance-report.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-manager-leave-balance-report.js
@@ -1,10 +1,10 @@
-var page = require('./page');
+const page = require('./page');
 
 module.exports = page.extend({
   /**
    * Wait for the page to be ready
    */
-  waitForReady: function () {
-    this.chromy.waitUntilVisible('.chr_leave-balance-tab');
+  async waitForReady () {
+    await this.puppet.waitFor('.chr_leave-balance-tab', { visible: true });
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-manager-leave-balance-report.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-manager-leave-balance-report.js
@@ -7,7 +7,7 @@ module.exports = page.extend({
   async waitForReady () {
     await this.puppet.waitFor('.chr_leave-balance-tab', { visible: true });
     await this.puppet.waitFor(function () {
-      var spinners = document.querySelectorAll('.spinner');
+      const spinners = document.querySelectorAll('.spinner');
 
       return Array.prototype.every.call(spinners, function (dom) {
         return dom === null || (dom.offsetWidth <= 0 && dom.offsetHeight <= 0);

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-manager-leave-calendar.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-manager-leave-calendar.js
@@ -1,33 +1,25 @@
-var page = require('./page');
+const page = require('./page');
 
 module.exports = page.extend({
   /**
    * Wait for the page to be ready by looking at
    * the visibility of a leave calendar item element
    */
-  waitForReady: function () {
-    this.chromy.waitUntilVisible('leave-calendar-month .chr_leave-calendar__item');
+  async waitForReady () {
+    await this.puppet.waitFor('leave-calendar-month .chr_leave-calendar__item', { visible: true });
   },
 
   /**
    * Toggle the calendar legend
-   *
-   * @return {Promise}
    */
-  toggleLegend: function () {
-    this.chromy.click('.chr_leave-calendar__legend__title');
-
-    return this;
+  async toggleLegend () {
+    await this.puppet.click('.chr_leave-calendar__legend__title');
   },
 
   /**
    * Toggle contacts with leaves
-   *
-   * @return {Promise}
    */
-  toggleContactsWithLeaves: function () {
-    this.chromy.click('.chr_leave-calendar__toggle-contacts-with-leaves');
-
-    return this;
+  async toggleContactsWithLeaves () {
+    await this.puppet.click('.chr_leave-calendar__toggle-contacts-with-leaves');
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-manager-leave-requests.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-manager-leave-requests.js
@@ -1,56 +1,47 @@
 /* global Event */
 
-var page = require('./page');
+const page = require('./page');
 
 module.exports = page.extend({
   /**
    * Wait for the page to be ready as it waits for the actions of the first
    * row of leave requests to be visible
-   *
-   * @return {Object} this object
    */
-  waitForReady: function () {
-    this.chromy.waitUntilVisible('tbody tr:nth-child(1) a');
+  async waitForReady () {
+    await this.puppet.waitFor('tbody tr:nth-child(1) a', { visible: true });
   },
 
   /**
    * Change the filter by Assignee
    *
    * @param {String} type (me|unassigned|all)
-   * @return {Object} this object
    */
-  changeFilterByAssignee: function (type) {
-    var filters = ['me', 'unassigned', 'all'];
+  async changeFilterByAssignee (type) {
+    const filters = ['me', 'unassigned', 'all'];
 
-    this.chromy.click(
+    await this.puppet.click(
       '.chr_manage_leave_requests__assignee_filter button:nth-of-type(' +
       (filters.indexOf(type) + 1) +
       ')');
-    this.chromy.waitUntilVisible('tbody tr:nth-child(1) a');
-
-    return this;
+    await this.puppet.waitFor('tbody tr:nth-child(1) a', { visible: true });
   },
 
   /**
    * Opens the dropdown for manager actions like edit/respond, cancel.
    *
    * @param {Number} row number corresponding to leave request in the list
-   * @return {Object} this object
    */
-  openActionsForRow: function (row) {
-    this.chromy.click('.chr_manage_leave_requests__panel_body tr:nth-child(' + (row || 1) + ') .dropdown-toggle');
-
-    return this;
+  async openActionsForRow (row) {
+    await this.puppet.click('.chr_manage_leave_requests__panel_body tr:nth-child(' + (row || 1) + ') .dropdown-toggle');
   },
 
   /**
    * Expands filters on screen
    *
-   * @return {Object} this object
    */
-  expandFilter: function () {
-    this.chromy.click('.chr_manage_leave_requests__filter');
-    this.chromy.waitUntilVisible('.chr_manage_leave_requests__sub-header div:nth-child(1)');
+  async expandFilter () {
+    await this.puppet.click('.chr_manage_leave_requests__filter');
+    await this.puppet.waitFor('.chr_manage_leave_requests__sub-header div:nth-child(1)', { visible: true });
 
     return this;
   },
@@ -59,53 +50,37 @@ module.exports = page.extend({
    * Opens leave type filter
    *
    * @param {Number} leaveType index like 1 for Holiday/Vacation, 2 for TOIL, 3 for Sickness
-   * @return {Object} this object
    */
-  openLeaveTypeFor: function (leaveType) {
-    this.chromy.evaluate(function (leaveType) {
-      var element = document.querySelector('.chr_manage_leave_requests__header div:nth-child(1) > select');
+  async openLeaveTypeFor (leaveType) {
+    await this.puppet.evaluate(function (leaveType) {
+      const element = document.querySelector('.chr_manage_leave_requests__header div:nth-child(1) > select');
 
       element.selectedIndex = leaveType;// for TOIL option
       element.dispatchEvent(new Event('change'));
-    }, [leaveType]);
-    this.chromy.waitUntilVisible('tbody tr:nth-child(1) a');
-
-    return this;
+    }, leaveType);
+    await this.puppet.waitFor('tbody tr:nth-child(1) a', { visible: true });
   },
 
   /**
    * User clicks on the edit/respond action
    *
    * @param {Number} row number corresponding to leave request in the list
-   * @return {Promise}
    */
-  editRequest: function (row) {
-    this.chromy.click('body > ul.dropdown-menu:nth-of-type(' + (row || 1) + ') li:first-child a');
-    this.chromy.wait(function () {
-      // = waitWhileVisible
-      var dom = document.querySelector('.modal-content .spinner:nth-child(1)');
-      return dom === null || (dom.offsetWidth <= 0 && dom.offsetHeight <= 0);
-    });
-    this.chromy.wait(function () {
-      // = waitWhileVisible
-      var dom = document.querySelector('leave-request-popup-details-tab .spinner');
-      return dom === null || (dom.offsetWidth <= 0 && dom.offsetHeight <= 0);
-    });
-
-    return this;
+  async editRequest (row) {
+    await this.puppet.click('body > ul.dropdown-menu:nth-of-type(' + (row || 1) + ') li:first-child a');
+    await this.puppet.waitFor('.modal-content .spinner:nth-child(1)', { hidden: true });
+    await this.puppet.waitFor('leave-request-popup-details-tab .spinner', { hidden: true });
   },
 
   /**
    * Apply leave on behalf of staff
    * @param {String} row number corresponding to leave request in the list like leave, sickness or toil
-   * @return {Promise}
    */
-  applyLeaveForStaff: function (leaveType) {
-    var leaveSerialNo = leaveType === 'leave' ? 1 : leaveType === 'sickness' ? 2 : 3;
+  async applyLeaveForStaff (leaveType) {
+    const leaveSerialNo = leaveType === 'leave' ? 1 : leaveType === 'sickness' ? 2 : 3;
 
-    this.chromy.click('.button-container leave-request-record-actions .dropdown-toggle');
-    this.chromy.click('.button-container li:nth-child(' + leaveSerialNo + ') a');
-
-    this.waitForModal('ssp-leave-request', '.chr_leave-request-modal__form');
+    await this.puppet.click('.button-container leave-request-record-actions .dropdown-toggle');
+    await this.puppet.click('.button-container li:nth-child(' + leaveSerialNo + ') a');
+    await this.waitForModal('ssp-leave-request', '.chr_leave-request-modal__form');
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-calendar.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-calendar.js
@@ -1,18 +1,13 @@
 /* globals jQuery, MouseEvent */
 
-var page = require('./page');
+const page = require('./page');
 
 module.exports = page.extend({
   /**
-   * Clears the currently selected month from the calendar "Selected Months"
-   * field.
-   *
-   * @returns {Object} - returns a reference to the page object.
+   * Clears the currently selected month from the calendar "Selected Months" field
    */
-  clearCurrentlySelectedMonth: function () {
-    this.chromy.click('.chr_leave-calendar__day-selector .close.ui-select-match-close');
-
-    return this;
+  async clearCurrentlySelectedMonth () {
+    await this.puppet.click('.chr_leave-calendar__day-selector .close.ui-select-match-close');
   },
 
   /**
@@ -21,34 +16,24 @@ module.exports = page.extend({
    *
    * @param {String} monthName - the month of the name as it appear in the
    * "Selected Months" options.
-   * @returns {Object} - returns a reference to the page object.
    */
-  showMonth: function (monthName) {
-    this.chromy.click('.chr_leave-calendar__day-selector input');
-    this.chromy.evaluate(function (monthName) {
+  async showMonth (monthName) {
+    await this.puppet.click('.chr_leave-calendar__day-selector input');
+    await this.puppet.evaluate(monthName => {
       jQuery('.ui-select-choices-row:contains(' + monthName + ')').click();
-    }, [monthName]);
-    this.chromy.waitUntilVisible('leave-calendar-month leave-calendar-day');
-
-    return this;
+    }, monthName);
+    await this.puppet.waitFor('leave-calendar-month leave-calendar-day', { visible: true });
   },
 
   /**
-   * Hovers on top of a leave day visible on the calendar until a tooltip
-   * pops up.
-   *
-   * @returns {Object} - returns a reference to the page object.
+   * Hovers on top of a leave day visible on the calendar until a tooltip pops up
    */
-  showTooltip: function () {
-    var chromy = this.chromy;
-
-    chromy.evaluate(function () {
-      var event = new MouseEvent('mouseover');
+  async showTooltip () {
+    await this.puppet.evaluate(() => {
+      const event = new MouseEvent('mouseover');
       document.querySelector('.chr_leave-calendar__item a').dispatchEvent(event);
     });
-    chromy.waitUntilVisible('.tooltip');
-
-    return this;
+    await this.puppet.waitFor('.tooltip', { visible: true });
   },
 
   /**
@@ -57,23 +42,21 @@ module.exports = page.extend({
    * @param {Number} year - the year to select from the absence period options.
    * @returns {Object} - returns a reference to the page object.
    */
-  showYear: function (year) {
-    this.chromy.evaluate(function (year) {
-      var select = jQuery('.chr_manager_calendar__sub-header select');
-      var yearValue = select.find('option:contains(' + year + ')').attr('value');
+  async showYear (year) {
+    await this.puppet.evaluate(year => {
+      const select = jQuery('.chr_manager_calendar__sub-header select');
+      const yearValue = select.find('option:contains(' + year + ')').attr('value');
 
       select.val(yearValue).change();
-    }, [year]);
-    this.chromy.waitUntilVisible('leave-calendar-month leave-calendar-day');
-
-    return this;
+    }, year);
+    await this.puppet.waitFor('leave-calendar-month leave-calendar-day', { visible: true });
   },
 
   /**
    * Wait for the page to be ready by looking at
    * the visibility of a leave calendar item element
    */
-  waitForReady: function () {
-    this.chromy.waitUntilVisible('leave-calendar-month .chr_leave-calendar__item');
+  async waitForReady () {
+    await this.puppet.waitFor('leave-calendar-month .chr_leave-calendar__item', { visible: true });
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-report.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-report.js
@@ -1,171 +1,126 @@
 /* globals Event */
 
-var _ = require('lodash');
-var Promise = require('es6-promise').Promise;
-var page = require('./page');
+const _ = require('lodash');
+const page = require('./page');
 
 module.exports = page.extend({
   /**
    * Selects the days mode for the opened leave request
    *
-   * @param  {String} mode single|multiple
-   * @return {Promise}
+   * @param {String} mode single|multiple
    */
-  changeRequestDaysMode: function (mode) {
-    var optionIndex = ['multiple', 'single'].indexOf(mode) + 1;
+  async changeRequestDaysMode (mode) {
+    const optionIndex = ['multiple', 'single'].indexOf(mode) + 1;
 
-    this.chromy.click('[ng-model="detailsTab.uiOptions.multipleDays"]:nth-child(' + optionIndex + ')');
-
-    return this;
+    await this.puppet.click('[ng-model="detailsTab.uiOptions.multipleDays"]:nth-child(' + optionIndex + ')');
   },
 
   /**
    * User clicks on the edit/respond action
    *
    * @param {Number} row number corresponding to leave request in the list
-   * @return {Promise}
+   * @return {Object} the request modal
    */
-  editRequest: function (row) {
-    var chromy = this.chromy;
+  async editRequest (row) {
+    await this.puppet.click('body > ul.dropdown-menu:nth-of-type(' + (row || 1) + ') li:first-child a');
+    await this.puppet.waitFor('.modal-content .spinner:nth-child(1)', { hidden: true });
+    await this.puppet.waitFor('leave-request-popup-details-tab .spinner', { hidden: true });
 
-    return new Promise(function (resolve) {
-      chromy.click('body > ul.dropdown-menu:nth-of-type(' + (row || 1) + ') li:first-child a');
-      chromy.wait(function () {
-        // = waitWhileVisible
-        var dom = document.querySelector('.modal-content .spinner:nth-child(1)');
-        return dom === null || (dom.offsetWidth <= 0 && dom.offsetHeight <= 0);
-      });
-      chromy.wait(function () {
-        // = waitWhileVisible
-        var dom = document.querySelector('leave-request-popup-details-tab .spinner');
-        return dom === null || (dom.offsetWidth <= 0 && dom.offsetHeight <= 0);
-      });
-
-      resolve(this.waitForModal('ssp-leave-request', '.chr_leave-request-modal__form'));
-    }.bind(this));
+    return this.waitForModal('ssp-leave-request', '.chr_leave-request-modal__form');
   },
 
   /**
    * Expands deduction field to show selectors
    *
-   * @param  {String} type from|to
-   * @return {Promise}
+   * @param {String} type from|to
    */
-  expandDeductionField: function (type) {
-    var fieldSelector = '[ng-switch="detailsTab.uiOptions.times.' + type + '.amountExpanded"] a';
+  async expandDeductionField (type) {
+    const fieldSelector = '[ng-switch="detailsTab.uiOptions.times.' + type + '.amountExpanded"] a';
 
-    this.chromy.wait(fieldSelector);
-    this.chromy.click(fieldSelector);
-
-    return this;
+    await this.puppet.waitFor(fieldSelector);
+    await this.puppet.click(fieldSelector);
   },
 
   /**
    * Opens the Leave Request Modal for a new request of the given type
    *
-   * @param  {String} requestType leave|sickness|toil
-   * @return {Promise}
+   * @param {String} requestType leave|sickness|toil
    */
-  newRequest: function (requestType) {
-    var requestTypes = ['leave', 'sickness', 'toil']; // must be in the same quantity and order as in UI
-    var requestTypeButtonIndex = requestTypes.indexOf(requestType) + 1;
-    var actionDropdownSelector = 'leave-request-record-actions';
-    var actionButtonSelector = actionDropdownSelector + ' .dropdown-menu li:nth-child(' + requestTypeButtonIndex + ') a';
+  async newRequest (requestType) {
+    const requestTypes = ['leave', 'sickness', 'toil']; // must be in the same quantity and order as in UI
+    const requestTypeButtonIndex = requestTypes.indexOf(requestType) + 1;
+    const actionDropdownSelector = 'leave-request-record-actions';
+    const actionButtonSelector = actionDropdownSelector + ' .dropdown-menu li:nth-child(' + requestTypeButtonIndex + ') a';
 
-    this.chromy.click(actionDropdownSelector + ' [uib-dropdown] > button');
-    this.chromy.wait(actionButtonSelector);
-    this.chromy.click(actionButtonSelector);
-    this.chromy.waitUntilVisible('.chr_leave-request-modal__tab .form-group');
-
-    return this;
+    await this.puppet.click(actionDropdownSelector + ' [uib-dropdown] > button');
+    await this.puppet.waitFor(actionButtonSelector);
+    await this.puppet.click(actionButtonSelector);
+    await this.puppet.waitFor('.chr_leave-request-modal__tab .form-group', { visible: true });
   },
 
   /**
    * Opens the dropdown for staff actions like edit/respond, cancel.
    *
    * @param {Number} row number corresponding to leave request in the list
-   * @return {Object} this object
    */
-  openActionsForRow: function (row) {
-    this.chromy.wait('tr:nth-child(1)  div[uib-dropdown] a:nth-child(1)');
-    this.chromy.click('div:nth-child(2) > div > table > tbody > tr:nth-child(' + (row || 1) + ')  div[uib-dropdown] a:nth-child(1)');
-
-    return this;
+  async openActionsForRow (row) {
+    await this.puppet.waitFor('tr:nth-child(1)  div[uib-dropdown] a:nth-child(1)');
+    await this.puppet.click('div:nth-child(2) > div > table > tbody > tr:nth-child(' + (row || 1) + ')  div[uib-dropdown] a:nth-child(1)');
   },
 
   /**
    * Opens the given section of my report pageName
    *
    * @param {String} section
-   * @return {Object} this object
    */
-  openSection: function (section) {
-    this.chromy.click('td[ng-click="report.toggleSection(\'' + section + '\')"]');
-    this.chromy.wait(function () {
-      // = waitWhileVisible
-      var dom = document.querySelector('.spinner');
-      return dom === null || (dom.offsetWidth <= 0 && dom.offsetHeight <= 0);
-    });
-
-    return this;
+  async openSection (section) {
+    await this.puppet.click('td[ng-click="report.toggleSection(\'' + section + '\')"]');
+    await this.puppet.waitFor('.spinner', { hidden: true });
   },
 
   /**
    * Selects the request Absence Type by the given label
    *
-   * @param  {String} absenceTypeLabel ex. "Holiday in Hours"
-   * @return {Promise}
+   * @param {String} absenceTypeLabel ex. "Holiday in Hours"
    */
-  selectRequestAbsenceType: function (absenceTypeLabel) {
-    this.chromy.evaluate(function (absenceTypeLabel) {
-      var absenceTypeSelect = document.querySelector('[name=absenceTypeSelect]');
+  async selectRequestAbsenceType (absenceTypeLabel) {
+    await this.puppet.evaluate(function (absenceTypeLabel) {
+      const absenceTypeSelect = document.querySelector('[name=absenceTypeSelect]');
 
       absenceTypeSelect.selectedIndex = _.findIndex(absenceTypeSelect.querySelectorAll('option'), function (option) {
         return option.text.search(absenceTypeLabel) !== -1;
       }); // Select the needed option
       absenceTypeSelect.dispatchEvent(new Event('change')); // Trigger onChange event
-    }, [absenceTypeLabel]);
-
-    return this;
+    }, absenceTypeLabel);
   },
 
   /**
    * Selects a date in the datepicker
    *
-   * @param  {String} type from|to
+   * @param {String} type from|to
    * @param  {Number} weekPosition eg. 2 for second week in the calendar
    * @param  {Number} weekDayPosition eg. 1 for Monday or 4 for Thursday
-   * @return {Promise}
    */
-  selectRequestDate: function (type, weekPosition, weekDayPosition) {
-    var daySelector = '.uib-daypicker tr:nth-child(' +
-      weekPosition + ') td:nth-child( ' + weekDayPosition + ') button';
+  async selectRequestDate (type, weekPosition, weekDayPosition) {
+    const daySelector = '.uib-daypicker tr:nth-child(' + weekPosition + ') td:nth-child( ' + weekDayPosition + ') button';
 
-    this.chromy.click('[ng-model="detailsTab.uiOptions.' + type + 'Date"]');
-    this.chromy.wait(daySelector);
-    this.chromy.click(daySelector);
-    this.chromy.waitUntilVisible('[ng-switch="detailsTab.uiOptions.times.' + type + '.amountExpanded"]');
-
-    return this;
+    await this.puppet.click('[ng-model="detailsTab.uiOptions.' + type + 'Date"]');
+    await this.puppet.waitFor(daySelector);
+    await this.puppet.click(daySelector);
+    await this.puppet.waitFor('[ng-switch="detailsTab.uiOptions.times.' + type + '.amountExpanded"]', { visible: true });
   },
 
   /**
    * Wait for the page to be ready
-   *
-   * @return {Object} this object
    */
-  waitForReady: function () {
-    this.chromy.waitUntilVisible('td[ng-click="report.toggleSection(\'pending\')"]');
+  async waitForReady () {
+    await this.puppet.waitFor('td[ng-click="report.toggleSection(\'pending\')"]', { visible: true });
   },
 
   /**
    * Waits for the request balance to be calculated
-   *
-   * @return {Promise}
    */
-  waitUntilRequestBalanceIsCalculated: function () {
-    this.chromy.waitUntilVisible('[ng-show="detailsTab.uiOptions.showBalance"]');
-
-    return this;
+  async waitUntilRequestBalanceIsCalculated () {
+    await this.puppet.waitFor('[ng-show="detailsTab.uiOptions.showBalance"]', { visible: true });
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-report.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-report.js
@@ -75,7 +75,13 @@ module.exports = page.extend({
    */
   async openSection (section) {
     await this.puppet.click('td[ng-click="report.toggleSection(\'' + section + '\')"]');
-    await this.puppet.waitFor('.spinner', { hidden: true });
+    await this.puppet.waitFor(function () {
+      var spinners = document.querySelectorAll('.spinner');
+
+      return Array.prototype.every.call(spinners, function (dom) {
+        return dom === null || (dom.offsetWidth <= 0 && dom.offsetHeight <= 0);
+      });
+    });
   },
 
   /**
@@ -114,6 +120,7 @@ module.exports = page.extend({
    * Wait for the page to be ready
    */
   async waitForReady () {
+    await this.puppet.waitFor('.spinner', { visible: false });
     await this.puppet.waitFor('td[ng-click="report.toggleSection(\'pending\')"]', { visible: true });
   },
 

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-report.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-leave-absences-my-leave-report.js
@@ -76,7 +76,7 @@ module.exports = page.extend({
   async openSection (section) {
     await this.puppet.click('td[ng-click="report.toggleSection(\'' + section + '\')"]');
     await this.puppet.waitFor(function () {
-      var spinners = document.querySelectorAll('.spinner');
+      const spinners = document.querySelectorAll('.spinner');
 
       return Array.prototype.every.call(spinners, function (dom) {
         return dom === null || (dom.offsetWidth <= 0 && dom.offsetHeight <= 0);

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-my-details.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-my-details.js
@@ -1,15 +1,12 @@
-var modal = require('./page');
+const modal = require('./page');
 
 module.exports = modal.extend({
   /**
    * Opens Edit My Details Popup
    *
-   * @return {Object}
    */
-  showEditMyDetailsPopup: function () {
-    this.chromy.click('[href="/my_details/nojs/view"]');
-    this.chromy.waitUntilVisible('.modal-civihr-custom__section');
-
-    return this;
+  async showEditMyDetailsPopup () {
+    await this.puppet.click('[href="/my_details/nojs/view"]');
+    await this.puppet.waitFor('.modal-civihr-custom__section', { visible: true });
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-reports.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-reports.js
@@ -1,4 +1,4 @@
-var modal = require('./page');
+const modal = require('./page');
 
 module.exports = modal.extend({
   /**
@@ -14,7 +14,7 @@ module.exports = modal.extend({
    */
   async waitForReady () {
     await this.puppet.evaluate(function () {
-      var tempStyle = document.createElement('style');
+      const tempStyle = document.createElement('style');
 
       tempStyle.type = 'text/css';
       tempStyle.innerHTML = '#reportsIframe { height: 1000px !important; }';

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-tasks.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-tasks.js
@@ -1,24 +1,20 @@
-var modal = require('./page');
+const modal = require('./page');
 
 module.exports = modal.extend({
   /**
    * Opens Completed tasks modal
    */
-  openCompletedTasksModal: function () {
-    this.chromy.click('.pane-views-tasks-block a.show-complete-tasks');
-    this.chromy.wait(function () {
-      // = waitWhileVisible
-      var dom = document.querySelector('.loading-spinner');
-      return dom === null || (dom.offsetWidth <= 0 && dom.offsetHeight <= 0);
-    });
-    this.chromy.waitUntilVisible('.view-Tasks');
+  async openCompletedTasksModal () {
+    await this.puppet.click('.pane-views-tasks-block a.show-complete-tasks');
+    await this.puppet.waitFor('.loading-spinner', { hidden: true });
+    await this.puppet.waitFor('.view-Tasks', { visible: true });
   },
 
   /**
    * Opens Create New Task modal
    */
-  openCreateNewTaskModal: function () {
-    this.chromy.click('.create-new-task');
-    this.chromy.waitUntilVisible('#civihr-employee-portal-civi-tasks-form');
+  async openCreateNewTaskModal () {
+    await this.puppet.click('.create-new-task');
+    await this.puppet.waitFor('#civihr-employee-portal-civi-tasks-form', { visible: true });
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-vacancies.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/ssp-vacancies.js
@@ -1,15 +1,11 @@
-var modal = require('./page');
+const modal = require('./page');
 
 module.exports = modal.extend({
   /**
    * Opens More Details section
-   *
-   * @return {object}
    */
-  showMoreDetails: function () {
-    this.chromy.click('.fieldset-title');
-    this.chromy.wait(2000);
-
-    return this;
+  async showMoreDetails () {
+    await this.puppet.click('.fieldset-title');
+    await this.puppet.waitFor(2000);
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/absence.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/absence.js
@@ -1,5 +1,4 @@
-var Promise = require('es6-promise').Promise;
-var tab = require('./tab');
+const tab = require('./tab');
 
 module.exports = tab.extend({
   readySelector: '.absence-tab-page',
@@ -8,15 +7,12 @@ module.exports = tab.extend({
   /**
    * Opens one of the absence sub tabs
    *
-   * @param  {string} tabId
-   * @return {object} resolves with the tab page object
+   * @param {String} tabId
    */
-  openSubTab: function (tabId) {
-    return new Promise(function (resolve) {
-      var tab = require('./absence/' + tabId);
+  async openSubTab (tabId) {
+    const tab = require('./absence/' + tabId);
 
-      this.chromy.click('[heading="' + tab.tabTitle + '"] > a');
-      resolve(tab.init(this.chromy, false));
-    }.bind(this));
+    await this.puppet.click('[heading="' + tab.tabTitle + '"] > a');
+    return tab.init(this.puppet, false);
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/absence/calendar.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/absence/calendar.js
@@ -1,5 +1,5 @@
-var tab = require('../tab');
-var sspMyLeaveCalendar = require('../../ssp-leave-absences-my-leave-calendar');
+const tab = require('../tab');
+const sspMyLeaveCalendar = require('../../ssp-leave-absences-my-leave-calendar');
 
 module.exports = sspMyLeaveCalendar.extend(tab).extend({
   readySelector: '.chr_leave-calendar__month-body',

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/absence/entitlements.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/absence/entitlements.js
@@ -1,4 +1,4 @@
-var tab = require('../tab');
+const tab = require('../tab');
 
 module.exports = tab.extend({
   tabTitle: 'Entitlements',
@@ -10,19 +10,11 @@ module.exports = tab.extend({
    * tab is ready, so as a quick workaround we simply override the method
    * and perform all the needed checks in it
    */
-  waitForReady: function () {
-    this.chromy.wait('contract-entitlements');
-    this.chromy.wait('annual-entitlements');
+  async waitForReady () {
+    await this.puppet.waitFor('contract-entitlements');
+    await this.puppet.waitFor('annual-entitlements');
     // Waits for spinners to hide which indicates the load of the data
-    this.chromy.wait(function () {
-      // = waitWhileVisible
-      var dom = document.querySelector('contract-entitlements .spinner');
-      return dom === null || (dom.offsetWidth <= 0 && dom.offsetHeight <= 0);
-    });
-    this.chromy.wait(function () {
-      // = waitWhileVisible
-      var dom = document.querySelector('annual-entitlements .spinner');
-      return dom === null || (dom.offsetWidth <= 0 && dom.offsetHeight <= 0);
-    });
+    await this.puppet.waitFor('contract-entitlements .spinner', { hidden: true });
+    await this.puppet.waitFor('annual-entitlements .spinner', { hidden: true });
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/absence/report.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/absence/report.js
@@ -1,4 +1,4 @@
-var tab = require('../tab');
+const tab = require('../tab');
 
 module.exports = tab.extend({
   readySelector: '.chr_leave-report__table',
@@ -8,34 +8,28 @@ module.exports = tab.extend({
    * Open the report section with the given name
    *
    * @param  {String} sectionName
-   * @return {Object}
    */
-  openSection: function (sectionName) {
-    this.chromy.click('[ng-click="report.toggleSection(\'' + sectionName + '\')"]');
+  async openSection (sectionName) {
+    await this.puppet.click('[ng-click="report.toggleSection(\'' + sectionName + '\')"]');
 
     // @NOTE when using chromy.waitUntilVisible(selector), it only considers
     // the *first* occurrence of the selector, not *any* occurrence
     // so the "wait for any of occurence of this selector" behaviour had to
     // be achieved manually
-    this.chromy.wait(function () {
-      var nestedTables = document.querySelectorAll('.table-nested');
+    await this.puppet.waitFor(function () {
+      const nestedTables = document.querySelectorAll('.table-nested');
 
       return Array.prototype.some.call(nestedTables, function (table) {
         return table.offsetWidth > 0 && table.offsetHeight > 0;
       });
     });
-
-    return this;
   },
 
   /**
    * Show the actions of the first leave request available
    *
-   * @return {Object}
    */
-  showActions: function () {
-    this.chromy.click('.table-nested .dropdown-toggle');
-
-    return this;
+  async showActions () {
+    await this.puppet.click('.table-nested .dropdown-toggle');
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/absence/work-patterns.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/absence/work-patterns.js
@@ -1,4 +1,4 @@
-var tab = require('../tab');
+const tab = require('../tab');
 
 module.exports = tab.extend({
   readySelector: 'absence-tab-work-patterns table',
@@ -7,8 +7,8 @@ module.exports = tab.extend({
   /**
    * Shows the Custom Work Pattern modal
    */
-  showModal: function () {
-    this.chromy.click('[ng-click="workpatterns.openModal()"]');
-    this.chromy.waitUntilVisible('absence-tab-custom-work-pattern-modal .modal-body > .row');
+  async showModal () {
+    await this.puppet.click('[ng-click="workpatterns.openModal()"]');
+    await this.puppet.waitFor('absence-tab-custom-work-pattern-modal .modal-body > .row', { visible: true });
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/documents.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/documents.js
@@ -1,4 +1,4 @@
-var tab = require('./tab');
+const tab = require('./tab');
 
 module.exports = tab.extend({
   tabTitle: 'Documents',
@@ -9,12 +9,8 @@ module.exports = tab.extend({
    * tab is ready, so as a quick workaround we simply override the method
    * and perform all the needed checks in it
    */
-  waitForReady: function () {
-    this.chromy.waitUntilVisible('form[name="formDocuments"]');
-    this.chromy.wait(function () {
-      // = waitWhileVisible
-      var dom = document.querySelector('.ct-spinner-cover');
-      return dom === null || (dom.offsetWidth <= 0 && dom.offsetHeight <= 0);
-    });
+  async waitForReady () {
+    await this.puppet.waitFor('form[name="formDocuments"]', { visible: true });
+    await this.puppet.waitFor('.ct-spinner-cover', { hidden: true });
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/job-contract.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/job-contract.js
@@ -1,44 +1,38 @@
-var Promise = require('es6-promise').Promise;
-var tab = require('./tab');
+const tab = require('./tab');
 
 module.exports = tab.extend({
   tabTitle: 'Job Contract',
 
   /**
    * Clicks on the delete button
-   *
-   * @return {object}
    */
-  attemptDelete: function () {
-    this.chromy.click('.hrjc-list-contract-item:nth-child(1) .btn-danger');
-    this.waitForModal();
+  async attemptDelete () {
+    await this.puppet.click('.hrjc-list-contract-item:nth-child(1) .btn-danger');
+    await this.waitForModal();
   },
 
   /**
    * Opens the modal of an already existing contract
    *
-   * @param  {string} mode "correct" or "revision"
-   * @return {Promise} resolves with the job contract modal object
+   * @param {String} mode "correct" or "revision"
+   * @return {Object} the job contract modal object
    */
-  openContractModal: function (mode) {
-    var param = mode === 'correct' ? 'edit' : (mode === 'revision' ? 'change' : '');
+  async openContractModal (mode) {
+    const param = mode === 'correct' ? 'edit' : (mode === 'revision' ? 'change' : '');
 
-    return new Promise(function (resolve) {
-      this.chromy.click('[ng-click="modalContract(\'' + param + '\')"]');
-      resolve(this.waitForModal('job-contract'));
-    }.bind(this));
+    await this.puppet.click('[ng-click="modalContract(\'' + param + '\')"]');
+    return this.waitForModal('job-contract');
   },
 
   /**
    * Opens the modal for creating a new contract
    *
-   * @return {Promise} resolves with the job contract modal object
+   * @return {Object} the job contract modal object
    */
-  openNewContractModal: function () {
-    return new Promise(function (resolve) {
-      this.chromy.click('.hrjc-btn-add-contract > .btn-primary');
-      resolve(this.waitForModal('job-contract'));
-    }.bind(this));
+  async openNewContractModal () {
+    await this.puppet.click('.hrjc-btn-add-contract > .btn-primary');
+
+    return this.waitForModal('job-contract');
   },
 
   /**
@@ -48,15 +42,10 @@ module.exports = tab.extend({
    * tab is ready, so as a quick workaround we simply override the method
    * and perform all the needed checks in it
    */
-  waitForReady: function () {
-    this.chromy.waitUntilVisible('.hrjc-summary');
-    this.chromy.wait(function () {
-      // = waitWhileVisible
-      var dom = document.querySelector('.hrjc-list-contract .spinner');
-      return dom === null || (dom.offsetWidth <= 0 && dom.offsetHeight <= 0);
-    });
-
-    this.chromy.wait(500);
+  async waitForReady () {
+    await this.puppet.waitFor('.hrjc-summary', { visible: true });
+    await this.puppet.waitFor('.hrjc-list-contract .spinner', { hidden: true });
+    await this.puppet.waitFor(500);
   },
 
   /**
@@ -64,8 +53,8 @@ module.exports = tab.extend({
    *
    * @return {object}
    */
-  showFullHistory: function () {
-    this.chromy.click('[heading="Full History"] > a');
-    this.chromy.wait('.hrjc-context-menu-toggle');
+  async showFullHistory () {
+    await this.puppet.click('[heading="Full History"] > a');
+    await this.puppet.waitFor('.hrjc-context-menu-toggle');
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/job-contract.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/job-contract.js
@@ -21,6 +21,7 @@ module.exports = tab.extend({
     const param = mode === 'correct' ? 'edit' : (mode === 'revision' ? 'change' : '');
 
     await this.puppet.click('[ng-click="modalContract(\'' + param + '\')"]');
+
     return this.waitForModal('job-contract');
   },
 

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/job-roles.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/job-roles.js
@@ -1,4 +1,4 @@
-var tab = require('./tab');
+const tab = require('./tab');
 
 module.exports = tab.extend({
   readySelector: '.job-role__tabs',
@@ -7,54 +7,44 @@ module.exports = tab.extend({
   /**
    * Clicks on the delete button
    */
-  attemptDelete: function () {
-    this.chromy.click('.job-role [ng-click*="removeRole"]');
-    this.waitForModal();
+  async attemptDelete () {
+    await this.puppet.click('.job-role [ng-click*="removeRole"]');
+    await this.waitForModal();
   },
 
   /**
    * Clicks on the edit button of a job role
-   *
-   * @return {Object}
    */
-  edit: function () {
-    this.chromy.click('.tab-pane.active .job-role__actions .btn-link[ng-click$="show()"]');
-    this.chromy.wait(100);
-
-    return this;
+  async edit () {
+    await this.puppet.click('.tab-pane.active .job-role__actions .btn-link[ng-click$="show()"]');
+    await this.puppet.waitFor(100);
   },
 
   /**
    * Opens the ui-select with the given name
    *
-   * @param  {String} name
-   * @return {Object}
+   * @param {String} name
    */
-  openDropdown: function (name) {
-    var common = 'jobroles.editData[job_roles_data.id]';
+  async openDropdown (name) {
+    const common = 'jobroles.editData[job_roles_data.id]';
 
-    this.chromy.click('[ng-model="' + common + '[\'' + name + '\']"] > a');
-    this.chromy.wait(100);
-
-    return this;
+    await this.puppet.click('[ng-model="' + common + '[\'' + name + '\']"] > a');
+    await this.puppet.waitFor(100);
   },
 
   /**
    * Show the form for adding a new job role
    */
-  showAddNew: function () {
-    this.chromy.click('.btn-primary[ng-click*="jobroles.addNewRole()"]');
+  async showAddNew () {
+    await this.puppet.click('.btn-primary[ng-click*="jobroles.addNewRole()"]');
   },
 
   /**
    * Changes active tab
    *
-   * @param  {String} tabName
-   * @return {Object}
+   * @param {String} tabName
    */
-  switchToTab: function (tabName) {
-    this.chromy.click('[heading="' + tabName + '"] > a');
-
-    return this;
+  async switchToTab (tabName) {
+    await this.puppet.click('[heading="' + tabName + '"] > a');
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/leave-balances.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/leave-balances.js
@@ -1,4 +1,4 @@
-var tab = require('./tab');
+const tab = require('./tab');
 
 module.exports = tab.extend({
   readySelector: '.chr_leave-balance-tab',

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/leave-calendar.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/leave-calendar.js
@@ -1,4 +1,4 @@
-var tab = require('./tab');
+const tab = require('./tab');
 
 module.exports = tab.extend({
   readySelector: 'leave-calendar-day',

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/leave-requests.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/leave-requests.js
@@ -1,4 +1,4 @@
-var tab = require('./tab');
+const tab = require('./tab');
 
 module.exports = tab.extend({
   readySelector: '.chr_manage_leave_requests__panel_body',
@@ -7,8 +7,8 @@ module.exports = tab.extend({
   /**
    * Shows filters
    */
-  showFilters: function () {
-    this.chromy.click('.chr_manage_leave_requests__filter');
-    this.chromy.waitUntilVisible('.chr_manage_leave_requests__sub-header');
+  async showFilters () {
+    await this.puppet.click('.chr_manage_leave_requests__filter');
+    await this.puppet.waitFor('.chr_manage_leave_requests__sub-header', { visible: true });
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/tab.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/tab.js
@@ -1,11 +1,10 @@
-var page = require('../page');
+const page = require('../page');
 
 module.exports = page.extend({
   /**
    * Defines that the tab is ready when the a specific selector is visible
-   * @return {boolean}
    */
-  waitForReady: function () {
-    this.chromy.waitUntilVisible(this.readySelector);
+  async waitForReady () {
+    await this.puppet.waitFor(this.readySelector, { visible: true });
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/tasks.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tabs/tasks.js
@@ -1,4 +1,4 @@
-var tab = require('./tab');
+const tab = require('./tab');
 
 module.exports = tab.extend({
   readySelector: '.ct-page-contact',

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tasks.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/tasks.js
@@ -1,8 +1,7 @@
-var Promise = require('es6-promise').Promise;
-var page = require('./page');
+const page = require('./page');
 
-var taskSelector = '.ct-list-task > li:nth-child(1)';
-var editableSelectors = {
+const taskSelector = '.ct-list-task > li:nth-child(1)';
+const editableSelectors = {
   assigned: '[editable-ui-select="task.assignee_contact_id[0]"]',
   date: '[editable-bsdate="task.activity_date_time"]',
   subject: '[editable-text="task.subject"]',
@@ -13,107 +12,84 @@ module.exports = page.extend({
   /**
    * Shows the assignment modal
    *
-   * @return {Promise} resolves with the assignment modal page object
+   * @return {Object} the assignment modal page object
    */
-  addAssignment: function () {
-    return new Promise(function (resolve) {
-      this.chromy.click('a[ng-click*="modalAssignment"]');
-      resolve(this.waitForModal('assignment'));
-    }.bind(this));
+  async addAssignment () {
+    await this.puppet.click('a[ng-click*="modalAssignment"]');
+
+    return this.waitForModal('assignment');
   },
 
   /**
    * Shows the task modal
    *
-   * @return {Promise} resolves with the task modal page object
+   * @return {Object} the task modal page object
    */
-  addTask: function () {
-    return new Promise(function (resolve) {
-      this.chromy.click('a[ng-click*="itemAdd"]');
-      resolve(this.waitForModal('task'));
-    }.bind(this));
+  async addTask () {
+    await this.puppet.click('a[ng-click*="itemAdd"]');
+
+    return this.waitForModal('task');
   },
 
   /**
    * Opens the advanced filters
-   *
-   * @return {object}
    */
-  advancedFilters: function () {
-    this.chromy.click('a[ng-click*="isCollapsed.filterAdvanced"]');
-    this.chromy.wait(500);
-
-    return this;
+  async advancedFilters () {
+    await this.puppet.click('a[ng-click*="isCollapsed.filterAdvanced"]');
+    await this.puppet.waitFor(500);
   },
 
   /**
    * Shows the given edit-in-place field
    *
    * @param {string} fieldName
-   * @return {object}
    */
-  inPlaceEdit: function (fieldName) {
-    this.chromy.click(editableSelectors[fieldName]);
-    this.chromy.wait(200);
-
-    return this;
+  async inPlaceEdit (fieldName) {
+    await this.puppet.click(editableSelectors[fieldName]);
+    await this.puppet.waitFor(200);
   },
 
   /**
    * Opens the first task of the list
    *
-   * @return {Promise} resolves with the task modal page object
+   * @return {Object} the task modal page object
    */
-  openTask: function () {
-    return new Promise(function (resolve) {
-      this.chromy.click(taskSelector + ' .task-title > a[ng-click*="modalTask"]');
-      this.chromy.wait(function () {
-        // = waitWhileVisible
-        var dom = document.querySelector('.spinner');
-        return dom === null || (dom.offsetWidth <= 0 && dom.offsetHeight <= 0);
-      });
+  async openTask () {
+    await this.puppet.click(taskSelector + ' .task-title > a[ng-click*="modalTask"]');
+    await this.puppet.waitFor('.spinner', { hidden: true });
 
-      resolve(this.waitForModal('task'));
-    }.bind(this));
+    return this.waitForModal('task');
   },
 
   /**
    * Shows the "select dates" filter
    */
-  selectDates: function () {
-    this.chromy.click('.ct-select-dates');
-    this.chromy.wait(500);
+  async selectDates () {
+    await this.puppet.click('.ct-select-dates');
+    await this.puppet.waitFor(500);
   },
 
   /**
    * Expands the "show more" area of the first task of the list
-   *
-   * @return {object}
    */
-  showMore: function () {
-    this.chromy.click(taskSelector + ' a[ng-click*="isCollapsed"]');
-    this.chromy.waitUntilVisible(taskSelector + ' article');
-    this.chromy.wait(500);
-
-    return this;
+  async showMore () {
+    await this.puppet.click(taskSelector + ' a[ng-click*="isCollapsed"]');
+    await this.puppet.waitFor(taskSelector + ' article', { visible: true });
+    await this.puppet.waitFor(500);
   },
 
   /**
    * Shows the dropdown of the actions available on any given task
-   *
-   * @return {object}
    */
-  taskActions: function () {
-    this.chromy.click(taskSelector + ' .ct-context-menu-toggle');
-
-    return this;
+  async taskActions () {
+    await this.puppet.click(taskSelector + ' .ct-context-menu-toggle');
   },
 
   /**
    * Waits until the specified select is visible on the page
    */
-  waitForReady: function () {
-    this.chromy.waitUntilVisible('.ct-container-inner');
-    this.chromy.wait(300);
+  async waitForReady () {
+    await this.puppet.waitFor('.ct-container-inner', { visible: true });
+    await this.puppet.waitFor(300);
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/work-patterns-form.js
+++ b/uk.co.compucorp.civicrm.hrcore/backstop_data/page-objects/work-patterns-form.js
@@ -1,21 +1,17 @@
-var page = require('./page');
+const page = require('./page');
 
 module.exports = page.extend({
   /**
    * Displays the work pattern calendar form.
-   *
-   * @return The Page instance.
    */
-  showCalendarForm: function () {
-    this.chromy.click('a[href="#work-pattern-calendar"]');
-
-    return this;
+  async showCalendarForm () {
+    await this.puppet.click('a[href="#work-pattern-calendar"]');
   },
 
   /**
    * Waits until the work pattern form is visible.
    */
-  waitForReady: function () {
-    this.chromy.visible('.work-pattern-form');
+  async waitForReady () {
+    await this.puppet.waitFor('.work-pattern-form', { visible: true });
   }
 });

--- a/uk.co.compucorp.civicrm.hrcore/npm-shrinkwrap.json
+++ b/uk.co.compucorp.civicrm.hrcore/npm-shrinkwrap.json
@@ -646,12 +646,22 @@
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
       "dev": true
     },
-    "backstopjs": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/backstopjs/-/backstopjs-3.2.0.tgz",
-      "integrity": "sha512-/drgHwUIfZiFLwXmpFVnK9ozxdbLFzcmgwQ3Cn+zqkLO6WwgI/K0TtO61aLXAQPwS2oHIjn46N7HwAFHlWEH0g==",
+    "backstop-twentytwenty": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/backstop-twentytwenty/-/backstop-twentytwenty-1.0.4.tgz",
+      "integrity": "sha512-sENfpossNAbVKZjTzBU6bkbR1vIb7t6brjqH9ZMEIYh/RyCIGFM3BSgERzh+tdwpAVXHSbIV1gQRrtzBYzUrjw==",
       "dev": true,
       "requires": {
+        "react": "15.6.2"
+      }
+    },
+    "backstopjs": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/backstopjs/-/backstopjs-3.2.3.tgz",
+      "integrity": "sha512-YURuEPLq2InkfTW9BRlXRWMDiluYZn7+vQNUpwTRVnKH66Bk/KCXTDBIbcqTZgJcR8DLoywOQYAOJG9RPBLJmA==",
+      "dev": true,
+      "requires": {
+        "backstop-twentytwenty": "1.0.4",
         "casperjs": "1.1.4",
         "chalk": "1.1.3",
         "chromy": "0.5.11",
@@ -674,7 +684,6 @@
         "react-redux": "5.0.7",
         "react-sticky": "6.0.1",
         "react-toggle-button": "2.2.0",
-        "react-twentytwenty": "1.1.0",
         "redux": "3.7.2",
         "sinon": "1.17.7",
         "styled-components": "2.4.0",
@@ -1287,17 +1296,6 @@
         "supports-color": "2.0.0"
       }
     },
-    "child-process-promise": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/child-process-promise/-/child-process-promise-2.2.1.tgz",
-      "integrity": "sha1-RzChHvYQ+tRQuPIjx50x172tgHQ=",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "4.0.2",
-        "node-version": "1.1.3",
-        "promise-polyfill": "6.1.0"
-      }
-    },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
@@ -1387,22 +1385,6 @@
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.1.tgz",
       "integrity": "sha512-UjgcRlTAhAkLeXmDe2wK7ktwy/tgAqxiSndTIPiFZuIPLZmzHzWMwUIe9h9m/OokypG7snxCDEuwJshGBdPvaw==",
       "dev": true
-    },
-    "civicrm-cv": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/civicrm-cv/-/civicrm-cv-0.1.2.tgz",
-      "integrity": "sha1-prn+pVahci1Km3ChHGSHVXGmNKg=",
-      "dev": true,
-      "requires": {
-        "child-process-promise": "2.2.1"
-      }
-    },
-    "civicrm-scssroot": {
-      "version": "git://github.com/totten/civicrm-scssroot.git#3fc126e91ea503420daedc82425e9b85085707f6",
-      "dev": true,
-      "requires": {
-        "civicrm-cv": "0.1.2"
-      }
     },
     "class-utils": {
       "version": "0.3.6",
@@ -1828,16 +1810,6 @@
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         }
-      }
-    },
-    "cross-spawn": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-      "dev": true,
-      "requires": {
-        "lru-cache": "4.1.1",
-        "which": "1.3.0"
       }
     },
     "cryptiles": {
@@ -8489,12 +8461,6 @@
       "dev": true,
       "optional": true
     },
-    "node-version": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/node-version/-/node-version-1.1.3.tgz",
-      "integrity": "sha512-rEwE51JWn0yN3Wl5BXeGn5d52OGbSXzWiiXRjAQeuyvcGKyvuSILW2rb3G7Xh+nexzLwhTpek6Ehxd6IjvHePg==",
-      "dev": true
-    },
     "node.extend": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-2.0.0.tgz",
@@ -9533,12 +9499,6 @@
         "asap": "2.0.6"
       }
     },
-    "promise-polyfill": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.1.0.tgz",
-      "integrity": "sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc=",
-      "dev": true
-    },
     "prop-types": {
       "version": "15.6.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
@@ -9906,15 +9866,6 @@
       "requires": {
         "prop-types": "15.6.1",
         "react-motion": "0.5.2"
-      }
-    },
-    "react-twentytwenty": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/react-twentytwenty/-/react-twentytwenty-1.1.0.tgz",
-      "integrity": "sha512-cSwoNCygg7K68yBmkIvOC0sPstkwCGlDpvbI93bJEyAuan3zwW7WFMY58uIfQMONz9qtqfcdmoS+Wy/FMpmnVA==",
-      "dev": true,
-      "requires": {
-        "prop-types": "15.6.1"
       }
     },
     "read-chunk": {

--- a/uk.co.compucorp.civicrm.hrcore/npm-shrinkwrap.json
+++ b/uk.co.compucorp.civicrm.hrcore/npm-shrinkwrap.json
@@ -6,12 +6,14 @@
     "@types/core-js": {
       "version": "0.9.46",
       "resolved": "https://registry.npmjs.org/@types/core-js/-/core-js-0.9.46.tgz",
-      "integrity": "sha512-LooLR6XHes9V+kNYRz1Qm8w3atw9QMn7XeZUmIpUelllF9BdryeUKd/u0Wh5ErcjpWfG39NrToU9MF7ngsTFVw=="
+      "integrity": "sha512-LooLR6XHes9V+kNYRz1Qm8w3atw9QMn7XeZUmIpUelllF9BdryeUKd/u0Wh5ErcjpWfG39NrToU9MF7ngsTFVw==",
+      "dev": true
     },
     "@types/mkdirp": {
       "version": "0.3.29",
       "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.3.29.tgz",
-      "integrity": "sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY="
+      "integrity": "sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY=",
+      "dev": true
     },
     "@types/node": {
       "version": "9.4.7",
@@ -431,7 +433,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.10.0"
+        "es-abstract": "1.11.0"
       }
     },
     "array-map": {
@@ -645,13 +647,14 @@
       "dev": true
     },
     "backstopjs": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/backstopjs/-/backstopjs-3.1.19.tgz",
-      "integrity": "sha512-IBOq69xz32OEXVgMN84dGYWq42PaQIew1rEhsecZ8GyOqYkw8hbGp3+iDhix0w3lFKK9F0N3ySdkdzlSPnHY5g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/backstopjs/-/backstopjs-3.2.0.tgz",
+      "integrity": "sha512-/drgHwUIfZiFLwXmpFVnK9ozxdbLFzcmgwQ3Cn+zqkLO6WwgI/K0TtO61aLXAQPwS2oHIjn46N7HwAFHlWEH0g==",
       "dev": true,
       "requires": {
         "casperjs": "1.1.4",
         "chalk": "1.1.3",
+        "chromy": "0.5.11",
         "fs-extra": "0.30.0",
         "jump.js": "1.0.2",
         "junitwriter": "0.3.1",
@@ -664,9 +667,10 @@
         "p-map": "1.2.0",
         "path": "0.12.7",
         "phantomjs-prebuilt": "2.1.16",
+        "puppeteer": "1.2.0",
         "react": "15.6.2",
         "react-dom": "15.6.2",
-        "react-modal": "3.3.1",
+        "react-modal": "3.3.2",
         "react-redux": "5.0.7",
         "react-sticky": "6.0.1",
         "react-toggle-button": "2.2.0",
@@ -677,54 +681,13 @@
         "temp": "0.8.3",
         "webpack": "3.11.0",
         "webpack-dev-server": "2.11.2"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "6.0.66",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.66.tgz",
-          "integrity": "sha1-VoC3SmE10z1MAER+fD3GkaRgFiU="
-        },
-        "chrome-launcher": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.4.0.tgz",
-          "integrity": "sha512-Uq34nQ2peVRwyjsyoLs01mL9aEQDbc5RCZWNyYjGPt5ZFPL2B4OazSc98hO6HZOvMUILLL4MyAEVMzA5OvwWug==",
-          "requires": {
-            "@types/core-js": "0.9.46",
-            "@types/mkdirp": "0.3.29",
-            "@types/node": "6.0.66",
-            "lighthouse-logger": "1.0.1",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2"
-          }
-        },
-        "chrome-remote-interface": {
-          "version": "0.23.3",
-          "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.23.3.tgz",
-          "integrity": "sha512-Bj3zMOEqJNVOll/5LrtvSdpbXSsCiSdnSQPmKUQDmAofahHczR3Qp5VJaAKrhNC/nlv9jj74aYzxTUPKrez8rA==",
-          "requires": {
-            "commander": "2.1.0",
-            "ws": "2.0.3"
-          }
-        },
-        "commander": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
-          "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E="
-        },
-        "ws": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-2.0.3.tgz",
-          "integrity": "sha1-Uy/UmcP319cg5UPx+AcQbPxX2cs=",
-          "requires": {
-            "ultron": "1.1.1"
-          }
-        }
       }
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -930,6 +893,7 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -1330,7 +1294,7 @@
       "dev": true,
       "requires": {
         "cross-spawn": "4.0.2",
-        "node-version": "1.1.0",
+        "node-version": "1.1.3",
         "promise-polyfill": "6.1.0"
       }
     },
@@ -1710,7 +1674,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.0",
@@ -1952,7 +1917,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.39"
+        "es5-ext": "0.10.41"
       }
     },
     "dashdash": {
@@ -1997,6 +1962,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -2106,7 +2072,7 @@
       "requires": {
         "globby": "6.1.0",
         "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
         "p-map": "1.2.0",
         "pify": "3.0.0",
         "rimraf": "2.6.2"
@@ -2444,9 +2410,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
-      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
+      "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
       "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
@@ -2468,13 +2434,14 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.39",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.39.tgz",
-      "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
+      "version": "0.10.41",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.41.tgz",
+      "integrity": "sha512-MYK02wXfwTMie5TEJWPolgOsXEmz7wKCQaGzgmRjZOoV6VLG8I5dSv2bn6AOClXhK64gnSQTQ9W9MKvx87J4gw==",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       }
     },
     "es6-iterator": {
@@ -2484,7 +2451,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39",
+        "es5-ext": "0.10.41",
         "es6-symbol": "3.1.1"
       }
     },
@@ -2495,7 +2462,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39",
+        "es5-ext": "0.10.41",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -2508,6 +2475,15 @@
       "integrity": "sha512-LSas5vsuA6Q4nEdf9wokY5/AJYXry98i0IzXsv49rYsgDGDNDPbqAYR1Pe23iFxygfbGZNR/5VrHXBCh2BhvUQ==",
       "dev": true
     },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "4.2.2"
+      }
+    },
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
@@ -2515,7 +2491,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39",
+        "es5-ext": "0.10.41",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -2528,7 +2504,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39"
+        "es5-ext": "0.10.41"
       }
     },
     "es6-weak-map": {
@@ -2538,7 +2514,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39",
+        "es5-ext": "0.10.41",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -2622,7 +2598,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39"
+        "es5-ext": "0.10.41"
       }
     },
     "eventemitter3": {
@@ -2896,9 +2872,9 @@
       }
     },
     "express": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
-      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "dev": true,
       "requires": {
         "accepts": "1.3.5",
@@ -2913,7 +2889,7 @@
         "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
-        "finalhandler": "1.1.0",
+        "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
@@ -2924,11 +2900,11 @@
         "qs": "6.5.1",
         "range-parser": "1.2.0",
         "safe-buffer": "5.1.1",
-        "send": "0.16.1",
-        "serve-static": "1.13.1",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "1.3.1",
-        "type-is": "1.6.15",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.1",
         "vary": "1.1.2"
       },
@@ -2950,9 +2926,9 @@
           "dev": true
         },
         "finalhandler": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
-          "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+          "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
           "dev": true,
           "requires": {
             "debug": "2.6.9",
@@ -2960,7 +2936,7 @@
             "escape-html": "1.0.3",
             "on-finished": "2.3.0",
             "parseurl": "1.3.2",
-            "statuses": "1.3.1",
+            "statuses": "1.4.0",
             "unpipe": "1.0.0"
           }
         },
@@ -2985,11 +2961,15 @@
           "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
           "dev": true
         },
-        "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-          "dev": true
+        "type-is": {
+          "version": "1.6.16",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+          "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+          "dev": true,
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "2.1.18"
+          }
         }
       }
     },
@@ -3363,7 +3343,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "1.1.3",
@@ -4436,6 +4417,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -5458,9 +5440,9 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "obuf": "1.1.1",
+        "obuf": "1.1.2",
         "readable-stream": "2.3.3",
-        "wbuf": "1.7.2"
+        "wbuf": "1.7.3"
       }
     },
     "html-entities": {
@@ -5502,9 +5484,9 @@
       }
     },
     "http-parser-js": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
-      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.11.tgz",
+      "integrity": "sha512-QCR5O2AjjMW8Mo4HyI1ctFcv+O99j/0g367V3YoVnrNw5hkDvAWZD0lWGcc+F4yN3V55USPCVix4efb75HxFfA==",
       "dev": true
     },
     "http-proxy": {
@@ -5728,6 +5710,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -5736,7 +5719,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -6012,9 +5996,9 @@
       "dev": true
     },
     "invariant": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
-      "integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
@@ -6234,9 +6218,9 @@
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
         "is-path-inside": "1.0.1"
@@ -7050,6 +7034,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.0.1.tgz",
       "integrity": "sha1-8HPYP3rLyWcpvxAKEhyPAGmRrmE=",
+      "dev": true,
       "requires": {
         "debug": "2.6.9"
       }
@@ -7115,9 +7100,9 @@
       "dev": true
     },
     "lodash-es": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.5.tgz",
-      "integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw==",
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.7.tgz",
+      "integrity": "sha512-jzqTi3vk4J5Dxq43cNjB0ekfCjPLHixoY2Sc0WHTo+0r928taLqe/VCt02vY5uQBvg0rdXgL3xWkK4X0MCmZcw==",
       "dev": true
     },
     "lodash._basecopy": {
@@ -7755,6 +7740,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -7800,6 +7786,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -7807,7 +7794,8 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         }
       }
     },
@@ -7881,7 +7869,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "multicast-dns": {
       "version": "6.2.3",
@@ -7965,6 +7954,12 @@
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
       "dev": true,
       "optional": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
     },
     "node-fetch": {
       "version": "1.7.3",
@@ -8495,9 +8490,9 @@
       "optional": true
     },
     "node-version": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/node-version/-/node-version-1.1.0.tgz",
-      "integrity": "sha512-t1V2RFiaTavaW3jtQO0A2nok6k7/Gghuvx2rjvICuT0B0dYaObBQ4U0xHL+ZTPFZodt1LMYG2Vi2nypfz4/AJg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/node-version/-/node-version-1.1.3.tgz",
+      "integrity": "sha512-rEwE51JWn0yN3Wl5BXeGn5d52OGbSXzWiiXRjAQeuyvcGKyvuSILW2rb3G7Xh+nexzLwhTpek6Ehxd6IjvHePg==",
       "dev": true
     },
     "node.extend": {
@@ -8824,9 +8819,9 @@
       }
     },
     "obuf": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
-      "integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
     "on-finished": {
@@ -8848,6 +8843,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -8859,9 +8855,9 @@
       "dev": true
     },
     "opn": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.2.0.tgz",
-      "integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+      "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
       "dev": true,
       "requires": {
         "is-wsl": "1.1.0"
@@ -9252,7 +9248,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -9597,6 +9594,12 @@
         }
       }
     },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "dev": true
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -9627,6 +9630,60 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
+    },
+    "puppeteer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.2.0.tgz",
+      "integrity": "sha512-4sY/6mB7+kNPGAzPGKq65tH0VG3ohUEkXHuOReB9K/tw3m1TqifYmxnMR/uDeci/UPwyk5K1gWYh8rw0U0Zscw==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "extract-zip": "1.6.6",
+        "https-proxy-agent": "2.2.0",
+        "mime": "1.6.0",
+        "progress": "2.0.0",
+        "proxy-from-env": "1.0.0",
+        "rimraf": "2.6.2",
+        "ws": "3.3.3"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+          "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+          "dev": true,
+          "requires": {
+            "es6-promisify": "5.0.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.0.tgz",
+          "integrity": "sha512-uUWcfXHvy/dwfM9bqa6AozvAjS32dZSTUYd/4SEpYKRg6LEcPLshksnQYRudM9AyNvUARMfAg5TLjUDyX/K4vA==",
+          "dev": true,
+          "requires": {
+            "agent-base": "4.2.0",
+            "debug": "3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "progress": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+          "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+          "dev": true
+        }
+      }
     },
     "q": {
       "version": "1.4.1",
@@ -9780,9 +9837,9 @@
       }
     },
     "react-modal": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.3.1.tgz",
-      "integrity": "sha512-d1A8xXIvW+YVKwRMrFY5qneuC5FSa4OnOE78hgqfz+MYLb1Ai/B3D3Dzx1Zrw4ZD5rS16SKiPe5rl4UZt+AjpQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.3.2.tgz",
+      "integrity": "sha512-DLrmPG9PyXWSNA2ve1LttnNRE9Umy3u3awFeK+72dLOksLM+EoTg8Z2h/i/DV3O8ZGvnEhacjAVXdZuRDGvaag==",
       "dev": true,
       "requires": {
         "exenv": "1.2.2",
@@ -9816,9 +9873,9 @@
       "dev": true,
       "requires": {
         "hoist-non-react-statics": "2.5.0",
-        "invariant": "2.2.3",
+        "invariant": "2.2.4",
         "lodash": "4.17.5",
-        "lodash-es": "4.17.5",
+        "lodash-es": "4.17.7",
         "loose-envify": "1.3.1",
         "prop-types": "15.6.1"
       },
@@ -9975,7 +10032,7 @@
       "dev": true,
       "requires": {
         "lodash": "4.17.4",
-        "lodash-es": "4.17.5",
+        "lodash-es": "4.17.7",
         "loose-envify": "1.3.1",
         "symbol-observable": "1.2.0"
       }
@@ -10185,6 +10242,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
       "requires": {
         "glob": "7.1.2"
       }
@@ -10389,9 +10447,9 @@
       "dev": true
     },
     "send": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
-      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -10406,19 +10464,13 @@
         "ms": "2.0.0",
         "on-finished": "2.3.0",
         "range-parser": "1.2.0",
-        "statuses": "1.3.1"
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "mime": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
           "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-          "dev": true
-        },
-        "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
           "dev": true
         }
       }
@@ -10474,15 +10526,15 @@
       }
     },
     "serve-static": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
-      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
         "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
-        "send": "0.16.1"
+        "send": "0.16.2"
       }
     },
     "set-blocking": {
@@ -10890,22 +10942,22 @@
         "http-deceiver": "1.2.7",
         "safe-buffer": "5.1.1",
         "select-hose": "2.0.0",
-        "spdy-transport": "2.0.20"
+        "spdy-transport": "2.1.0"
       }
     },
     "spdy-transport": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz",
-      "integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
+      "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
         "detect-node": "2.0.3",
         "hpack.js": "2.1.6",
-        "obuf": "1.1.1",
+        "obuf": "1.1.2",
         "readable-stream": "2.3.3",
         "safe-buffer": "5.1.1",
-        "wbuf": "1.7.2"
+        "wbuf": "1.7.3"
       }
     },
     "split-string": {
@@ -11219,7 +11271,7 @@
         "hoist-non-react-statics": "1.2.0",
         "is-plain-object": "2.0.4",
         "prop-types": "15.6.1",
-        "stylis": "3.4.10",
+        "stylis": "3.5.0",
         "supports-color": "3.2.3"
       },
       "dependencies": {
@@ -11241,9 +11293,9 @@
       }
     },
     "stylis": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.4.10.tgz",
-      "integrity": "sha512-J7CXAfeyhjdgvdQMz2yy0gTDccq0nVmatx6IlX1je1kCqdNgk3npGOzX6qprEd2oHVv7IF5HXO08i6XFQs/JRA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.0.tgz",
+      "integrity": "sha512-pP7yXN6dwMzAR29Q0mBrabPCe0/mNO1MSr93bhay+hcZondvMMTpeGyd8nbhYJdyperNT2DRxONQuUGcJr5iPw==",
       "dev": true
     },
     "subarg": {
@@ -11702,7 +11754,8 @@
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+      "dev": true
     },
     "umd": {
       "version": "3.0.1",
@@ -12175,7 +12228,7 @@
       "integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
       "dev": true,
       "requires": {
-        "chokidar": "2.0.2",
+        "chokidar": "2.0.3",
         "graceful-fs": "4.1.11",
         "neo-async": "2.5.0"
       },
@@ -12191,9 +12244,9 @@
           }
         },
         "chokidar": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.2.tgz",
-          "integrity": "sha512-l32Hw3wqB0L2kGVmSbK/a+xXLDrUEsc84pSgMkmwygHvD7ubRsP/vxxHa5BtB6oix1XLLVCHyYMsckRXxThmZw==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
+          "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
           "dev": true,
           "requires": {
             "anymatch": "2.0.0",
@@ -12243,9 +12296,9 @@
       }
     },
     "wbuf": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
-      "integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dev": true,
       "requires": {
         "minimalistic-assert": "1.0.0"
@@ -12257,9 +12310,9 @@
       "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.0",
+        "acorn": "5.5.3",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "6.2.1",
+        "ajv": "6.3.0",
         "ajv-keywords": "3.1.0",
         "async": "2.1.5",
         "enhanced-resolve": "3.4.1",
@@ -12282,15 +12335,15 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
+          "version": "5.5.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
           "dev": true
         },
         "ajv": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.2.1.tgz",
-          "integrity": "sha1-KKarxJOiq+D7TIUHrK7bQ/pVBnE=",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.3.0.tgz",
+          "integrity": "sha1-FlCkERTvAFdMrBC4Ay2PTBSBLac=",
           "dev": true,
           "requires": {
             "fast-deep-equal": "1.0.0",
@@ -12480,12 +12533,12 @@
         "ansi-html": "0.0.7",
         "array-includes": "3.0.3",
         "bonjour": "3.5.0",
-        "chokidar": "2.0.2",
+        "chokidar": "2.0.3",
         "compression": "1.7.2",
         "connect-history-api-fallback": "1.5.0",
         "debug": "3.1.0",
         "del": "3.0.0",
-        "express": "4.16.2",
+        "express": "4.16.3",
         "html-entities": "1.2.1",
         "http-proxy-middleware": "0.17.4",
         "import-local": "1.0.0",
@@ -12493,7 +12546,7 @@
         "ip": "1.1.5",
         "killable": "1.0.0",
         "loglevel": "1.6.1",
-        "opn": "5.2.0",
+        "opn": "5.3.0",
         "portfinder": "1.0.13",
         "selfsigned": "1.10.2",
         "serve-index": "1.9.1",
@@ -12523,9 +12576,9 @@
           "dev": true
         },
         "chokidar": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.2.tgz",
-          "integrity": "sha512-l32Hw3wqB0L2kGVmSbK/a+xXLDrUEsc84pSgMkmwygHvD7ubRsP/vxxHa5BtB6oix1XLLVCHyYMsckRXxThmZw==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
+          "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
           "dev": true,
           "requires": {
             "anymatch": "2.0.0",
@@ -12746,7 +12799,7 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": "0.4.10",
+        "http-parser-js": "0.4.11",
         "websocket-extensions": "0.1.3"
       }
     },
@@ -12818,7 +12871,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "ws": {
       "version": "3.3.3",

--- a/uk.co.compucorp.civicrm.hrcore/package-lock.json
+++ b/uk.co.compucorp.civicrm.hrcore/package-lock.json
@@ -16,9 +16,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.4.7",
-      "resolved": "http://registry.npmjs.org/@types/node/-/node-9.4.7.tgz",
-      "integrity": "sha512-4Ba90mWNx8ddbafuyGGwjkZMigi+AWfYLSDCpovwsE63ia8w93r3oJ8PIAQc3y8U+XHcnMOHPIzNe3o438Ywcw==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.2.tgz",
+      "integrity": "sha512-UWkRY9X7RQHp5OhhRIIka58/gVVycL1zHZu0OTsT5LI86ABaMOSbUjAl+b0FeDhQcxclrkyft3kW5QWdMRs8wQ==",
       "dev": true
     },
     "@types/rimraf": {
@@ -44,19 +44,19 @@
       "dev": true
     },
     "accepts": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.17",
+        "mime-types": "2.1.18",
         "negotiator": "0.6.1"
       }
     },
     "acorn": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
       "dev": true
     },
     "acorn-dynamic-import": {
@@ -66,6 +66,24 @@
       "dev": true,
       "requires": {
         "acorn": "4.0.13"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "4.0.13",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+          "dev": true
+        }
+      }
+    },
+    "acorn-node": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.3.0.tgz",
+      "integrity": "sha512-efP54n3d1aLfjL2UMdaXa6DsswwzJeI5rqhbFvXMrKiJ6eJFpf+7R0zN7t8IC+XKn2YOAFAv6xbBNgHUkoHWLw==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.5.3",
+        "xtend": "4.0.1"
       }
     },
     "addressparser": {
@@ -82,21 +100,12 @@
       "dev": true
     },
     "agent-base": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
       "dev": true,
       "requires": {
-        "extend": "3.0.1",
-        "semver": "5.0.3"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-          "dev": true
-        }
+        "es6-promisify": "5.0.0"
       }
     },
     "ajv": {
@@ -106,7 +115,7 @@
       "dev": true,
       "requires": {
         "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
+        "fast-deep-equal": "1.1.0",
         "fast-json-stable-stringify": "2.0.0",
         "json-schema-traverse": "0.3.1"
       }
@@ -126,17 +135,6 @@
         "kind-of": "3.2.2",
         "longest": "1.0.1",
         "repeat-string": "1.6.1"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        }
       }
     },
     "amdefine": {
@@ -159,13 +157,6 @@
         "safe-buffer": "5.1.1"
       },
       "dependencies": {
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-          "dev": true,
-          "optional": true
-        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -196,9 +187,9 @@
       }
     },
     "ansi-colors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.0.1.tgz",
-      "integrity": "sha512-yopkAU0ZD/WQ56Tms3xLn6jRuX3SyUMAVi0FdmDIbmmnHW3jHiI1sQFdUl3gfVddjnrsP3Y6ywFKvCRopvoVIA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "dev": true,
       "requires": {
         "ansi-wrap": "0.1.0"
@@ -256,104 +247,13 @@
       "dev": true
     },
     "anymatch": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
       "requires": {
-        "micromatch": "2.3.11",
+        "micromatch": "3.1.10",
         "normalize-path": "2.1.1"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "1.1.0"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "0.1.1"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
-          }
-        }
       }
     },
     "aproba": {
@@ -375,7 +275,7 @@
       "dev": true,
       "requires": {
         "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.6"
       }
     },
     "arr-diff": {
@@ -475,6 +375,12 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
+    "arraybuffer.slice": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
+      "dev": true
+    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -494,9 +400,9 @@
       "dev": true
     },
     "asn1.js": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
-      "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
@@ -526,9 +432,9 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
-      "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.3.tgz",
+      "integrity": "sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA==",
       "dev": true,
       "optional": true
     },
@@ -539,15 +445,23 @@
       "dev": true,
       "requires": {
         "acorn": "4.0.13"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "4.0.13",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+          "dev": true
+        }
       }
     },
     "async": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
-      "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       }
     },
     "async-chain-proxy": {
@@ -584,9 +498,9 @@
       "dev": true
     },
     "atob": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
-      "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
+      "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
       "dev": true
     },
     "aws-sign2": {
@@ -596,9 +510,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
       "dev": true
     },
     "axios": {
@@ -618,8 +532,16 @@
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
+        "core-js": "2.5.5",
         "regenerator-runtime": "0.10.5"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+          "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+          "dev": true
+        }
       }
     },
     "babel-runtime": {
@@ -628,10 +550,16 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.5",
         "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+          "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -668,7 +596,7 @@
         "fs-extra": "0.30.0",
         "jump.js": "1.0.2",
         "junitwriter": "0.3.1",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "minimist": "1.2.0",
         "node-resemble-js": "0.2.0",
         "object-hash": "1.1.5",
@@ -682,7 +610,7 @@
         "react-dom": "15.6.2",
         "react-modal": "3.3.2",
         "react-redux": "5.0.7",
-        "react-sticky": "6.0.1",
+        "react-sticky": "6.0.2",
         "react-toggle-button": "2.2.0",
         "redux": "3.7.2",
         "sinon": "1.17.7",
@@ -709,8 +637,54 @@
         "component-emitter": "1.2.1",
         "define-property": "1.0.0",
         "isobject": "3.0.1",
-        "mixin-deep": "1.3.0",
+        "mixin-deep": "1.3.1",
         "pascalcase": "0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
       }
     },
     "base64-arraybuffer": {
@@ -720,9 +694,9 @@
       "dev": true
     },
     "base64-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
+      "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
       "dev": true
     },
     "base64id": {
@@ -806,6 +780,13 @@
         "readable-stream": "2.0.6"
       },
       "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true,
+          "optional": true
+        },
         "readable-stream": {
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
@@ -845,6 +826,12 @@
         "inherits": "2.0.3"
       }
     },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "dev": true
+    },
     "bmp-js": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.0.3.tgz",
@@ -867,12 +854,20 @@
         "content-type": "1.0.4",
         "debug": "2.6.9",
         "depd": "1.1.2",
-        "http-errors": "1.6.2",
+        "http-errors": "1.6.3",
         "iconv-lite": "0.4.19",
         "on-finished": "2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.15"
+        "type-is": "1.6.16"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+          "dev": true
+        }
       }
     },
     "bonjour": {
@@ -895,13 +890,13 @@
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
       }
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
@@ -909,22 +904,32 @@
       }
     },
     "braces": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.0.tgz",
-      "integrity": "sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
         "arr-flatten": "1.1.0",
         "array-unique": "0.3.2",
-        "define-property": "1.0.0",
         "extend-shallow": "2.0.1",
         "fill-range": "4.0.0",
         "isobject": "3.0.1",
         "repeat-element": "1.1.2",
-        "snapdragon": "0.8.1",
+        "snapdragon": "0.8.2",
         "snapdragon-node": "2.1.1",
         "split-string": "3.1.0",
-        "to-regex": "3.0.1"
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
       }
     },
     "brorand": {
@@ -934,9 +939,9 @@
       "dev": true
     },
     "browser-pack": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.3.tgz",
-      "integrity": "sha512-Jo+RYsn8X8OhyP9tMXXg0ueR2fW696HUu1Hf3/DeiwNean1oGiPtdgGRNuUHBpPHzBH3x4n1kzAlgOgHSIq88g==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
+      "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
       "dev": true,
       "requires": {
         "JSONStream": "1.3.2",
@@ -944,7 +949,7 @@
         "defined": "1.0.0",
         "safe-buffer": "5.1.1",
         "through2": "2.0.3",
-        "umd": "3.0.1"
+        "umd": "3.0.3"
       }
     },
     "browser-resolve": {
@@ -972,10 +977,10 @@
       "requires": {
         "JSONStream": "1.3.2",
         "assert": "1.4.1",
-        "browser-pack": "6.0.3",
+        "browser-pack": "6.1.0",
         "browser-resolve": "1.11.2",
         "browserify-zlib": "0.2.0",
-        "buffer": "5.0.8",
+        "buffer": "5.1.0",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.5.2",
         "console-browserify": "1.1.0",
@@ -991,8 +996,8 @@
         "htmlescape": "1.1.1",
         "https-browserify": "1.0.0",
         "inherits": "2.0.3",
-        "insert-module-globals": "7.0.1",
-        "labeled-stream-splicer": "2.0.0",
+        "insert-module-globals": "7.0.6",
+        "labeled-stream-splicer": "2.0.1",
         "module-deps": "4.1.1",
         "os-browserify": "0.3.0",
         "parents": "1.0.1",
@@ -1001,15 +1006,15 @@
         "punycode": "1.4.1",
         "querystring-es3": "0.2.1",
         "read-only-stream": "2.0.0",
-        "readable-stream": "2.3.3",
-        "resolve": "1.5.0",
+        "readable-stream": "2.3.6",
+        "resolve": "1.7.0",
         "shasum": "1.0.2",
         "shell-quote": "1.6.1",
         "stream-browserify": "2.0.1",
-        "stream-http": "2.8.0",
+        "stream-http": "2.8.1",
         "string_decoder": "1.0.3",
         "subarg": "1.0.0",
-        "syntax-error": "1.3.0",
+        "syntax-error": "1.4.0",
         "through2": "2.0.3",
         "timers-browserify": "1.4.2",
         "tty-browserify": "0.0.0",
@@ -1052,13 +1057,19 @@
             }
           }
         },
+        "domain-browser": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+          "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
+          "dev": true
+        },
         "duplexer2": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.3"
+            "readable-stream": "2.3.6"
           }
         },
         "process": {
@@ -1066,13 +1077,37 @@
           "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
           "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
           "dev": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "timers-browserify": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+          "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+          "dev": true,
+          "requires": {
+            "process": "0.11.10"
+          }
         }
       }
     },
     "browserify-aes": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
-      "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
         "buffer-xor": "1.0.3",
@@ -1089,7 +1124,7 @@
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.1.1",
+        "browserify-aes": "1.2.0",
         "browserify-des": "1.0.0",
         "evp_bytestokey": "1.0.3"
       }
@@ -1140,19 +1175,25 @@
       }
     },
     "buffer": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.8.tgz",
-      "integrity": "sha512-xXvjQhVNz50v2nPeoOsNqWCLGfiv4ji/gXZM28jnVwdLJxH4mFyqgqCKfaK9zf1KUbG6zTkjLOy7ou+jSMarGA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
+      "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
       "dev": true,
       "requires": {
-        "base64-js": "1.2.1",
-        "ieee754": "1.1.8"
+        "base64-js": "1.2.3",
+        "ieee754": "1.1.11"
       }
     },
     "buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
       "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
       "dev": true
     },
     "buffer-indexof": {
@@ -1273,14 +1314,6 @@
       "requires": {
         "align-text": "0.1.4",
         "lazy-cache": "1.0.4"
-      },
-      "dependencies": {
-        "lazy-cache": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-          "dev": true
-        }
       }
     },
     "chalk": {
@@ -1296,38 +1329,47 @@
         "supports-color": "2.0.0"
       }
     },
-    "chokidar": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+    "child-process-promise": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/child-process-promise/-/child-process-promise-2.2.1.tgz",
+      "integrity": "sha1-RzChHvYQ+tRQuPIjx50x172tgHQ=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "cross-spawn": "4.0.2",
+        "node-version": "1.1.3",
+        "promise-polyfill": "6.1.0"
       },
       "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "lru-cache": "4.1.2",
+            "which": "1.3.0"
           }
         }
+      }
+    },
+    "chokidar": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
+      "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+      "dev": true,
+      "requires": {
+        "anymatch": "2.0.0",
+        "async-each": "1.0.1",
+        "braces": "2.3.2",
+        "fsevents": "1.1.3",
+        "glob-parent": "3.1.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "4.0.0",
+        "normalize-path": "2.1.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0",
+        "upath": "1.0.4"
       }
     },
     "chrome-launcher": {
@@ -1338,7 +1380,7 @@
       "requires": {
         "@types/core-js": "0.9.46",
         "@types/mkdirp": "0.3.29",
-        "@types/node": "9.4.7",
+        "@types/node": "9.6.2",
         "@types/rimraf": "0.0.28",
         "is-wsl": "1.1.0",
         "lighthouse-logger": "1.0.1",
@@ -1386,6 +1428,22 @@
       "integrity": "sha512-UjgcRlTAhAkLeXmDe2wK7ktwy/tgAqxiSndTIPiFZuIPLZmzHzWMwUIe9h9m/OokypG7snxCDEuwJshGBdPvaw==",
       "dev": true
     },
+    "civicrm-cv": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/civicrm-cv/-/civicrm-cv-0.1.2.tgz",
+      "integrity": "sha1-prn+pVahci1Km3ChHGSHVXGmNKg=",
+      "dev": true,
+      "requires": {
+        "child-process-promise": "2.2.1"
+      }
+    },
+    "civicrm-scssroot": {
+      "version": "git://github.com/totten/civicrm-scssroot.git#3fc126e91ea503420daedc82425e9b85085707f6",
+      "dev": true,
+      "requires": {
+        "civicrm-cv": "0.1.2"
+      }
+    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -1406,81 +1464,24 @@
           "requires": {
             "is-descriptor": "0.1.6"
           }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "dev": true
         }
       }
     },
     "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
       }
     },
     "clone": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
-      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
     "clone-buffer": {
@@ -1496,14 +1497,14 @@
       "dev": true
     },
     "cloneable-readable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
-      "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
+      "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "process-nextick-args": "1.0.7",
-        "through2": "2.0.3"
+        "process-nextick-args": "2.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "co": {
@@ -1535,9 +1536,9 @@
       "dev": true
     },
     "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
+      "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg==",
       "dev": true
     },
     "combine-lists": {
@@ -1546,7 +1547,7 @@
       "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       }
     },
     "combine-source-map": {
@@ -1562,9 +1563,9 @@
       }
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
@@ -1601,19 +1602,11 @@
       "dev": true,
       "requires": {
         "mime-db": "1.33.0"
-      },
-      "dependencies": {
-        "mime-db": {
-          "version": "1.33.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
-          "dev": true
-        }
       }
     },
     "compression": {
       "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "dev": true,
       "requires": {
@@ -1624,33 +1617,6 @@
         "on-headers": "1.0.1",
         "safe-buffer": "5.1.1",
         "vary": "1.1.2"
-      },
-      "dependencies": {
-        "accepts": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-          "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-          "dev": true,
-          "requires": {
-            "mime-types": "2.1.18",
-            "negotiator": "0.6.1"
-          }
-        },
-        "mime-db": {
-          "version": "1.33.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.18",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.33.0"
-          }
-        }
       }
     },
     "concat-map": {
@@ -1666,20 +1632,43 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.6",
         "typedarray": "0.0.6"
       }
     },
     "connect": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.5.tgz",
-      "integrity": "sha1-+43ee6B2OHfQ7J352sC0tA5yx9o=",
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+      "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "finalhandler": "1.0.6",
+        "finalhandler": "1.1.0",
         "parseurl": "1.3.2",
         "utils-merge": "1.0.1"
+      },
+      "dependencies": {
+        "finalhandler": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+          "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "statuses": "1.3.1",
+            "unpipe": "1.0.0"
+          }
+        },
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
+        }
       }
     },
     "connect-history-api-fallback": {
@@ -1746,9 +1735,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
       "dev": true
     },
     "core-util-is": {
@@ -1776,7 +1765,7 @@
         "cipher-base": "1.0.4",
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
-        "sha.js": "2.4.10"
+        "sha.js": "2.4.11"
       }
     },
     "create-hmac": {
@@ -1790,7 +1779,7 @@
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
-        "sha.js": "2.4.10"
+        "sha.js": "2.4.11"
       }
     },
     "create-react-class": {
@@ -1802,14 +1791,17 @@
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
+      }
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.2",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       }
     },
     "cryptiles": {
@@ -1827,7 +1819,7 @@
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.2.1"
           }
         }
       }
@@ -1848,7 +1840,7 @@
         "pbkdf2": "3.0.14",
         "public-encrypt": "4.0.0",
         "randombytes": "2.0.6",
-        "randomfill": "1.0.3"
+        "randomfill": "1.0.4"
       }
     },
     "css-color-keywords": {
@@ -1889,7 +1881,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.41"
+        "es5-ext": "0.10.42"
       }
     },
     "dashdash": {
@@ -1988,7 +1980,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "1.0.3"
+        "clone": "1.0.4"
       }
     },
     "define-properties": {
@@ -1999,23 +1991,53 @@
       "requires": {
         "foreach": "2.0.5",
         "object-keys": "1.0.11"
-      },
-      "dependencies": {
-        "object-keys": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-          "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-          "dev": true
-        }
       }
     },
     "define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "1.0.2"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
       }
     },
     "defined": {
@@ -2031,8 +2053,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "ast-types": "0.10.1",
-        "escodegen": "1.9.0",
+        "ast-types": "0.11.3",
+        "escodegen": "1.9.1",
         "esprima": "3.1.3"
       }
     },
@@ -2129,16 +2151,8 @@
       "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
       "dev": true,
       "requires": {
-        "acorn": "5.3.0",
+        "acorn": "5.5.3",
         "defined": "1.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
-          "dev": true
-        }
       }
     },
     "di": {
@@ -2172,14 +2186,6 @@
       "requires": {
         "ip": "1.1.5",
         "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "ip": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-          "dev": true
-        }
       }
     },
     "dns-txt": {
@@ -2210,9 +2216,9 @@
       "dev": true
     },
     "domain-browser": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-      "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
     },
     "double-ended-queue": {
@@ -2306,7 +2312,7 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "requires": {
-        "iconv-lite": "0.4.19"
+        "iconv-lite": "0.4.21"
       }
     },
     "end-of-stream": {
@@ -2329,6 +2335,75 @@
         }
       }
     },
+    "engine.io": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.1.5.tgz",
+      "integrity": "sha512-D06ivJkYxyRrcEe0bTpNnBQNgP9d3xog+qZlLbui8EsMr/DouQpf5o9FzJnWYHEYE0YsFHllUv2R1dkgYZXHcA==",
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.5",
+        "base64id": "1.0.0",
+        "cookie": "0.3.1",
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
+        "uws": "9.14.0",
+        "ws": "3.3.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "engine.io-client": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.6.tgz",
+      "integrity": "sha512-hnuHsFluXnsKOndS4Hv6SvUrgdYx1pk2NqfaDMW+GWdgfU3+/V25Cj7I8a0x92idSpa5PIhJRKxPvp9mnoLsfg==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1",
+        "component-inherit": "0.0.3",
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "ws": "3.3.3",
+        "xmlhttprequest-ssl": "1.5.5",
+        "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
+      "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
+      "dev": true,
+      "requires": {
+        "after": "0.8.2",
+        "arraybuffer.slice": "0.0.7",
+        "base64-arraybuffer": "0.1.5",
+        "blob": "0.0.4",
+        "has-binary2": "1.0.2"
+      }
+    },
     "enhanced-resolve": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
@@ -2339,14 +2414,6 @@
         "memory-fs": "0.4.1",
         "object-assign": "4.1.1",
         "tapable": "0.2.8"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
       }
     },
     "ent": {
@@ -2371,14 +2438,6 @@
       "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
-      },
-      "dependencies": {
-        "is-arrayish": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-          "dev": true
-        }
       }
     },
     "es-abstract": {
@@ -2406,9 +2465,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.41",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.41.tgz",
-      "integrity": "sha512-MYK02wXfwTMie5TEJWPolgOsXEmz7wKCQaGzgmRjZOoV6VLG8I5dSv2bn6AOClXhK64gnSQTQ9W9MKvx87J4gw==",
+      "version": "0.10.42",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
+      "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
@@ -2423,7 +2482,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41",
+        "es5-ext": "0.10.42",
         "es6-symbol": "3.1.1"
       }
     },
@@ -2434,7 +2493,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41",
+        "es5-ext": "0.10.42",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -2442,9 +2501,9 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.2.tgz",
-      "integrity": "sha512-LSas5vsuA6Q4nEdf9wokY5/AJYXry98i0IzXsv49rYsgDGDNDPbqAYR1Pe23iFxygfbGZNR/5VrHXBCh2BhvUQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
       "dev": true
     },
     "es6-promisify": {
@@ -2453,7 +2512,7 @@
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.2.2"
+        "es6-promise": "4.2.4"
       }
     },
     "es6-set": {
@@ -2463,7 +2522,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41",
+        "es5-ext": "0.10.42",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -2476,7 +2535,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41"
+        "es5-ext": "0.10.42"
       }
     },
     "es6-weak-map": {
@@ -2486,7 +2545,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41",
+        "es5-ext": "0.10.42",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -2504,9 +2563,9 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+      "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -2514,7 +2573,16 @@
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "optionator": "0.8.2",
-        "source-map": "0.5.7"
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "escope": {
@@ -2570,7 +2638,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41"
+        "es5-ext": "0.10.42"
       }
     },
     "eventemitter3": {
@@ -2617,19 +2685,6 @@
         "p-finally": "1.0.0",
         "signal-exit": "3.0.2",
         "strip-eof": "1.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
-          }
-        }
       }
     },
     "exenv": {
@@ -2710,9 +2765,9 @@
         "define-property": "0.2.5",
         "extend-shallow": "2.0.1",
         "posix-character-classes": "0.1.1",
-        "regex-not": "1.0.0",
-        "snapdragon": "0.8.1",
-        "to-regex": "3.0.1"
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -2724,62 +2779,14 @@
             "is-descriptor": "0.1.6"
           }
         },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
+            "is-extendable": "0.1.1"
           }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "dev": true
         }
       }
     },
@@ -2821,15 +2828,6 @@
           "dev": true,
           "requires": {
             "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
           }
         }
       }
@@ -2881,67 +2879,11 @@
         "vary": "1.1.2"
       },
       "dependencies": {
-        "accepts": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-          "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-          "dev": true,
-          "requires": {
-            "mime-types": "2.1.18",
-            "negotiator": "0.6.1"
-          }
-        },
         "array-flatten": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
           "dev": true
-        },
-        "finalhandler": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-          "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "statuses": "1.4.0",
-            "unpipe": "1.0.0"
-          }
-        },
-        "mime-db": {
-          "version": "1.33.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.18",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.33.0"
-          }
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true
-        },
-        "type-is": {
-          "version": "1.6.16",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-          "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
-          "dev": true,
-          "requires": {
-            "media-typer": "0.3.0",
-            "mime-types": "2.1.18"
-          }
         }
       }
     },
@@ -2952,12 +2894,24 @@
       "dev": true
     },
     "extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "is-extendable": "0.1.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
       }
     },
     "extglob": {
@@ -2971,9 +2925,64 @@
         "expand-brackets": "2.1.4",
         "extend-shallow": "2.0.1",
         "fragment-cache": "0.2.1",
-        "regex-not": "1.0.0",
-        "snapdragon": "0.8.1",
-        "to-regex": "3.0.1"
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
       }
     },
     "extract-zip": {
@@ -3020,12 +3029,20 @@
         "ansi-gray": "0.1.1",
         "color-support": "1.1.3",
         "time-stamp": "1.1.0"
+      },
+      "dependencies": {
+        "time-stamp": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+          "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+          "dev": true
+        }
       }
     },
     "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -3063,20 +3080,6 @@
         "promise": "7.3.1",
         "setimmediate": "1.0.5",
         "ua-parser-js": "0.7.17"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
       }
     },
     "fd-slicer": {
@@ -3117,12 +3120,23 @@
         "is-number": "3.0.0",
         "repeat-string": "1.6.1",
         "to-regex-range": "2.1.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
       }
     },
     "finalhandler": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
-      "integrity": "sha1-AHrqM9Gk0+QgF/YkhIrVjSEvgU8=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -3130,22 +3144,14 @@
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
-        "statuses": "1.3.1",
+        "statuses": "1.4.0",
         "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-          "dev": true
-        }
       }
     },
     "find": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/find/-/find-0.2.8.tgz",
-      "integrity": "sha512-7Z96U7PMb7ijrinFZka5N5DWtgziLKdO8EFJSK3AiPqiUkJRcGNofV0/N/Pbe6myimrn7JCpqn+Pvb+Xz9q0NQ==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/find/-/find-0.2.9.tgz",
+      "integrity": "sha1-S3Px/55WrZG3bnFkB/5f/mVUu4w=",
       "dev": true,
       "requires": {
         "traverse-chain": "0.1.0"
@@ -3174,8 +3180,19 @@
       "requires": {
         "detect-file": "1.0.0",
         "is-glob": "3.1.0",
-        "micromatch": "3.1.5",
+        "micromatch": "3.1.10",
         "resolve-dir": "1.0.1"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        }
       }
     },
     "fined": {
@@ -3229,9 +3246,9 @@
       "dev": true
     },
     "for-own": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
         "for-in": "1.0.2"
@@ -3250,14 +3267,14 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
         "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
       }
     },
     "formatio": {
@@ -3325,7 +3342,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.8.0",
+        "nan": "2.10.0",
         "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
@@ -4296,11 +4313,16 @@
         "wide-align": "1.1.2"
       },
       "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },
@@ -4367,7 +4389,7 @@
         "extend": "3.0.1",
         "file-uri-to-path": "1.0.0",
         "ftp": "0.3.10",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.6"
       }
     },
     "get-value": {
@@ -4409,6 +4431,15 @@
         "is-glob": "2.0.1"
       },
       "dependencies": {
+        "glob-parent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "dev": true,
+          "requires": {
+            "is-glob": "2.0.1"
+          }
+        },
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
@@ -4427,27 +4458,22 @@
       }
     },
     "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
       },
       "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
         "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -4490,7 +4516,7 @@
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "1.1.11"
           }
         },
         "readable-stream": {
@@ -4558,7 +4584,7 @@
       "dev": true,
       "requires": {
         "global-prefix": "1.0.2",
-        "is-windows": "1.0.1",
+        "is-windows": "1.0.2",
         "resolve-dir": "1.0.1"
       }
     },
@@ -4571,7 +4597,7 @@
         "expand-tilde": "2.0.2",
         "homedir-polyfill": "1.0.1",
         "ini": "1.3.5",
-        "is-windows": "1.0.1",
+        "is-windows": "1.0.2",
         "which": "1.3.0"
       }
     },
@@ -4588,12 +4614,6 @@
         "pinkie-promise": "2.0.1"
       },
       "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -4661,9 +4681,9 @@
       }
     },
     "glogg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+      "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
       "dev": true,
       "requires": {
         "sparkles": "1.0.0"
@@ -4746,9 +4766,9 @@
           "dev": true
         },
         "clone": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
           "dev": true
         },
         "clone-stats": {
@@ -4797,10 +4817,10 @@
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "dev": true,
           "requires": {
-            "clone": "2.1.1",
+            "clone": "2.1.2",
             "clone-buffer": "1.0.0",
             "clone-stats": "1.0.0",
-            "cloneable-readable": "1.0.0",
+            "cloneable-readable": "1.1.2",
             "remove-trailing-separator": "1.1.0",
             "replace-ext": "1.0.0"
           }
@@ -4824,9 +4844,9 @@
       },
       "dependencies": {
         "clone": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
           "dev": true
         },
         "clone-stats": {
@@ -4839,6 +4859,12 @@
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "object-keys": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
           "dev": true
         },
         "readable-stream": {
@@ -4881,10 +4907,10 @@
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "dev": true,
           "requires": {
-            "clone": "2.1.1",
+            "clone": "2.1.2",
             "clone-buffer": "1.0.0",
             "clone-stats": "1.0.0",
-            "cloneable-readable": "1.0.0",
+            "cloneable-readable": "1.1.2",
             "remove-trailing-separator": "1.1.0",
             "replace-ext": "1.0.0"
           }
@@ -4906,7 +4932,7 @@
       "integrity": "sha512-qEocs1UVoDKKUjfsxJNMNwkRla0PbsyJwsqNNXpzYWsLQ29LhxRMY3wnTGZcc4hMHtalnvah/Dwlwb4NijH/0A==",
       "dev": true,
       "requires": {
-        "ansi-colors": "1.0.1",
+        "ansi-colors": "1.1.0",
         "fancy-log": "1.3.2",
         "lodash.template": "4.4.0",
         "node-notifier": "5.2.1",
@@ -4999,19 +5025,19 @@
       "dev": true,
       "requires": {
         "istextorbinary": "1.0.2",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.6",
         "replacestream": "4.0.3"
       }
     },
     "gulp-sass": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-3.1.0.tgz",
-      "integrity": "sha1-U9xLaKH13f5EJKtMJHZVJpqLdLc=",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-3.2.1.tgz",
+      "integrity": "sha512-UATbRpSDsyXCnpYSPBUEvdvtSEzksJs7/oQ0CujIpzKqKrO6vlnYwhX2UTsGrf4rNLwqlSSaM271It0uHYvJ3Q==",
       "dev": true,
       "requires": {
         "gulp-util": "3.0.8",
         "lodash.clonedeep": "4.5.0",
-        "node-sass": "4.7.2",
+        "node-sass": "4.8.3",
         "through2": "2.0.3",
         "vinyl-sourcemaps-apply": "0.2.1"
       }
@@ -5051,7 +5077,7 @@
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "1.1.11"
           }
         },
         "readable-stream": {
@@ -5090,7 +5116,7 @@
       "integrity": "sha512-c+p+EcyBl1UCpbfFA/vUD6MuC7uxoY6Y4g2lq9lLtzOHh9o1wijAQ4o0TIRQ14C7cG6zR6Zi+bpA0cW78CFt6g==",
       "dev": true,
       "requires": {
-        "thunks": "4.9.0"
+        "thunks": "4.9.2"
       }
     },
     "gulp-strip-css-comments": {
@@ -5187,6 +5213,12 @@
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
           "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
           "dev": true
+        },
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+          "dev": true
         }
       }
     },
@@ -5196,7 +5228,7 @@
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
-        "glogg": "1.0.0"
+        "glogg": "1.0.1"
       }
     },
     "handle-thing": {
@@ -5352,7 +5384,7 @@
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "sntp": "2.1.0"
       }
     },
@@ -5363,8 +5395,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "lodash": "4.17.4",
-        "request": "2.83.0"
+        "lodash": "4.17.5",
+        "request": "2.85.0"
       }
     },
     "hmac-drbg": {
@@ -5379,9 +5411,9 @@
       }
     },
     "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
       "dev": true
     },
     "hoist-non-react-statics": {
@@ -5400,9 +5432,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
       "dev": true
     },
     "hpack.js": {
@@ -5413,7 +5445,7 @@
       "requires": {
         "inherits": "2.0.3",
         "obuf": "1.1.2",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.6",
         "wbuf": "1.7.3"
       }
     },
@@ -5436,23 +5468,15 @@
       "dev": true
     },
     "http-errors": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "1.1.1",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
-        "setprototypeof": "1.0.3",
+        "setprototypeof": "1.1.0",
         "statuses": "1.4.0"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-          "dev": true
-        }
       }
     },
     "http-parser-js": {
@@ -5480,6 +5504,24 @@
         "agent-base": "2.1.1",
         "debug": "2.6.9",
         "extend": "3.0.1"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+          "dev": true,
+          "requires": {
+            "extend": "3.0.1",
+            "semver": "5.0.3"
+          }
+        },
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+          "dev": true
+        }
       }
     },
     "http-proxy-middleware": {
@@ -5490,7 +5532,7 @@
       "requires": {
         "http-proxy": "1.16.2",
         "is-glob": "3.1.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "micromatch": "2.3.11"
       },
       "dependencies": {
@@ -5536,21 +5578,23 @@
           "dev": true,
           "requires": {
             "is-extglob": "1.0.0"
+          },
+          "dependencies": {
+            "is-extglob": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+              "dev": true
+            }
           }
         },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-extglob": "2.1.1"
           }
         },
         "micromatch": {
@@ -5574,6 +5618,12 @@
             "regex-cache": "0.4.4"
           },
           "dependencies": {
+            "is-extglob": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+              "dev": true
+            },
             "is-glob": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
@@ -5595,7 +5645,7 @@
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "sshpk": "1.14.1"
       }
     },
     "httpntlm": {
@@ -5621,26 +5671,39 @@
       "dev": true
     },
     "https-proxy-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
       "requires": {
-        "agent-base": "2.1.1",
-        "debug": "2.6.9",
-        "extend": "3.0.1"
+        "agent-base": "4.2.0",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-      "dev": true
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+      "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
     },
     "ieee754": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
+      "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
       "dev": true
     },
     "import-local": {
@@ -5710,41 +5773,31 @@
       }
     },
     "insert-module-globals": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
-      "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.6.tgz",
+      "integrity": "sha512-R3sidKJr3SsggqQQ5cEwQb3pWG8RNx0UnpyeiOSR6jorRIeAOzH2gkTWnNdMnyRiVbjrG047K7UCtlMkQ1Mo9w==",
       "dev": true,
       "requires": {
         "JSONStream": "1.3.2",
-        "combine-source-map": "0.7.2",
-        "concat-stream": "1.5.2",
+        "combine-source-map": "0.8.0",
+        "concat-stream": "1.6.2",
         "is-buffer": "1.1.6",
         "lexical-scope": "1.2.0",
+        "path-is-absolute": "1.0.1",
         "process": "0.11.10",
         "through2": "2.0.3",
         "xtend": "4.0.1"
       },
       "dependencies": {
-        "combine-source-map": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
-          "integrity": "sha1-CHAxKFazB6h8xKxIbzqaYq7MwJ4=",
-          "dev": true,
-          "requires": {
-            "convert-source-map": "1.1.3",
-            "inline-source-map": "0.6.2",
-            "lodash.memoize": "3.0.4",
-            "source-map": "0.5.7"
-          }
-        },
         "concat-stream": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
-          "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
+            "buffer-from": "1.0.0",
             "inherits": "2.0.3",
-            "readable-stream": "2.0.6",
+            "readable-stream": "2.3.6",
             "typedarray": "0.0.6"
           }
         },
@@ -5752,26 +5805,6 @@
           "version": "0.11.10",
           "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
           "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
       }
@@ -5862,12 +5895,6 @@
             "redent": "1.0.0",
             "trim-newlines": "1.0.0"
           }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
@@ -5983,11 +6010,10 @@
       "dev": true
     },
     "ip": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.0.1.tgz",
-      "integrity": "sha1-x+NWzeoiWucbNtcPLnGpK6TkJZA=",
-      "dev": true,
-      "optional": true
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
     },
     "ip-regex": {
       "version": "1.0.3",
@@ -6014,17 +6040,23 @@
       "dev": true,
       "requires": {
         "is-relative": "1.0.0",
-        "is-windows": "1.0.1"
+        "is-windows": "1.0.2"
       }
     },
     "is-accessor-descriptor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "3.2.2"
       }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -6057,12 +6089,12 @@
       "dev": true
     },
     "is-data-descriptor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-date-object": {
@@ -6072,14 +6104,22 @@
       "dev": true
     },
     "is-descriptor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "1.0.0",
-        "is-data-descriptor": "1.0.0",
-        "kind-of": "6.0.2"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
       }
     },
     "is-dotfile": {
@@ -6134,22 +6174,29 @@
       "dev": true
     },
     "is-glob": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
       "dev": true,
       "requires": {
         "is-extglob": "2.1.1"
       }
     },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
+    },
     "is-my-json-valid": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
-      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "dev": true,
       "requires": {
         "generate-function": "2.0.0",
         "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
         "jsonpointer": "4.0.1",
         "xtend": "4.0.1"
       }
@@ -6161,26 +6208,23 @@
       "dev": true,
       "requires": {
         "kind-of": "3.2.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        }
       }
     },
     "is-odd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
-      "integrity": "sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0"
+        "is-number": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
       }
     },
     "is-path-cwd": {
@@ -6298,9 +6342,9 @@
       "dev": true
     },
     "is-windows": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
-      "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
     "is-wsl": {
@@ -6340,7 +6384,7 @@
       "dev": true,
       "requires": {
         "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
+        "whatwg-fetch": "2.0.4"
       }
     },
     "isstream": {
@@ -6360,9 +6404,9 @@
       }
     },
     "jasmine-core": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.9.1.tgz",
-      "integrity": "sha1-trvB2OZSUNVvWIhGFwXr7uuI8i8=",
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.99.1.tgz",
+      "integrity": "sha1-5kAN8ea1bhMLYcS80JPap/boyhU=",
       "dev": true
     },
     "jimp": {
@@ -6383,7 +6427,7 @@
         "pixelmatch": "4.0.2",
         "pngjs": "3.3.2",
         "read-chunk": "1.0.1",
-        "request": "2.83.0",
+        "request": "2.85.0",
         "stream-to-buffer": "0.1.0",
         "tinycolor2": "1.4.1",
         "url-regex": "3.2.0"
@@ -6404,9 +6448,9 @@
       "dev": true
     },
     "js-base64": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.2.tgz",
-      "integrity": "sha512-lLkz3IRPTNeATsKQGeltbzRK/5+bWsXBHfpZrxJAi4N30RtCtNA+rJznp4uR2+4OgkBsoeeFwONVLr4gzIVErQ==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
+      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw==",
       "dev": true
     },
     "js-tokens": {
@@ -6429,9 +6473,9 @@
       "dev": true
     },
     "json-parse-better-errors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
     "json-schema": {
@@ -6572,10 +6616,10 @@
         "body-parser": "1.18.2",
         "browserify": "14.5.0",
         "chokidar": "1.7.0",
-        "colors": "1.1.2",
+        "colors": "1.2.1",
         "combine-lists": "1.0.1",
-        "connect": "3.6.5",
-        "core-js": "2.5.3",
+        "connect": "3.6.6",
+        "core-js": "2.5.5",
         "di": "0.0.1",
         "dom-serialize": "2.2.1",
         "expand-braces": "0.1.2",
@@ -6583,244 +6627,147 @@
         "graceful-fs": "4.1.11",
         "http-proxy": "1.16.2",
         "isbinaryfile": "3.0.2",
-        "lodash": "4.17.4",
-        "log4js": "2.5.2",
+        "lodash": "4.17.5",
+        "log4js": "2.5.3",
         "mime": "1.6.0",
         "minimatch": "3.0.4",
         "optimist": "0.6.1",
-        "qjobs": "1.1.5",
+        "qjobs": "1.2.0",
         "range-parser": "1.2.0",
         "rimraf": "2.6.2",
         "safe-buffer": "5.1.1",
         "socket.io": "2.0.4",
         "source-map": "0.6.1",
         "tmp": "0.0.33",
-        "useragent": "2.2.1"
+        "useragent": "2.3.0"
       },
       "dependencies": {
-        "arraybuffer.slice": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-          "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
+        "anymatch": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+          "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+          "dev": true,
+          "requires": {
+            "micromatch": "2.3.11",
+            "normalize-path": "2.1.1"
+          }
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
           "dev": true
         },
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "chokidar": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+          "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+          "dev": true,
+          "requires": {
+            "anymatch": "1.3.2",
+            "async-each": "1.0.1",
+            "fsevents": "1.1.3",
+            "glob-parent": "2.0.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "2.0.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0"
+          }
+        },
+        "core-js": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+          "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
           "dev": true
         },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
-        "engine.io": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.1.4.tgz",
-          "integrity": "sha1-PQIRtwpVLOhB/8fahiezAamkFi4=",
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "accepts": "1.3.3",
-            "base64id": "1.0.0",
-            "cookie": "0.3.1",
-            "debug": "2.6.9",
-            "engine.io-parser": "2.1.2",
-            "uws": "0.14.5",
-            "ws": "3.3.3"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
+            "is-extglob": "1.0.0"
           }
         },
-        "engine.io-client": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.4.tgz",
-          "integrity": "sha1-T88TcLRxY70s6b4nM5ckMDUNTqE=",
+        "glob-parent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "component-emitter": "1.2.1",
-            "component-inherit": "0.0.3",
-            "debug": "2.6.9",
-            "engine.io-parser": "2.1.2",
-            "has-cors": "1.1.0",
-            "indexof": "0.0.1",
-            "parseqs": "0.0.5",
-            "parseuri": "0.0.5",
-            "ws": "3.3.3",
-            "xmlhttprequest-ssl": "1.5.5",
-            "yeast": "0.1.2"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
+            "is-glob": "2.0.1"
           }
         },
-        "engine.io-parser": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
-          "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
-          "dev": true,
-          "requires": {
-            "after": "0.8.2",
-            "arraybuffer.slice": "0.0.7",
-            "base64-arraybuffer": "0.1.5",
-            "blob": "0.0.4",
-            "has-binary2": "1.0.2"
-          }
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
         },
-        "isarray": {
+        "is-glob": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
-          "dev": true
-        },
-        "log4js": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/log4js/-/log4js-2.5.2.tgz",
-          "integrity": "sha512-MmZhzQCfCV5+nQgOqy34V9EV3k+Z/rPCdxyq+25EePKpwdUQxCb19BTmL5iX3iOCSAV/tWh7KVYqchwrx3+S2Q==",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "amqplib": "0.5.2",
-            "axios": "0.15.3",
-            "circular-json": "0.5.1",
-            "date-format": "1.2.0",
-            "debug": "3.1.0",
-            "hipchat-notifier": "1.1.0",
-            "loggly": "1.1.1",
-            "mailgun-js": "0.7.15",
-            "nodemailer": "2.7.2",
-            "redis": "2.8.0",
-            "semver": "5.5.0",
-            "slack-node": "0.2.0",
-            "streamroller": "0.7.0"
+            "is-extglob": "1.0.0"
           }
         },
-        "socket.io": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.0.4.tgz",
-          "integrity": "sha1-waRZDO/4fs8TxyZS8Eb3FrKeYBQ=",
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "engine.io": "3.1.4",
-            "socket.io-adapter": "1.1.1",
-            "socket.io-client": "2.0.4",
-            "socket.io-parser": "3.1.2"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
-        "socket.io-adapter": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
-          "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs=",
-          "dev": true
-        },
-        "socket.io-client": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.4.tgz",
-          "integrity": "sha1-CRilUkBtxeVAs4Dc2Xr8SmQzL44=",
-          "dev": true,
-          "requires": {
-            "backo2": "1.0.2",
-            "base64-arraybuffer": "0.1.5",
-            "component-bind": "1.0.0",
-            "component-emitter": "1.2.1",
-            "debug": "2.6.9",
-            "engine.io-client": "3.1.4",
-            "has-cors": "1.1.0",
-            "indexof": "0.0.1",
-            "object-component": "0.0.3",
-            "parseqs": "0.0.5",
-            "parseuri": "0.0.5",
-            "socket.io-parser": "3.1.2",
-            "to-array": "0.1.4"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
-        "socket.io-parser": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.2.tgz",
-          "integrity": "sha1-28IoIVH8T6675Aru3Ady66YZ9/I=",
-          "dev": true,
-          "requires": {
-            "component-emitter": "1.2.1",
-            "debug": "2.6.9",
-            "has-binary2": "1.0.2",
-            "isarray": "2.0.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           }
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "ws": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-          "dev": true,
-          "requires": {
-            "async-limiter": "1.0.0",
-            "safe-buffer": "5.1.1",
-            "ultron": "1.1.1"
-          }
-        },
-        "xmlhttprequest-ssl": {
-          "version": "1.5.5",
-          "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-          "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
           "dev": true
         }
       }
@@ -6884,10 +6831,13 @@
       "dev": true
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-      "dev": true
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
     },
     "klaw": {
       "version": "1.3.1",
@@ -6899,32 +6849,29 @@
       }
     },
     "labeled-stream-splicer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
-      "integrity": "sha1-pS4dE4AkwAuGscDJH2d5GLiuClk=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.1.tgz",
+      "integrity": "sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "isarray": "0.0.1",
+        "isarray": "2.0.4",
         "stream-splicer": "2.0.0"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.4.tgz",
+          "integrity": "sha512-GMxXOiUirWg1xTKRipM0Ek07rX+ubx4nNVElTJdNLYmNO/2YrDkgJGw9CljXn+r4EWiDQg/8lsRdHyg2PJuUaA==",
           "dev": true
         }
       }
     },
     "lazy-cache": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-      "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-      "dev": true,
-      "requires": {
-        "set-getter": "0.1.0"
-      }
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true
     },
     "lcid": {
       "version": "1.0.0",
@@ -6999,7 +6946,7 @@
         "is-plain-object": "2.0.4",
         "object.map": "1.0.1",
         "rechoir": "0.6.2",
-        "resolve": "1.5.0"
+        "resolve": "1.7.0"
       }
     },
     "lighthouse-logger": {
@@ -7066,15 +7013,15 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
       "dev": true
     },
     "lodash-es": {
-      "version": "4.17.7",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.7.tgz",
-      "integrity": "sha512-jzqTi3vk4J5Dxq43cNjB0ekfCjPLHixoY2Sc0WHTo+0r928taLqe/VCt02vY5uQBvg0rdXgL3xWkK4X0MCmZcw==",
+      "version": "4.17.8",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.8.tgz",
+      "integrity": "sha512-I9mjAxengFAleSThFhhAhvba6fsO0hunb9/0sQ6qQihSZsJRBofv2rYH58WXaOb/O++eUmYpCLywSQ22GfU+sA==",
       "dev": true
     },
     "lodash._basecopy": {
@@ -7182,9 +7129,9 @@
       "dev": true
     },
     "lodash.mergewith": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
-      "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU=",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
       "dev": true
     },
     "lodash.restparam": {
@@ -7218,6 +7165,38 @@
       "requires": {
         "lodash._reinterpolate": "3.0.0",
         "lodash.escape": "3.2.0"
+      }
+    },
+    "log4js": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-2.5.3.tgz",
+      "integrity": "sha512-YL/qpTxYtK0iWWbuKCrevDZz5lh+OjyHHD+mICqpjnYGKdNRBvPeh/1uYjkKUemT1CSO4wwLOwphWMpKAnD9kw==",
+      "dev": true,
+      "requires": {
+        "amqplib": "0.5.2",
+        "axios": "0.15.3",
+        "circular-json": "0.5.1",
+        "date-format": "1.2.0",
+        "debug": "3.1.0",
+        "hipchat-notifier": "1.1.0",
+        "loggly": "1.1.1",
+        "mailgun-js": "0.7.15",
+        "nodemailer": "2.7.2",
+        "redis": "2.8.0",
+        "semver": "5.5.0",
+        "slack-node": "0.2.0",
+        "streamroller": "0.7.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "loggly": {
@@ -7262,13 +7241,6 @@
           "dev": true,
           "optional": true
         },
-        "commander": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-          "dev": true,
-          "optional": true
-        },
         "cryptiles": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
@@ -7287,8 +7259,8 @@
           "optional": true,
           "requires": {
             "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
           }
         },
         "har-validator": {
@@ -7299,8 +7271,8 @@
           "optional": true,
           "requires": {
             "chalk": "1.1.3",
-            "commander": "2.13.0",
-            "is-my-json-valid": "2.17.1",
+            "commander": "2.11.0",
+            "is-my-json-valid": "2.17.2",
             "pinkie-promise": "2.0.1"
           }
         },
@@ -7332,8 +7304,15 @@
           "requires": {
             "assert-plus": "0.2.0",
             "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "sshpk": "1.14.1"
           }
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+          "dev": true,
+          "optional": true
         },
         "qs": {
           "version": "6.2.3",
@@ -7350,10 +7329,10 @@
           "optional": true,
           "requires": {
             "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
+            "aws4": "1.7.0",
             "bl": "1.1.2",
             "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
+            "combined-stream": "1.0.6",
             "extend": "3.0.1",
             "forever-agent": "0.6.1",
             "form-data": "2.0.0",
@@ -7363,12 +7342,12 @@
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
+            "mime-types": "2.1.18",
             "node-uuid": "1.4.8",
             "oauth-sign": "0.8.2",
             "qs": "6.2.3",
             "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
+            "tough-cookie": "2.3.4",
             "tunnel-agent": "0.4.3"
           }
         },
@@ -7429,21 +7408,13 @@
       }
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-          "dev": true
-        }
       }
     },
     "mailcomposer": {
@@ -7475,6 +7446,16 @@
         "tsscmp": "1.0.5"
       },
       "dependencies": {
+        "async": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+          "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "lodash": "4.17.5"
+          }
+        },
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
@@ -7493,8 +7474,8 @@
           "optional": true,
           "requires": {
             "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
           }
         },
         "ms": {
@@ -7507,22 +7488,19 @@
       }
     },
     "make-iterator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.0.tgz",
-      "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
+      "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
@@ -7581,7 +7559,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "memory-fs": {
@@ -7591,7 +7569,7 @@
       "dev": true,
       "requires": {
         "errno": "0.1.7",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.6"
       }
     },
     "meow": {
@@ -7630,24 +7608,32 @@
       "dev": true
     },
     "micromatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.5.tgz",
-      "integrity": "sha512-ykttrLPQrz1PUJcXjwsTUjGoPJ64StIGNE2lGVD1c9CuguJ+L7/navsE8IcDNndOoCMvYV0qc/exfVbMHkUhvA==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
         "arr-diff": "4.0.0",
         "array-unique": "0.3.2",
-        "braces": "2.3.0",
-        "define-property": "1.0.0",
-        "extend-shallow": "2.0.1",
+        "braces": "2.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
         "extglob": "2.0.4",
         "fragment-cache": "0.2.1",
         "kind-of": "6.0.2",
-        "nanomatch": "1.2.7",
+        "nanomatch": "1.2.9",
         "object.pick": "1.3.0",
-        "regex-not": "1.0.0",
-        "snapdragon": "0.8.1",
-        "to-regex": "3.0.1"
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
       }
     },
     "miller-rabin": {
@@ -7667,24 +7653,24 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "dev": true,
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "1.33.0"
       }
     },
     "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
     "min-document": {
@@ -7714,7 +7700,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -7734,9 +7720,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.0.tgz",
-      "integrity": "sha512-dgaCvoh6i1nosAUBKb0l0pfJ78K8+S9fluyIR2YvAeUD/QuMahnFnF3xYty5eYXMjhGSsB0DsW6A0uAZyetoAg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
         "for-in": "1.0.2",
@@ -7786,8 +7772,8 @@
         "duplexer2": "0.1.4",
         "inherits": "2.0.3",
         "parents": "1.0.1",
-        "readable-stream": "2.3.3",
-        "resolve": "1.5.0",
+        "readable-stream": "2.3.6",
+        "resolve": "1.7.0",
         "stream-combiner2": "1.1.1",
         "subarg": "1.0.0",
         "through2": "2.0.3",
@@ -7827,8 +7813,14 @@
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.3"
+            "readable-stream": "2.3.6"
           }
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -7870,42 +7862,43 @@
       }
     },
     "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
       "dev": true
     },
     "nanomatch": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.7.tgz",
-      "integrity": "sha512-/5ldsnyurvEw7wNpxLFgjVvBLMta43niEYOy0CJ4ntcYSbx6bugRUTQeFb4BR/WanEL1o3aQgHuVLHQaB6tOqg==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "dev": true,
       "requires": {
         "arr-diff": "4.0.0",
         "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "extend-shallow": "2.0.1",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
         "fragment-cache": "0.2.1",
-        "is-odd": "1.0.0",
-        "kind-of": "5.1.0",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
         "object.pick": "1.3.0",
-        "regex-not": "1.0.0",
-        "snapdragon": "0.8.1",
-        "to-regex": "3.0.1"
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
     },
     "natives": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
-      "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.3.tgz",
+      "integrity": "sha512-BZGSYV4YOLxzoTK73l0/s/0sH9l8SHs2ocReMH1f8JYSh5FUWu4ZrKCpJdRkWXV6HFR/pZDz7bwWOVAY07q77g==",
       "dev": true
     },
     "negotiator": {
@@ -7962,8 +7955,8 @@
         "mkdirp": "0.5.1",
         "nopt": "3.0.6",
         "npmlog": "4.1.2",
-        "osenv": "0.1.4",
-        "request": "2.83.0",
+        "osenv": "0.1.5",
+        "request": "2.85.0",
         "rimraf": "2.6.2",
         "semver": "5.3.0",
         "tar": "2.2.1",
@@ -7975,17 +7968,6 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "dev": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
         }
       }
     },
@@ -8001,7 +7983,7 @@
         "console-browserify": "1.1.0",
         "constants-browserify": "1.0.0",
         "crypto-browserify": "3.12.0",
-        "domain-browser": "1.1.7",
+        "domain-browser": "1.2.0",
         "events": "1.1.1",
         "https-browserify": "1.0.0",
         "os-browserify": "0.3.0",
@@ -8009,10 +7991,10 @@
         "process": "0.11.10",
         "punycode": "1.4.1",
         "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.6",
         "stream-browserify": "2.0.1",
-        "stream-http": "2.8.0",
-        "string_decoder": "1.0.3",
+        "stream-http": "2.8.1",
+        "string_decoder": "1.1.1",
         "timers-browserify": "2.0.6",
         "tty-browserify": "0.0.0",
         "url": "0.11.0",
@@ -8026,8 +8008,8 @@
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "dev": true,
           "requires": {
-            "base64-js": "1.2.1",
-            "ieee754": "1.1.8",
+            "base64-js": "1.2.3",
+            "ieee754": "1.1.11",
             "isarray": "1.0.0"
           }
         },
@@ -8036,15 +8018,6 @@
           "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
           "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
           "dev": true
-        },
-        "timers-browserify": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
-          "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
-          "dev": true,
-          "requires": {
-            "setimmediate": "1.0.5"
-          }
         }
       }
     },
@@ -8079,9 +8052,9 @@
       }
     },
     "node-sass": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.7.2.tgz",
-      "integrity": "sha512-CaV+wLqZ7//Jdom5aUFCpGNoECd7BbNhjuwdsX/LkXBrHl8eb1Wjw4HvWqcFvhr5KuNgAk8i/myf/MQ1YYeroA==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.8.3.tgz",
+      "integrity": "sha512-tfFWhUsCk/Y19zarDcPo5xpj+IW3qCfOjVdHtYeG6S1CKbQOh1zqylnQK6cV3z9k80yxAnFX9Y+a9+XysDhhfg==",
       "dev": true,
       "requires": {
         "async-foreach": "0.1.3",
@@ -8093,10 +8066,10 @@
         "in-publish": "2.0.0",
         "lodash.assign": "4.2.0",
         "lodash.clonedeep": "4.5.0",
-        "lodash.mergewith": "4.6.0",
+        "lodash.mergewith": "4.6.1",
         "meow": "3.7.0",
         "mkdirp": "0.5.1",
-        "nan": "2.8.0",
+        "nan": "2.10.0",
         "node-gyp": "3.6.2",
         "npmlog": "4.1.2",
         "request": "2.79.0",
@@ -8148,19 +8121,13 @@
           "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
           "dev": true
         },
-        "commander": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-          "dev": true
-        },
         "cross-spawn": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.1",
+            "lru-cache": "4.1.2",
             "which": "1.3.0"
           }
         },
@@ -8190,8 +8157,8 @@
           "dev": true,
           "requires": {
             "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
           }
         },
         "gaze": {
@@ -8216,7 +8183,7 @@
           "dev": true,
           "requires": {
             "glob": "7.1.2",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "minimatch": "3.0.4"
           }
         },
@@ -8227,8 +8194,8 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "commander": "2.13.0",
-            "is-my-json-valid": "2.17.1",
+            "commander": "2.11.0",
+            "is-my-json-valid": "2.17.2",
             "pinkie-promise": "2.0.1"
           }
         },
@@ -8258,7 +8225,7 @@
           "requires": {
             "assert-plus": "0.2.0",
             "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "sshpk": "1.14.1"
           }
         },
         "indent-string": {
@@ -8306,12 +8273,6 @@
             "redent": "1.0.0",
             "trim-newlines": "1.0.0"
           }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
@@ -8392,9 +8353,9 @@
           "dev": true,
           "requires": {
             "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
+            "aws4": "1.7.0",
             "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
+            "combined-stream": "1.0.6",
             "extend": "3.0.1",
             "forever-agent": "0.6.1",
             "form-data": "2.1.4",
@@ -8404,11 +8365,11 @@
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
+            "mime-types": "2.1.18",
             "oauth-sign": "0.8.2",
             "qs": "6.3.2",
             "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
+            "tough-cookie": "2.3.4",
             "tunnel-agent": "0.4.3",
             "uuid": "3.2.1"
           }
@@ -8454,12 +8415,11 @@
         }
       }
     },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-      "dev": true,
-      "optional": true
+    "node-version": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/node-version/-/node-version-1.1.3.tgz",
+      "integrity": "sha512-rEwE51JWn0yN3Wl5BXeGn5d52OGbSXzWiiXRjAQeuyvcGKyvuSILW2rb3G7Xh+nexzLwhTpek6Ehxd6IjvHePg==",
+      "dev": true
     },
     "node.extend": {
       "version": "2.0.0",
@@ -8486,13 +8446,6 @@
         "socks": "1.1.9"
       },
       "dependencies": {
-        "ip": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-          "dev": true,
-          "optional": true
-        },
         "socks": {
           "version": "1.1.9",
           "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.9.tgz",
@@ -8577,10 +8530,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
+        "hosted-git-info": "2.6.0",
         "is-builtin-module": "1.0.0",
         "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.1"
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "normalize-path": {
@@ -8632,9 +8585,9 @@
       "dev": true
     },
     "object-assign": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-      "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-component": {
@@ -8662,52 +8615,6 @@
           "requires": {
             "is-descriptor": "0.1.6"
           }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
-            }
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
         }
       }
     },
@@ -8718,9 +8625,9 @@
       "dev": true
     },
     "object-keys": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true
     },
     "object-visit": {
@@ -8742,6 +8649,17 @@
         "array-slice": "1.1.0",
         "for-own": "1.0.0",
         "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "for-own": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+          "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+          "dev": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        }
       }
     },
     "object.map": {
@@ -8751,7 +8669,18 @@
       "dev": true,
       "requires": {
         "for-own": "1.0.0",
-        "make-iterator": "1.0.0"
+        "make-iterator": "1.0.1"
+      },
+      "dependencies": {
+        "for-own": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+          "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+          "dev": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        }
       }
     },
     "object.omit": {
@@ -8762,17 +8691,6 @@
       "requires": {
         "for-own": "0.1.5",
         "is-extendable": "0.1.1"
-      },
-      "dependencies": {
-        "for-own": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-          "dev": true,
-          "requires": {
-            "for-in": "1.0.2"
-          }
-        }
       }
     },
     "object.pick": {
@@ -8836,7 +8754,7 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "wordwrap": "0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -8879,7 +8797,7 @@
       "requires": {
         "end-of-stream": "0.1.5",
         "sequencify": "0.0.7",
-        "stream-consume": "0.1.0"
+        "stream-consume": "0.1.1"
       }
     },
     "ordered-read-streams": {
@@ -8928,12 +8846,14 @@
       "dev": true
     },
     "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
-        "lcid": "1.0.0"
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
       }
     },
     "os-tmpdir": {
@@ -8943,9 +8863,9 @@
       "dev": true
     },
     "osenv": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
         "os-homedir": "1.0.2",
@@ -9004,6 +8924,36 @@
         "pac-resolver": "2.0.0",
         "raw-body": "2.3.2",
         "socks-proxy-agent": "2.1.1"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+          "dev": true,
+          "requires": {
+            "extend": "3.0.1",
+            "semver": "5.0.3"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+          "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "agent-base": "2.1.1",
+            "debug": "2.6.9",
+            "extend": "3.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+          "dev": true
+        }
       }
     },
     "pac-resolver": {
@@ -9024,6 +8974,13 @@
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/co/-/co-3.0.6.tgz",
           "integrity": "sha1-FEXyJsXrlWE45oyawwFn6n0ua9o=",
+          "dev": true,
+          "optional": true
+        },
+        "ip": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/ip/-/ip-1.0.1.tgz",
+          "integrity": "sha1-x+NWzeoiWucbNtcPLnGpK6TkJZA=",
           "dev": true,
           "optional": true
         }
@@ -9050,8 +9007,8 @@
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "dev": true,
       "requires": {
-        "asn1.js": "4.9.2",
-        "browserify-aes": "1.1.1",
+        "asn1.js": "4.10.1",
+        "browserify-aes": "1.2.0",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.3",
         "pbkdf2": "3.0.14"
@@ -9136,7 +9093,7 @@
       "dev": true,
       "requires": {
         "error-ex": "1.3.1",
-        "json-parse-better-errors": "1.0.1"
+        "json-parse-better-errors": "1.0.2"
       }
     },
     "parse-passwd": {
@@ -9300,7 +9257,7 @@
         "create-hmac": "1.1.6",
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
-        "sha.js": "2.4.10"
+        "sha.js": "2.4.11"
       }
     },
     "pend": {
@@ -9321,13 +9278,13 @@
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.2.2",
+        "es6-promise": "4.2.4",
         "extract-zip": "1.6.6",
         "fs-extra": "1.0.0",
         "hasha": "2.2.0",
         "kew": "0.7.0",
         "progress": "1.1.8",
-        "request": "2.83.0",
+        "request": "2.85.0",
         "request-progress": "2.0.1",
         "which": "1.3.0"
       },
@@ -9385,36 +9342,15 @@
       }
     },
     "plugin-error": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.0.tgz",
-      "integrity": "sha1-N9Zr2W6jNLdHJYTbFJZ3uiM3ck4=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+      "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
       "dev": true,
       "requires": {
-        "ansi-colors": "1.0.1",
+        "ansi-colors": "1.1.0",
         "arr-diff": "4.0.0",
         "arr-union": "3.1.0",
         "extend-shallow": "3.0.2"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-          "dev": true,
-          "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
-          }
-        },
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "dev": true,
-          "requires": {
-            "is-plain-object": "2.0.4"
-          }
-        }
       }
     },
     "pngjs": {
@@ -9479,9 +9415,9 @@
       "dev": true
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
     },
     "progress": {
@@ -9499,6 +9435,12 @@
         "asap": "2.0.6"
       }
     },
+    "promise-polyfill": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.1.0.tgz",
+      "integrity": "sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc=",
+      "dev": true
+    },
     "prop-types": {
       "version": "15.6.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
@@ -9508,14 +9450,6 @@
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
       }
     },
     "proxy-addr": {
@@ -9545,12 +9479,40 @@
         "socks-proxy-agent": "2.1.1"
       },
       "dependencies": {
+        "agent-base": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+          "dev": true,
+          "requires": {
+            "extend": "3.0.1",
+            "semver": "5.0.3"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+          "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "agent-base": "2.1.1",
+            "debug": "2.6.9",
+            "extend": "3.0.1"
+          }
+        },
         "lru-cache": {
           "version": "2.6.5",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
           "integrity": "sha1-5W1jVBSO3o13B7WNFDIg/QjfD9U=",
           "dev": true,
           "optional": true
+        },
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+          "dev": true
         }
       }
     },
@@ -9599,7 +9561,7 @@
       "requires": {
         "debug": "2.6.9",
         "extract-zip": "1.6.6",
-        "https-proxy-agent": "2.2.0",
+        "https-proxy-agent": "2.2.1",
         "mime": "1.6.0",
         "progress": "2.0.0",
         "proxy-from-env": "1.0.0",
@@ -9607,36 +9569,6 @@
         "ws": "3.3.3"
       },
       "dependencies": {
-        "agent-base": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
-          "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
-          "dev": true,
-          "requires": {
-            "es6-promisify": "5.0.0"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.0.tgz",
-          "integrity": "sha512-uUWcfXHvy/dwfM9bqa6AozvAjS32dZSTUYd/4SEpYKRg6LEcPLshksnQYRudM9AyNvUARMfAg5TLjUDyX/K4vA==",
-          "dev": true,
-          "requires": {
-            "agent-base": "4.2.0",
-            "debug": "3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
         "progress": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
@@ -9653,9 +9585,9 @@
       "optional": true
     },
     "qjobs": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.1.5.tgz",
-      "integrity": "sha1-ZZ3p8s+NzCehSBJ28gU3cnI4LnM=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.2.0.tgz",
+      "integrity": "sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==",
       "dev": true
     },
     "qs": {
@@ -9728,9 +9660,9 @@
       }
     },
     "randomfill": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
-      "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
         "randombytes": "2.0.6",
@@ -9753,6 +9685,38 @@
         "http-errors": "1.6.2",
         "iconv-lite": "0.4.19",
         "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+          "dev": true
+        },
+        "http-errors": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+          "dev": true,
+          "requires": {
+            "depd": "1.1.1",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.0.3",
+            "statuses": "1.4.0"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+          "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+          "dev": true
+        }
       }
     },
     "react": {
@@ -9766,14 +9730,6 @@
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
         "prop-types": "15.6.1"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
       }
     },
     "react-dom": {
@@ -9786,14 +9742,6 @@
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
         "prop-types": "15.6.1"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
       }
     },
     "react-modal": {
@@ -9835,23 +9783,15 @@
         "hoist-non-react-statics": "2.5.0",
         "invariant": "2.2.4",
         "lodash": "4.17.5",
-        "lodash-es": "4.17.7",
+        "lodash-es": "4.17.8",
         "loose-envify": "1.3.1",
         "prop-types": "15.6.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-          "dev": true
-        }
       }
     },
     "react-sticky": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/react-sticky/-/react-sticky-6.0.1.tgz",
-      "integrity": "sha1-NWmIvcxvyM0tiXRtIwLtzmfYZoc=",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/react-sticky/-/react-sticky-6.0.2.tgz",
+      "integrity": "sha512-eXsij6ifE2k1d6eCwQzil0JRS3VLP6BYfiF7qEbVPL3GLqciedGJfbavpXx5T95x5HvhuAA4FChYEDv83r1NyQ==",
       "dev": true,
       "requires": {
         "prop-types": "15.6.1",
@@ -9880,7 +9820,7 @@
       "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.6"
       }
     },
     "read-pkg": {
@@ -9905,17 +9845,17 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
+        "process-nextick-args": "2.0.0",
         "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
+        "string_decoder": "1.1.1",
         "util-deprecate": "1.0.2"
       }
     },
@@ -9927,7 +9867,7 @@
       "requires": {
         "graceful-fs": "4.1.11",
         "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.6",
         "set-immediate-shim": "1.0.1"
       }
     },
@@ -9937,7 +9877,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.5.0"
+        "resolve": "1.7.0"
       }
     },
     "redent": {
@@ -9958,14 +9898,14 @@
       "optional": true,
       "requires": {
         "double-ended-queue": "2.1.0-0",
-        "redis-commands": "1.3.1",
+        "redis-commands": "1.3.5",
         "redis-parser": "2.6.0"
       }
     },
     "redis-commands": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
-      "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.5.tgz",
+      "integrity": "sha512-foGF8u6MXGFF++1TZVC6icGXuMYPftKXt1FBT2vrfU9ZATNtZJ8duRC5d1lEfE8hyVe3jhelHGB91oB7I6qLsA==",
       "dev": true,
       "optional": true
     },
@@ -9982,8 +9922,8 @@
       "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4",
-        "lodash-es": "4.17.7",
+        "lodash": "4.17.5",
+        "lodash-es": "4.17.8",
         "loose-envify": "1.3.1",
         "symbol-observable": "1.2.0"
       }
@@ -10004,12 +9944,13 @@
       }
     },
     "regex-not": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
-      "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "remove-trailing-separator": {
@@ -10053,43 +9994,35 @@
       "requires": {
         "escape-string-regexp": "1.0.5",
         "object-assign": "4.1.1",
-        "readable-stream": "2.3.3"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
+        "readable-stream": "2.3.6"
       }
     },
     "request": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "version": "2.85.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "dev": true,
       "requires": {
         "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
+        "aws4": "1.7.0",
         "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
+        "combined-stream": "1.0.6",
         "extend": "3.0.1",
         "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
+        "form-data": "2.3.2",
         "har-validator": "5.0.3",
         "hawk": "6.0.2",
         "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
+        "mime-types": "2.1.18",
         "oauth-sign": "0.8.2",
         "performance-now": "2.1.0",
         "qs": "6.5.1",
         "safe-buffer": "5.1.1",
         "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
+        "tough-cookie": "2.3.4",
         "tunnel-agent": "0.6.0",
         "uuid": "3.2.1"
       }
@@ -10111,8 +10044,8 @@
       "optional": true,
       "requires": {
         "extend": "3.0.1",
-        "lodash": "4.17.4",
-        "request": "2.83.0",
+        "lodash": "4.17.5",
+        "request": "2.85.0",
         "when": "3.7.8"
       }
     },
@@ -10141,9 +10074,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.0.tgz",
+      "integrity": "sha512-QdgZ5bjR1WAlpLaO5yHepFvC+o3rCr6wpfE2tpJNMkXdulf2jKomQBdNRQITF3ZKHNlT71syG98yQP03gasgnA==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
@@ -10180,6 +10113,12 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -10214,6 +10153,21 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "0.1.15"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
     "samsam": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
@@ -10227,7 +10181,7 @@
       "dev": true,
       "requires": {
         "glob": "7.1.2",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "scss-tokenizer": "0.2.3",
         "yargs": "7.1.0"
       },
@@ -10237,6 +10191,17 @@
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
         },
         "find-up": {
           "version": "1.1.2",
@@ -10259,6 +10224,15 @@
             "pify": "2.3.0",
             "pinkie-promise": "2.0.1",
             "strip-bom": "2.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "1.0.0"
           }
         },
         "parse-json": {
@@ -10317,6 +10291,17 @@
             "read-pkg": "1.1.0"
           }
         },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
         "strip-bom": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
@@ -10325,6 +10310,12 @@
           "requires": {
             "is-utf8": "0.2.1"
           }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
         },
         "yargs": {
           "version": "7.1.0",
@@ -10346,6 +10337,15 @@
             "y18n": "3.2.1",
             "yargs-parser": "5.0.0"
           }
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          }
         }
       }
     },
@@ -10361,7 +10361,7 @@
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "2.4.2",
+        "js-base64": "2.4.3",
         "source-map": "0.4.4"
       },
       "dependencies": {
@@ -10410,7 +10410,7 @@
         "escape-html": "1.0.3",
         "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.2",
+        "http-errors": "1.6.3",
         "mime": "1.4.1",
         "ms": "2.0.0",
         "on-finished": "2.3.0",
@@ -10442,38 +10442,9 @@
         "batch": "0.6.1",
         "debug": "2.6.9",
         "escape-html": "1.0.3",
-        "http-errors": "1.6.2",
-        "mime-types": "2.1.17",
+        "http-errors": "1.6.3",
+        "mime-types": "2.1.18",
         "parseurl": "1.3.2"
-      },
-      "dependencies": {
-        "accepts": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-          "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-          "dev": true,
-          "requires": {
-            "mime-types": "2.1.18",
-            "negotiator": "0.6.1"
-          },
-          "dependencies": {
-            "mime-types": {
-              "version": "2.1.18",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-              "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-              "dev": true,
-              "requires": {
-                "mime-db": "1.33.0"
-              }
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.33.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
-          "dev": true
-        }
       }
     },
     "serve-static": {
@@ -10494,15 +10465,6 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
-    "set-getter": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
-      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
-      "dev": true,
-      "requires": {
-        "to-object-path": "0.3.0"
-      }
-    },
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
@@ -10519,6 +10481,17 @@
         "is-extendable": "0.1.1",
         "is-plain-object": "2.0.4",
         "split-string": "3.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
       }
     },
     "setimmediate": {
@@ -10528,15 +10501,15 @@
       "dev": true
     },
     "setprototypeof": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
       "dev": true
     },
     "sha.js": {
-      "version": "2.4.10",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
-      "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
@@ -10550,7 +10523,7 @@
       "dev": true,
       "requires": {
         "json-stable-stringify": "0.0.1",
-        "sha.js": "2.4.10"
+        "sha.js": "2.4.11"
       }
     },
     "shebang-command": {
@@ -10637,9 +10610,9 @@
       }
     },
     "snapdragon": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
-      "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
         "base": "0.11.2",
@@ -10649,7 +10622,7 @@
         "map-cache": "0.2.2",
         "source-map": "0.5.7",
         "source-map-resolve": "0.5.1",
-        "use": "2.0.2"
+        "use": "3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -10661,62 +10634,14 @@
             "is-descriptor": "0.1.6"
           }
         },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
+            "is-extendable": "0.1.1"
           }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "dev": true
         }
       }
     },
@@ -10729,6 +10654,52 @@
         "define-property": "1.0.0",
         "isobject": "3.0.1",
         "snapdragon-util": "3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
       }
     },
     "snapdragon-util": {
@@ -10738,17 +10709,6 @@
       "dev": true,
       "requires": {
         "kind-of": "3.2.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        }
       }
     },
     "sntp": {
@@ -10757,7 +10717,76 @@
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
+      }
+    },
+    "socket.io": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.0.4.tgz",
+      "integrity": "sha1-waRZDO/4fs8TxyZS8Eb3FrKeYBQ=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "engine.io": "3.1.5",
+        "socket.io-adapter": "1.1.1",
+        "socket.io-client": "2.0.4",
+        "socket.io-parser": "3.1.3"
+      }
+    },
+    "socket.io-adapter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
+      "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs=",
+      "dev": true
+    },
+    "socket.io-client": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.4.tgz",
+      "integrity": "sha1-CRilUkBtxeVAs4Dc2Xr8SmQzL44=",
+      "dev": true,
+      "requires": {
+        "backo2": "1.0.2",
+        "base64-arraybuffer": "0.1.5",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.1",
+        "debug": "2.6.9",
+        "engine.io-client": "3.1.6",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "socket.io-parser": "3.1.3",
+        "to-array": "0.1.4"
+      }
+    },
+    "socket.io-parser": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.3.tgz",
+      "integrity": "sha512-g0a2HPqLguqAczs3dMECuA1RgoGFPyvDqcbaDEdCWY9g59kdUAz3YRmaJBNKXflrHNwB7Q12Gkf/0CZXfdHR7g==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1",
+        "debug": "3.1.0",
+        "has-binary2": "1.0.2",
+        "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
+        }
       }
     },
     "sockjs": {
@@ -10781,7 +10810,7 @@
         "faye-websocket": "0.11.1",
         "inherits": "2.0.3",
         "json3": "3.3.2",
-        "url-parse": "1.2.0"
+        "url-parse": "1.3.0"
       },
       "dependencies": {
         "faye-websocket": {
@@ -10803,14 +10832,6 @@
       "requires": {
         "ip": "1.1.5",
         "smart-buffer": "1.1.15"
-      },
-      "dependencies": {
-        "ip": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-          "dev": true
-        }
       }
     },
     "socks-proxy-agent": {
@@ -10822,6 +10843,24 @@
         "agent-base": "2.1.1",
         "extend": "3.0.1",
         "socks": "1.1.10"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+          "dev": true,
+          "requires": {
+            "extend": "3.0.1",
+            "semver": "5.0.3"
+          }
+        },
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+          "dev": true
+        }
       }
     },
     "source-list-map": {
@@ -10842,7 +10881,7 @@
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "dev": true,
       "requires": {
-        "atob": "2.0.3",
+        "atob": "2.1.0",
         "decode-uri-component": "0.2.0",
         "resolve-url": "0.2.1",
         "source-map-url": "0.4.0",
@@ -10862,24 +10901,35 @@
       "dev": true
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
-    "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
       "dev": true
     },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
     "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
       "dev": true
     },
     "spdy": {
@@ -10906,7 +10956,7 @@
         "detect-node": "2.0.3",
         "hpack.js": "2.1.6",
         "obuf": "1.1.2",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.6",
         "safe-buffer": "5.1.1",
         "wbuf": "1.7.3"
       }
@@ -10918,33 +10968,12 @@
       "dev": true,
       "requires": {
         "extend-shallow": "3.0.2"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-          "dev": true,
-          "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
-          }
-        },
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "dev": true,
-          "requires": {
-            "is-plain-object": "2.0.4"
-          }
-        }
       }
     },
     "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "dev": true,
       "requires": {
         "asn1": "0.2.3",
@@ -10975,63 +11004,6 @@
           "requires": {
             "is-descriptor": "0.1.6"
           }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "dev": true
         }
       }
     },
@@ -11047,7 +11019,7 @@
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.6"
       }
     },
     "stream-browserify": {
@@ -11057,7 +11029,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.6"
       }
     },
     "stream-combiner2": {
@@ -11067,7 +11039,7 @@
       "dev": true,
       "requires": {
         "duplexer2": "0.1.4",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "duplexer2": {
@@ -11076,26 +11048,26 @@
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.3"
+            "readable-stream": "2.3.6"
           }
         }
       }
     },
     "stream-consume": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
-      "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
+      "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
       "dev": true
     },
     "stream-http": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz",
-      "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
+      "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
       "dev": true,
       "requires": {
         "builtin-status-codes": "3.0.0",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.6",
         "to-arraybuffer": "1.0.1",
         "xtend": "4.0.1"
       }
@@ -11107,7 +11079,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.6"
       }
     },
     "stream-to": {
@@ -11134,7 +11106,7 @@
         "date-format": "1.2.0",
         "debug": "3.1.0",
         "mkdirp": "0.5.1",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "debug": {
@@ -11149,20 +11121,42 @@
       }
     },
     "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
       }
     },
     "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
@@ -11216,7 +11210,7 @@
       "integrity": "sha512-bLW0/lQxTgJ0y+TEllctly+/B0Hz2N82e5AhubP+FIVPSisyOzyFnZzWdqRml7RDwRCsT+EGNN8YYa0VFutT+w==",
       "dev": true,
       "requires": {
-        "buffer": "5.0.8",
+        "buffer": "5.1.0",
         "css-to-react-native": "2.1.2",
         "fbjs": "0.8.16",
         "hoist-non-react-statics": "1.2.0",
@@ -11271,12 +11265,12 @@
       "dev": true
     },
     "syntax-error": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.3.0.tgz",
-      "integrity": "sha1-HtkmbE1AvnXcVb+bsct3Biu5bKE=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+      "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn-node": "1.3.0"
       }
     },
     "tapable": {
@@ -11284,6 +11278,17 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
       "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
       "dev": true
+    },
+    "tar": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "dev": true,
+      "requires": {
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
+      }
     },
     "temp": {
       "version": "0.8.3",
@@ -11327,7 +11332,7 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.6",
         "xtend": "4.0.1"
       }
     },
@@ -11339,9 +11344,9 @@
       "optional": true
     },
     "thunks": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/thunks/-/thunks-4.9.0.tgz",
-      "integrity": "sha512-Bp4sGtcf8/SAgX2XBXYH2Crc7ESL7xuTuQ5kx84Tvz7VSkLFg6bfjFBpRmX2DLAWaLeK6q32ogqAnXcr5NAQtw==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/thunks/-/thunks-4.9.2.tgz",
+      "integrity": "sha1-qsLTU4ElEhYKRhHjAI16luN1b44=",
       "dev": true
     },
     "thunky": {
@@ -11360,26 +11365,18 @@
       }
     },
     "time-stamp": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
+      "integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c=",
       "dev": true
     },
     "timers-browserify": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
-      "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
+      "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
       "dev": true,
       "requires": {
-        "process": "0.11.10"
-      },
-      "dependencies": {
-        "process": {
-          "version": "0.11.10",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-          "dev": true
-        }
+        "setimmediate": "1.0.5"
       }
     },
     "timespan": {
@@ -11423,96 +11420,18 @@
       "dev": true,
       "requires": {
         "kind-of": "3.2.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        }
       }
     },
     "to-regex": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz",
-      "integrity": "sha1-FTWL7kosg712N3uh3ASdDxiDeq4=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "regex-not": "1.0.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "dev": true
-        }
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -11526,9 +11445,9 @@
       }
     },
     "tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "dev": true,
       "requires": {
         "punycode": "1.4.1"
@@ -11615,13 +11534,13 @@
       }
     },
     "type-is": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.17"
+        "mime-types": "2.1.18"
       }
     },
     "typedarray": {
@@ -11651,23 +11570,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
-          "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          }
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
           "dev": true
         },
         "yargs": {
@@ -11709,9 +11611,9 @@
       "dev": true
     },
     "umd": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
-      "integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
+      "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
       "dev": true
     },
     "unc-path-regex": {
@@ -11738,6 +11640,15 @@
         "set-value": "0.4.3"
       },
       "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
         "set-value": {
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
@@ -11810,6 +11721,23 @@
       "integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw==",
       "dev": true
     },
+    "uri-js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
+      "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+          "dev": true
+        }
+      }
+    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -11835,9 +11763,9 @@
       }
     },
     "url-parse": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
-      "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.3.0.tgz",
+      "integrity": "sha512-zPvPA3T7P6M+0iNsgX+iAcAz4GshKrowtQBHHc/28tVsBc8jK7VRCNX+2GEcoE6zDB6XqXhcyiUWPVZY6C70Cg==",
       "dev": true,
       "requires": {
         "querystringify": "1.0.0",
@@ -11862,80 +11790,18 @@
       }
     },
     "use": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
-      "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "lazy-cache": "2.0.2"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
-        },
         "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -11947,21 +11813,13 @@
       "dev": true
     },
     "useragent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.2.1.tgz",
-      "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
+      "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
       "dev": true,
       "requires": {
-        "lru-cache": "2.2.4",
+        "lru-cache": "4.1.2",
         "tmp": "0.0.33"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
-          "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=",
-          "dev": true
-        }
       }
     },
     "util": {
@@ -12000,9 +11858,9 @@
       "dev": true
     },
     "uws": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/uws/-/uws-0.14.5.tgz",
-      "integrity": "sha1-Z6rzPEaypYel9mZtAPdpEyjxSdw=",
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/uws/-/uws-9.14.0.tgz",
+      "integrity": "sha512-HNMztPP5A1sKuVFmdZ6BPVpBQd5bUjNC8EFMFiICK+oho/OQsAJy5hnIx4btMHiOk8j04f/DbIlqnEZ9d72dqg==",
       "dev": true,
       "optional": true
     },
@@ -12016,13 +11874,13 @@
       }
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "vary": {
@@ -12048,7 +11906,7 @@
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
       "dev": true,
       "requires": {
-        "clone": "1.0.3",
+        "clone": "1.0.4",
         "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       }
@@ -12081,7 +11939,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "1.1.1"
+            "natives": "1.1.3"
           }
         },
         "isarray": {
@@ -12182,68 +12040,6 @@
         "chokidar": "2.0.3",
         "graceful-fs": "4.1.11",
         "neo-async": "2.5.0"
-      },
-      "dependencies": {
-        "anymatch": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-          "dev": true,
-          "requires": {
-            "micromatch": "3.1.5",
-            "normalize-path": "2.1.1"
-          }
-        },
-        "chokidar": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
-          "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
-          "dev": true,
-          "requires": {
-            "anymatch": "2.0.0",
-            "async-each": "1.0.1",
-            "braces": "2.3.0",
-            "fsevents": "1.1.3",
-            "glob-parent": "3.1.0",
-            "inherits": "2.0.3",
-            "is-binary-path": "1.0.1",
-            "is-glob": "4.0.0",
-            "normalize-path": "2.1.1",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.1.0",
-            "upath": "1.0.4"
-          }
-        },
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "dev": true,
-          "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-              "dev": true,
-              "requires": {
-                "is-extglob": "2.1.1"
-              }
-            }
-          }
-        },
-        "is-glob": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "2.1.1"
-          }
-        }
       }
     },
     "wbuf": {
@@ -12263,9 +12059,9 @@
       "requires": {
         "acorn": "5.5.3",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "6.3.0",
+        "ajv": "6.4.0",
         "ajv-keywords": "3.1.0",
-        "async": "2.1.5",
+        "async": "2.6.0",
         "enhanced-resolve": "3.4.1",
         "escope": "3.6.0",
         "interpret": "1.1.0",
@@ -12285,39 +12081,46 @@
         "yargs": "8.0.2"
       },
       "dependencies": {
-        "acorn": {
-          "version": "5.5.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
-          "dev": true
-        },
         "ajv": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.3.0.tgz",
-          "integrity": "sha1-FlCkERTvAFdMrBC4Ay2PTBSBLac=",
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
+          "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "1.0.0",
+            "fast-deep-equal": "1.1.0",
             "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "3.0.2"
           }
         },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
         },
         "has-flag": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "load-json-file": {
@@ -12330,17 +12133,6 @@
             "parse-json": "2.2.0",
             "pify": "2.3.0",
             "strip-bom": "3.0.0"
-          }
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
-          "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
           }
         },
         "parse-json": {
@@ -12388,25 +12180,6 @@
             "read-pkg": "2.0.0"
           }
         },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        },
         "supports-color": {
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
@@ -12415,12 +12188,6 @@
           "requires": {
             "has-flag": "2.0.0"
           }
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-          "dev": true
         },
         "yargs": {
           "version": "8.0.2",
@@ -12442,15 +12209,6 @@
             "y18n": "3.2.1",
             "yargs-parser": "7.0.0"
           }
-        },
-        "yargs-parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0"
-          }
         }
       }
     },
@@ -12465,14 +12223,6 @@
         "path-is-absolute": "1.0.1",
         "range-parser": "1.2.0",
         "time-stamp": "2.0.0"
-      },
-      "dependencies": {
-        "time-stamp": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
-          "integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c=",
-          "dev": true
-        }
       }
     },
     "webpack-dev-server": {
@@ -12510,40 +12260,21 @@
         "yargs": "6.6.0"
       },
       "dependencies": {
-        "anymatch": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-          "dev": true,
-          "requires": {
-            "micromatch": "3.1.5",
-            "normalize-path": "2.1.1"
-          }
-        },
         "camelcase": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         },
-        "chokidar": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
-          "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "anymatch": "2.0.0",
-            "async-each": "1.0.1",
-            "braces": "2.3.0",
-            "fsevents": "1.1.3",
-            "glob-parent": "3.1.0",
-            "inherits": "2.0.3",
-            "is-binary-path": "1.0.1",
-            "is-glob": "4.0.0",
-            "normalize-path": "2.1.1",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.1.0",
-            "upath": "1.0.4"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           }
         },
         "debug": {
@@ -12565,47 +12296,11 @@
             "pinkie-promise": "2.0.1"
           }
         },
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "dev": true,
-          "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-              "dev": true,
-              "requires": {
-                "is-extglob": "2.1.1"
-              }
-            }
-          }
-        },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
-        },
-        "ip": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "2.1.1"
-          }
         },
         "load-json-file": {
           "version": "1.1.0",
@@ -12618,6 +12313,15 @@
             "pify": "2.3.0",
             "pinkie-promise": "2.0.1",
             "strip-bom": "2.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "1.0.0"
           }
         },
         "parse-json": {
@@ -12676,6 +12380,17 @@
             "read-pkg": "1.1.0"
           }
         },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
         "strip-bom": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
@@ -12693,6 +12408,12 @@
           "requires": {
             "has-flag": "3.0.0"
           }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
         },
         "yargs": {
           "version": "6.6.0",
@@ -12761,9 +12482,9 @@
       "dev": true
     },
     "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
       "dev": true
     },
     "when": {
@@ -12783,9 +12504,9 @@
       }
     },
     "which-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
     "wide-align": {
@@ -12795,6 +12516,19 @@
       "dev": true,
       "requires": {
         "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
       }
     },
     "window-size": {
@@ -12804,9 +12538,9 @@
       "dev": true
     },
     "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
       "dev": true
     },
     "wrap-ansi": {
@@ -12817,6 +12551,19 @@
       "requires": {
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
       }
     },
     "wrappy": {
@@ -12876,6 +12623,12 @@
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
       "dev": true
     },
+    "xmlhttprequest-ssl": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "dev": true
+    },
     "xregexp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
@@ -12895,10 +12648,16 @@
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
     },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
     "yargs": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.1.tgz",
-      "integrity": "sha512-7uRL1HZdCbc1QTP+X8mehOPuCYKC/XTaqAPj7gABLfTt6pgLyVRn3QVte4qhtilZouWCvqd1kipgMKl5tKsFiw==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+      "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
       "dev": true,
       "requires": {
         "cliui": "4.0.0",
@@ -12932,33 +12691,6 @@
             "wrap-ansi": "2.1.0"
           }
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
-          "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -12967,12 +12699,6 @@
           "requires": {
             "ansi-regex": "3.0.0"
           }
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-          "dev": true
         },
         "yargs-parser": {
           "version": "8.1.0",
@@ -12986,20 +12712,12 @@
       }
     },
     "yargs-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-      "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        }
+        "camelcase": "4.1.0"
       }
     },
     "yauzl": {

--- a/uk.co.compucorp.civicrm.hrcore/package.json
+++ b/uk.co.compucorp.civicrm.hrcore/package.json
@@ -6,7 +6,7 @@
   },
   "devDependencies": {
     "ansi-colors": "^1.0.1",
-    "backstopjs": "^3.2.0",
+    "backstopjs": "^3.2.3",
     "civicrm-scssroot": "git://github.com/totten/civicrm-scssroot.git#v0.1.1",
     "detect-installed": "^2.0.4",
     "es6-promise": "^4.2.2",

--- a/uk.co.compucorp.civicrm.hrcore/package.json
+++ b/uk.co.compucorp.civicrm.hrcore/package.json
@@ -6,8 +6,7 @@
   },
   "devDependencies": {
     "ansi-colors": "^1.0.1",
-    "backstopjs": "^3.1.19",
-    "chromy": "^0.5.11",
+    "backstopjs": "^3.2.0",
     "civicrm-scssroot": "git://github.com/totten/civicrm-scssroot.git#v0.1.1",
     "detect-installed": "^2.0.4",
     "es6-promise": "^4.2.2",


### PR DESCRIPTION
_(This PR build on top of the work as part of #2535)_

## Overview
This PR migrates our BackstopJS test suite from [Chromy](https://github.com/OnetapInc/chromy) to [Puppeteer](https://github.com/GoogleChrome/puppeteer), now that BackstopJS [support](https://github.com/garris/BackstopJS/commit/72d0b0534927e8b4143991b4a2c7b11932833c8c) for the latter is, at the time of this writing, in canary version

Couple of reasons for the switch to Puppeteer:
1. It's developed and maintained by the Chrome DevTools team, so it stands to reason that it should be the preferred option
2. It's api is much more comprehensive than Chromy's
3. It's much faster than Chromy's (I noticed an improvement of ~7 mins when running our full suite)

## Technical details
### ECMAScript 2017
Given the very integral use of `async/await` in Puppeteer, it didn't make sense to try to do things the old way with `then()`, `Promise.resolve()`, and the like. So all the code written for BackstopJS had been migrated to ECMAScript 2017

### No need for shrinkwrap anymore
The use of a *npm-shrinkwrap.json* file was dictated by the need to use a Chromy version that BackstopJS didn't officially depended on yet. The switch to Puppeteer makes this dependency not needed anymore, so we can switch back to the usual `package-lock.json` file

### Improved wait/ready logic
A couple of pages/sections (my leave report, L&A import) had a wait/ready logic that didn't work well in Puppeteer, so it needed some refinement

#### My leave report
First of all, we wait for the main spinner to disappear
```js
async waitForReady () {
  await this.puppet.waitFor('.spinner', { visible: false });
  // ...
},
```
then, when opening a section, we wait for *all* the spinner to be hidden (unfortunately when using `waitFor(<selector>)`, it considers only the first element that matches `<selector>`)
```js
async openSection (section) {
  await this.puppet.click('td[ng-click="report.toggleSection(\'' + section + '\')"]');
  await this.puppet.waitFor(function () {
    var spinners = document.querySelectorAll('.spinner');

    return Array.prototype.every.call(spinners, function (dom) {
      return dom === null || (dom.offsetWidth <= 0 && dom.offsetHeight <= 0);
    });
  });
},
```
#### L&A Import
Puppeteer struggled to understand when step 3 and step 4 where ready, leading to random waitTimeout errors

Initially the `domcontentloaded` event was used
```js
async submitAndWait () { 
  // ...
  await this.puppet.waitForNavigation({ waitUntil: 'domcontentloaded' });
}
```
but this lead to the aforementioned random timeout errors

So now we wait for the breadcrumb (`li`) of the step that we need to capture to be marked as active (via the `.active` class), which makes sure that the page is fully loaded
```js
async submitAndWaitForStep (step) {
  // ...
  await this.puppet.waitFor(`.crm_wizard__title .nav-pills li.active:nth-child(${step})`);
}