### PR TITLE
PCHR-3570: Footer Updates

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Page/View/Summary.tpl
+++ b/hrjobcontract/CRM/Hrjobcontract/Page/View/Summary.tpl
@@ -49,7 +49,7 @@
 
         {* CRM-12735 - Conditionally include the Actions and Edit buttons if contact is NOT in trash.*}
         {if !$isDeleted}
-          {if call_user_func(array('CRM_Core_Permission','check'), 'access CiviCRM')}
+          {if $canAccessCiviCRM }
             <li class="crm-contact-activity crm-summary-block">
               {include file="CRM/Contact/Page/Inline/Actions.tpl"}
             </li>

--- a/hrui/templates/CRM/Contact/Page/View/Summary.tpl
+++ b/hrui/templates/CRM/Contact/Page/View/Summary.tpl
@@ -47,7 +47,7 @@
 
         {* CRM-12735 - Conditionally include the Actions and Edit buttons if contact is NOT in trash.*}
         {if !$isDeleted}
-          {if call_user_func(array('CRM_Core_Permission','check'), 'access CiviCRM')}
+          {if $canAccessCiviCRM}
             <li class="crm-contact-activity crm-summary-block">
               {if !empty($alternativeActionsTemplate)}
                 {include file="$alternativeActionsTemplate"}

--- a/hrui/templates/CRM/common/footer.tpl
+++ b/hrui/templates/CRM/common/footer.tpl
@@ -31,15 +31,14 @@
 
   <div class="crm-footer" id="civicrm-footer">
     {* PCHR-1323 - Display CiviHR version info. *}
-    {ts}Powered by CiviHR version{/ts} {civihrVersion}.
+    {ts}Powered by CiviHR {/ts} {civihrVersion}.
 
     {if !empty($footer_status_severity)}
       <span class="status{if $footer_status_severity gt 3} crm-error{elseif $footer_status_severity gt 2} crm-warning{else} crm-ok{/if}">
       <a target="_blank" href="{crmURL p='civicrm/a/#/status'}">{$footer_status_message}</a>.
     </span>&nbsp;
     {/if}
-    CiviHR is openly available under the <a target="_blank" href="http://www.gnu.org/licenses/agpl-3.0.html">GNU AGPL License</a> and can be downloaded from the
-    <a target="_blank" href="https://civihr.org">Project website</a>&nbsp;.
+    CiviHR is openly available under Version 3 of the <a target="_blank" href="http://www.gnu.org/licenses/agpl-3.0.html">GNU AGPL License</a> and can be downloaded from <a target="_blank" href="https://civihr.org">www.civihr.org</a>.
     <div class="text-center">
       <div class="footer-logo">
         <span class="chr_logo chr_logo--full chr_logo--default-size"><i></i></span>

--- a/hrui/templates/CRM/common/footer.tpl
+++ b/hrui/templates/CRM/common/footer.tpl
@@ -23,7 +23,8 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{if call_user_func(array('CRM_Core_Permission','check'), 'access CiviCRM')}
+
+{if $canAccessCiviCRM }
   {include file="CRM/common/accesskeys.tpl"}
   {if !empty($contactId)}
     {include file="CRM/common/contactFooter.tpl"}

--- a/hrui/templates/CRM/common/footer.tpl
+++ b/hrui/templates/CRM/common/footer.tpl
@@ -34,7 +34,7 @@
     {* PCHR-1323 - Display CiviHR version info. *}
     {ts}Powered by CiviHR {/ts} {civihrVersion}.
 
-    {if !empty($footer_status_severity)}
+    {if $isRoot && !empty ($footer_status_severity)}
       <span class="status{if $footer_status_severity gt 3} crm-error{elseif $footer_status_severity gt 2} crm-warning{else} crm-ok{/if}">
       <a target="_blank" href="{crmURL p='civicrm/a/#/status'}">{$footer_status_message}</a>.
     </span>&nbsp;

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -10,6 +10,8 @@ use CRM_HRCore_Service_Manager as ManagerService;
 use CRM_HRContactActionsMenu_Component_Menu as ActionsMenu;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use CRM_HRContactActionsMenu_Helper_Contact as ContactHelper;
+use CRM_HRCore_CMSData_UserRoleFactory as CMSUserRoleFactory;
 
 /**
  * Implements hook_civicrm_config().
@@ -270,12 +272,27 @@ function hrcore_civicrm_pre($op, $objectName, $objectId, &$params) {
 }
 
 /**
- * Implements hrcore_civicrm_pageRun.
+ * Implements hrcore_civicrm_pageRun()
  *
- * @link https://docs.civicrm.org/dev/en/master/hooks/hook_civicrm_pageRun/
+ * @param CRM_Core_Page $page
  */
 function hrcore_civicrm_pageRun($page) {
   _hrcore_add_js_session_vars();
+
+  $contactID = CRM_Core_Session::getLoggedInContactID();
+
+  $isRoot = FALSE;
+  if ($contactID) {
+    $framework = CRM_Core_Config::singleton()->userFramework;
+    $userInfo = ContactHelper::getUserInformation($contactID);
+    $roleService = CMSUserRoleFactory::create($framework, $userInfo);
+    $userRoles = $roleService->getRoles();
+    $isRoot = in_array('administrator', $userRoles);
+  }
+
+  // assign these variables for use in all pages (in use in the footer)
+  $page->assign('isRoot', $isRoot);
+  $page->assign('canAccessCiviCRM', CRM_Core_Permission::check('access CiviCRM'));
 }
 
 /**


### PR DESCRIPTION
## Overview

The footer text should be updated to show the licence version and the site URL instead of "Project Website".

We will also restrict the site status to only root users.

## Before

* The licence was "Powered by CiviHR version 1.7.5.  CiviHR is openly available under the GNU AGPL License and can be downloaded from the Project website ."
* Any user with access to CiviCRM could see the site status in the footer

#### As Root User

![image](https://user-images.githubusercontent.com/6374064/39296412-be53e150-4938-11e8-9b8a-90ac33102bf7.png)

#### As Non-Root

![image](https://user-images.githubusercontent.com/6374064/39296361-a1076fe0-4938-11e8-82a4-6c6d1b7ff82a.png)

## After

* The licence is "Powered by CiviHR 1.7.5. CiviHR is openly available under Version 3 of the GNU AGPL License and can be downloaded from www.civihr.org."
* Only root users can see the site status in the footer

#### As Root User

![image](https://user-images.githubusercontent.com/6374064/39296149-0d0dfa8e-4938-11e8-8bf3-55b41cb538e2.png)

#### As Non-Root

![image](https://user-images.githubusercontent.com/6374064/39296315-80ea1c1c-4938-11e8-821d-3b7bf22f6ba3.png)