### PR TITLE
PCHR-3650: New Fields for Pingback

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/Stats/StatsGatherer.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/Stats/StatsGatherer.php
@@ -85,6 +85,7 @@ class CRM_HRCore_Service_Stats_StatsGatherer {
     $entityCounts += $this->getRecruitmentEntityCounts();
     $entityCounts += $this->getJobRoleEntityCounts();
     $entityCounts += $this->getCustomDataCounts();
+    $entityCounts += $this->getCaseEntityCounts();
 
     return $entityCounts;
   }
@@ -311,6 +312,18 @@ class CRM_HRCore_Service_Stats_StatsGatherer {
     $counts = [];
     $counts['customGroup'] = $this->getEntityCount('CustomGroup');
     $counts['customField'] = $this->getEntityCount('CustomField');
+
+    return $counts;
+  }
+
+  /**
+   * Gets counts for the case entities
+   *
+   * @return array
+   */
+  private function getCaseEntityCounts() {
+    $counts = [];
+    $counts['caseType'] = $this->getEntityCount('CaseType');
 
     return $counts;
   }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/Stats/StatsGatherer.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/Stats/StatsGatherer.php
@@ -102,7 +102,7 @@ class CRM_HRCore_Service_Stats_StatsGatherer {
    * @return int
    */
   private function getEntityCount($entity, $params = []) {
-    $params += ['is_deleted' => FALSE];
+    $params += ['is_deleted' => FALSE, 'is_active' => TRUE];
 
     return (int) civicrm_api3($entity, 'getcount', $params);
   }
@@ -273,10 +273,10 @@ class CRM_HRCore_Service_Stats_StatsGatherer {
    * @return array
    */
   private function getJobRoleEntityCounts() {
-    $recruitmentKey = 'com.civicrm.hrjobroles';
+    $jobRoleExtKey = 'com.civicrm.hrjobroles';
     $counts = [];
 
-    if (!ExtensionHelper::isExtensionEnabled($recruitmentKey)) {
+    if (!ExtensionHelper::isExtensionEnabled($jobRoleExtKey)) {
       return $counts;
     }
 
@@ -297,7 +297,8 @@ class CRM_HRCore_Service_Stats_StatsGatherer {
   private function getFunderCount() {
     $result = civicrm_api3('HrJobRoles', 'get', ['return' => ['funder']]);
     $result = array_column($result['values'], 'funder');
-    $funderIds = implode('', $result);
+    // some funder data may not include the delimiter so make sure to add it
+    $funderIds = implode('|', $result);
     $funderIds = explode('|', $funderIds);
     $funderIds = array_unique(array_filter($funderIds));
 

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/Stats/StatsGatherer.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/Stats/StatsGatherer.php
@@ -84,6 +84,7 @@ class CRM_HRCore_Service_Stats_StatsGatherer {
     $entityCounts += $this->getLeaveAndAbsenceEntityCounts();
     $entityCounts += $this->getRecruitmentEntityCounts();
     $entityCounts += $this->getJobRoleEntityCounts();
+    $entityCounts += $this->getCustomDataCounts();
 
     return $entityCounts;
   }
@@ -299,6 +300,19 @@ class CRM_HRCore_Service_Stats_StatsGatherer {
     $funderIds = array_unique(array_filter($funderIds));
 
     return count($funderIds);
+  }
+
+  /**
+   * Gets the count of custom groups and fields
+   *
+   * @return array
+   */
+  private function getCustomDataCounts() {
+    $counts = [];
+    $counts['customGroup'] = $this->getEntityCount('CustomGroup');
+    $counts['customField'] = $this->getEntityCount('CustomField');
+
+    return $counts;
   }
 
 }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Test/BaseHeadlessTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Test/BaseHeadlessTest.php
@@ -12,7 +12,8 @@ abstract class CRM_HRCore_Test_BaseHeadlessTest extends PHPUnit_Framework_TestCa
       'org.civicrm.hrrecruitment',
       'uk.co.compucorp.civicrm.hrleaveandabsences',
       'org.civicrm.hrjobcontract', // L&A depends on HRJobContract
-      'uk.co.compucorp.civicrm.hrcontactactionsmenu'
+      'uk.co.compucorp.civicrm.hrcontactactionsmenu',
+      'com.civicrm.hrjobroles',
     ];
 
     return \Civi\Test::headless()

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsGathererTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsGathererTest.php
@@ -98,6 +98,7 @@ class StatsGathererTest extends CRM_HRCore_Test_BaseHeadlessTest {
   }
 
   public function testTaskCountWillMatchExpectedCounts() {
+    $this->setDomainFromAddress('test@test.com', 'Test');
     $contactID = ContactFabricator::fabricateWithEmail()['id'];
     $params = ['component_id' => 'CiviTask', 'option_group_id' => 'activity_type'];
     $taskType = OptionValueFabricator::fabricate($params);
@@ -164,7 +165,7 @@ class StatsGathererTest extends CRM_HRCore_Test_BaseHeadlessTest {
     $contactID = ContactFabricator::fabricateWithEmail()['id'];
 
     $params = ['contact_id' => $contactID];
-    $contract = CRM_Hrjobcontract_Test_Fabricator_HRJobContract::fabricate($params);
+    $contract = HRJobContractFabricator::fabricate($params);
     $params = ['job_contract_id' => $contract['id']];
     HrJobRolesFabricator::fabricate($params);
     HrJobRolesFabricator::fabricate($params);

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsGathererTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsGathererTest.php
@@ -18,6 +18,7 @@ use CRM_HRCore_Test_Fabricator_ContactType as ContactTypeFabricator;
 use CRM_HRCore_Test_Fabricator_OptionValue as OptionValueFabricator;
 use CRM_HRCore_Service_Stats_StatsGatherer as StatsGatherer;
 use CRM_HRCore_Test_Helpers_SessionHelper as SessionHelper;
+use CRM_Hrjobroles_Test_Fabricator_HrJobRoles as HrJobRolesFabricator;
 
 /**
  * @group headless
@@ -60,29 +61,44 @@ class StatsGathererTest extends CRM_HRCore_Test_BaseHeadlessTest {
     $this->assertEquals($expected, $stats->getSiteUrl());
   }
 
-  public function testEntityCountsWillMatchExpectedCount() {
-    $this->truncateTables(['civicrm_contact']);
-    $this->setDomainFromAddress('test@test.com', 'Test');
+  public function testContactCountWillMatchExpectedCount() {
+    $existingContactCount = civicrm_api3('Contact', 'getcount');
+    ContactFabricator::fabricate();
+    ContactFabricator::fabricate();
+    ContactFabricator::fabricate();
+    $expectedContactCount = $existingContactCount + 3;
+    $stats = $this->getGatherer()->gather();
 
-    $documentType = OptionValueFabricator::fabricate([
-      'option_group_id' => 'activity_type',
-      'component_id' => 'CiviDocument'
+    $this->assertEquals($expectedContactCount, $stats->getEntityCount('contact'));
+  }
+
+  public function testCMSUserCountWillMatchExpectedCount() {
+    $this->setDomainFromAddress('test@test.com', 'Test');
+    $contactA = ContactFabricator::fabricateWithEmail([], 'a@test.com');
+    $contactB = ContactFabricator::fabricateWithEmail([], 'b@test.com');
+    UFMatchFabricator::fabricate([
+      'uf_name' => 'a@test.com',
+      'contact_id' => $contactA['id']
+    ]);
+    UFMatchFabricator::fabricate([
+      'uf_name' => 'b@test.com',
+      'contact_id' => $contactB['id']
     ]);
 
-    // expect 3
-    ContactFabricator::fabricate();
-    ContactFabricator::fabricate();
+    $stats = $this->getGatherer()->gather();
+    $this->assertEquals(2, $stats->getEntityCount('cmsUser'));
+  }
+
+  public function testVacancyCountWillMatchExpectedCount() {
+    HRVacancyFabricator::fabricate();
+    HRVacancyFabricator::fabricate();
+    $stats = $this->getGatherer()->gather();
+
+    $this->assertEquals(2, $stats->getEntityCount('vacancy'));
+  }
+
+  public function testTaskCountWillMatchExpectedCounts() {
     $contactID = ContactFabricator::fabricateWithEmail()['id'];
-    SessionHelper::registerCurrentLoggedInContactInSession($contactID);
-
-    // expect 1 UFMatch
-    UFMatchFabricator::fabricate(['contact_id' => $contactID]);
-
-    // expect 2 Vacancies
-    HRVacancyFabricator::fabricate();
-    HRVacancyFabricator::fabricate();
-
-    // expect 1 Task
     $params = ['component_id' => 'CiviTask', 'option_group_id' => 'activity_type'];
     $taskType = OptionValueFabricator::fabricate($params);
     $params = [
@@ -92,35 +108,77 @@ class StatsGathererTest extends CRM_HRCore_Test_BaseHeadlessTest {
     ];
     TaskFabricator::fabricate($params);
 
-    // expect 2 CaseTypes
-    $caseType = CaseTypeFabricator::fabricate();
+    $stats = $this->getGatherer()->gather();
+
+    $this->assertEquals(1, $stats->getEntityCount('task'));
+  }
+
+  public function testCaseTypeCountWillMatchExpectedCount() {
+    CaseTypeFabricator::fabricate();
     CaseTypeFabricator::fabricate(['name' => 'test_case_type_2']);
 
-    // expect 1 Assignment
+    $stats = $this->getGatherer()->gather();
+
+    $this->assertEquals(2, $stats->getEntityCount('caseType'));
+  }
+
+  public function testAssignmentCountsWillMatchExpectedCount() {
+    $caseType = CaseTypeFabricator::fabricate();
     AssignmentFabricator::fabricate(['case_type_id' => $caseType['id']]);
 
-    // expect 2 Documents
+    $stats = $this->getGatherer()->gather();
+
+    $this->assertEquals(1, $stats->getEntityCount('assignment'));
+  }
+
+  public function testDocumentCountWillMatchExpectedCount() {
+    $contactId = ContactFabricator::fabricate()['id'];
+    $documentType = OptionValueFabricator::fabricate([
+      'option_group_id' => 'activity_type',
+      'component_id' => 'CiviDocument',
+    ]);
     $params['activity_type_id'] = $documentType['value'];
+    $params['target_contact_id'] = $contactId;
+    $params['source_contact_id'] = $contactId;
     DocumentFabricator::fabricate($params);
     DocumentFabricator::fabricate($params);
 
-    // expect 2 LeaveRequests
+    $stats = $this->getGatherer()->gather();
+
+    $this->assertEquals(2, $stats->getEntityCount('document'));
+  }
+
+  public function testLeaveRequestCountsWillMatchExpectedCount() {
+    $contactID = ContactFabricator::fabricateWithEmail()['id'];
+
     $this->setUpLeaveRequest($contactID);
     $this->fabricateLeaveRequest($contactID);
     $this->fabricateLeaveRequest($contactID);
 
-    // expect 2 JobRoles
+    $stats = $this->getGatherer()->gather();
+
+    $this->assertEquals(2, $stats->getEntityCount('leaveRequest'));
+  }
+
+  public function testJobRoleCountWillMatchExpectedCount() {
+    $contactID = ContactFabricator::fabricateWithEmail()['id'];
+
     $params = ['contact_id' => $contactID];
     $contract = CRM_Hrjobcontract_Test_Fabricator_HRJobContract::fabricate($params);
     $params = ['job_contract_id' => $contract['id']];
-    CRM_Hrjobroles_Test_Fabricator_HrJobRoles::fabricate($params);
-    CRM_Hrjobroles_Test_Fabricator_HrJobRoles::fabricate($params);
+    HrJobRolesFabricator::fabricate($params);
+    HrJobRolesFabricator::fabricate($params);
 
-    // expect 1 + existing CostCenter
+    $stats = $this->getGatherer()->gather();
+
+    $this->assertEquals(2, $stats->getEntityCount('jobRole'));
+  }
+
+  public function testCostCenterCountWillMatchExpectedCount() {
     $existingCostCenterCount = civicrm_api3('OptionValue', 'getcount', [
       'option_group_id' => 'cost_centres'
     ]);
-    civicrm_api3('OptionValue', 'create', [
+    OptionValueFabricator::fabricate([
       'option_group_id' => 'cost_centres',
       'name' => 'Test Cost Center'
     ]);
@@ -128,17 +186,7 @@ class StatsGathererTest extends CRM_HRCore_Test_BaseHeadlessTest {
 
     $stats = $this->getGatherer()->gather();
 
-    $this->assertEquals(3, $stats->getEntityCount('contact'));
-    $this->assertEquals(1, $stats->getEntityCount('cmsUser'));
-    $this->assertEquals(2, $stats->getEntityCount('vacancy'));
-    $this->assertEquals(1, $stats->getEntityCount('task'));
-    $this->assertEquals(1, $stats->getEntityCount('assignment'));
-    $this->assertEquals(2, $stats->getEntityCount('document'));
-    $this->assertEquals(2, $stats->getEntityCount('leaveRequest'));
-
-    $this->assertEquals(2, $stats->getEntityCount('jobRole'));
     $this->assertEquals($costCenterCount, $stats->getEntityCount('costCenter'));
-    $this->assertEquals(2, $stats->getEntityCount('caseType'));
   }
 
   public function testLeaveRequestInLast100DaysCountMatchesExpectedCount() {
@@ -282,6 +330,15 @@ class StatsGathererTest extends CRM_HRCore_Test_BaseHeadlessTest {
       $now->format($comparisonFormat),
       $login->format($comparisonFormat)
     );
+  }
+
+  public function testInactiveCaseTypesWillNotBeIncluded() {
+    CaseTypeFabricator::fabricate(['is_active' => 0]);
+    CaseTypeFabricator::fabricate(['name' => 'test_case_type_2']);
+
+    $stats = $this->getGatherer()->gather();
+
+    $this->assertEquals(1, $stats->getEntityCount('caseType'));
   }
 
   /**


### PR DESCRIPTION
## Overview

Data for the following new fields should be collected for each client site:

- number of job roles
- number of cost centres
- number of funders
- number of custom field groups
- number of custom fields
- number of case types
- number of HR resources
- number of HR resource types

## Before

Data for these fields was not collected or sent

## After

Data for these fields is collected and sent

## Technical Details

I was unaware of some of these definitions before so it might help the reviewer to know:

- Funder is a list of contact IDs that is part of the job roles table. Each job role can have multiple funders, which are separated by `|`
- HR Resource Type is Drupal content of a specific type. It is viewable from "HR Resources" from the SSP
- HR Resources are files attached to any of the HR Resource Types

## Notes

I did not include HR Resource entity count testing in this PR as it is primarily a Drupal entity and would involve a lot of Drupal function calls, making the coupling between CiviHR and Drupal even stronger