### PR TITLE
PCHR-3660: Make it impossible to set a disabled Work pattern as default.

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkPattern.php
@@ -140,23 +140,21 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPattern extends CRM_HRLeaveAndAbsences_DAO_
     }
 
     $workPattern = self::findById($params['id']);
-    $isDefaultWorkPattern = self::isDefault($workPattern);
-    $isDisabledWorkPattern = !self::isActive($workPattern);
 
-    if($isDisabledWorkPattern && $isToBeSetAsDefault) {
+    if(!$workPattern->isActive() && $isToBeSetAsDefault) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidWorkPatternException(
         'You cannot set a disabled work pattern as the default'
       );
     }
 
-    if($isToBeDisabled && $isDefaultWorkPattern) {
+    if($isToBeDisabled && $workPattern->isDefault()) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidWorkPatternException(
         'You cannot disable the default Work Pattern'
       );
     }
 
     $isToBeUncheckedAsDefault = isset($params['is_default']) && !$params['is_default'];
-    if($isToBeUncheckedAsDefault && $isDefaultWorkPattern) {
+    if($isToBeUncheckedAsDefault && $workPattern->isDefault()) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidWorkPatternException(
         'It is not possible to have no default Work Pattern'
       );
@@ -197,24 +195,20 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPattern extends CRM_HRLeaveAndAbsences_DAO_
   /**
    * Checks whether the Work Pattern is the default Work Pattern or not.
    *
-   * @param WorkPattern $workPattern
-   *
    * @return boolean
    */
-  private static function isDefault(WorkPattern $workPattern) {
-    return $workPattern->is_default;
+  public function isDefault() {
+    return (bool)$this->is_default;
   }
 
   /**
    *
    * Checks whether the Work Pattern is enabled.
    *
-   * @param WorkPattern $workPattern
-   *
    * @return boolean
    */
-  private static function isActive(WorkPattern $workPattern) {
-    return $workPattern->is_active;
+  public function isActive() {
+    return (bool)$this->is_active;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkPattern.php
@@ -139,7 +139,15 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPattern extends CRM_HRLeaveAndAbsences_DAO_
       return;
     }
 
-    $isDefaultWorkPattern = self::isDefault($params['id']);
+    $workPattern = self::findById($params['id']);
+    $isDefaultWorkPattern = self::isDefault($workPattern);
+    $isDisabledWorkPattern = !self::isActive($workPattern);
+
+    if($isDisabledWorkPattern && $isToBeSetAsDefault) {
+      throw new CRM_HRLeaveAndAbsences_Exception_InvalidWorkPatternException(
+        'You cannot set a disabled work pattern as the default'
+      );
+    }
 
     if($isToBeDisabled && $isDefaultWorkPattern) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidWorkPatternException(
@@ -187,17 +195,26 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPattern extends CRM_HRLeaveAndAbsences_DAO_
   }
 
   /**
-   * Checks whether the Work Pattern with the given ID
-   * is the default Work Pattern or not.
+   * Checks whether the Work Pattern is the default Work Pattern or not.
    *
-   * @param int $workPatternID
+   * @param WorkPattern $workPattern
    *
    * @return boolean
    */
-  private static function isDefault($workPatternID) {
-    $workPattern = self::findById($workPatternID);
-
+  private static function isDefault(WorkPattern $workPattern) {
     return $workPattern->is_default;
+  }
+
+  /**
+   *
+   * Checks whether the Work Pattern is enabled.
+   *
+   * @param WorkPattern $workPattern
+   *
+   * @return boolean
+   */
+  private static function isActive(WorkPattern $workPattern) {
+    return $workPattern->is_active;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
@@ -692,6 +692,30 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends BaseHeadlessTest {
     WorkPattern::create($params);
   }
 
+  public function testisActiveReturnsTrueWhenWorkPatternIsActive() {
+    $workPattern = WorkPatternFabricator::fabricate(['is_active' => 1]);
+
+    $this->assertTrue($workPattern->isActive());
+  }
+
+  public function testisActiveReturnsFalseWhenWorkPatternIsNotActive() {
+    $workPattern = WorkPatternFabricator::fabricate(['is_active' => 0]);
+
+    $this->assertFalse($workPattern->isActive());
+  }
+
+  public function testisDefaultReturnsTrueWhenWorkPatternIsTheDefault() {
+    $workPattern = WorkPatternFabricator::fabricate(['is_default' => 1]);
+
+    $this->assertTrue($workPattern->isDefault());
+  }
+
+  public function testisDefaultReturnsFalseWhenWorkPatternIsNotTheDefault() {
+    $workPattern = WorkPatternFabricator::fabricate(['is_default' => 0]);
+
+    $this->assertFalse($workPattern->isDefault());
+  }
+
   public function testCannotMakeTheDefaultWorkPatternNonDefault() {
     $workPattern = WorkPatternFabricator::fabricate(['is_default' => 1]);
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/WorkPatternTest.php
@@ -704,6 +704,18 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPatternTest extends BaseHeadlessTest {
     WorkPattern::create($params);
   }
 
+  public function testCannotMakeADisabledWorkPatternAsDefault() {
+    $workPattern = WorkPatternFabricator::fabricate(['is_active' => 0]);
+
+    $this->setExpectedException(
+      CRM_HRLeaveAndAbsences_Exception_InvalidWorkPatternException::class,
+      'You cannot set a disabled work pattern as the default'
+    );
+
+    $params = ['id' => $workPattern->id, 'is_default' => 1];
+    WorkPattern::create($params);
+  }
+
   public function testWorkPatternLabelsShouldBeUnique() {
     WorkPatternFabricator::fabricate(['label' => 'WorkPattern 1']);
 


### PR DESCRIPTION
## Overview
Currently, It is possible to disable a custom Work pattern and subsequently make such work pattern to be the default work pattern. This PR fixes the issue and makes this action not to be possible.

## Before
-  It is possible to disable a custom Work pattern and subsequently make such work pattern to be the default work pattern.

![disabledasdefaultbefore](https://user-images.githubusercontent.com/6951813/39871381-85a4f572-545c-11e8-9ff3-5862d3c38f3f.gif)


## After
-  It is not possible to disable a custom Work pattern and subsequently make such work pattern to be the default work pattern

![disabledasdefaultafter](https://user-images.githubusercontent.com/6951813/39871393-9062de0c-545c-11e8-9e27-8ac155bcd201.gif)

