### PR TITLE
PCHR-3516: Allow Contact to get Leave Requests For Other Contacts via API

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -1326,9 +1326,14 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
       return;
     }
 
-    $clauses['contact_id'] = $this->getLeaveInformationACLClauses();
+    $leaveTable =  CRM_HRLeaveAndAbsences_BAO_LeaveRequest::getTableName();
+
+    $query = "IN (SELECT DISTINCT contact_id FROM {$leaveTable})";
+
+    $clauses['contact_id'] = $query;
 
     CRM_Utils_Hook::selectWhereClause($this, $clauses);
+
     return $clauses;
   }
 


### PR DESCRIPTION
## Overview
Based on the specification for the New Staff Calendar, A contact should be able to view other contact's leave requests via the API, This was not previously possible because of the Leave Request ACL rules allows a staff to view only his leave requests, a manager to only view leave requests of his managees while an administrator can view leave requests for all contacts.

## Before
- The former Leave Request ACL rules applies when a contact tries to get another contact's request via the API.

## After
- The Leave ACL query in the `addSelectWhereClause` function in the Leave Request BAO was modified to allow a contact get other contact's leave requests via the API irrespective of whether the contact is a staff, leave manager or Admin.

## Comments
- A couple of tests in the `api_v3_LeaveRequestTest` class was broken after the changes, Most of the broken tests were modified to suit the new ACL. Some tests were also merged to avoid redundancy. 
