### PR TITLE
PCHR-3497: Suppress Leave Request Notification Emails for Person Creating/Editing the Request

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Message.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Mail/Message.php
@@ -160,6 +160,12 @@ class CRM_HRLeaveAndAbsences_Mail_Message {
 
     $leaveContact = [$this->leaveRequest->contact_id];
     $allRecipients = array_merge($leaveApprovers, $leaveContact);
+    $loggedInContactID = CRM_Core_Session::getLoggedInContactID();
+    $currentContactKey = array_search($loggedInContactID, $allRecipients);
+
+    if ($currentContactKey !== FALSE) {
+      unset($allRecipients[$currentContactKey]);
+    }
 
     $result = civicrm_api3('Email', 'get', [
       'contact_id' => ['IN' => $allRecipients],
@@ -179,7 +185,7 @@ class CRM_HRLeaveAndAbsences_Mail_Message {
    */
   private function getLeaveApprovers() {
     $leaveApprovers = $this->leaveManagerService->getLeaveApproversForContact($this->leaveRequest->contact_id);
-    
+
     return array_keys($leaveApprovers);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
@@ -266,8 +266,9 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
   }
 
   public function testGetRecipientEmailsWillNotIncludeEmailOfLeaveContactIfLoggedIn() {
+    $managerEmail = 'manager1@dummysite.com';
     $manager = ContactFabricator::fabricateWithEmail([
-      'first_name' => 'Manager1', 'last_name' => 'Manager1'], 'manager1@dummysite.com'
+      'first_name' => 'Manager1', 'last_name' => 'Manager1'], $managerEmail
     );
 
     $managerService = $this->prophesize(LeaveManagerService::class);
@@ -285,7 +286,7 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
       'contact_id' => $this->leaveContact['id'],
       'from_date' => CRM_Utils_Date::processDate('tomorrow'),
       'to_date' => CRM_Utils_Date::processDate('tomorrow'),
-    ], false);
+    ], FALSE);
 
     $message = new Message($leaveRequest, $this->leaveRequestTemplateFactory, $managerService->reveal());
 
@@ -295,8 +296,7 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
     //the leave contact email will not be included.
     $this->assertCount(1, $recipientEmails);
 
-    $expectedEmails = ['manager1@dummysite.com'];
-    $this->assertEquals($expectedEmails, $recipientEmails);
+    $this->assertEquals([$managerEmail], $recipientEmails);
     $this->unregisterCurrentLoggedInContactFromSession($this->leaveContact['id']);
   }
 
@@ -320,7 +320,7 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
       'contact_id' => $this->leaveContact['id'],
       'from_date' => CRM_Utils_Date::processDate('tomorrow'),
       'to_date' => CRM_Utils_Date::processDate('tomorrow'),
-    ], false);
+    ], FALSE);
 
     $message = new Message($leaveRequest, $this->leaveRequestTemplateFactory, $managerService->reveal());
 


### PR DESCRIPTION
## Overview
Leave request notification emails need to be suppressed for user creating or editing the leave request. 
For example, If a staff member creates a new leave request or edits an existing leave request the staff member should not get a notification email but the leave approver should get a notification email. Also If a leave approver creates/edit a leave request, the leave approver should not get a notification email but the target staff member should.

## Before
- Leave request notifications are sent for all eligible recipients including the user creating/editing the request

## After
- Leave request notifications are sent for all eligible recipients excluding the user creating/editing the request

## Technical Details
- The email of the current logged in user (i.e the user creating or editing the leave request) is excluded from the recipient emails in the `getRecipientEmails` function of the `CRM_HRLeaveAndAbsences_Mail_Message` class.

