### PR TITLE
PCHR-3580: Allow multiple requests on same date on backend

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -863,6 +863,16 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    * for the given leave request parameters and statuses supplied.
    *
    * @param array $leaveRequestParams
+   *   List of parameters to use to create the Case.
+   *   [
+   *     'contact_id' => int,
+   *     'type_id' => int,
+   *     'request_type' => int,
+   *     'from_date' => string,
+   *     'from_date_type' => string|int optional,
+   *     'to_date' => string,
+   *     'to_date_type' => string|int optional
+   *   ]
    * @param array $leaveRequestStatus
    * @param boolean $excludePublicHolidayLeaveRequests
    *   Whether to exclude public holiday leave requests from overlapping leave requests or not
@@ -871,9 +881,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
    */
   public static function findOverlappingLeaveRequests($leaveRequestParams, $leaveRequestStatus = [], $excludePublicHolidayLeaveRequests = TRUE) {
     $fromDate = $leaveRequestParams['from_date'];
-    $fromDateType = isset($leaveRequestParams['from_date_type']) ? $leaveRequestParams['from_date_type'] : NULL;
+    $fromDateType = isset($leaveRequestParams['from_date_type']) ? (int)$leaveRequestParams['from_date_type'] : NULL;
     $toDate = $leaveRequestParams['to_date'];
-    $toDateType = isset($leaveRequestParams['to_date_type']) ? $leaveRequestParams['to_date_type'] : NULL;
+    $toDateType = isset($leaveRequestParams['to_date_type']) ? (int)$leaveRequestParams['to_date_type'] : NULL;
 
     $leaveRequestTable = self::getTableName();
     $leaveRequestDateTable = LeaveRequestDate::getTableName();
@@ -902,8 +912,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
         "(lr.from_date < '{$toDate}' AND lr.to_date > '{$fromDate}'" . (!$isTOIL ? " AND lr.type_id IN (" . join(',', $absenceTypesIDsWithSameUnit) . ")" : "") . ")" .
         (count($absenceTypesIDsWithDifferentUnit) && !$isTOIL ? " OR ((lrd.date BETWEEN %3 AND %4) AND lr.type_id IN (" . join(',', $absenceTypesIDsWithDifferentUnit) . "))" : "")
       : "lrd.date BETWEEN %3 AND %4 AND lr.type_id IN (" . join(',', array_merge($absenceTypesIDsWithSameUnit, $absenceTypesIDsWithDifferentUnit)) . ")" .
-        ($fromDateType !== null && (int)$fromDateType === (int)$halfDayPMID ? " AND (DATE_FORMAT(lr.to_date, '%y-%m-%d') != DATE_FORMAT('{$fromDate}', '%y-%m-%d') OR lr.to_date_type != {$halfDayAMID})" : "") .
-        ($toDateType !== null && (int)$toDateType === (int)$halfDayAMID ? " AND (DATE_FORMAT(lr.from_date, '%y-%m-%d') != DATE_FORMAT('{$toDate}', '%y-%m-%d') OR lr.from_date_type != {$halfDayPMID})" : "");
+        ($fromDateType !== null && $fromDateType === $halfDayPMID ? " AND (DATE_FORMAT(lr.to_date, '%y-%m-%d') != DATE_FORMAT('{$fromDate}', '%y-%m-%d') OR lr.to_date_type != {$halfDayAMID})" : "") .
+        ($toDateType !== null && $toDateType === $halfDayAMID ? " AND (DATE_FORMAT(lr.from_date, '%y-%m-%d') != DATE_FORMAT('{$toDate}', '%y-%m-%d') OR lr.from_date_type != {$halfDayPMID})" : "");
 
     $ignoreRequestTypes =
       'lr.request_type ' . ($isTOIL ? '=' : '!=') . "'" . LeaveRequest::REQUEST_TYPE_TOIL . "'";

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -904,7 +904,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     $noOverlappingCondition =
       $isCalculationUnitInHours || $isTOIL
       ?
-        "(lr.from_date < '{$toDate}' AND lr.to_date > '{$fromDate}' AND lr.type_id IN (" . join(',', $absenceTypesIDsWithSameUnit) . "))" .
+        "(lr.from_date < '{$toDate}' AND lr.to_date > '{$fromDate}'" . (!$isTOIL ? " AND lr.type_id IN (" . join(',', $absenceTypesIDsWithSameUnit) . ")" : "") . ")" .
         (count($absenceTypesIDsWithDifferentUnit) && !$isTOIL ? " OR ((lrd.date BETWEEN %3 AND %4) AND lr.type_id IN (" . join(',', $absenceTypesIDsWithDifferentUnit) . "))" : "")
       : "lrd.date BETWEEN %3 AND %4 AND lr.type_id IN (" . join(',', array_merge($absenceTypesIDsWithSameUnit, $absenceTypesIDsWithDifferentUnit)) . ")" .
         ($fromDateType !== null && (int)$fromDateType === (int)$halfDayPMID ? " AND (DATE_FORMAT(lr.to_date, '%y-%m-%d') != DATE_FORMAT('{$fromDate}', '%y-%m-%d') OR lr.to_date_type != {$halfDayAMID})" : "") .

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -544,7 +544,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     // This will deduct 11 days, but the respective balance changes
     // won't be returned as part of the breakdown
     $this->createLeaveRequestBalanceChange(
-      $entitlement->id,
+      $entitlement->type_id,
       $leaveRequestStatuses['approved'],
       date('Y-m-d'),
       date('Y-m-d', strtotime('+10 days'))

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeavePeriodEntitlementTest.php
@@ -305,7 +305,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
     $this->createPublicHolidayBalanceChange($periodEntitlement->id, 8);
 
     $this->createLeaveRequestBalanceChange(
-      $periodEntitlement->id,
+      $periodEntitlement->type_id,
       $this->leaveRequestStatuses['approved'],
       date('Y-m-d'),
       date('Y-m-d', strtotime('+2 days'))
@@ -1723,13 +1723,14 @@ class CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlementTest extends BaseHeadless
   }
 
   public function testGetBalanceShouldNotIncludeBalanceForExcludedLeaveRequests() {
+    $absenceType = AbsenceTypeFabricator::fabricate();
     $period = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'end_date'   => CRM_Utils_Date::processDate('2016-12-31'),
     ]);
 
     $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
-      'type_id' => 4,
+      'type_id' => $absenceType->id,
       'contact_id' => 1,
       'period_id' => $period->id
     ]);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -65,13 +65,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromDate = new DateTime();
     $date = $fromDate->format('YmdHis');
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1, //The status is not important here. We just need a value to be stored in the DB
       'from_date' => $date,
-      'from_date_type' => 1,
-      'to_date' => $date,
-      'to_date_type' => 1,
+      'to_date' => $date
     ]);
 
     $dates = $leaveRequest->getDates();
@@ -83,13 +81,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromDate = new DateTime();
     $toDate = new DateTime('+3 days');
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
-      'status_id' => 1, //The status is not important here. We just need a value to be stored in the DB
       'from_date' => $fromDate->format('YmdHis'),
-      'from_date_type' => 1, //The type is not important here. We just need a value to be stored in the DB
-      'to_date' => $toDate->format('YmdHis'),
-      'to_date_type' => 1 //The type is not important here. We just need a value to be stored in the DB
+      'to_date' => $toDate->format('YmdHis')
     ]);
 
     $dates = $leaveRequest->getDates();
@@ -108,9 +103,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => 1,
       'status_id' => 1,
       'from_date' => $date,
-      'from_date_type' => 1,
-      'to_date' => $date,
-      'to_date_type' => 1
+      'to_date' => $date
     ]);
 
     $dates = $leaveRequest->getDates();
@@ -122,13 +115,12 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $toDate->modify('+1 day');
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $this->absenceType->id,
       'id' => $leaveRequest->id,
       'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'from_date' => $fromDate->format('YmdHis'),
-      'from_date_type' => 1,
-      'to_date' => $toDate->format('YmdHis'),
-      'to_date_type' => 1,
+      'to_date' => $toDate->format('YmdHis')
     ]);
 
     $dates = $leaveRequest->getDates();
@@ -168,9 +160,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => 1,
       'status_id' => $leaveRequestStatuses['awaiting_approval'],
       'from_date' => CRM_Utils_Date::processDate('2016-11-02'),
-      'from_date_type' => 1,
-      'to_date' => CRM_Utils_Date::processDate('2016-11-04'),
-      'to_date_type' => 1
+      'to_date' => CRM_Utils_Date::processDate('2016-11-04')
     ], true);
 
     //updating leave request
@@ -1025,9 +1015,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $contactID,
       'status_id' => $leaveRequestStatuses['awaiting_approval'],
       'from_date' => CRM_Utils_Date::processDate('now'),
-      'from_date_type' => 1,
-      'to_date' => CRM_Utils_Date::processDate('+4 days'),
-      'to_date_type' => 1
+      'to_date' => CRM_Utils_Date::processDate('+4 days')
     ]);
 
     $this->setExpectedException('CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException', 'Absence Type does not allow leave request cancellation');
@@ -1060,9 +1048,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $contactID,
       'status_id' => $leaveRequestStatuses['awaiting_approval'],
       'from_date' => CRM_Utils_Date::processDate('-1 day'),
-      'from_date_type' => 1,
-      'to_date' => CRM_Utils_Date::processDate('+4 days'),
-      'to_date_type' => 1
+      'to_date' => CRM_Utils_Date::processDate('+4 days')
     ]);
 
     $this->setExpectedException('CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException', 'Leave Request with past days cannot be cancelled');
@@ -1093,9 +1079,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $contactID,
       'status_id' => 1,
       'from_date' => $fromDate1->format('YmdHis'),
-      'from_date_type' => 1,
-      'to_date' => $toDate1->format('YmdHis'),
-      'to_date_type' => 1
+      'to_date' => $toDate1->format('YmdHis')
     ], true);
 
     LeaveRequestFabricator::fabricateWithoutValidation([
@@ -1103,9 +1087,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $contactID,
       'status_id' => 1,
       'from_date' => $fromDate2->format('YmdHis'),
-      'from_date_type' => 1,
-      'to_date' => $toDate2->format('YmdHis'),
-      'to_date_type' => 1
+      'to_date' => $toDate2->format('YmdHis')
     ], true);
 
     //The start date and end date has dates in only leaveRequest1
@@ -1210,7 +1192,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
         'contact_id' => $contactID,
         'from_date' => $requestFromDate->format('YmdHis'),
         'to_date' => $requestToDate->format('YmdHis')
-      ], true);
+      ]);
 
       $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests([
         'contact_id' => $contactID,
@@ -1227,11 +1209,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     }
   }
 
-  public function testFindOverlappingLeaveRequestsForAMPMRequests() {
+  public function testFindOverlappingLeaveRequestsForHalfDayMultipleDayRequests() {
     $contactID = 1;
 
-    $testFromDate = '2018-04-13 00:00:00';
-    $testToDate = '2018-04-15 23:59:00';
+    $testFromDate = '2018-04-13';
+    $testToDate = '2018-04-15';
     $halfDayAMID = $this->leaveRequestDayTypes['half_day_am']['value'];
     $halfDayPMID = $this->leaveRequestDayTypes['half_day_pm']['value'];
 
@@ -1285,7 +1267,62 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     }
   }
 
-  public function testFindOverlappingLeaveRequestsTOILinDaysTreatedAsRequestInHours() {
+  public function testFindOverlappingLeaveRequestsForHalfDaySingleDayRequests() {
+    $contactID = 1;
+    $testFromDate = '2018-04-13 00:00:00';
+    $testToDate = '2018-04-13 23:59:00';
+    $halfDayAMID = $this->leaveRequestDayTypes['half_day_am']['value'];
+    $halfDayPMID = $this->leaveRequestDayTypes['half_day_pm']['value'];
+
+    $absenceType = AbsenceTypeFabricator::fabricate([ 'calculation_unit' => 1 ]);
+
+    // Test suites: existing request date type, tested request date type, should overlap or not
+    $overlappingRequestsTestSuites = [
+      [$halfDayAMID, $halfDayPMID, FALSE],
+      [$halfDayAMID, $halfDayAMID, TRUE],
+      [$halfDayPMID, $halfDayPMID, TRUE],
+      [$halfDayPMID, $halfDayAMID, FALSE]
+    ];
+
+    foreach ($overlappingRequestsTestSuites as $overlappingRequestsTestSuite) {
+      $requestFromDate = new DateTime($testFromDate);
+      $requestDateType = $overlappingRequestsTestSuite[0];
+      $requestToDate = new DateTime($testToDate);
+      $testDateType = $overlappingRequestsTestSuite[1];
+      $shouldRequestOverlap = $overlappingRequestsTestSuite[2];
+
+      $leaveRequestToTest = LeaveRequestFabricator::fabricateWithoutValidation([
+        'type_id' => $absenceType->id,
+        'contact_id' => $contactID,
+        'from_date' => $requestFromDate->format('YmdHis'),
+        'from_date_type' => $requestDateType,
+        'to_date' => $requestToDate->format('YmdHis'),
+        'to_date_type' => $requestDateType
+      ], true);
+
+      $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests([
+        'contact_id' => $contactID,
+        'from_date' => $testFromDate,
+        'from_date_type' => $testDateType,
+        'to_date' => $testToDate,
+        'to_date_type' => $testDateType,
+        'type_id' => $absenceType->id,
+        'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
+      ]);
+      $leaveRequestToTestID = $leaveRequestToTest->id;
+
+      // Flush leave request from DB to get ready for the next test suite
+      $leaveRequestToTest->delete();
+
+      $this->assertCount($shouldRequestOverlap ? 1 : 0, $overlappingRequests);
+      if ($shouldRequestOverlap) {
+        $this->assertInstanceOf(LeaveRequest::class, $overlappingRequests[0]);
+        $this->assertEquals($overlappingRequests[0]->id, $leaveRequestToTestID);
+      }
+    }
+  }
+
+  public function testFindOverlappingLeaveRequestsBetweenTOILRequests() {
     $contactID = 1;
 
     $testFromDate = '2018-04-13 10:00:00';
@@ -1320,7 +1357,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
         'from_date' => $requestFromDate->format('YmdHis'),
         'to_date' => $requestToDate->format('YmdHis'),
         'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
-      ], true);
+      ], TRUE);
 
       $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests([
         'contact_id' => $contactID,
@@ -1468,9 +1505,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $contactID,
       'status_id' => 1,
       'from_date' => $fromDate1->format('YmdHis'),
-      'from_date_type' => 1,
-      'to_date' => $toDate1->format('YmdHis'),
-      'to_date_type' => 1
+      'to_date' => $toDate1->format('YmdHis')
     ], true);
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
@@ -1478,9 +1513,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $contactID,
       'status_id' => 1,
       'from_date' => $fromDate2->format('YmdHis'),
-      'from_date_type' => 1,
       'to_date' => $toDate2->format('YmdHis'),
-      'to_date_type' => 1
     ], true);
 
     //The start date and end date has dates in both leave request dates in both leaveRequest1 and leaveRequest2
@@ -1511,9 +1544,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $contactID,
       'status_id' => 1,
       'from_date' => $fromDate->format('YmdHis'),
-      'from_date_type' => 1,
-      'to_date' => $fromDate->format('YmdHis'),
-      'to_date_type' => 1
+      'to_date' => $fromDate->format('YmdHis')
     ], true);
 
     LeaveRequest::softDelete($leaveRequest->id);
@@ -1556,9 +1587,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $contactID,
       'status_id' => 1,
       'from_date' => $fromDate1->format('YmdHis'),
-      'from_date_type' => 1,
       'to_date' => $toDate1->format('YmdHis'),
-      'to_date_type' => 1
     ], true);
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
@@ -1566,9 +1595,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $contactID,
       'status_id' => 1,
       'from_date' => $fromDate2->format('YmdHis'),
-      'from_date_type' => 1,
-      'to_date' => $toDate2->format('YmdHis'),
-      'to_date_type' => 1
+      'to_date' => $toDate2->format('YmdHis')
     ], true);
 
     //The start date and end date has dates in both leave request dates in both leaveRequest1 and leaveRequest2
@@ -1611,9 +1638,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $contactID,
       'status_id' => 1,
       'from_date' => $fromDate1->format('YmdHis'),
-      'from_date_type' => 1,
-      'to_date' => $toDate1->format('YmdHis'),
-      'to_date_type' => 1
+      'to_date' => $toDate1->format('YmdHis')
     ], true);
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
@@ -1621,9 +1646,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $contactID,
       'status_id' => 1,
       'from_date' => $fromDate2->format('YmdHis'),
-      'from_date_type' => 1,
       'to_date' => $toDate2->format('YmdHis'),
-      'to_date_type' => 1
     ], true);
 
     PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
@@ -1675,9 +1698,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $contactID,
       'status_id' => $leaveRequestStatuses['awaiting_approval'],
       'from_date' => $fromDate1->format('YmdHis'),
-      'from_date_type' => 1,
-      'to_date' => $toDate1->format('YmdHis'),
-      'to_date_type' => 1
+      'to_date' => $toDate1->format('YmdHis')
     ], true);
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
@@ -1685,9 +1706,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $contactID,
       'status_id' => $leaveRequestStatuses['more_information_required'],
       'from_date' => $fromDate2->format('YmdHis'),
-      'from_date_type' => 1,
-      'to_date' => $toDate2->format('YmdHis'),
-      'to_date_type' => 1
+      'to_date' => $toDate2->format('YmdHis')
     ], true);
 
     LeaveRequestFabricator::fabricateWithoutValidation([
@@ -1695,9 +1714,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $contactID,
       'status_id' => $leaveRequestStatuses['rejected'],
       'from_date' => $fromDate3->format('YmdHis'),
-      'from_date_type' => 1,
-      'to_date' => $toDate3->format('YmdHis'),
-      'to_date_type' => 1
+      'to_date' => $toDate3->format('YmdHis')
     ], true);
 
     PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
@@ -1764,9 +1781,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $contactID,
       'status_id' => $leaveRequestStatuses['awaiting_approval'],
       'from_date' => $fromDate1->format('YmdHis'),
-      'from_date_type' => 1,
-      'to_date' => $toDate1->format('YmdHis'),
-      'to_date_type' => 1
+      'to_date' => $toDate1->format('YmdHis')
     ], true);
 
     LeaveRequestFabricator::fabricateWithoutValidation([
@@ -1774,9 +1789,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $contactID,
       'status_id' => $leaveRequestStatuses['rejected'],
       'from_date' => $fromDate2->format('YmdHis'),
-      'from_date_type' => 1,
-      'to_date' => $toDate2->format('YmdHis'),
-      'to_date_type' => 1
+      'to_date' => $toDate2->format('YmdHis')
     ], true);
 
     //from date and to date have date in both leave request
@@ -1880,9 +1893,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $contactID,
       'status_id' => $leaveRequestStatuses['rejected'],
       'from_date' => $fromDate2->format('YmdHis'),
-      'from_date_type' => 1,
-      'to_date' => $toDate2->format('YmdHis'),
-      'to_date_type' => 1
+      'to_date' => $toDate2->format('YmdHis')
     ], true);
 
     //this date overlaps with a Rejected status leave request
@@ -3107,8 +3118,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
   public function testFindByIdThrowsAnExceptionWhenFindingASoftDeletedLeaveRequest() {
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
-      'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-01-02'),
       'status_id' => 1
@@ -3122,8 +3133,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
   public function testFindByIdThrowsAnExceptionWhenFindingADeletedLeaveRequest() {
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
-      'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-01-02'),
       'status_id' => 1
@@ -3158,11 +3169,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
   public function testLeaveRequestIsDeletedValueCanNotBeSetWhenCreatingALeaveRequest() {
     $params = [
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
-      'type_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
-      'from_date_type' => 1,
-      'to_date_type' => 1,
       'to_date' =>  CRM_Utils_Date::processDate('2016-01-02'),
       'status_id' => 1,
       'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE,
@@ -3194,9 +3203,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => $leaveContact['id'],
       'status_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('tomorrow'),
-      'from_date_type' => 1,
       'to_date' => CRM_Utils_Date::processDate('tomorrow'),
-      'to_date_type' => 1,
       'toil_to_accrue' => 2,
       'toil_duration' => 120,
       'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
@@ -3399,8 +3406,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $toilToAccrueAmounts = [1.5, 1.8, 2.5];
     foreach ($toilToAccrueAmounts as $toilToAccrueAmount) {
       LeaveRequestFabricator::fabricateWithoutValidation([
+      'type_id' => $this->absenceType->id,
         'contact_id' => 1,
-        'type_id' => 1,
         'toil_to_accrue'=> $toilToAccrueAmount,
         'from_date' => CRM_Utils_Date::processDate('yesterday'),
         'to_date' => CRM_Utils_Date::processDate('today'),
@@ -3454,8 +3461,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'from_date' => CRM_Utils_Date::processDate('monday'),
       'to_date' => CRM_Utils_Date::processDate('monday'),
       'request_type' => LeaveRequest::REQUEST_TYPE_TOIL,
-      'from_date_type' => 1,
-      'to_date_type' => 1,
       'toil_duration' => 60
     ];
 
@@ -3513,8 +3518,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'from_date' => CRM_Utils_Date::processDate('monday'),
       'to_date' => CRM_Utils_Date::processDate('monday'),
       'request_type' => LeaveRequest::REQUEST_TYPE_TOIL,
-      'from_date_type' => 1,
-      'to_date_type' => 1,
       'toil_duration' => 60
     ];
 
@@ -3570,8 +3573,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'from_date' => CRM_Utils_Date::processDate('monday'),
       'to_date' => CRM_Utils_Date::processDate('monday'),
       'request_type' => LeaveRequest::REQUEST_TYPE_TOIL,
-      'from_date_type' => 1,
-      'to_date_type' => 1,
       'toil_duration' => 60
     ];
 
@@ -3627,8 +3628,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'from_date' => CRM_Utils_Date::processDate('monday'),
       'to_date' => CRM_Utils_Date::processDate('monday'),
       'request_type' => LeaveRequest::REQUEST_TYPE_TOIL,
-      'from_date_type' => 1,
-      'to_date_type' => 1,
       'toil_duration' => 60
     ];
 
@@ -3697,8 +3696,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'from_date' => CRM_Utils_Date::processDate('2016-01-06'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-06'),
       'request_type' => LeaveRequest::REQUEST_TYPE_TOIL,
-      'from_date_type' => 1,
-      'to_date_type' => 1,
       'toil_duration' => 60
     ];
 
@@ -3750,9 +3747,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'contact_id' => 1,
       'status_id' => 1,
       'from_date' => $fromDate,
-      'from_date_type' => 1,
-      'to_date' => $toDate,
-      'to_date_type' => 1,
+      'to_date' => $toDate
     ];
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
 
@@ -3779,13 +3774,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromDate = CRM_Utils_Date::processDate('2016-01-08');
     $toDate = CRM_Utils_Date::processDate('2016-01-10');
     $params = [
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
       'from_date' => $fromDate,
-      'from_date_type' => 1,
-      'to_date' => $toDate,
-      'to_date_type' => 1,
+      'to_date' => $toDate
     ];
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
@@ -3801,13 +3794,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromDate = CRM_Utils_Date::processDate('2016-01-08');
     $toDate = CRM_Utils_Date::processDate('2016-01-10');
     $params = [
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
       'from_date' => $fromDate,
-      'from_date_type' => 1,
-      'to_date' => $toDate,
-      'to_date_type' => 1,
+      'to_date' => $toDate
     ];
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
@@ -3823,13 +3814,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromDate = CRM_Utils_Date::processDate('2016-01-08');
     $toDate = CRM_Utils_Date::processDate('2016-01-10');
     $params = [
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
       'from_date' => $fromDate,
-      'from_date_type' => 1,
-      'to_date' => $toDate,
-      'to_date_type' => 1,
+      'to_date' => $toDate
     ];
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
@@ -3845,13 +3834,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromDate = CRM_Utils_Date::processDate('2016-01-08');
     $toDate = CRM_Utils_Date::processDate('2016-01-10');
     $params = [
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
       'from_date' => $fromDate,
-      'from_date_type' => 1,
-      'to_date' => $toDate,
-      'to_date_type' => 1,
+      'to_date' => $toDate
     ];
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
@@ -3867,13 +3854,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromDate = CRM_Utils_Date::processDate('2016-01-08');
     $toDate = CRM_Utils_Date::processDate('2016-01-10');
     $params = [
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
       'from_date' => $fromDate,
-      'from_date_type' => 1,
-      'to_date' => $toDate,
-      'to_date_type' => 1,
+      'to_date' => $toDate
     ];
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
@@ -3892,13 +3877,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromDate = CRM_Utils_Date::processDate('2016-01-08');
     $toDate = CRM_Utils_Date::processDate('2016-01-10');
     $params = [
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
       'from_date' => $fromDate,
-      'from_date_type' => 1,
-      'to_date' => $toDate,
-      'to_date_type' => 1,
+      'to_date' => $toDate
     ];
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
@@ -3915,13 +3898,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromDate = CRM_Utils_Date::processDate('2016-01-08');
     $toDate = CRM_Utils_Date::processDate('2016-01-10');
     $params = [
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
       'from_date' => $fromDate,
-      'from_date_type' => 1,
-      'to_date' => $toDate,
-      'to_date_type' => 1,
+      'to_date' => $toDate
     ];
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
@@ -3938,7 +3919,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $fromDate = CRM_Utils_Date::processDate('2016-01-08');
     $toDate = CRM_Utils_Date::processDate('2016-01-10');
     $params = [
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
       'from_date' => $fromDate,
@@ -4047,7 +4028,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
       'period_id' => $period->id
     ]);
 
-    $this->createLeaveBalanceChange($periodEntitlement->id, 3);
+    $this->createLeaveBalanceChange($periodEntitlement->id, 100);
 
     HRJobContractFabricator::fabricate(
       ['contact_id' => $periodEntitlement->contact_id],
@@ -4069,6 +4050,363 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     ], LeaveRequest::IMPORT_VALIDATION);
 
     $this->assertNotNull($leaveRequest->id);
+  }
+
+  public function testMultipleLeaveRequestsInHoursCanNotBeCreatedForTheSameDayIfTheirTimeIntersect() {
+    $date = '2018-04-13';
+    $contactId = 1;
+    $absenceType = AbsenceTypeFabricator::fabricate([ 'calculation_unit' => 2 ]);
+
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2018-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2018-12-31'),
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceType->id,
+      'contact_id' => $contactId,
+      'period_id' => $absencePeriod->id
+    ]);
+
+    $this->createLeaveBalanceChange($periodEntitlement->id, 100);
+
+    $params = [
+      'type_id' => $absenceType->id,
+      'contact_id' => $contactId,
+      'from_date' => CRM_Utils_Date::processDate($date . ' 01:00:00'),
+      'to_date' => CRM_Utils_Date::processDate($date . ' 03:00:00')
+    ];
+
+    $leaveRequest1 = LeaveRequestFabricator::fabricate($params, true);
+
+    $params['from_date'] = CRM_Utils_Date::processDate($date . ' 02:00:00');
+    $params['to_date'] = CRM_Utils_Date::processDate($date . ' 04:00:00');
+
+    $this->setExpectedException(
+      'CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException',
+      'This leave request overlaps with another request. Please modify dates of this request'
+    );
+
+    $leaveRequest2 = LeaveRequestFabricator::fabricate($params, true);
+  }
+
+  public function testMultipleLeaveRequestsInHoursCanBeCreatedForTheSameDayIfTheirTimeDoNotIntersect() {
+    $date = '2018-04-13';
+    $contactId = 1;
+    $absenceType = AbsenceTypeFabricator::fabricate([ 'calculation_unit' => 2 ]);
+
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2018-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2018-12-31'),
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceType->id,
+      'contact_id' => $contactId,
+      'period_id' => $absencePeriod->id
+    ]);
+
+    $this->createLeaveBalanceChange($periodEntitlement->id, 3);
+
+    $params = [
+      'type_id' => $absenceType->id,
+      'contact_id' => $contactId,
+      'from_date' => CRM_Utils_Date::processDate($date . ' 01:00:00'),
+      'to_date' => CRM_Utils_Date::processDate($date . ' 03:00:00')
+    ];
+
+    $leaveRequest1 = LeaveRequestFabricator::fabricate($params, true);
+
+    $params['from_date'] = CRM_Utils_Date::processDate($date . ' 03:00:00');
+    $params['to_date'] = CRM_Utils_Date::processDate($date . ' 05:00:00');
+
+    $leaveRequest2 = LeaveRequestFabricator::fabricate($params, true);
+
+    $this->assertNotNull($leaveRequest1->id);
+    $this->assertNotNull($leaveRequest2->id);
+  }
+
+  public function testTOILAccrualAndLeaveRequestCanBeCreatedForTheSameDay() {
+    $date = '2018-04-13';
+    $contactId = 1;
+    $absenceTypeLeave = AbsenceTypeFabricator::fabricate();
+    $absenceTypeTOIL = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'allow_accrue_in_the_past' => true
+    ]);
+
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2018-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2018-12-31'),
+    ]);
+
+    $periodEntitlementLeave = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceTypeLeave->id,
+      'contact_id' => $contactId,
+      'period_id' => $absencePeriod->id
+    ]);
+
+    $periodEntitlementTOIL = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceTypeTOIL->id,
+      'contact_id' => $contactId,
+      'period_id' => $absencePeriod->id
+    ]);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contactId],
+      ['period_start_date' => CRM_Utils_Date::processDate('2018-01-01')]
+    );
+
+    $this->createLeaveBalanceChange($periodEntitlementLeave->id, 3);
+    $this->createLeaveBalanceChange($periodEntitlementTOIL->id, 3);
+
+    $params = [
+      'type_id' => $absenceTypeLeave->id,
+      'contact_id' => $contactId,
+      'from_date' => CRM_Utils_Date::processDate($date),
+      'to_date' => CRM_Utils_Date::processDate($date)
+    ];
+
+    $leaveRequest1 = LeaveRequestFabricator::fabricate($params, true);
+
+    $params['request_type'] = LeaveRequest::REQUEST_TYPE_TOIL;
+    $params['type_id'] = $absenceTypeTOIL->id;
+
+    $leaveRequest2 = LeaveRequestFabricator::fabricate($params, true);
+
+    $this->assertNotNull($leaveRequest1->id);
+    $this->assertNotNull($leaveRequest2->id);
+  }
+
+  public function testTwoLeaveRequestsOneAMAndAnotherPMCanBeCreatedForTheSameDay() {
+    $date = '2018-04-13';
+    $contactId = 1;
+    $absenceType = AbsenceTypeFabricator::fabricate();
+    $halfDayAMID = $this->leaveRequestDayTypes['half_day_am']['value'];
+    $halfDayPMID = $this->leaveRequestDayTypes['half_day_pm']['value'];
+
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2018-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2018-12-31'),
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceType->id,
+      'contact_id' => $contactId,
+      'period_id' => $absencePeriod->id
+    ]);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contactId],
+      ['period_start_date' => CRM_Utils_Date::processDate('2018-01-01')]
+    );
+
+    $this->createLeaveBalanceChange($periodEntitlement->id, 3);
+
+    $params = [
+      'type_id' => $absenceType->id,
+      'contact_id' => $contactId,
+      'from_date' => CRM_Utils_Date::processDate($date),
+      'to_date' => CRM_Utils_Date::processDate($date),
+      'from_date_type' => $halfDayAMID,
+      'to_date_type' => $halfDayAMID
+    ];
+
+    $leaveRequest1 = LeaveRequestFabricator::fabricate($params, true);
+
+    $params['from_date_type'] = $halfDayPMID;
+    $params['to_date_type'] = $halfDayPMID;
+
+    $leaveRequest2 = LeaveRequestFabricator::fabricate($params, true);
+
+    $this->assertNotNull($leaveRequest1->id);
+    $this->assertNotNull($leaveRequest2->id);
+  }
+
+  public function testTwoTOILRequestsCanBeCreatedForTheSameDay() {
+    $date = '2018-04-13';
+    $contactId = 1;
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'allow_accruals_request' => true,
+      'allow_accrue_in_the_past' => true,
+      'calculation_unit' => 2
+    ]);
+
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2018-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2018-12-31'),
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceType->id,
+      'contact_id' => $contactId,
+      'period_id' => $absencePeriod->id
+    ]);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contactId],
+      ['period_start_date' => CRM_Utils_Date::processDate('2018-01-01')]
+    );
+
+    $this->createLeaveBalanceChange($periodEntitlement->id, 100);
+
+    $params = [
+      'type_id' => $absenceType->id,
+      'contact_id' => $contactId,
+      'from_date' => CRM_Utils_Date::processDate($date . ' 10:00:00'),
+      'to_date' => CRM_Utils_Date::processDate($date . ' 10:15:00'),
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL,
+      'toil_to_accrue' => 2
+    ];
+
+    $leaveRequest1 = LeaveRequestFabricator::fabricate($params, true);
+
+    $params['from_date'] = CRM_Utils_Date::processDate($date . ' 11:00:00');
+    $params['to_date'] = CRM_Utils_Date::processDate($date . ' 11:15:00');
+
+    $leaveRequest2 = LeaveRequestFabricator::fabricate($params, true);
+
+    $this->assertNotNull($leaveRequest1->id);
+    $this->assertNotNull($leaveRequest2->id);
+  }
+
+  public function testTwoLeaveRequestsBothForAMCannotBeCreatedForTheSameDay() {
+    $date = '2018-04-13';
+    $contactId = 1;
+    $absenceType = AbsenceTypeFabricator::fabricate();
+    $halfDayAMID = $this->leaveRequestDayTypes['half_day_am']['value'];
+
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2018-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2018-12-31'),
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceType->id,
+      'contact_id' => $contactId,
+      'period_id' => $absencePeriod->id
+    ]);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contactId],
+      ['period_start_date' => CRM_Utils_Date::processDate('2018-01-01')]
+    );
+
+    $this->createLeaveBalanceChange($periodEntitlement->id, 100);
+
+    $leaveRequestParams = [
+      'type_id' => $absenceType->id,
+      'contact_id' => $contactId,
+      'from_date' => CRM_Utils_Date::processDate($date),
+      'to_date' => CRM_Utils_Date::processDate($date),
+      'from_date_type' => $halfDayAMID,
+      'to_date_type' => $halfDayAMID
+    ];
+
+    LeaveRequestFabricator::fabricate($leaveRequestParams, true);
+
+    $this->setExpectedException(
+      'CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException',
+      'This leave request overlaps with another request. Please modify dates of this request'
+    );
+
+    LeaveRequestFabricator::fabricate($leaveRequestParams, true);
+  }
+
+  public function testTwoLeaveRequestsBothForPMCannotBeCreatedForTheSameDay() {
+    $date = '2018-04-13';
+    $contactId = 1;
+    $absenceType = AbsenceTypeFabricator::fabricate();
+    $halfDayPMID = $this->leaveRequestDayTypes['half_day_pm']['value'];
+
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2018-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2018-12-31'),
+    ]);
+
+    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceType->id,
+      'contact_id' => $contactId,
+      'period_id' => $absencePeriod->id
+    ]);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contactId],
+      ['period_start_date' => CRM_Utils_Date::processDate('2018-01-01')]
+    );
+
+    $this->createLeaveBalanceChange($periodEntitlement->id, 100);
+
+    $leaveRequestParams = [
+      'type_id' => $absenceType->id,
+      'contact_id' => $contactId,
+      'from_date' => CRM_Utils_Date::processDate($date),
+      'to_date' => CRM_Utils_Date::processDate($date),
+      'from_date_type' => $halfDayPMID,
+      'to_date_type' => $halfDayPMID
+    ];
+
+    LeaveRequestFabricator::fabricate($leaveRequestParams, true);
+
+    $this->setExpectedException(
+      'CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException',
+      'This leave request overlaps with another request. Please modify dates of this request'
+    );
+
+    LeaveRequestFabricator::fabricate($leaveRequestParams, true);
+  }
+
+  public function testTwoLeaveRequestsOneInDaysAndAnotherInHoursCannotBeCreatedForTheSameDay() {
+    $date = '2018-04-13';
+    $contactId = 1;
+    $absenceTypeInDays = AbsenceTypeFabricator::fabricate();
+    $absenceTypeInHours = AbsenceTypeFabricator::fabricate(['calculation_unit' => 2]);
+    $halfDayAMID = $this->leaveRequestDayTypes['half_day_am']['value'];
+
+    $absencePeriod = AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2018-01-01'),
+      'end_date'   => CRM_Utils_Date::processDate('2018-12-31'),
+    ]);
+
+    $periodEntitlementInDays = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceTypeInDays->id,
+      'contact_id' => $contactId,
+      'period_id' => $absencePeriod->id
+    ]);
+    $periodEntitlementInHours = LeavePeriodEntitlementFabricator::fabricate([
+      'type_id' => $absenceTypeInHours->id,
+      'contact_id' => $contactId,
+      'period_id' => $absencePeriod->id
+    ]);
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contactId],
+      ['period_start_date' => CRM_Utils_Date::processDate('2018-01-01')]
+    );
+
+    $this->createLeaveBalanceChange($periodEntitlementInDays->id, 100);
+    $this->createLeaveBalanceChange($periodEntitlementInHours->id, 100);
+
+    LeaveRequestFabricator::fabricate([
+      'type_id' => $absenceTypeInDays->id,
+      'contact_id' => $contactId,
+      'from_date' => CRM_Utils_Date::processDate($date),
+      'to_date' => CRM_Utils_Date::processDate($date),
+      'from_date_type' => $halfDayAMID,
+      'to_date_type' => $halfDayAMID
+    ], true);
+
+    $this->setExpectedException(
+      'CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestException',
+      'This leave request overlaps with another request. Please modify dates of this request'
+    );
+
+    LeaveRequestFabricator::fabricate([
+      'type_id' => $absenceTypeInHours->id,
+      'contact_id' => $contactId,
+      'from_date' => CRM_Utils_Date::processDate($date . ' 23:00:00'),
+      'to_date' => CRM_Utils_Date::processDate($date . ' 23:15:00')
+    ], true);
   }
 
   public function testAnAlreadyApprovedLeaveRequestCanBeUpdatedWhenEntitlementBalanceIsZero() {
@@ -4541,7 +4879,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   public function testToilToAccrueChangedReturnsTrueWhenToilToAccrueChanges(){
     $date = CRM_Utils_Date::processDate('2016-01-10');
     $params = [
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'from_date' => $date,
       'to_date' => $date,
@@ -4561,7 +4899,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   public function testToilToAccrueChangedReturnsFalseWhenToilToAccrueDoesNotChange(){
     $date = CRM_Utils_Date::processDate('2016-01-08');
     $params = [
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'from_date' => $date,
       'to_date' => $date,
@@ -4580,7 +4918,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   public function testToilToAccrueChangedReturnsNullWhenRequestTypeIsNotToil(){
     $date = CRM_Utils_Date::processDate('2016-01-08');
     $params = [
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'from_date' => $date,
       'to_date' => $date,
@@ -4598,7 +4936,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   public function testToilToAccrueChangedReturnsNullWhenCreatingANewRequest(){
     $date = CRM_Utils_Date::processDate('2016-01-08');
     $params = [
-      'type_id' => 1,
       'contact_id' => 1,
       'from_date' => $date,
       'to_date' => $date,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -1259,20 +1259,28 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $testFromDate = '2018-04-13 10:00:00';
     $testToDate = '2018-04-15 15:00:00';
 
-    $absenceType = AbsenceTypeFabricator::fabricate();
+    $absenceTypes = [
+      'days' => AbsenceTypeFabricator::fabricate([ 'calculation_unit' => 1 ]),
+      'hours' => AbsenceTypeFabricator::fabricate([ 'calculation_unit' => 2 ])
+    ];
 
-    // Test suites: date from, date to, should overlap or not
+    // Test suites: date from, date to, unit, should overlap or not
     $overlappingRequestsTestSuites = [
-      ['2018-04-11 00:00:00', '2018-04-13 10:00:00', FALSE],
-      ['2018-04-11 00:00:00', '2018-04-13 11:00:00', TRUE],
-      ['2018-04-15 14:00:00', '2018-04-18 00:00:00', TRUE],
-      ['2018-04-15 15:00:00', '2018-04-18 00:00:00', FALSE]
+      ['2018-04-11 00:00:00', '2018-04-13 10:00:00', 'days', FALSE],
+      ['2018-04-11 00:00:00', '2018-04-13 11:00:00', 'days', TRUE],
+      ['2018-04-15 14:00:00', '2018-04-18 00:00:00', 'days', TRUE],
+      ['2018-04-15 15:00:00', '2018-04-18 00:00:00', 'days', FALSE],
+      ['2018-04-11 00:00:00', '2018-04-13 10:00:00', 'hours', FALSE],
+      ['2018-04-11 00:00:00', '2018-04-13 11:00:00', 'hours', TRUE],
+      ['2018-04-15 14:00:00', '2018-04-18 00:00:00', 'hours', TRUE],
+      ['2018-04-15 15:00:00', '2018-04-18 00:00:00', 'hours', FALSE]
     ];
 
     foreach ($overlappingRequestsTestSuites as $overlappingRequestsTestSuite) {
       $requestFromDate = new DateTime($overlappingRequestsTestSuite[0]);
       $requestToDate = new DateTime($overlappingRequestsTestSuite[1]);
-      $shouldRequestOverlap = $overlappingRequestsTestSuite[2];
+      $absenceType = $absenceTypes[$overlappingRequestsTestSuite[2]];
+      $shouldRequestOverlap = $overlappingRequestsTestSuite[3];
 
       $leaveRequestToTest = LeaveRequestFabricator::fabricateWithoutValidation([
         'type_id' => $absenceType->id,
@@ -1282,7 +1290,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
         'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
       ], true);
 
-      $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests($contactID, $testFromDate, 1, $testToDate, 1, $absenceType->id, LeaveRequest::REQUEST_TYPE_TOIL);
+      $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests($contactID, $testFromDate, 1, $testToDate, 1, $absenceTypes['days']->id, LeaveRequest::REQUEST_TYPE_TOIL);
       $leaveRequestToTestID = $leaveRequestToTest->id;
       // Flush leave request from DB to get ready for the next test suite
       $leaveRequestToTest->delete();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -1112,7 +1112,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $startDate = '2016-11-01';
     $endDate = '2016-11-03';
 
-    $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests($contactID, $startDate, 1, $endDate, 1, $this->absenceType->id, LeaveRequest::REQUEST_TYPE_LEAVE);
+    $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests([
+      'contact_id' => $contactID,
+      'from_date' => $startDate,
+      'to_date' => $endDate,
+      'type_id' => $this->absenceType->id,
+      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
+    ]);
     $this->assertCount(1, $overlappingRequests);
     $this->assertInstanceOf(LeaveRequest::class, $overlappingRequests[0]);
     $this->assertEquals($leaveRequest1->id, $overlappingRequests[0]->id);
@@ -1157,8 +1163,15 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
         'to_date' => $requestToDate->format('YmdHis'),
       ], true);
 
-      $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests($contactID, $testFromDate, 1, $testToDate, 1, $absenceTypes['hours']->id, LeaveRequest::REQUEST_TYPE_LEAVE);
+      $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests([
+        'contact_id' => $contactID,
+        'from_date' => $testFromDate,
+        'to_date' => $testToDate,
+        'type_id' => $absenceTypes['hours']->id,
+        'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
+      ]);
       $leaveRequestToTestID = $leaveRequestToTest->id;
+
       // Flush leave request from DB to get ready for the next test suite
       $leaveRequestToTest->delete();
 
@@ -1184,7 +1197,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     foreach ([
       [LeaveRequest::REQUEST_TYPE_LEAVE, LeaveRequest::REQUEST_TYPE_TOIL],
-      [LeaveRequest::REQUEST_TYPE_TOIL, LeaveRequest::REQUEST_TYPE_LEAVE]
+      [LeaveRequest::REQUEST_TYPE_TOIL, LeaveRequest::REQUEST_TYPE_LEAVE],
+      [LeaveRequest::REQUEST_TYPE_SICKNESS, LeaveRequest::REQUEST_TYPE_TOIL],
+      [LeaveRequest::REQUEST_TYPE_TOIL, LeaveRequest::REQUEST_TYPE_SICKNESS]
     ] as $testSuite) {
       $existingRequestType = $testSuite[0];
       $testingRequestType = $testSuite[1];
@@ -1196,10 +1211,18 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
         'from_date' => $requestFromDate->format('YmdHis'),
         'to_date' => $requestToDate->format('YmdHis')
       ], true);
+
+      $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests([
+        'contact_id' => $contactID,
+        'from_date' => $testFromDate,
+        'to_date' => $testToDate,
+        'type_id' => $absenceTypeForTOILAccrual->id,
+        'request_type' => $testingRequestType
+      ]);
+
       // Flush leave request from DB to get ready for the next test suite
       $leaveRequestToTest->delete();
 
-      $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests($contactID, $testFromDate, 1, $testToDate, 1, $absenceTypeForTOILAccrual->id, $testingRequestType);
       $this->assertCount(0, $overlappingRequests);
     }
   }
@@ -1240,8 +1263,17 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
         'to_date_type' => $requestToDateType
       ], true);
 
-      $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests($contactID, $testFromDate, $halfDayPMID, $testToDate, $halfDayAMID, $absenceType->id, LeaveRequest::REQUEST_TYPE_LEAVE);
+      $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests([
+        'contact_id' => $contactID,
+        'from_date' => $testFromDate,
+        'from_date_type' => $halfDayPMID,
+        'to_date' => $testToDate,
+        'to_date_type' => $halfDayAMID,
+        'type_id' => $absenceType->id,
+        'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
+      ]);
       $leaveRequestToTestID = $leaveRequestToTest->id;
+
       // Flush leave request from DB to get ready for the next test suite
       $leaveRequestToTest->delete();
 
@@ -1290,8 +1322,15 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
         'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
       ], true);
 
-      $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests($contactID, $testFromDate, 1, $testToDate, 1, $absenceTypes['days']->id, LeaveRequest::REQUEST_TYPE_TOIL);
+      $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests([
+        'contact_id' => $contactID,
+        'from_date' => $testFromDate,
+        'to_date' => $testToDate,
+        'type_id' => $absenceTypes['days']->id,
+        'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
+      ]);
       $leaveRequestToTestID = $leaveRequestToTest->id;
+
       // Flush leave request from DB to get ready for the next test suite
       $leaveRequestToTest->delete();
 
@@ -1448,7 +1487,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $startDate = '2016-11-01';
     $endDate = '2016-11-06';
 
-    $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests($contactID, $startDate, 1, $endDate, 1, $this->absenceType->id, LeaveRequest::REQUEST_TYPE_LEAVE);
+    $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests([
+      'contact_id' => $contactID,
+      'from_date' => $startDate,
+      'to_date' => $endDate,
+      'type_id' => $this->absenceType->id,
+      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
+    ]);
     $this->assertCount(2, $overlappingRequests);
     $this->assertInstanceOf(LeaveRequest::class, $overlappingRequests[0]);
     $this->assertEquals($leaveRequest1->id, $overlappingRequests[0]->id);
@@ -1478,7 +1523,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $startDate = '2016-11-01';
     $endDate = '2016-11-02';
 
-    $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests($contactID, $startDate, 1, $endDate, 1, $this->absenceType->id, LeaveRequest::REQUEST_TYPE_LEAVE);
+    $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests([
+      'contact_id' => $contactID,
+      'from_date' => $startDate,
+      'to_date' => $endDate,
+      'type_id' => $this->absenceType->id,
+      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
+    ]);
     $this->assertCount(0, $overlappingRequests);
   }
 
@@ -1524,7 +1575,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     //public holiday is excluded by default
     $startDate = '2016-11-01';
     $endDate = '2016-11-12';
-    $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests($contactID, $startDate, 1, $endDate, 1, $this->absenceType->id, LeaveRequest::REQUEST_TYPE_LEAVE);
+    $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests([
+      'contact_id' => $contactID,
+      'from_date' => $startDate,
+      'to_date' => $endDate,
+      'type_id' => $this->absenceType->id,
+      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
+    ]);
     $this->assertCount(2, $overlappingRequests);
     $this->assertInstanceOf(LeaveRequest::class, $overlappingRequests[0]);
     $this->assertEquals($leaveRequest1->id, $overlappingRequests[0]->id);
@@ -1576,7 +1633,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     //leaveRequest2 and public holiday
     $startDate = '2016-11-01';
     $endDate = '2016-11-12';
-    $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests($contactID, $startDate, 1, $endDate, 1, $this->absenceType->id, LeaveRequest::REQUEST_TYPE_LEAVE, [], false);
+    $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests([
+      'contact_id' => $contactID,
+      'from_date' => $startDate,
+      'to_date' => $endDate,
+      'type_id' => $this->absenceType->id,
+      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
+    ], [], false);
     $this->assertCount(3, $overlappingRequests);
     $this->assertInstanceOf(LeaveRequest::class, $overlappingRequests[0]);
     $this->assertEquals($leaveRequest1->id, $overlappingRequests[0]->id);
@@ -1645,7 +1708,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $startDate = '2016-11-02';
     $endDate = '2016-11-15';
     $filterStatus = [$leaveRequestStatuses['more_information_required']];
-    $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests($contactID, $startDate, 1, $endDate, 1, $this->absenceType->id, LeaveRequest::REQUEST_TYPE_LEAVE, $filterStatus);
+    $overlappingRequests = LeaveRequest::findOverlappingLeaveRequests([
+      'contact_id' => $contactID,
+      'from_date' => $startDate,
+      'to_date' => $endDate,
+      'type_id' => $this->absenceType->id,
+      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
+    ], $filterStatus);
     $this->assertCount(1, $overlappingRequests);
     $this->assertInstanceOf(LeaveRequest::class, $overlappingRequests[0]);
     $this->assertEquals($leaveRequest2->id, $overlappingRequests[0]->id);
@@ -1657,7 +1726,13 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $startDate = '2016-11-01';
     $endDate = '2016-11-16';
     $filterStatus = [$leaveRequestStatuses['more_information_required'], $leaveRequestStatuses['awaiting_approval']];
-    $overlappingRequests2 = LeaveRequest::findOverlappingLeaveRequests($contactID, $startDate, 1, $endDate, 1, $this->absenceType->id, LeaveRequest::REQUEST_TYPE_LEAVE, $filterStatus, false);
+    $overlappingRequests2 = LeaveRequest::findOverlappingLeaveRequests([
+      'contact_id' => $contactID,
+      'from_date' => $startDate,
+      'to_date' => $endDate,
+      'type_id' => $this->absenceType->id,
+      'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
+    ], $filterStatus, false);
     $this->assertCount(2, $overlappingRequests2);
     $this->assertInstanceOf(LeaveRequest::class, $overlappingRequests[0]);
     $this->assertEquals($leaveRequest1->id, $overlappingRequests2[0]->id);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -194,7 +194,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
       'contact_id' => 1,
       'period_id' => $absencePeriod->id,
-      'type_id' => 1
+      'type_id' => $this->absenceType->id
     ]);
 
     HRJobContractFabricator::fabricate(
@@ -656,7 +656,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     //This leave request is before the contract start date and will not be returned
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2015-12-30'),
       'to_date' => CRM_Utils_Date::processDate('2015-12-31'),
       'status_id' => $leaveRequestStatuses['awaiting_approval']
@@ -665,7 +665,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     //This will be returned as it is after the contract start date
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2017-12-30'),
       'to_date' => CRM_Utils_Date::processDate('2017-12-31'),
       'status_id' => $leaveRequestStatuses['awaiting_approval']
@@ -690,7 +690,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     //This leave request is before the contract start date and will not be returned
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2015-12-30'),
       'to_date' => CRM_Utils_Date::processDate('2015-12-31'),
       'status_id' => $leaveRequestStatuses['awaiting_approval']
@@ -699,7 +699,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     // This will be returned
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-02'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-03'),
       'status_id' => $leaveRequestStatuses['approved']
@@ -708,7 +708,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     // This will be returned
     $leaveRequest3 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-09-07'),
       'to_date' => CRM_Utils_Date::processDate('2016-09-08'),
       'status_id' => $leaveRequestStatuses['approved']
@@ -717,7 +717,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     //This will not be returned as it is after the contract start date
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2017-12-30'),
       'to_date' => CRM_Utils_Date::processDate('2017-12-31'),
       'status_id' => $leaveRequestStatuses['awaiting_approval']
@@ -737,7 +737,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     //This leave request is before the contract start date and will not be returned
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2015-12-30'),
       'to_date' => CRM_Utils_Date::processDate('2015-12-30'),
       'from_date_type' => 1,
@@ -748,7 +748,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     // This will be returned as it's after the contract start date
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2017-09-02'),
       'to_date' => CRM_Utils_Date::processDate('2017-09-02'),
       'from_date_type' => 1,
@@ -759,7 +759,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     // This will be returned as it's after the contract start date as well
     $leaveRequest3 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2018-01-02'),
       'to_date' => CRM_Utils_Date::processDate('2018-01-02'),
       'from_date_type' => 1,
@@ -787,7 +787,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     //This leave request is before the contract start date and will not be returned
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2015-12-30'),
       'to_date' => CRM_Utils_Date::processDate('2015-12-30'),
       'from_date_type' => 1,
@@ -798,7 +798,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     // This will be returned
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'from_date_type' => 1,
@@ -809,7 +809,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     // This will be returned
     $leaveRequest3 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
       'to_date' => CRM_Utils_Date::processDate('2016-02-20'),
       'from_date_type' => 1,
@@ -820,7 +820,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     //This will not be returned as it is after the contract start date
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2017-12-30'),
       'to_date' => CRM_Utils_Date::processDate('2017-12-30'),
       'from_date_type' => 1,
@@ -848,7 +848,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     // This will be returned. The balance change will be -1
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'from_date_type' => 1,
@@ -859,7 +859,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     // This will be returned. The balance change will be -4
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-02-23'),
       'from_date_type' => 1,
@@ -895,7 +895,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'from_date_type' => 1,
@@ -905,7 +905,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-02-20'),
       'from_date_type' => 1,
@@ -945,7 +945,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'from_date_type' => 1,
@@ -955,7 +955,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-02-20'),
       'from_date_type' => 1,
@@ -995,7 +995,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'from_date_type' => 1,
@@ -1005,7 +1005,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-02-20'),
       'from_date_type' => 1,
@@ -1014,7 +1014,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ], true);
 
     $toilRequest = LeaveRequestFabricator::fabricateWithoutValidation([
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
       'from_date' => CRM_Utils_Date::processDate('2016-02-21'),
@@ -1066,7 +1066,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'from_date_type' => 1,
@@ -1076,7 +1076,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-02-20'),
       'from_date_type' => 1,
@@ -1092,11 +1092,11 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $expectedValues = [
       [
         'id' => $leaveRequest1->id,
-        'type_id' => 1
+        'type_id' => $this->absenceType->id
       ],
       [
         'id' => $leaveRequest2->id,
-        'type_id' => 1
+        'type_id' => $this->absenceType->id
       ]
     ];
 
@@ -1118,7 +1118,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     //so it will not be returned
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2015-12-30'),
       'to_date' =>  CRM_Utils_Date::processDate('2015-12-30'),
       'from_date_type' => 1,
@@ -1138,7 +1138,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contract['contact_id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('+1 days'),
       'to_date' => CRM_Utils_Date::processDate('+2 days'),
       'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
@@ -1146,7 +1146,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contract['contact_id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('+3 days'),
       'to_date' => CRM_Utils_Date::processDate('+4 days'),
       'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
@@ -1154,7 +1154,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest3 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contract['contact_id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('+5 days'),
       'to_date' => CRM_Utils_Date::processDate('+6 days'),
       'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
@@ -1426,7 +1426,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember1['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'from_date_type' => 1,
@@ -1435,7 +1435,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember2['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-05'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-05'),
       'from_date_type' => 1,
@@ -1444,7 +1444,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest3 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember3['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-13'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-13'),
       'from_date_type' => 1,
@@ -1492,7 +1492,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'from_date_type' => 1,
@@ -1524,7 +1524,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember1['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'from_date_type' => 1,
@@ -1533,7 +1533,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember2['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-05-01'),
       'to_date' => CRM_Utils_Date::processDate('2016-05-02'),
       'from_date_type' => 1,
@@ -1573,7 +1573,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember1['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'from_date_type' => 1,
@@ -1582,7 +1582,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember2['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-05-01'),
       'to_date' => CRM_Utils_Date::processDate('2016-05-02'),
       'from_date_type' => 1,
@@ -1642,7 +1642,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember1['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'from_date_type' => 1,
@@ -1651,7 +1651,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember2['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-05'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-05'),
       'from_date_type' => 1,
@@ -1660,7 +1660,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest3 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember3['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-13'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-13'),
       'from_date_type' => 1,
@@ -1709,7 +1709,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember1['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'from_date_type' => 1,
@@ -1718,7 +1718,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember2['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-05'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-05'),
       'from_date_type' => 1,
@@ -1767,7 +1767,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember1['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'from_date_type' => 1,
@@ -1776,7 +1776,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember2['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-05'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-05'),
       'from_date_type' => 1,
@@ -1818,7 +1818,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember2['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-05'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-05'),
       'from_date_type' => 1,
@@ -1872,7 +1872,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember1['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'from_date_type' => 1,
@@ -1881,7 +1881,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember2['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-05'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-05'),
       'from_date_type' => 1,
@@ -1890,7 +1890,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest3 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember3['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-13'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-13'),
       'from_date_type' => 1,
@@ -1899,7 +1899,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest4 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember4['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-15'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-17'),
       'from_date_type' => 1,
@@ -1954,7 +1954,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'from_date_type' => $this->leaveRequestDayTypes['half_day_am']['value'],
       'to_date' => '2016-11-10',
       'to_date_type' => $this->leaveRequestDayTypes['half_day_pm']['value'],
-      'type_id' => 1
+      'type_id' => $this->absenceType->id
     ]);
   }
 
@@ -1968,7 +1968,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'from_date_type' => $this->leaveRequestDayTypes['half_day_am']['value'],
       'to_date' => '2016-11-10',
       'to_date_type' => $this->leaveRequestDayTypes['half_day_pm']['value'],
-      'type_id' => 1
+      'type_id' => $this->absenceType->id
     ]);
   }
 
@@ -2014,7 +2014,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'from_date' => '2016-11-05',
       'from_date_type' => $this->leaveRequestDayTypes['half_day_pm']['value'],
       'to_date_type' => $this->leaveRequestDayTypes['half_day_pm']['value'],
-      'type_id' => 1
+      'type_id' => $this->absenceType->id
     ]);
   }
 
@@ -2061,7 +2061,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'from_date_type' => $this->leaveRequestDayTypes['half_day_am']['value'],
       'to_date' => '2016-11-10',
       'to_date_type' => $this->leaveRequestDayTypes['half_day_pm']['value'],
-      'type_id' => 1
+      'type_id' => $this->absenceType->id
     ]);
   }
 
@@ -3209,7 +3209,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => $startDate->format('Ymd'),
       'from_date_type' => $this->leaveRequestDayTypes['all_day']['value'],
       'to_date' => $endDate->format('Ymd'),
@@ -3279,7 +3279,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember1['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'from_date_type' => 1,
@@ -3288,7 +3288,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember1['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-01'),
       'to_date' => CRM_Utils_Date::processDate('2016-02-01'),
       'from_date_type' => 1,
@@ -3297,7 +3297,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest3 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember2['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-05'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-05'),
       'from_date_type' => 1,
@@ -3306,7 +3306,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest4 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember3['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-13'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-13'),
       'from_date_type' => 1,
@@ -3315,7 +3315,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest5 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember4['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-10-23'),
       'to_date' => CRM_Utils_Date::processDate('2016-10-23'),
       'from_date_type' => 1,
@@ -3366,7 +3366,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'from_date_type' => 1,
@@ -3411,7 +3411,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'from_date_type' => 1,
@@ -3464,7 +3464,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'from_date_type' => 1,
@@ -3494,7 +3494,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'from_date_type' => 1,
@@ -3615,7 +3615,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact1['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'from_date_type' => 1,
@@ -3625,7 +3625,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact2['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-02-23'),
       'from_date_type' => 1,
@@ -3670,7 +3670,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact1['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'from_date_type' => 1,
@@ -3680,7 +3680,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact2['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-02-23'),
       'from_date_type' => 1,
@@ -3739,7 +3739,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequestContact1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact1['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'from_date_type' => 1,
@@ -3749,7 +3749,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact2['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-02-23'),
       'from_date_type' => 1,
@@ -3759,7 +3759,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequestContact3 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact3['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
       'to_date' => CRM_Utils_Date::processDate('2016-02-20'),
       'from_date_type' => 1,
@@ -3822,7 +3822,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact1['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'from_date_type' => 1,
@@ -3832,7 +3832,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact2['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-02-23'),
       'from_date_type' => 1,
@@ -3877,7 +3877,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact1['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'from_date_type' => 1,
@@ -3887,7 +3887,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact2['id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-02-23'),
       'from_date_type' => 1,
@@ -3919,14 +3919,14 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contract1['contact_id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'), //Hour will be automatically set to 00:00:00
       'to_date' =>  CRM_Utils_Date::processDate('2016-02-23'), //Hour will be automatically set to 23:59:59
     ], true);
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contract2['contact_id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-23 10:00:00'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-02-23 16:00:00'),
     ], true);
@@ -3961,14 +3961,14 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contract1['contact_id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'), //Hour will be automatically set to 00:00:00
       'to_date' =>  CRM_Utils_Date::processDate('2016-02-20'), //Hour will be automatically set to 23:59:59
     ], true);
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contract2['contact_id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20 23:59:59'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-02-23 16:00:00'),
     ], true);
@@ -3998,28 +3998,28 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contract['contact_id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-17 08:00'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-03-17 09:00:00')
     ], true);
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contract['contact_id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-17 11:00'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-03-18 11:00:00')
     ], true);
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contract['contact_id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-25 17:00:00'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-03-25 18:00:00'),
     ], true);
 
     LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contract['contact_id'],
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-25 19:00:00'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-03-25 20:00:00'),
     ], true);
@@ -4143,7 +4143,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     );
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => $contact2['id'],
       'from_date' => CRM_Utils_Date::processDate('+5 days'),
       'to_date' =>  CRM_Utils_Date::processDate('+7 days'),
@@ -4180,7 +4180,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     );
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => $contact2['id'],
       'from_date' => CRM_Utils_Date::processDate('+5 days'),
       'to_date' =>  CRM_Utils_Date::processDate('+7 days'),
@@ -4210,7 +4210,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     );
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => $contact2['id'],
       'from_date' => CRM_Utils_Date::processDate('+5 days'),
       'to_date' =>  CRM_Utils_Date::processDate('+7 days'),
@@ -4243,14 +4243,14 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     );
 
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => $contact1['id'],
       'from_date' => CRM_Utils_Date::processDate('+5 days'),
       'to_date' =>  CRM_Utils_Date::processDate('+7 days'),
     ], true);
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => $contact2['id'],
       'from_date' => CRM_Utils_Date::processDate('+8 days'),
       'to_date' =>  CRM_Utils_Date::processDate('+8 days'),
@@ -4286,7 +4286,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
   private function mergeWithDefaultLeaveRequestParams($params) {
     return array_merge([
-      'type_id' => 1,
+      'type_id' => $this->absenceType->id,
       'contact_id' => 1,
       'status_id' => 1,
       'from_date_type' => 1,


### PR DESCRIPTION
## Overview

At the moment it is impossible to create Leave Requests and TOIL Accruals for the same day.

This PR allows to create requests for the same day according to the rules:

1) It should be possible to create multiple leave requests in hours within the same day. They can also "touch" together in terms of time, for example, one request ends at 9:00 and another starts at 9:00 of the same day.
2) It should be possible to create one AM and one PM leave request within the same day using leave in days allowance.
3) It should not be possible to create one leave request in days and one leave request in hours on the same day, regardless of the request in hours start and end time. 
4) It should not be possible to create more than one AM leave request within the same day. Same for PM.
5) It should be possible for a TOIL Accrual request to overlap one or more leave (non-TOIL) requests.
6) It should be possible for multiple TOIL requests to be created for one day as long as their start-end time does not overlap.

## Technical Details

The only function that was touched is `findOverlappingLeaveRequests`.

ℹ️`findOverlappingLeaveRequests` function is only used ONCE in the whole codebase, so it is safe to change accepted args:

![image](https://user-images.githubusercontent.com/3973243/38942368-7db5188e-4326-11e8-8d72-183138fcdda2.png)

```php
// since we now need to pass 5 more leave request params
// we now pass a whole assoc array $leaveRequestParams as an arg instead of separate args
public static function findOverlappingLeaveRequests($leaveRequestParams, $leaveRequestStatus = [], $excludePublicHolidayLeaveRequests = TRUE) {
  // these vars are needed since they are either used in multiple places
  // or are simply optional and/or should be converted type-wise
  $fromDate = $leaveRequestParams['from_date'];
  $fromDateType = isset($leaveRequestParams['from_date_type']) ? (int)$leaveRequestParams['from_date_type'] : NULL;
  $toDate = $leaveRequestParams['to_date'];
  $toDateType = isset($leaveRequestParams['to_date_type']) ? (int)$leaveRequestParams['to_date_type'] : NULL;

  // ...

  // due to new rules a the following variables need to be considered
  $leaveRequestAbsenceType = AbsenceType::findById($leaveRequestParams['type_id']);
  $isCalculationUnitInHours = $leaveRequestAbsenceType->isCalculationUnitInHours();
  $absenceTypes = AbsenceType::getEnabledAbsenceTypes();
  $absenceTypesIDsWithSameUnit = [];
  $absenceTypesIDsWithDifferentUnit = [];
  $leaveRequestDayTypes = array_flip(self::buildOptions('from_date_type', 'validate'));
  $halfDayAMID = $leaveRequestDayTypes['half_day_am'];
  $halfDayPMID = $leaveRequestDayTypes['half_day_pm'];
  $isTOIL = $leaveRequestParams['request_type'] === LeaveRequest::REQUEST_TYPE_TOIL;

  // we should consider units
  foreach ($absenceTypes as $absenceType) {
    if ($leaveRequestAbsenceType->calculation_unit === $absenceType->calculation_unit) {
      $absenceTypesIDsWithSameUnit[] = $absenceType->id;
    } else {
      $absenceTypesIDsWithDifferentUnit[] = $absenceType->id;
    }
  }

  // this SQL WHERE rule actually considers only those requests that are needed
  $noOverlappingCondition =
    $isCalculationUnitInHours || $isTOIL
    ?
      "(lr.from_date < '{$toDate}' AND lr.to_date > '{$fromDate}'" . (!$isTOIL ? " AND lr.type_id IN (" . join(',', $absenceTypesIDsWithSameUnit) . ")" : "") . ")" .
      (count($absenceTypesIDsWithDifferentUnit) && !$isTOIL ? " OR ((lrd.date BETWEEN %3 AND %4) AND lr.type_id IN (" . join(',', $absenceTypesIDsWithDifferentUnit) . "))" : "")
    : "lrd.date BETWEEN %3 AND %4 AND lr.type_id IN (" . join(',', array_merge($absenceTypesIDsWithSameUnit, $absenceTypesIDsWithDifferentUnit)) . ")" .
      ($fromDateType !== null && $fromDateType === $halfDayPMID ? " AND (DATE_FORMAT(lr.to_date, '%y-%m-%d') != DATE_FORMAT('{$fromDate}', '%y-%m-%d') OR lr.to_date_type != {$halfDayAMID})" : "") .
      ($toDateType !== null && $toDateType === $halfDayAMID ? " AND (DATE_FORMAT(lr.from_date, '%y-%m-%d') != DATE_FORMAT('{$toDate}', '%y-%m-%d') OR lr.from_date_type != {$halfDayPMID})" : "");

  // as a generic rule, we do not mind to *completely* overlay TOIL and Non-TOIL (Leave/Sick) requests
  $ignoreRequestTypes =
    'lr.request_type ' . ($isTOIL ? '=' : '!=') . "'" . LeaveRequest::REQUEST_TYPE_TOIL . "'";

  // the query now includes the conditions described above
  $query = "
    SELECT DISTINCT lr.* FROM {$leaveRequestTable} lr
    INNER JOIN {$leaveRequestDateTable} lrd
      ON lrd.leave_request_id = lr.id
    INNER JOIN {$leaveBalanceChangeTable} lbc
      ON lbc.source_id = lrd.id AND lbc.source_type = %1
    WHERE lr.contact_id = %2 AND lr.is_deleted = 0 AND ({$noOverlappingCondition})
      AND {$ignoreRequestTypes}";

  // the rest code remains the same
}
```

And finally, the usage:

```php
private static function validateNoOverlappingLeaveRequests($params) {
  // ...

  $overlappingLeaveRequests = self::findOverlappingLeaveRequests(
    $params, // <-- now an assoc array is passed
    $leaveRequestStatusFilter // not touched
  );

  // ...
}
```

## Comments

### Fabricator improvement

Now Leave Request fabricator considers calculation unit when adding default params:

```php
private static function mergeDefaultParams($params) {
  $absenceType = AbsenceType::findById($params['type_id']);
  $isCalculationUnitInHours = $absenceType->isCalculationUnitInHours();
  $isTOIL = isset($params['request_type']) && $params['request_type'] === LeaveRequest::REQUEST_TYPE_TOIL;

  $defaultParams = [
    'type_id' => $absenceType->id,
    'status_id' => self::getStatusId('approved'),
    'request_type' => LeaveRequest::REQUEST_TYPE_LEAVE
  ];
 
  if (!$isCalculationUnitInHours) {
    $defaultParams['from_date_type'] = self::getDayTypeId('all_day');

    if (!empty($params['to_date']) && empty($params['to_date_type'])) {
      $defaultParams['to_date_type'] = self::getDayTypeId('all_day');
    }
  } else {
    $defaultParams['from_date_amount'] = 1;
    $defaultParams['to_date_amount'] = 1;
  }

  if ($isTOIL) {
    $defaultParams['toil_duration'] = 1;
    $defaultParams['toil_to_accrue'] = 1;
  }
 
  return array_merge($defaultParams, $params);
}
```

### Bug in tests

CreateLeaveBalanceChange accepts Absence Type ID as a first param, not Absence Period.

![image](https://user-images.githubusercontent.com/3973243/39062192-b723b92e-44be-11e8-8714-a756046544b9.png)



------

✅PHP Unit Tests - augmented and passed