### PR TITLE
PCHR-3464: Hide link to edit locked option groups in forms

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/OptionEditPathFilter.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/OptionEditPathFilter.php
@@ -1,0 +1,72 @@
+<?php
+
+class CRM_HRCore_Hook_BuildForm_OptionEditPathFilter {
+
+  /**
+   * @var bool[]
+   *   A mapping of option group name to its "is_locked" status
+   */
+  private $optionGroupLockedStatuses = [];
+
+  /**
+   * Handle the form. Any form that can contain elements referencing an
+   * option group should be handled, i.e. all forms
+   *
+   * @param string $formName
+   * @param CRM_Core_Form $form
+   */
+  public function handle($formName, &$form) {
+    $this->filterOptionEditPaths($form);
+  }
+
+  /**
+   * Loop through the form, removing the 'data-option-edit-path' from form
+   * elements that reference locked option groups. If this attribute is not set
+   * then the icon to provide a shortcut to edit this group will not be shown.
+   *
+   * @see \CRM_Core_Form_Renderer::addOptionsEditLink
+   *
+   * @param CRM_Core_Form $form
+   */
+  private function filterOptionEditPaths($form) {
+    /** @var HTML_QuickForm_element $element */
+    foreach ($form->_elements as &$element) {
+      $optionEditPath = $element->getAttribute('data-option-edit-path');
+      if (!$optionEditPath) {
+        continue;
+      }
+
+      $prefix = 'civicrm/admin/options/';
+      if (strpos($optionEditPath, $prefix) !== 0) {
+        // this is not an option group edit link
+        continue;
+      }
+
+      $optionGroupName = str_replace($prefix, '', $optionEditPath);
+
+      if ($this->isLockedOptionGroup($optionGroupName)) {
+        $element->removeAttribute('data-option-edit-path');
+      }
+    }
+  }
+
+  /**
+   * Check whether a given option group is locked
+   *
+   * @param string $optionGroupName
+   *
+   * @return bool
+   */
+  private function isLockedOptionGroup($optionGroupName) {
+    if (!isset($this->optionGroupLockedStatuses[$optionGroupName])) {
+      $params = ['return' => 'is_locked', 'name' => $optionGroupName];
+      $result = civicrm_api3('OptionGroup', 'get', $params);
+      $result = array_shift($result['values']);
+      $isLocked = CRM_Utils_Array::value('is_locked', $result, FALSE);
+      $this->optionGroupLockedStatuses[$optionGroupName] = (bool) $isLocked;
+    }
+
+    return $this->optionGroupLockedStatuses[$optionGroupName];
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/OptionEditPathFilter.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/OptionEditPathFilter.php
@@ -3,10 +3,10 @@
 class CRM_HRCore_Hook_BuildForm_OptionEditPathFilter {
 
   /**
-   * @var bool[]
-   *   A mapping of option group name to its "is_locked" status
+   * @var string[]
+   *   An array of locked option group names, indexed by group ID
    */
-  private $optionGroupLockedStatuses = [];
+  private $lockedOptionGroups = [];
 
   /**
    * Handle the form. Any form that can contain elements referencing an
@@ -58,15 +58,13 @@ class CRM_HRCore_Hook_BuildForm_OptionEditPathFilter {
    * @return bool
    */
   private function isLockedOptionGroup($optionGroupName) {
-    if (!isset($this->optionGroupLockedStatuses[$optionGroupName])) {
-      $params = ['return' => 'is_locked', 'name' => $optionGroupName];
-      $result = civicrm_api3('OptionGroup', 'get', $params);
-      $result = array_shift($result['values']);
-      $isLocked = CRM_Utils_Array::value('is_locked', $result, FALSE);
-      $this->optionGroupLockedStatuses[$optionGroupName] = (bool) $isLocked;
+    if (empty($this->lockedOptionGroups)) {
+      $params = ['return' => 'name', 'is_locked' => 1];
+      $result = civicrm_api3('OptionGroup', 'get', $params)['values'];
+      $this->lockedOptionGroups = array_column($result, 'name', 'id');
     }
 
-    return $this->optionGroupLockedStatuses[$optionGroupName];
+    return in_array($optionGroupName, $this->lockedOptionGroups);
   }
 
 }

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -107,7 +107,7 @@ function hrcore_civicrm_container($container) {
 }
 
 /**
- * Implements hook_civicrm_buildForm
+ * Implements hook_civicrm_buildForm().
  *
  * @param string $formName
  * @param CRM_Core_Form $form
@@ -117,6 +117,7 @@ function hrcore_civicrm_buildForm($formName, &$form) {
     new CRM_HRCore_Hook_BuildForm_ActivityFilterSelectFieldsModifier(),
     new CRM_HRCore_Hook_BuildForm_ActivityLinksFilter(),
     new CRM_HRCore_Hook_BuildForm_LocalisationPageFilter(),
+    new CRM_HRCore_Hook_BuildForm_OptionEditPathFilter(),
   ];
 
   foreach ($listeners as $currentListener) {

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Hook/BuildForm/OptionEditPathFilterTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Hook/BuildForm/OptionEditPathFilterTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use CRM_HRCore_Test_BaseHeadlessTest as BaseHeadlessTest;
+use CRM_HRCore_Hook_BuildForm_OptionEditPathFilter as OptionEditPathFilter;
+
+/**
+ * @group headless
+ */
+class CRM_HRCore_Hook_BuildForm_OptionEditPathFilterTest extends BaseHeadlessTest {
+
+  public function testNothingWillBeChangedIfOptionEditPathNotSet() {
+    $filter = new OptionEditPathFilter();
+    $form = new CRM_Contact_Form_Contact();
+    $original = clone $form;
+
+    $element = $form->add('text', 'bar');
+    $cloneElement = clone $element;
+    $original->addElement($cloneElement);
+
+    $filter->handle('TestForm', $form);
+
+    $this->assertEquals($original, $form);
+  }
+
+  public function testOptionEditPathWillNotBeRemovedIfNotLocked() {
+    civicrm_api3('OptionGroup', 'create', ['name' => 'foo']);
+
+    $filter = new OptionEditPathFilter();
+    $form = new CRM_Contact_Form_Contact();
+
+    $element = $form->add('text', 'bar');
+    $editPath = 'civicrm/admin/options/foo';
+    $attrKey = 'data-option-edit-path';
+    $element->setAttribute($attrKey, $editPath);
+
+    $filter->handle('TestForm', $form);
+
+    $this->assertEquals($editPath, $element->getAttribute($attrKey));
+  }
+
+  public function testOptionEditPathWillBeRemovedIfLocked() {
+    civicrm_api3('OptionGroup', 'create', ['name' => 'bar', 'is_locked' => 1]);
+
+    $filter = new OptionEditPathFilter();
+    $form = new CRM_Contact_Form_Contact();
+    $element = $form->add('text', 'bar');
+    $attrKey = 'data-option-edit-path';
+    $element->setAttribute($attrKey, 'civicrm/admin/options/bar');
+
+    $filter->handle('TestForm', $form);
+
+    $this->assertNull($element->getAttribute($attrKey));
+  }
+
+}


### PR DESCRIPTION
## Overview

For locked option groups we don't want to show the gear icon to allow inline editing. This PR hides that link.

## Before

Locked option groups (where `is_locked` is true) would still have a link to edit them inline in forms.

In this example **phone types** is locked

![image](https://user-images.githubusercontent.com/6374064/38550380-49c82cec-3cae-11e8-91ba-c658b6bf6668.png)

## After

Locked option groups (where `is_locked` is true) do not show a link to edit them inline in forms.

In this example **phone types** is locked

![image](https://user-images.githubusercontent.com/6374064/38550369-38ebec74-3cae-11e8-92bc-a1fe46c6a7be.png)

## Technical Details

The way this works is based on the implementation of the [addOptionsEditLink](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Form/Renderer.php#L350) method. The method will only add the link _if_ the `data-option-edit-path` is set. By removing it we make sure this method does not show the link.
