### PR TITLE
PCHR-3567: Restrict Message Template Form Access Based on Permission

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/MessageTemplatesFormFilter.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/MessageTemplatesFormFilter.php
@@ -1,0 +1,54 @@
+<?php
+
+class CRM_HRCore_Hook_BuildForm_MessageTemplatesFormFilter {
+  
+  /**
+   * Restrict access to form page based on permission
+   *
+   * @param $formName
+   * @param $form
+   */
+  public function handle($formName, &$form) {
+    if (!$this->shouldHandle($formName)) {
+      return;
+    }
+    
+    $this->filterMessageTemplates($form);
+  }
+  
+  /**
+   * Checks if the hook should be handled.
+   *
+   * @param string $formName
+   *
+   * @return bool
+   */
+  private function shouldHandle($formName) {
+    if ($formName === CRM_Admin_Form_MessageTemplates::class) {
+      return TRUE;
+    }
+    
+    return FALSE;
+  }
+  
+  /**
+   * Restrict access of message template editing based on permission
+   *
+   * @param CRM_Core_Form $form
+   */
+  private function filterMessageTemplates($form) {
+    // Only system workflow message template have workflow id set
+    $workflowId = $form->getVar("_workflow_id");
+    if (isset($workflowId)) {
+      $canView = CRM_Core_Permission::check('edit system workflow message templates');
+    } else {
+      $canView = CRM_Core_Permission::check('edit user-driven message templates');
+    }
+    
+    if (! $canView && ! CRM_Core_Permission::check('edit message templates')) {
+      CRM_Core_Session::setStatus(ts('You do not have permission to view requested page.'), ts('Access Denied'));
+      $url = CRM_Utils_System::url('civicrm/admin/messageTemplates', "reset=1");
+      CRM_Utils_System::redirect($url);
+    }
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -118,6 +118,7 @@ function hrcore_civicrm_buildForm($formName, &$form) {
     new CRM_HRCore_Hook_BuildForm_ActivityLinksFilter(),
     new CRM_HRCore_Hook_BuildForm_LocalisationPageFilter(),
     new CRM_HRCore_Hook_BuildForm_OptionEditPathFilter(),
+    new CRM_HRCore_Hook_BuildForm_MessageTemplatesFormFilter()
   ];
 
   foreach ($listeners as $currentListener) {


### PR DESCRIPTION
## Overview
Two new granular permissions for `edit message template` permission are being added to CiviCRM Core. The new permissions are `edit system workflow message templates` and `edit user-driven message templates`. The `edit user-driven message templates` is assigned to `civihr_admin` role by default. The initial permission for super admin to `edit message template` permission was also retained. This calls for restriction on the form editing page.

## Before
![before](https://user-images.githubusercontent.com/1507645/38689688-2ab88b22-3e74-11e8-8f57-cd1b7356f976.gif)

![before_2](https://user-images.githubusercontent.com/1507645/38689881-9b076d8a-3e74-11e8-8434-5d9b9e23fce0.gif)

## After
![after](https://user-images.githubusercontent.com/1507645/38689421-8db469d6-3e73-11e8-8d6d-9b4e2c8e59e3.gif)

![after_2](https://user-images.githubusercontent.com/1507645/38689567-e4c0e056-3e73-11e8-8964-a5875da71c7e.gif)

## Technical Details
A form filter hook `CRM_HRCore_Hook_BuildForm_MessageTemplatesFormFilter` was added to ensure users with one of the permission does not have access to edit form belonging to other permission group.
```php
private function filterMessageTemplates($form) {
    // Only system workflow message template have workflow id set
    $workflowId = $form->getVar("_workflow_id");
    if (isset($workflowId)) {
      $canView = CRM_Core_Permission::check('edit system workflow message templates');
    } else {
      $canView = CRM_Core_Permission::check('edit user-driven message templates');
    }
  
    if (! $canView  && ! CRM_Core_Permission::check('edit message templates')) {
      CRM_Core_Session::setStatus(ts('You do not have permission to view requested page.'), ts('Access Denied'));
      $url = CRM_Utils_System::url('civicrm/admin/messageTemplates', "reset=1");
      CRM_Utils_System::redirect($url);
    }
  }
```
