### PR TITLE
FAR-252: Fix error with Scheduled Job trying to expire balances linked to deleted TOIL requests

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php
@@ -755,7 +755,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange extends CRM_HRLeaveAndAbsenc
       WHERE balance_to_expire.expiry_date IS NOT NULL AND
             balance_to_expire.expiry_date < %3 AND
             balance_to_expire.expired_balance_change_id IS NULL AND
-            expired_balance_change.id IS NULL
+            expired_balance_change.id IS NULL AND
+            coalesce(leave_request.type_id, period_entitlement.type_id) IS NOT NULL
       ORDER BY balance_to_expire.expiry_date ASC, balance_to_expire.id ASC
     ";
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -3642,7 +3642,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $this->assertEquals($expectedBroughtForwardLog, $balanceExpiryLogs[$broughtForwardExpiryRecord->id]);
   }
 
-  public function testCreateExpiryRecordsDoesTryToExpireBalanceChangesLinkedToSoftDeletedToilRequest() {
+  public function testCreateExpiryRecordsDoesNotExpireBalanceChangesLinkedToSoftDeletedToilRequest() {
     $absencePeriod = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
       'end_date' => CRM_Utils_Date::processDate('2017-12-31')
@@ -3663,7 +3663,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'toil_to_accrue' => 1,
       'toil_duration' => 100,
       'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
-    ], true);
+    ], TRUE);
 
     $toilRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $periodEntitlement->contact_id,
@@ -3674,7 +3674,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'toil_to_accrue' => 1,
       'toil_duration' => 100,
       'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
-    ], true);
+    ], TRUE);
 
     //Delete the first TOIL request
     LeaveRequest::softDelete($toilRequest->id);


### PR DESCRIPTION
## Overview
The SQL query responsible for selecting balance changes to expire selects balance changes linked to already deleted TOIL accrual requests. The query is only supposed to select balance changes linked to non deleted TOIL accrual requests.

## Before
- When SQL query selects balances linked to a deleted TOIL request, this causes an exception to be thrown when selecting dates overlapping balance to [expire ](https://github.com/civicrm/civihr/blob/81d97c204a4e6f84ec836f07b055f481a88b6360/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php#L656), particularly when fetching the LeaveRequest linked to the leave date in order to get the [entitlement](https://github.com/civicrm/civihr/blob/81d97c204a4e6f84ec836f07b055f481a88b6360/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChange.php#L441) . 
An Exception: `Unable to find a Leave Request with id XX` is thrown halting the execution of the Scheduled job script..
 

## After
- Since the query to JOIN to the Leave request table is a LEFT JOIN(And we can't change it to an INNER JOIN because of JOINS to the Period Entitlement table), It is possible for the Expression on the Join condition `ON leave_request_date.leave_request_id = leave_request.id AND leave_request.is_deleted = 0` to be ignored and Null rows are returned for the leave request table instead. This is fixed by checking that the Absence Type ID column of the results fetched is NOT NULL
