### PR TITLE
PCHR-3671: Revert Changes to Footer

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Page/View/Summary.tpl
+++ b/hrjobcontract/CRM/Hrjobcontract/Page/View/Summary.tpl
@@ -49,7 +49,7 @@
 
         {* CRM-12735 - Conditionally include the Actions and Edit buttons if contact is NOT in trash.*}
         {if !$isDeleted}
-          {if $canAccessCiviCRM }
+          {if call_user_func(array('CRM_Core_Permission','check'), 'access CiviCRM')}
             <li class="crm-contact-activity crm-summary-block">
               {include file="CRM/Contact/Page/Inline/Actions.tpl"}
             </li>

--- a/hrui/templates/CRM/Contact/Page/View/Summary.tpl
+++ b/hrui/templates/CRM/Contact/Page/View/Summary.tpl
@@ -47,7 +47,7 @@
 
         {* CRM-12735 - Conditionally include the Actions and Edit buttons if contact is NOT in trash.*}
         {if !$isDeleted}
-          {if $canAccessCiviCRM}
+          {if call_user_func(array('CRM_Core_Permission','check'), 'access CiviCRM')}
             <li class="crm-contact-activity crm-summary-block">
               {if !empty($alternativeActionsTemplate)}
                 {include file="$alternativeActionsTemplate"}

--- a/hrui/templates/CRM/common/footer.tpl
+++ b/hrui/templates/CRM/common/footer.tpl
@@ -23,8 +23,7 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-
-{if $canAccessCiviCRM }
+{if call_user_func(array('CRM_Core_Permission','check'), 'access CiviCRM')}
   {include file="CRM/common/accesskeys.tpl"}
   {if !empty($contactId)}
     {include file="CRM/common/contactFooter.tpl"}
@@ -34,7 +33,7 @@
     {* PCHR-1323 - Display CiviHR version info. *}
     {ts}Powered by CiviHR {/ts} {civihrVersion}.
 
-    {if $isRoot && !empty ($footer_status_severity)}
+    {if !empty($footer_status_severity)}
       <span class="status{if $footer_status_severity gt 3} crm-error{elseif $footer_status_severity gt 2} crm-warning{else} crm-ok{/if}">
       <a target="_blank" href="{crmURL p='civicrm/a/#/status'}">{$footer_status_message}</a>.
     </span>&nbsp;

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -10,8 +10,6 @@ use CRM_HRCore_Service_Manager as ManagerService;
 use CRM_HRContactActionsMenu_Component_Menu as ActionsMenu;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use CRM_HRContactActionsMenu_Helper_Contact as ContactHelper;
-use CRM_HRCore_CMSData_UserRoleFactory as CMSUserRoleFactory;
 
 /**
  * Implements hook_civicrm_config().
@@ -272,27 +270,12 @@ function hrcore_civicrm_pre($op, $objectName, $objectId, &$params) {
 }
 
 /**
- * Implements hrcore_civicrm_pageRun()
+ * Implements hrcore_civicrm_pageRun.
  *
- * @param CRM_Core_Page $page
+ * @link https://docs.civicrm.org/dev/en/master/hooks/hook_civicrm_pageRun/
  */
 function hrcore_civicrm_pageRun($page) {
   _hrcore_add_js_session_vars();
-
-  $contactID = CRM_Core_Session::getLoggedInContactID();
-
-  $isRoot = FALSE;
-  if ($contactID) {
-    $framework = CRM_Core_Config::singleton()->userFramework;
-    $userInfo = ContactHelper::getUserInformation($contactID);
-    $roleService = CMSUserRoleFactory::create($framework, $userInfo);
-    $userRoles = $roleService->getRoles();
-    $isRoot = in_array('administrator', $userRoles);
-  }
-
-  // assign these variables for use in all pages (in use in the footer)
-  $page->assign('isRoot', $isRoot);
-  $page->assign('canAccessCiviCRM', CRM_Core_Permission::check('access CiviCRM'));
 }
 
 /**


### PR DESCRIPTION
## Overview

In https://github.com/civicrm/civihr/pull/2584 I changed the permission check to use a global template variable defined in the `pageRun` hook. In pages where you're editing something this hook is not called and this leads to the footer not being displayed. This causes further problems when displaying help texts.

## Before

- The footer was not displayed on edit pages
- Help text icons did not correctly show the help text bubble

![before](https://user-images.githubusercontent.com/6374064/39998857-4ed6f86c-577f-11e8-82b5-e6ae00e44350.gif)

## After

- The footer is displayed on edit pages
- Help text icons correctly show the help text bubble

![after](https://user-images.githubusercontent.com/6374064/39998873-574414a8-577f-11e8-8063-271e71b881de.gif)
