### PR TITLE
PCHR-3526: Fix Warnings In Tests

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1008.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1008.php
@@ -8,12 +8,20 @@ trait CRM_HRCore_Upgrader_Steps_1008 {
    * @return bool
    */
   public function upgrade_1008() {
-    civicrm_api3('RelationshipType', 'get', [
+    $type = civicrm_api3('RelationshipType', 'get', [
       'sequential' => 1,
       'name_a_b' => 'Line Manager is',
       'name_b_a' => 'Line Manager',
-      'api.RelationshipType.create' => ['id' => '$value.id', 'is_reserved' => 1],
     ]);
+
+    if ($type['count'] != 1) {
+      return TRUE;
+    }
+
+    $type = array_shift($type['values']);
+    $type['is_reserved'] = 1;
+
+    civicrm_api3('RelationshipType', 'create', $type);
 
     return TRUE;
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1019.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1019.php
@@ -9,12 +9,20 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1019 {
    * @return bool
    */
   public function upgrade_1019() {
-    civicrm_api3('RelationshipType', 'get', [
+    $type = civicrm_api3('RelationshipType', 'get', [
       'sequential' => 1,
       'name_a_b' => 'has Leave Approved by',
       'name_b_a' => 'is Leave Approver of',
-      'api.RelationshipType.create' => ['id' => '$value.id', 'is_reserved' => 1],
     ]);
+
+    if ($type['count'] != 1) {
+      return TRUE;
+    }
+
+    $type = array_shift($type['values']);
+    $type['is_reserved'] = 1;
+
+    civicrm_api3('RelationshipType', 'create', $type);
 
     return TRUE;
   }


### PR DESCRIPTION
## Overview

When running PHPUnit tests some warnings are displayed during extension setup. This PR fixes those warnings.

## Before

Warnings are displayed during setup of PHPUnit test

![image](https://user-images.githubusercontent.com/6374064/38564338-d9286424-3cd6-11e8-9a46-a418ebc3c1cf.png)

## After

No warnings are displayed

![image](https://user-images.githubusercontent.com/6374064/38564387-f3115aee-3cd6-11e8-8aeb-3e1ef0635a56.png)

## Technical Details

The real culprit is the `civicrm_api3_relationship_type_create` function, in particular [this line](https://github.com/civicrm/civicrm-core/blob/4.7.27/api/v3/RelationshipType.php#L46):

```
if (!isset($params['label_a_b'])) {
  $params['label_a_b'] = $params['name_a_b'];
}
```
Which issues a warning when `$params['name_a_b']` is not set. As a fix for now we include all data in the update request and avoid the missing index notices.

This has already been fixed in core in [this commit](https://github.com/civicrm/civicrm-core/commit/0782c7b9321591b43bb46ae698dc71224ad50672#diff-a5b74abbbbe643c7f71f5856d6c9d138R45) but until we upgrade to a later version we will face the warnings.