### PR TITLE
PCHR-3669: Use Drupal User Count Instead Of UFMatch

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/SiteInformation/DrupalSiteInformation.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/SiteInformation/DrupalSiteInformation.php
@@ -14,4 +14,15 @@ class CRM_HRCore_CMSData_SiteInformation_DrupalSiteInformation implements SiteIn
     return variable_get('site_name');
   }
 
+  /**
+   * @inheritdoc
+   */
+  public function getActiveUserCount() {
+    return (int) db_select('users')
+      ->condition('status', 1, '=')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+  }
+
 }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/SiteInformation/SiteInformationInterface.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/CMSData/SiteInformation/SiteInformationInterface.php
@@ -12,4 +12,11 @@ interface CRM_HRCore_CMSData_SiteInformation_SiteInformationInterface {
    */
   public function getSiteName();
 
+  /**
+   * Gets the number of active users for the site
+   *
+   * @return int
+   */
+  public function getActiveUserCount();
+
 }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/Stats/StatsGatherer.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/Stats/StatsGatherer.php
@@ -79,7 +79,7 @@ class CRM_HRCore_Service_Stats_StatsGatherer {
   private function getEntityCounts() {
     $entityCounts = [];
     $entityCounts['contact'] = $this->getEntityCount('Contact');
-    $entityCounts['cmsUser'] = $this->getEntityCount('UFMatch');
+    $entityCounts['cmsUser'] = $this->siteInformation->getActiveUserCount();
     $entityCounts += $this->getTaskAndAssignmentEntityCounts();
     $entityCounts += $this->getLeaveAndAbsenceEntityCounts();
     $entityCounts += $this->getRecruitmentEntityCounts();
@@ -121,7 +121,8 @@ class CRM_HRCore_Service_Stats_StatsGatherer {
 
       if (!empty($contactType['parent_id'])) {
         $params = ['contact_sub_type' => $name];
-      } else {
+      }
+      else {
         $params = ['contact_type' => $name];
       }
 
@@ -146,7 +147,6 @@ class CRM_HRCore_Service_Stats_StatsGatherer {
 
     $query = db_select('reports_configuration', 'rc')->fields('rc');
     $result = $query->execute();
-
 
     while ($row = $result->fetchAssoc()) {
       $config = new ReportConfiguration();

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsGathererTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsGathererTest.php
@@ -73,20 +73,8 @@ class StatsGathererTest extends CRM_HRCore_Test_BaseHeadlessTest {
   }
 
   public function testCMSUserCountWillMatchExpectedCount() {
-    $this->setDomainFromAddress('test@test.com', 'Test');
-    $contactA = ContactFabricator::fabricateWithEmail([], 'a@test.com');
-    $contactB = ContactFabricator::fabricateWithEmail([], 'b@test.com');
-    UFMatchFabricator::fabricate([
-      'uf_name' => 'a@test.com',
-      'contact_id' => $contactA['id']
-    ]);
-    UFMatchFabricator::fabricate([
-      'uf_name' => 'b@test.com',
-      'contact_id' => $contactB['id']
-    ]);
-
     $stats = $this->getGatherer()->gather();
-    $this->assertEquals(2, $stats->getEntityCount('cmsUser'));
+    $this->assertEquals(20, $stats->getEntityCount('cmsUser'));
   }
 
   public function testVacancyCountWillMatchExpectedCount() {
@@ -348,6 +336,7 @@ class StatsGathererTest extends CRM_HRCore_Test_BaseHeadlessTest {
   private function getGatherer() {
     $siteInformation = $this->prophesize(SiteInformationInterface::class);
     $siteInformation->getSiteName()->willReturn('foo');
+    $siteInformation->getActiveUserCount()->willReturn(20);
 
     $roleService = $this->prophesize(RoleServiceInterface::class);
     $roleService->getRoleNames()->willReturn([1 => 'fake_role']);

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsGathererTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsGathererTest.php
@@ -302,7 +302,6 @@ class StatsGathererTest extends CRM_HRCore_Test_BaseHeadlessTest {
     $stats = $this->getGatherer()->gather();
 
     $this->assertEquals(1, $stats->getEntityCount('contact'));
-    $this->assertEquals(0, $stats->getEntityCount('cmsUser'));
     $this->assertEquals(0, $stats->getEntityCount('task'));
     $this->assertEquals(0, $stats->getEntityCount('assignment'));
     $this->assertEquals(0, $stats->getEntityCount('document'));


### PR DESCRIPTION
## Overview

CiviCRM has a contacts table, Drupal has a users table. To link these two tables there is a UFMatch table.

We use the UFMatch table for tracking CMS user count. Usually this is fine because when new users are created, a corresponding record is created for them in UFMatch. However if a contact record is deleted, but the Drupal user account still exists we have a disparity in the counts.

## Before

We used UFMatch to count CMS users

## After

We use the Drupal user table to count CMS users