### PR TITLE
PCHR-3652: Fix failing PHP test

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -3415,8 +3415,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testToilCanBeAccruedWhenTheToilRequestHasNoWorkingDay() {
-    $dateSaturday = CRM_Utils_Date::processDate('2018-05-05');
-    $dateSunday = CRM_Utils_Date::processDate('2018-05-06');
+    $dateSaturday = CRM_Utils_Date::processDate('saturday next week');
+    $dateSunday = CRM_Utils_Date::processDate('sunday next week');
 
     $period = AbsencePeriodFabricator::fabricate([
       'start_date' => $dateSaturday,


### PR DESCRIPTION
## Overview

The `CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest::testToilCanBeAccruedWhenTheToilRequestHasNoWorkingDay` test started failing on staging and on all Pull Requests targeting staging. The reason is that the test creates a TOILRequest with some hardcoded dates. Such requests can only be created with dates in the future and the hardcoded dates are now in the past.

## Before

The `from` and `to` dates for the request were hardcoded as `2018-05-05` and `2018-05-06` respectively.

## After

The test verifies the validation of TOIL Requests during non-working days and the hardcoded dates were for a saturday and sunday. To make sure we'll always have a date in the future, the code was changed to always use the saturday and sunday of the next week, relative to the current date.

## Technical Details

The reason the code uses `'sunday next week'` and `'saturday next week'` is to make sure that both dates will be in the same week. If we would just use `'next sunday'` and `'next saturday'` we would have issues when running the test on a saturday, as   the sunday and the saturday will fall on different weeks. For example, consider the date `2018-05-12`, a saturday. Trying to get the `next saturday` on that day will return `2018-05-19`, which is correct as it is the next saturday. The same way, calling `next sunday` on that same date, it will return `2018-05-13`. This is also correct, as this is the next sunday, but we can't create a leave request with these dates, because now the `to` date (the next sunday) is less than the `from` date (the saturday).

Here's an example of that happening in practice: https://3v4l.org/dXTov