### PR TITLE
FAR-247: Implement logging for Expired Balance Changes

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -753,7 +753,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
       LEFT JOIN {$absencePeriodTable} absence_period
             ON period_entitlement.period_id = absence_period.id
       WHERE balance_to_expire.expiry_date IS NOT NULL AND
-            balance_to_expire.expiry_date < CURDATE() AND
+            balance_to_expire.expiry_date < %3 AND
             balance_to_expire.expired_balance_change_id IS NULL AND
             expired_balance_change.id IS NULL
       ORDER BY balance_to_expire.expiry_date ASC, balance_to_expire.id ASC
@@ -762,6 +762,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
     $params = [
       1 => [self::SOURCE_LEAVE_REQUEST_DAY, 'String'],
       2 => [self::SOURCE_ENTITLEMENT, 'String'],
+      3 => [date('Y-m-d'), 'String']
     ];
 
     $result = CRM_Core_DAO::executeQuery($query, $params);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
@@ -28,6 +28,7 @@ class CRM_HRLeaveAndAbsences_Upgrader extends CRM_HRLeaveAndAbsences_Upgrader_Ba
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1020;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1021;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1022;
+  use CRM_HRLeaveAndAbsences_Upgrader_Step_1023;
 
   /**
    * A list of directories to be scanned for XML installation files

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1023.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1023.php
@@ -1,0 +1,24 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
+
+trait CRM_HRLeaveAndAbsences_Upgrader_Step_1023 {
+
+  /**
+   * Deletes Expired balance changes records that were wrongly expired by the
+   * scheduled job responsible for creating balance expiry records.
+   *
+   * @return bool
+   */
+  public function upgrade_1023() {
+    $today = date('Y-m-d');
+    $leaveBalanceChangeTable  =  LeaveBalanceChange::getTableName();
+
+    CRM_Core_DAO::executeQuery("
+      DELETE FROM {$leaveBalanceChangeTable} 
+      WHERE expired_balance_change_id IS NOT NULL
+      AND expiry_date > '$today'");
+
+    return TRUE;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -12,6 +12,7 @@ use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricato
 use CRM_HRLeaveAndAbsences_Test_Fabricator_LeavePeriodEntitlement as LeavePeriodEntitlementFabricator;
 use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
 use CRM_HRLeaveAndAbsences_Factory_LeaveDateAmountDeduction as LeaveDateAmountDeductionFactory;
+use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeExpiryLog as LeaveBalanceChangeExpiryLog;
 
 /**
  * Class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest
@@ -3558,6 +3559,101 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $amount = $this->calculateAmountForDateWhenWorkDayIsNull($leaveRequest, new DateTime('2016-07-28'), $amountToReturn);
     $this->assertEquals(0, $amount);
   }
+
+  public function testCreateExpiryRecordsLogsExpiredBalanceChanges() {
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2017-12-31')
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => 1,
+      'period_id' => $absencePeriod->id,
+      'type_id' => 1,
+    ]);
+
+    $broughtForwardAmount = 5;
+    $broughtForwardExpiryDate = new DateTime('2017-04-01');
+    $broughtForwardBalance = $this->createBroughtForwardBalanceChange(
+      $periodEntitlement->id,
+      $broughtForwardAmount,
+      $broughtForwardExpiryDate->format('YmdHis')
+    );
+
+    $toilLeaveDate = new DateTime('2017-05-17');
+    $toilExpiryDate = new DateTime('2017-08-01');
+    $toilRequest = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $periodEntitlement->contact_id,
+      'type_id' => $periodEntitlement->type_id,
+      'from_date' => $toilLeaveDate->format('YmdHis'),
+      'to_date' => $toilLeaveDate->format('YmdHis'),
+      'toil_expiry_date' => $toilExpiryDate->format('YmdHis'),
+      'toil_to_accrue' => 1,
+      'toil_duration' => 100,
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
+    ], true);
+
+    LeaveBalanceChange::createExpiryRecords();
+
+    $balanceExpiryLogs = $this->getBalanceChangeExpiryLogRecords();
+    $this->assertCount(2, $balanceExpiryLogs);
+
+    //Get the expiry balance record for the TOIL balance change
+    $toilBalanceChange = $this->findToilRequestMainBalanceChange($toilRequest->id);
+    $toilExpiryRecord = $this->getExpiryRecordForBalanceChange($toilBalanceChange->id);
+    $toilDate = $toilRequest->getDates()[0];
+
+    //Get expiry balance record for the brought forward balance change
+    $broughtForwardExpiryRecord = $this->getExpiryRecordForBalanceChange($broughtForwardBalance->id);
+
+    $expectedToilLog = [
+      'id' => $balanceExpiryLogs[$toilExpiryRecord->id]['id'],
+      'balance_change_id' => $toilExpiryRecord->id,
+      'amount' => -1 * $toilRequest->toil_to_accrue,
+      'source_id' => $toilDate->id,
+      'source_type' => LeaveBalanceChange::SOURCE_LEAVE_REQUEST_DAY,
+      'expiry_date' => $toilExpiryDate->format('Y-m-d'),
+      'balance_type_id' => $toilExpiryRecord->type_id,
+      'leave_date' => $toilLeaveDate->format('Y-m-d'),
+      'leave_request_id' => $toilRequest->id
+    ];
+
+    $expectedBroughtForwardLog = [
+      'id' => $balanceExpiryLogs[$broughtForwardExpiryRecord->id]['id'],
+      'balance_change_id' => $broughtForwardExpiryRecord->id,
+      'amount' => -1 * $broughtForwardAmount,
+      'source_id' => $periodEntitlement->id,
+      'source_type' => LeaveBalanceChange::SOURCE_ENTITLEMENT,
+      'expiry_date' => $broughtForwardExpiryDate->format('Y-m-d'),
+      'balance_type_id' => $broughtForwardExpiryRecord->type_id,
+      'leave_date' => NULL,
+      'leave_request_id' => NULL
+    ];
+
+    $dateNow = new DateTime();
+    $this->assertEquals($dateNow, new DateTime($balanceExpiryLogs[$toilExpiryRecord->id]['created_date']), 10);
+    $this->assertEquals($dateNow, new DateTime($balanceExpiryLogs[$broughtForwardExpiryRecord->id]['created_date']), 10);
+
+    //we need to remove the created dates from the array as its not possible to assert the exact value.
+    unset($balanceExpiryLogs[$toilExpiryRecord->id]['created_date']);
+    unset($balanceExpiryLogs[$broughtForwardExpiryRecord->id]['created_date']);
+
+    $this->assertEquals($expectedToilLog, $balanceExpiryLogs[$toilExpiryRecord->id]);
+    $this->assertEquals($expectedBroughtForwardLog, $balanceExpiryLogs[$broughtForwardExpiryRecord->id]);
+  }
+
+  private function getBalanceChangeExpiryLogRecords() {
+    $leaveExpiryLog = new LeaveBalanceChangeExpiryLog();
+    $leaveExpiryLog->find();
+
+    $records = [];
+    while($leaveExpiryLog->fetch()) {
+      $records[$leaveExpiryLog->balance_change_id] = $leaveExpiryLog->toArray() ;
+    }
+
+    return $records;
+  }
+
 
   private function getBalanceChangesForPeriodEntitlement($leavePeriodEntitlement) {
     $record = new LeaveBalanceChange();


### PR DESCRIPTION
## Overview
Sequel to #2572, which creates the LeaveBalanceChangeExpiryLog entity, This PR utilizes the entity to log expired balance change records created by the Scheduled job that expires balance changes. 

Also an Upgrader was added to revert the wrong expiration of some balance change records that were expired before due date.

## Before
- No logging is done when the  Scheduled job that expires balance changes runs.
- There exists some balance change records that were wrongly expired by the scheduled job.

## After
- Logging is done when the  Scheduled job that expires balance changes runs using the LeaveBalanceChangeExpiryLog entity.
- Balance change records that were wrongly expired by the scheduled job were fixed and made not to appear expired again.


