### PR TITLE
PCHR-3701: Selectively Modify Leave Request API Field return Value based on User Role and Leave ACL Permissions

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/ACL/LeaveInformationTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/ACL/LeaveInformationTrait.php
@@ -47,8 +47,7 @@ trait CRM_HRLeaveAndAbsences_ACL_LeaveInformationTrait {
     FROM {$contactsTable} c
     LEFT JOIN {$relationshipTable} r ON c.id = r.contact_id_a
     LEFT JOIN {$relationshipTypeTable} rt ON rt.id = r.relationship_type_id
-    WHERE $conditions
-  ";
+    WHERE $conditions";
 
     return $query;
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/ACL/LeaveInformationTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/ACL/LeaveInformationTrait.php
@@ -5,14 +5,27 @@ trait CRM_HRLeaveAndAbsences_ACL_LeaveInformationTrait {
   use CRM_HRLeaveAndAbsences_Service_SettingsManagerTrait;
 
   /**
+   * This method creates ACL clause that can be added to queries in order to
+   * filter results to follow leave request ACL rules.
+   *
+   * @return string
+   *   Query String
+   */
+  public function getLeaveInformationACLClauses() {
+    $query = "IN ({$this->getLeaveInformationACLQuery()})";
+
+    return $query;
+  }
+
+  /**
    * For any leave information (Entitlement, Leave Requests etc) the access
    * rules are:
    *   - Staff members can only see their own information
    *   - Managers can see their own information + the information from their
    *     managees
    *
-   * This method creates ACL clauses that can be added to queries in order to
-   * filter results to follow these rules.
+   * This method creates an ACL query that selects contact IDs that the currently
+   * logged in contact has access to based on these rules, i.e
    *
    * The manager > managee relationship is determined by checking if there's an
    * active relationship between the two contacts and that the type of this
@@ -22,20 +35,20 @@ trait CRM_HRLeaveAndAbsences_ACL_LeaveInformationTrait {
    * @return string
    *   Query String
    */
-  public function getLeaveInformationACLClauses() {
+  public function getLeaveInformationACLQuery() {
     $contactsTable = CRM_Contact_BAO_Contact::getTableName();
     $relationshipTable = CRM_Contact_BAO_Relationship::getTableName();
     $relationshipTypeTable = CRM_Contact_BAO_RelationshipType::getTableName();
 
     $conditions = $this->getLeaveInformationACLWhereConditions('c.id');
 
-    $query = "IN (
-      SELECT c.id
-      FROM {$contactsTable} c
-      LEFT JOIN {$relationshipTable} r ON c.id = r.contact_id_a
-      LEFT JOIN {$relationshipTypeTable} rt ON rt.id = r.relationship_type_id
-      WHERE $conditions
-    )";
+    $query = "
+    SELECT c.id
+    FROM {$contactsTable} c
+    LEFT JOIN {$relationshipTable} r ON c.id = r.contact_id_a
+    LEFT JOIN {$relationshipTypeTable} rt ON rt.id = r.relationship_type_id
+    WHERE $conditions
+  ";
 
     return $query;
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissions.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissions.php
@@ -1,0 +1,189 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
+
+class  CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissions extends CRM_HRLeaveAndAbsences_API_Handler_LeaveFieldPermissions {
+
+  use CRM_HRLeaveAndAbsences_ACL_LeaveInformationTrait;
+
+  const ADMIN_ROLE = 'Admin';
+  const MANAGER_ROLE = 'Manager';
+  const STAFF_ROLE = 'Staff';
+
+  /**
+   * @var array
+   *   Stores the contact Id's that the current user has access to.
+   */
+  protected $accessibleContacts = [];
+
+  /**
+   * @var array
+   *   The original API request data.
+   */
+  protected $apiRequest;
+
+  /**
+   * @var string
+   *   User role of the currently logged in user.
+   */
+  public $loggedInUserRole;
+
+  /**
+   * @var LeaveRequestRightsService
+   */
+  protected $leaveRequestRightsService;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getDataRowIdentifierKey() {
+    return 'contact_id';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getDataRowIdentifierLevel() {
+    return 1;
+  }
+
+  /**
+   * @var array
+   */
+  private $restrictedFields = [
+    'from_date_amount' => [
+      'restricted_for' => [
+        self::MANAGER_ROLE => ['replace_with' => ''],
+        self::STAFF_ROLE => ['replace_with' => '']
+      ],
+      'level' => 1
+    ],
+    'to_date_amount' => [
+      'restricted_for' => [
+        self::MANAGER_ROLE => ['replace_with' => ''],
+        self::STAFF_ROLE => ['replace_with' => '']
+      ],
+      'level' => 1
+    ],
+    'balance_change' => [
+      'restricted_for' => [
+        self::MANAGER_ROLE => ['replace_with' => ''],
+        self::STAFF_ROLE => ['replace_with' => '']
+      ],
+      'level' => 1
+    ],
+    'toil_duration' => [
+      'restricted_for' => [
+        self::MANAGER_ROLE => ['replace_with' => ''],
+        self::STAFF_ROLE => ['replace_with' => '']
+      ],
+      'level' => 1
+    ],
+    'toil_to_accrue' => [
+      'restricted_for' => [
+        self::MANAGER_ROLE => ['replace_with' => ''],
+        self::STAFF_ROLE => ['replace_with' => '']
+      ],
+      'level' => 1
+    ],
+    'toil_expiry_date' => [
+      'restricted_for' => [
+        self::MANAGER_ROLE => ['replace_with' => ''],
+        self::STAFF_ROLE => ['replace_with' => '']
+      ],
+      'level' => 1
+    ],
+    'sickness_reason' => [
+      'restricted_for' => [
+        self::MANAGER_ROLE => ['replace_with' => ''],
+        self::STAFF_ROLE => ['replace_with' => '']
+      ],
+      'level' => 1
+    ],
+  ];
+
+  /**
+   * CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissions constructor.
+   *
+   * @param array $apiRequest
+   *   The Original API request parameters.
+   * @param LeaveRequestRightsService $leaveRequestRights
+   */
+  public function __construct($apiRequest, LeaveRequestRightsService $leaveRequestRights) {
+    $this->setLoggedInUserRole();
+    $this->leaveRequestRightsService = $leaveRequestRights;
+    $this->apiRequest = $apiRequest;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getRestrictedFields() {
+    return $this->restrictedFields;
+  }
+
+  /**
+   * Returns accessible contacts for a logged in user. i.e contact
+   * that a user has access to via the Leave Request ACL rules.
+   *
+   * @return array
+   */
+  protected function getAccessibleContacts() {
+    $isAdminUser = $this->loggedInUserRole === self::ADMIN_ROLE;
+    if(!$this->accessibleContacts && !$isAdminUser) {
+      $this->accessibleContacts = $this->leaveRequestRightsService->getLeaveContactsCurrentUserHasAccessTo();
+    }
+
+    return $this->accessibleContacts;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getNewFieldValue($field, $oldValue, $dataRowIdentifierValue) {
+    $isAdminUser = $this->loggedInUserRole === self::ADMIN_ROLE;
+    $canAccessRestrictedData = $this->canAccessRestrictedData($dataRowIdentifierValue);
+
+    if($isAdminUser || $canAccessRestrictedData) {
+      return $oldValue;
+    }
+
+    $rolesRestrictedFor = array_keys($this->getRestrictedFields()[$field]['restricted_for']);
+    $inRestrictedRoles = in_array($this->loggedInUserRole, $rolesRestrictedFor);
+
+    if(!empty($inRestrictedRoles)) {
+      return $this->getRestrictedFields()[$field]['restricted_for'][$this->loggedInUserRole]['replace_with'];
+    }
+
+    return $oldValue;
+  }
+
+  /**
+   * Checks whether current user has access to the restricted data for the contact having its
+   * data represented by the Identifier value.
+   *
+   * @param mixed $dataRowIdentifierValue
+   *
+   * @return bool
+   */
+  protected function canAccessRestrictedData($dataRowIdentifierValue) {
+    return in_array($dataRowIdentifierValue, $this->getAccessibleContacts());
+  }
+
+  /**
+   * Sets the Role for the current logged in user.
+   */
+  protected function setLoggedInUserRole() {
+    if (CRM_Core_Permission::check('administer leave and absences')) {
+      $role = self::ADMIN_ROLE;
+    }
+    elseif(CRM_Core_Permission::check('manage leave and absences in ssp')) {
+      $role = self::MANAGER_ROLE;
+    }
+    else {
+      $role = self::STAFF_ROLE;
+    }
+
+    $this->loggedInUserRole = $role;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissions.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissions.php
@@ -65,6 +65,13 @@ class  CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissions extends C
       ],
       'level' => 1
     ],
+    'type_id' => [
+      'restricted_for' => [
+        self::MANAGER_ROLE => ['replace_with' => ''],
+        self::STAFF_ROLE => ['replace_with' => '']
+      ],
+      'level' => 1
+    ],
     'balance_change' => [
       'restricted_for' => [
         self::MANAGER_ROLE => ['replace_with' => ''],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissions.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissions.php
@@ -91,6 +91,7 @@ class  CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissions extends C
   public function __construct($apiRequest, LeaveRequestRightsService $leaveRequestRights) {
     $this->leaveRequestRightsService = $leaveRequestRights;
     $this->apiRequest = $apiRequest;
+    $this->setShouldRemoveDataRowIdentifier();
   }
 
   /**
@@ -146,5 +147,18 @@ class  CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissions extends C
    */
   protected function currentUserIsAdmin() {
     return CRM_Core_Permission::check('administer leave and absences');
+  }
+
+  /**
+   * Sets the value of the removeDataRowIdentifier variable.
+   */
+  private function setShouldRemoveDataRowIdentifier() {
+    if(empty($this->apiRequest['params']['initial_return'])){
+      return;
+    }
+
+    if (!in_array($this->getDataRowIdentifierKey(), $this->apiRequest['params']['initial_return'])) {
+      $this->removeDataRowIdentifier = TRUE;
+    }
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Handler/GetBreakDownFieldPermissions.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Handler/GetBreakDownFieldPermissions.php
@@ -62,11 +62,7 @@ class CRM_HRLeaveAndAbsences_API_Handler_GetBreakDownFieldPermissions extends CR
   protected function getRestrictedFields() {
     $fields = [
       'amount' => [
-        'restricted_for' => [
-          self::MANAGER_ROLE => ['replace_with' => ''],
-          self::STAFF_ROLE => ['replace_with' => '']
-
-        ],
+        'restricted_value' => '',
         'level' => 1
       ],
     ];

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Handler/GetBreakDownFieldPermissions.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Handler/GetBreakDownFieldPermissions.php
@@ -1,0 +1,88 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
+
+class CRM_HRLeaveAndAbsences_API_Handler_GetBreakDownFieldPermissions extends CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissions {
+
+  /**
+   * @var int|string
+   *   The contact ID whom the request results belongs to.
+   */
+  private $contactID;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getDataRowIdentifierKey() {
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getDataRowIdentifierLevel() {
+    return NULL;
+  }
+
+  /**
+   * CRM_HRLeaveAndAbsences_API_Handler_GetBreakDownFieldPermissions constructor.
+   *
+   * @param array $apiRequest
+   * @param LeaveRequestRightsService $leaveRequestRights
+   */
+  public function __construct(array $apiRequest, LeaveRequestRightsService $leaveRequestRights) {
+    $this->contactID = $this->getContactID($apiRequest);
+
+    parent::__construct($apiRequest, $leaveRequestRights);
+  }
+
+  /**
+   * Gets the contact ID that the request results belongs to.
+   *
+   * @param array $apiRequest
+   *
+   * @return int|string
+   */
+  private function getContactID($apiRequest) {
+    $leaveRequestID = $apiRequest['params']['leave_request_id'];
+
+    try {
+      $leaveRequest = LeaveRequest::findById($leaveRequestID);
+
+      return $leaveRequest->contact_id;
+    } catch(Exception $e) {
+      return '';
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getRestrictedFields() {
+    $fields = [
+      'amount' => [
+        'restricted_for' => [
+          self::MANAGER_ROLE => ['replace_with' => ''],
+          self::STAFF_ROLE => ['replace_with' => '']
+
+        ],
+        'level' => 1
+      ],
+    ];
+
+    return $fields;
+  }
+
+  /**
+   * Checks whether current user has access to the restricted data for the contact_id linked
+   * to the request results.
+   *
+   * @param mixed $dataRowIdentifierValue
+   *
+   * @return bool
+   */
+  protected function canAccessRestrictedData($dataRowIdentifierValue) {
+    return in_array($this->contactID, $this->getAccessibleContacts());
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Handler/LeaveFieldPermissions.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Handler/LeaveFieldPermissions.php
@@ -50,6 +50,11 @@ abstract class CRM_HRLeaveAndAbsences_API_Handler_LeaveFieldPermissions {
   protected $currentDataRowIdentifierValue = '';
 
   /**
+   * @var bool
+   */
+  protected $removeDataRowIdentifier = FALSE;
+
+  /**
    * Processes the result set and replaces field values as necessary.
    *
    * @param array $results
@@ -69,6 +74,10 @@ abstract class CRM_HRLeaveAndAbsences_API_Handler_LeaveFieldPermissions {
       if($this->getDataRowIdentifierKey() && $this->getDataRowIdentifierLevel() && $level == 0) {
         $rowData = [$field => $value];
         $this->setCurrentDataRowIdentifierValue($rowData);
+      }
+
+      if ($this->removeDataRowIdentifier && $field === $this->getDataRowIdentifierKey() && $level === $this->getDataRowIdentifierLevel()) {
+        unset($data[$field]);
       }
 
       if(array_key_exists($field, $this->getRestrictedFields()) && $level == $this->getRestrictedFields()[$field]['level']) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Handler/LeaveFieldPermissions.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Handler/LeaveFieldPermissions.php
@@ -1,0 +1,122 @@
+<?php
+
+abstract class CRM_HRLeaveAndAbsences_API_Handler_LeaveFieldPermissions {
+
+  /**
+   * Gets the restricted fields that needs to have their values replaced in
+   * the result set.
+   *
+   * @return array
+   */
+  abstract protected function getRestrictedFields();
+
+  /**
+   * Function to get the new field value if the field is among the restricted
+   * fields list.
+   *
+   * @param string $field
+   * @param mixed $value
+   * @param mixed $dataIdentifier
+   *
+   * @return mixed
+   */
+  abstract protected function getNewFieldValue($field, $value, $dataIdentifier);
+
+  /**
+   * The identifier field for each result row set, This field if specified will
+   * have its value passed to the getNewFieldValue function when called. It allows
+   * the extending class to use the value to make some decisions regarding the value to be
+   * replaced for the current restricted field.
+   *
+   * @return string
+   */
+  abstract protected function getDataRowIdentifierKey();
+
+  /**
+   * The level of the identifier field for each result row set.
+   * The level depends on the position of the field in the nested array
+   * result row set.
+   *
+   * @return int
+   */
+  abstract protected function getDataRowIdentifierLevel();
+
+  /**
+   * Used to temporarily store the current value of the identifier field for a result
+   * row set.
+   *
+   * @var string
+   */
+  protected $currentDataRowIdentifierValue = '';
+
+  /**
+   * Processes the result set and replaces field values as necessary.
+   *
+   * @param array $results
+   */
+  public function process(&$results) {
+    $this->filterFields($results['values']);
+  }
+
+  /**
+   * Filters the fields and replaces values for restricted fields as necessary.
+   *
+   * @param array $data
+   * @param int $level
+   */
+  protected function filterFields(&$data, $level = 0) {
+    foreach($data as $field => &$value) {
+      if($this->getDataRowIdentifierKey() && $this->getDataRowIdentifierLevel() && $level == 0) {
+        $rowData = [$field => $value];
+        $this->setCurrentDataRowIdentifierValue($rowData);
+      }
+
+      if(array_key_exists($field, $this->getRestrictedFields()) && $level == $this->getRestrictedFields()[$field]['level']) {
+        $oldValue = $value;
+        $data[$field] = $this->getNewFieldValue($field, $oldValue, $this->getCurrentDataRowIdentifierValue());
+      }
+
+      if(is_array($value)) {
+        $this->filterFields($value, $level + 1);
+      }
+    }
+  }
+
+  /**
+   * Sets the Identifier field value for the current result row set.
+   * It resets the value for the previous result row set first
+   * before attempting to store the value for the current row.
+   *
+   * @param array $data
+   * @param int $level
+   */
+  private function setCurrentDataRowIdentifierValue($data, $level = 0) {
+    if ($level == 0) {
+      $this->currentDataRowIdentifierValue = '';
+    }
+
+    foreach($data as $field => $value) {
+      if($this->currentDataRowIdentifierValue) {
+        break;
+      }
+
+      if($field == $this->getDataRowIdentifierKey() && $level == $this->getDataRowIdentifierLevel()) {
+        $this->currentDataRowIdentifierValue = $value;
+        break;
+      }
+
+      if(is_array($value)) {
+        $this->setCurrentDataRowIdentifierValue($value, $level + 1);
+      }
+    }
+  }
+
+  /**
+   * Gets the Identifier field value for the current result row set
+   *
+   * @return string
+   */
+  private function getCurrentDataRowIdentifierValue() {
+    return $this->currentDataRowIdentifierValue;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Wrapper/LeaveRequestFieldsVisibility.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Wrapper/LeaveRequestFieldsVisibility.php
@@ -37,11 +37,7 @@ class CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestFieldsVisibility implements
    */
   public function fromApiInput($apiRequest) {
     if ($this->canHandleApiInput($apiRequest)) {
-      $returnParams = $this->getRequestReturnParameter($apiRequest);
-
-      if(!empty($returnParams)) {
-        $apiRequest['params']['return'] = $returnParams;
-      }
+      $this->setRequestReturnParameter($apiRequest);
     }
 
     return $apiRequest;
@@ -75,7 +71,7 @@ class CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestFieldsVisibility implements
 
   /**
    * Checks whether the request can be handled or not.
-   * 
+   *
    * @param $apiRequest
    *
    * @return bool
@@ -118,18 +114,17 @@ class CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestFieldsVisibility implements
    *
    * @param array $apiRequest
    *
-   * @return array
    */
-  private function getRequestReturnParameter($apiRequest) {
+  private function setRequestReturnParameter(&$apiRequest) {
     $options = _civicrm_api3_get_options_from_params($apiRequest['params']);
     $returnParams = array_keys($options['return']);
 
     if (!empty($returnParams)) {
       if (FALSE === array_search('contact_id', $returnParams)) {
+        $apiRequest['params']['initial_return'] = $returnParams;
         $returnParams[] = 'contact_id';
+        $apiRequest['params']['return'] = $returnParams;
       }
     }
-
-    return $returnParams;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Wrapper/LeaveRequestFieldsVisibility.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Wrapper/LeaveRequestFieldsVisibility.php
@@ -3,15 +3,32 @@
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
 use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
 
+/**
+ * Class CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestFieldsVisibility
+ */
 class CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestFieldsVisibility implements API_Wrapper {
 
   /**
    * @var array
+   *   An array of API actions for the LeaveRequest Entity with properties for
+   *   each action that determine which handler should handle which API and also
+   *   if the contact_id should be among the fields to be returned for the API
+   *   for the respective handler to work properly. Since the Identifier field used
+   *   by some of the handler to process the field values to be hidden is the contact_id,
+   *   There will be unreliable results if this field is absent in the results set.
    */
   protected $apiActions = [
-    'getfull' => ['handler' => 'CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissions'],
-    'get' => ['handler' => 'CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissions'],
-    'getbreakdown' => ['handler' => 'CRM_HRLeaveAndAbsences_API_Handler_GetBreakDownFieldPermissions'],
+    'getfull' => [
+      'handler' => 'CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissions',
+      'request_requires_contact_id' => TRUE
+    ],
+    'get' => [
+      'handler' => 'CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissions',
+      'request_requires_contact_id' => TRUE
+    ],
+    'getbreakdown' => [
+      'handler' => 'CRM_HRLeaveAndAbsences_API_Handler_GetBreakDownFieldPermissions'
+    ],
   ];
 
   /**
@@ -19,6 +36,13 @@ class CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestFieldsVisibility implements
    * @return mixed
    */
   public function fromApiInput($apiRequest) {
+    if ($this->canHandleApiInput($apiRequest)) {
+      $returnParams = $this->getRequestReturnParameter($apiRequest);
+
+      if(!empty($returnParams)) {
+        $apiRequest['params']['return'] = $returnParams;
+      }
+    }
 
     return $apiRequest;
   }
@@ -27,7 +51,7 @@ class CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestFieldsVisibility implements
    * {@inheritdoc}
    */
   public function toApiOutput($apiRequest, $result) {
-    if ($this->canHandleTheRequest($apiRequest)) {
+    if ($this->canHandleAPiOutput($apiRequest)) {
       $handler = $this->getHandler($apiRequest);
       $handler->process($result);
     }
@@ -36,7 +60,10 @@ class CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestFieldsVisibility implements
   }
 
   /**
+   * Returns the handler for the API action.
+   *
    * @param $apiRequest
+   *
    * @return mixed
    */
   private function getHandler($apiRequest) {
@@ -47,11 +74,62 @@ class CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestFieldsVisibility implements
   }
 
   /**
+   * Checks whether the request can be handled or not.
+   * 
    * @param $apiRequest
+   *
    * @return bool
    */
   private function canHandleTheRequest($apiRequest) {
     $isTargetAction = array_key_exists($apiRequest['action'], $this->apiActions);
     return $apiRequest['entity'] === 'LeaveRequest' && $isTargetAction;
+  }
+
+  /**
+   * Checks If the API request output can be handled.
+   *
+   * @param $apiRequest
+   *
+   * @return bool
+   */
+  private function canHandleAPiOutput($apiRequest) {
+    return $this->canHandleTheRequest($apiRequest);
+  }
+
+  /**
+   * Checks If the API request input can be handled.
+   *
+   * @param array $apiRequest
+   *
+   * @return bool
+   */
+  private function canHandleApiInput($apiRequest) {
+    $canHandleRequest = $this->canHandleTheRequest($apiRequest);
+    $requiresContactID = !empty($this->apiActions[$apiRequest['action']]['request_requires_contact_id']);
+
+    return $canHandleRequest && $requiresContactID;
+  }
+
+  /**
+   * Ensures that the return parameter for the API input has all the dependencies
+   * needed to make the API handlers work. In this case the contact_id should be
+   * present in the list of fields to be returned in the result set so that the API
+   * handlers that requires this can return accurate results.
+   *
+   * @param array $apiRequest
+   *
+   * @return array
+   */
+  private function getRequestReturnParameter($apiRequest) {
+    $options = _civicrm_api3_get_options_from_params($apiRequest['params']);
+    $returnParams = array_keys($options['return']);
+
+    if (!empty($returnParams)) {
+      if (FALSE === array_search('contact_id', $returnParams)) {
+        $returnParams[] = 'contact_id';
+      }
+    }
+
+    return $returnParams;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Wrapper/LeaveRequestFieldsVisibility.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Wrapper/LeaveRequestFieldsVisibility.php
@@ -32,6 +32,13 @@ class CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestFieldsVisibility implements
   ];
 
   /**
+   * The contact_id parameter needs to be present in the list of parameters
+   * to be returned so that each result row set to be precessed by the API
+   * handler can identify which data belongs to which contact depending on
+   * the data the current user has access to. If the contact_id is absent,
+   * the result set returned will hide restricted fields even for contact
+   * that should originally have access to those fields.
+   *
    * @param $apiRequest
    * @return mixed
    */
@@ -47,7 +54,7 @@ class CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestFieldsVisibility implements
    * {@inheritdoc}
    */
   public function toApiOutput($apiRequest, $result) {
-    if ($this->canHandleAPiOutput($apiRequest)) {
+    if ($this->canHandleApiOutput($apiRequest)) {
       $handler = $this->getHandler($apiRequest);
       $handler->process($result);
     }
@@ -88,7 +95,7 @@ class CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestFieldsVisibility implements
    *
    * @return bool
    */
-  private function canHandleAPiOutput($apiRequest) {
+  private function canHandleApiOutput($apiRequest) {
     return $this->canHandleTheRequest($apiRequest);
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Wrapper/LeaveRequestFieldsVisibility.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Wrapper/LeaveRequestFieldsVisibility.php
@@ -1,0 +1,57 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
+use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
+
+class CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestFieldsVisibility implements API_Wrapper {
+
+  /**
+   * @var array
+   */
+  protected $apiActions = [
+    'getfull' => ['handler' => 'CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissions'],
+    'get' => ['handler' => 'CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissions'],
+    'getbreakdown' => ['handler' => 'CRM_HRLeaveAndAbsences_API_Handler_GetBreakDownFieldPermissions'],
+  ];
+
+  /**
+   * @param $apiRequest
+   * @return mixed
+   */
+  public function fromApiInput($apiRequest) {
+
+    return $apiRequest;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function toApiOutput($apiRequest, $result) {
+    if ($this->canHandleTheRequest($apiRequest)) {
+      $handler = $this->getHandler($apiRequest);
+      $handler->process($result);
+    }
+
+    return $result;
+  }
+
+  /**
+   * @param $apiRequest
+   * @return mixed
+   */
+  private function getHandler($apiRequest) {
+    $handler = $this->apiActions[$apiRequest['action']]['handler'];
+    $leaveRequestRights = new LeaveRequestRightsService(new LeaveManagerService());
+
+    return new $handler($apiRequest, $leaveRequestRights);
+  }
+
+  /**
+   * @param $apiRequest
+   * @return bool
+   */
+  private function canHandleTheRequest($apiRequest) {
+    $isTargetAction = array_key_exists($apiRequest['action'], $this->apiActions);
+    return $apiRequest['entity'] === 'LeaveRequest' && $isTargetAction;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
@@ -6,6 +6,8 @@ use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 
 class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
 
+  use CRM_HRLeaveAndAbsences_ACL_LeaveInformationTrait;
+
   /**
    * @var \CRM_HRLeaveAndAbsences_Service_LeaveManager
    */
@@ -172,5 +174,29 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
     }
 
     return TRUE;
+  }
+
+  /**
+   * Returns the leave contact ids that the current logged in user has access to, For a
+   * user with staff role it would be that user contact id alone, for a manager it
+   * would be the contact Id's of the staff he approves leave for. The query is not ran
+   * for an Admin user because in reality an Admin user has access to all contacts.
+   *
+   * @return array
+   */
+  public function getLeaveContactsCurrentUserHasAccessTo() {
+    $results = [];
+
+    if($this->currentUserIsAdmin()) {
+      return $results;
+    }
+    $query = $this->getLeaveInformationACLQuery();
+    $contactIds = CRM_CORE_DAO::executeQuery($query);
+
+    while ($contactIds->fetch()) {
+      $results[] = $contactIds->id;
+    }
+
+    return $results;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -452,6 +452,7 @@ function hrleaveandabsences_civicrm_validateForm($formName, &$fields, &$files, &
  */
 function hrleaveandabsences_civicrm_apiWrappers(&$wrappers, $apiRequest) {
   $wrappers[] = new CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestDates();
+  $wrappers[] = new CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestFieldsVisibility();
 }
 
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissionsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissionsTest.php
@@ -1,0 +1,271 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
+use CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissions as GenericLeaveFieldPermissions;
+/**
+ * Class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extends BaseHeadlessTest  {
+
+  use CRM_HRLeaveAndAbsences_SessionHelpersTrait;
+
+  private $sampleData = [
+    'is_error' => 0,
+    'version' => 3,
+    'count' => 6,
+    'values' =>
+      [
+        0 =>
+          [
+            'id' => '17',
+            'type_id' => '1',
+            'contact_id' => '209',
+            'status_id' => '6',
+            'from_date' => '2016-01-30 00:00:00',
+            'from_date_type' => '1',
+            'to_date' => '2016-02-01 00:00:00',
+            'to_date_type' => '1',
+            'request_type' => 'leave',
+            'is_deleted' => '0',
+            'from_date_amount' => '0.00',
+            'to_date_amount' => '0.00',
+            'balance_change' => -1,
+            'dates' =>
+              [
+                0 =>
+                  [
+                    'id' => '17',
+                    'date' => '2016-01-30',
+                  ],
+                1 =>
+                  [
+                    'id' => '18',
+                    'date' => '2016-01-31',
+                  ],
+                2 =>
+                  [
+                    'id' => '19',
+                    'date' => '2016-02-01',
+                  ],
+              ],
+          ],
+        1 =>
+          [
+            'id' => '18',
+            'type_id' => '1',
+            'contact_id' => '204',
+            'status_id' => '1',
+            'from_date' => '2016-02-01 00:00:00',
+            'from_date_type' => '1',
+            'to_date' => '2016-02-03 00:00:00',
+            'to_date_type' => '1',
+            'request_type' => 'leave',
+            'is_deleted' => '0',
+            'from_date_amount' => '0.00',
+            'to_date_amount' => '0.00',
+            'balance_change' => -3,
+            'dates' =>
+              [
+                0 =>
+                  [
+                    'id' => '20',
+                    'date' => '2016-02-01',
+                  ],
+                1 =>
+                  [
+                    'id' => '21',
+                    'date' => '2016-02-02',
+                  ],
+                2 =>
+                  [
+                    'id' => '22',
+                    'date' => '2016-02-03',
+                  ],
+              ],
+          ],
+        2 =>
+          [
+            'id' => '24',
+            'type_id' => '2',
+            'contact_id' => '204',
+            'status_id' => '1',
+            'from_date' => '2016-10-20 00:00:00',
+            'from_date_type' => '1',
+            'to_date' => '2016-10-20 23:45:00',
+            'to_date_type' => '1',
+            'toil_duration' => '200',
+            'toil_to_accrue' => '1',
+            'toil_expiry_date' => '2016-11-01',
+            'request_type' => 'toil',
+            'is_deleted' => '0',
+            'from_date_amount' => '0.00',
+            'to_date_amount' => '0.00',
+            'balance_change' => 1,
+            'dates' =>
+              [
+                0 =>
+                  [
+                    'id' => '51',
+                    'date' => '2016-10-20',
+                  ],
+              ],
+          ],
+        3 =>
+          [
+            'id' => '25',
+            'type_id' => '2',
+            'contact_id' => '208',
+            'status_id' => '4',
+            'from_date' => '2016-12-15 00:00:00',
+            'from_date_type' => '1',
+            'to_date' => '2016-12-15 23:45:00',
+            'to_date_type' => '1',
+            'toil_duration' => '360',
+            'toil_to_accrue' => '2',
+            'toil_expiry_date' => '2016-12-31',
+            'request_type' => 'toil',
+            'is_deleted' => '0',
+            'from_date_amount' => '0.00',
+            'to_date_amount' => '0.00',
+            'balance_change' => 2,
+            'dates' =>
+              [
+                0 =>
+                  [
+                    'id' => '52',
+                    'date' => '2016-12-15',
+                  ],
+              ],
+          ],
+        4 =>
+          [
+            'id' => '27',
+            'type_id' => '3',
+            'contact_id' => '204',
+            'status_id' => '6',
+            'from_date' => '2017-02-01 00:00:00',
+            'from_date_type' => '1',
+            'to_date' => '2017-02-01 00:00:00',
+            'to_date_type' => '1',
+            'sickness_reason' => '2',
+            'request_type' => 'sickness',
+            'is_deleted' => '0',
+            'from_date_amount' => '0.00',
+            'to_date_amount' => '0.00',
+            'balance_change' => -1,
+            'dates' =>
+              [
+                0 =>
+                  [
+                    'id' => '63',
+                    'date' => '2017-02-01',
+                  ],
+              ],
+          ],
+        5 =>
+          [
+            'id' => '28',
+            'type_id' => '3',
+            'contact_id' => '209',
+            'status_id' => '6',
+            'from_date' => '2017-02-01 00:00:00',
+            'from_date_type' => '1',
+            'to_date' => '2017-02-01 00:00:00',
+            'to_date_type' => '1',
+            'sickness_reason' => '2',
+            'request_type' => 'sickness',
+            'is_deleted' => '0',
+            'from_date_amount' => '0.00',
+            'to_date_amount' => '0.00',
+            'balance_change' => -1,
+            'dates' =>
+              [
+                0 =>
+                  [
+                    'id' => '63',
+                    'date' => '2017-02-01',
+                  ],
+              ],
+          ],
+      ],
+  ];
+
+  public function setUp() {
+
+  }
+
+  public function testProcessWhenUserIsStaff() {
+    //User is Staff with ID of 204 and has full access to only his data
+    $this->setPermissions();
+    $leaveRequestRights = $this->prophesize(LeaveRequestRightsService::class);
+    $leaveRequestRights->getLeaveContactsCurrentUserHasAccessTo()->willReturn([204]);
+    $apiRequest = [];
+    $genericFieldHandler = new GenericLeaveFieldPermissions($apiRequest, $leaveRequestRights->reveal());
+
+    $results = $this->sampleData;
+    $expectedParams = $this->sampleData;
+    $expectedParams['values'][0]['from_date_amount'] = '';
+    $expectedParams['values'][0]['to_date_amount'] = '';
+    $expectedParams['values'][0]['balance_change'] = '';
+    $expectedParams['values'][3]['from_date_amount'] = '';
+    $expectedParams['values'][3]['to_date_amount'] = '';
+    $expectedParams['values'][3]['balance_change'] = '';
+    $expectedParams['values'][3]['toil_duration'] = '';
+    $expectedParams['values'][3]['toil_to_accrue'] = '';
+    $expectedParams['values'][3]['toil_expiry_date'] = '';
+    $expectedParams['values'][5]['sickness_reason'] = '';
+    $expectedParams['values'][5]['from_date_amount'] = '';
+    $expectedParams['values'][5]['to_date_amount'] = '';
+    $expectedParams['values'][5]['balance_change'] = '';
+    $genericFieldHandler->process($results);
+
+    $this->assertEquals($expectedParams, $results);
+  }
+
+  public function testProcessWhenUserIsManager() {
+    //Manager with access to all data for contact 208 and 209 and restricted access to
+    //other contacts.
+    $this->setPermissions(['manage leave and absences in ssp']);
+    $leaveRequestRights = $this->prophesize(LeaveRequestRightsService::class);
+    $leaveRequestRights->getLeaveContactsCurrentUserHasAccessTo()->willReturn([209, 208]);
+    $apiRequest = [];
+    $genericFieldHandler = new GenericLeaveFieldPermissions($apiRequest, $leaveRequestRights->reveal());
+
+    $results = $this->sampleData;
+    $expectedParams = $this->sampleData;
+    $expectedParams['values'][1]['from_date_amount'] = '';
+    $expectedParams['values'][1]['to_date_amount'] = '';
+    $expectedParams['values'][1]['balance_change'] = '';
+    $expectedParams['values'][2]['from_date_amount'] = '';
+    $expectedParams['values'][2]['to_date_amount'] = '';
+    $expectedParams['values'][2]['balance_change'] = '';
+    $expectedParams['values'][2]['toil_duration'] = '';
+    $expectedParams['values'][2]['toil_to_accrue'] = '';
+    $expectedParams['values'][2]['toil_expiry_date'] = '';
+    $expectedParams['values'][4]['sickness_reason'] = '';
+    $expectedParams['values'][4]['from_date_amount'] = '';
+    $expectedParams['values'][4]['to_date_amount'] = '';
+    $expectedParams['values'][4]['balance_change'] = '';
+    $genericFieldHandler->process($results);
+
+    $this->assertEquals($expectedParams, $results);
+  }
+
+
+  public function testProcessWhenUserIsAdmin() {
+    //Admin User
+    $this->setPermissions(['administer leave and absences']);
+    $leaveRequestRights = $this->prophesize(LeaveRequestRightsService::class);
+    $leaveRequestRights->getLeaveContactsCurrentUserHasAccessTo()->willReturn([]);
+    $apiRequest = [];
+    $genericFieldHandler = new GenericLeaveFieldPermissions($apiRequest, $leaveRequestRights->reveal());
+
+    $results = $this->sampleData;
+    $expectedParams = $this->sampleData;
+    $genericFieldHandler->process($results);
+
+    $this->assertEquals($expectedParams, $results);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissionsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissionsTest.php
@@ -209,16 +209,19 @@ class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extend
     $expectedParams['values'][0]['from_date_amount'] = '';
     $expectedParams['values'][0]['to_date_amount'] = '';
     $expectedParams['values'][0]['balance_change'] = '';
+    $expectedParams['values'][0]['type_id'] = '';
     $expectedParams['values'][3]['from_date_amount'] = '';
     $expectedParams['values'][3]['to_date_amount'] = '';
     $expectedParams['values'][3]['balance_change'] = '';
     $expectedParams['values'][3]['toil_duration'] = '';
     $expectedParams['values'][3]['toil_to_accrue'] = '';
     $expectedParams['values'][3]['toil_expiry_date'] = '';
+    $expectedParams['values'][3]['type_id'] = '';
     $expectedParams['values'][5]['sickness_reason'] = '';
     $expectedParams['values'][5]['from_date_amount'] = '';
     $expectedParams['values'][5]['to_date_amount'] = '';
     $expectedParams['values'][5]['balance_change'] = '';
+    $expectedParams['values'][5]['type_id'] = '';
     $genericFieldHandler->process($results);
 
     $this->assertEquals($expectedParams, $results);
@@ -238,16 +241,19 @@ class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extend
     $expectedParams['values'][1]['from_date_amount'] = '';
     $expectedParams['values'][1]['to_date_amount'] = '';
     $expectedParams['values'][1]['balance_change'] = '';
+    $expectedParams['values'][1]['type_id'] = '';
     $expectedParams['values'][2]['from_date_amount'] = '';
     $expectedParams['values'][2]['to_date_amount'] = '';
     $expectedParams['values'][2]['balance_change'] = '';
     $expectedParams['values'][2]['toil_duration'] = '';
     $expectedParams['values'][2]['toil_to_accrue'] = '';
     $expectedParams['values'][2]['toil_expiry_date'] = '';
+    $expectedParams['values'][2]['type_id'] = '';
     $expectedParams['values'][4]['sickness_reason'] = '';
     $expectedParams['values'][4]['from_date_amount'] = '';
     $expectedParams['values'][4]['to_date_amount'] = '';
     $expectedParams['values'][4]['balance_change'] = '';
+    $expectedParams['values'][4]['type_id'] = '';
     $genericFieldHandler->process($results);
 
     $this->assertEquals($expectedParams, $results);
@@ -293,16 +299,19 @@ class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extend
     $expectedParams['values'][1]['from_date_amount'] = '';
     $expectedParams['values'][1]['to_date_amount'] = '';
     $expectedParams['values'][1]['balance_change'] = '';
+    $expectedParams['values'][1]['type_id'] = '';
     $expectedParams['values'][2]['from_date_amount'] = '';
     $expectedParams['values'][2]['to_date_amount'] = '';
     $expectedParams['values'][2]['balance_change'] = '';
     $expectedParams['values'][2]['toil_duration'] = '';
     $expectedParams['values'][2]['toil_to_accrue'] = '';
     $expectedParams['values'][2]['toil_expiry_date'] = '';
+    $expectedParams['values'][2]['type_id'] = '';
     $expectedParams['values'][4]['sickness_reason'] = '';
     $expectedParams['values'][4]['from_date_amount'] = '';
     $expectedParams['values'][4]['to_date_amount'] = '';
     $expectedParams['values'][4]['balance_change'] = '';
+    $expectedParams['values'][4]['type_id'] = '';
 
     $genericFieldHandler->process($results);
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissionsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissionsTest.php
@@ -191,46 +191,10 @@ class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extend
           ],
       ],
   ];
-
-  public function setUp() {
-
-  }
-
-  public function testProcessWhenUserIsStaff() {
-    //User is Staff with ID of 204 and has full access to only his data
+  
+  public function testProcessWhenUserIsNotAnAdminUser() {
     $this->setPermissions();
-    $leaveRequestRights = $this->prophesize(LeaveRequestRightsService::class);
-    $leaveRequestRights->getLeaveContactsCurrentUserHasAccessTo()->willReturn([204]);
-    $apiRequest = [];
-    $genericFieldHandler = new GenericLeaveFieldPermissions($apiRequest, $leaveRequestRights->reveal());
-
-    $results = $this->sampleData;
-    $expectedParams = $this->sampleData;
-    $expectedParams['values'][0]['from_date_amount'] = '';
-    $expectedParams['values'][0]['to_date_amount'] = '';
-    $expectedParams['values'][0]['balance_change'] = '';
-    $expectedParams['values'][0]['type_id'] = '';
-    $expectedParams['values'][3]['from_date_amount'] = '';
-    $expectedParams['values'][3]['to_date_amount'] = '';
-    $expectedParams['values'][3]['balance_change'] = '';
-    $expectedParams['values'][3]['toil_duration'] = '';
-    $expectedParams['values'][3]['toil_to_accrue'] = '';
-    $expectedParams['values'][3]['toil_expiry_date'] = '';
-    $expectedParams['values'][3]['type_id'] = '';
-    $expectedParams['values'][5]['sickness_reason'] = '';
-    $expectedParams['values'][5]['from_date_amount'] = '';
-    $expectedParams['values'][5]['to_date_amount'] = '';
-    $expectedParams['values'][5]['balance_change'] = '';
-    $expectedParams['values'][5]['type_id'] = '';
-    $genericFieldHandler->process($results);
-
-    $this->assertEquals($expectedParams, $results);
-  }
-
-  public function testProcessWhenUserIsManager() {
-    //Manager with access to all data for contact 208 and 209 and restricted access to
-    //other contacts.
-    $this->setPermissions(['manage leave and absences in ssp']);
+    //User has access to two leave contacts.
     $leaveRequestRights = $this->prophesize(LeaveRequestRightsService::class);
     $leaveRequestRights->getLeaveContactsCurrentUserHasAccessTo()->willReturn([209, 208]);
     $apiRequest = [];
@@ -257,7 +221,6 @@ class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extend
     $genericFieldHandler->process($results);
 
     $this->assertEquals($expectedParams, $results);
-    $this->setPermissions();
   }
 
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissionsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissionsTest.php
@@ -251,6 +251,7 @@ class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extend
     $genericFieldHandler->process($results);
 
     $this->assertEquals($expectedParams, $results);
+    $this->setPermissions();
   }
 
 
@@ -264,6 +265,45 @@ class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extend
 
     $results = $this->sampleData;
     $expectedParams = $this->sampleData;
+    $genericFieldHandler->process($results);
+
+    $this->assertEquals($expectedParams, $results);
+    $this->setPermissions();
+  }
+
+  public function testProcessWillHideAccessibleFieldsWhenRowIdentifierIsAbsentEvenIfUserHasAccess() {
+    //User is Staff with ID of 204 and has full access to only his data
+    $this->setPermissions();
+    $leaveRequestRights = $this->prophesize(LeaveRequestRightsService::class);
+    $leaveRequestRights->getLeaveContactsCurrentUserHasAccessTo()->willReturn([204]);
+    $apiRequest = [];
+    $genericFieldHandler = new GenericLeaveFieldPermissions($apiRequest, $leaveRequestRights->reveal());
+
+    $sampleData = $this->sampleData;
+    unset($sampleData['values'][0], $sampleData['values'][3], $sampleData['values'][5]);
+    unset($sampleData['values'][1]['contact_id']);
+    unset($sampleData['values'][2]['contact_id']);
+    unset($sampleData['values'][4]['contact_id']);
+
+    $results = $sampleData;
+    $expectedParams = $sampleData;
+
+    //Staff will not be able to access all restricted fields for his
+    //records since the row identifier is absent
+    $expectedParams['values'][1]['from_date_amount'] = '';
+    $expectedParams['values'][1]['to_date_amount'] = '';
+    $expectedParams['values'][1]['balance_change'] = '';
+    $expectedParams['values'][2]['from_date_amount'] = '';
+    $expectedParams['values'][2]['to_date_amount'] = '';
+    $expectedParams['values'][2]['balance_change'] = '';
+    $expectedParams['values'][2]['toil_duration'] = '';
+    $expectedParams['values'][2]['toil_to_accrue'] = '';
+    $expectedParams['values'][2]['toil_expiry_date'] = '';
+    $expectedParams['values'][4]['sickness_reason'] = '';
+    $expectedParams['values'][4]['from_date_amount'] = '';
+    $expectedParams['values'][4]['to_date_amount'] = '';
+    $expectedParams['values'][4]['balance_change'] = '';
+
     $genericFieldHandler->process($results);
 
     $this->assertEquals($expectedParams, $results);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Handler/GetBreakDownFieldPermissionsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Handler/GetBreakDownFieldPermissionsTest.php
@@ -60,8 +60,8 @@ class CRM_HRLeaveAndAbsences_API_Handler_GetBreakDownFieldPermissionsTest extend
     ]);
   }
 
-  public function testProcessForStaffRequestingOwnBreakDown() {
-    //Staff with contact ID of 204
+  public function testProcessForUserRequestingBreakDownForLeaveRequestContactHeHasAccessTo() {
+    //User with contact ID of 204
     $contactID = 204;
     $this->setPermissions();
     $leaveRequestRights = $this->prophesize(LeaveRequestRightsService::class);
@@ -80,7 +80,7 @@ class CRM_HRLeaveAndAbsences_API_Handler_GetBreakDownFieldPermissionsTest extend
     $this->assertEquals($expectedParams, $results);
   }
 
-  public function testProcessForStaffRequestingBreakdownForAnotherStaff() {
+  public function testProcessForUserRequestingBreakdownForLeaveRequestContactHeDoesNotHaveAccessTo() {
     //Staff with contact ID of 204 trying to access breakdown of staff with contact ID 206
     $contactID = 204;
     $staffID = 206;
@@ -103,51 +103,7 @@ class CRM_HRLeaveAndAbsences_API_Handler_GetBreakDownFieldPermissionsTest extend
     $getBreakDownFieldHandler->process($results);
     $this->assertEquals($expectedParams, $results);
   }
-
-  public function testProcessForManagerRequestingBreakdownForManagee() {
-    //Manager trying to access breakdown for his managee
-    $staffID = 206;
-    $this->setPermissions(['manage leave and absences in ssp']);
-    $leaveRequestRights = $this->prophesize(LeaveRequestRightsService::class);
-    $leaveRequestRights->getLeaveContactsCurrentUserHasAccessTo()->willReturn([$staffID]);
-    $leaveRequest = $this->createLeaveRequest($staffID);
-    $apiRequest = [
-      'params' => [
-        'leave_request_id' => $leaveRequest->id
-      ]
-    ];
-    $getBreakDownFieldHandler = new GetBreakDownFieldHandler($apiRequest, $leaveRequestRights->reveal());
-    $results = $this->sampleData;
-    $expectedParams = $this->sampleData;
-
-    $getBreakDownFieldHandler->process($results);
-    $this->assertEquals($expectedParams, $results);
-  }
-
-  public function testProcessForManagerRequestingBreakdownForNonManagee() {
-    //Manager trying to access breakdown for non managee
-    $staffID = 204;
-    $staffID2 = 206;
-    $this->setPermissions(['manage leave and absences in ssp']);
-    $leaveRequestRights = $this->prophesize(LeaveRequestRightsService::class);
-    $leaveRequestRights->getLeaveContactsCurrentUserHasAccessTo()->willReturn([$staffID]);
-    $leaveRequest = $this->createLeaveRequest($staffID2);
-    $apiRequest = [
-      'params' => [
-        'leave_request_id' => $leaveRequest->id
-      ]
-    ];
-    $getBreakDownFieldHandler = new GetBreakDownFieldHandler($apiRequest, $leaveRequestRights->reveal());
-    $results = $this->sampleData;
-    $expectedParams = $this->sampleData;
-    $expectedParams['values'][0]['amount'] = '';
-    $expectedParams['values'][1]['amount'] = '';
-    $expectedParams['values'][2]['amount'] = '';
-
-    $getBreakDownFieldHandler->process($results);
-    $this->assertEquals($expectedParams, $results);
-  }
-
+  
   public function testProcessForAdmin() {
     //Admin can access all restricted fields for a contaxt
     $this->setPermissions(['administer leave and absences']);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Handler/GetBreakDownFieldPermissionsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Handler/GetBreakDownFieldPermissionsTest.php
@@ -1,0 +1,171 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_Test_Fabricator_LeaveRequest as LeaveRequestFabricator;
+use CRM_HRLeaveAndAbsences_API_Handler_GetBreakDownFieldPermissions as GetBreakDownFieldHandler;
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
+
+/**
+ * Class CRM_HRLeaveAndAbsences_API_Handler_GetBreakDownFieldPermissionsTest
+ *
+ * @group headless
+ */
+class CRM_HRLeaveAndAbsences_API_Handler_GetBreakDownFieldPermissionsTest extends BaseHeadlessTest {
+
+  use CRM_HRLeaveAndAbsences_SessionHelpersTrait;
+
+  public function setUp() {
+    CRM_Core_DAO::executeQuery("SET foreign_key_checks = 0;");
+  }
+
+  private $sampleData = [
+    'is_error' => 0,
+    'version' => 3,
+    'count' => 3,
+    'values' =>
+      [
+        0 =>
+          [
+            'id' => '17',
+            'type' => 1,
+            'label' => 'Test Label',
+            'date' => '2016-01-30',
+            'amount' => '0.00',
+          ],
+        1 =>
+          [
+            'id' => '18',
+            'type' => 1,
+            'label' => 'Test Label',
+            'date' => '2016-01-31',
+            'amount' => '0.00',
+          ],
+        2 =>
+          [
+            'id' => '19',
+            'type' => 1,
+            'label' => 'Test Label',
+            'date' => '2016-02-01',
+            'amount' => '-1.00',
+          ],
+      ],
+  ];
+
+  private function createLeaveRequest($contactID) {
+    return LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contactID,
+      'type_id' => 1,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-30'),
+      'to_date' => CRM_Utils_Date::processDate('2016-02-01'),
+      'status_id' => 1
+    ]);
+  }
+
+  public function testProcessForStaffRequestingOwnBreakDown() {
+    //Staff with contact ID of 204
+    $contactID = 204;
+    $this->setPermissions();
+    $leaveRequestRights = $this->prophesize(LeaveRequestRightsService::class);
+    $leaveRequestRights->getLeaveContactsCurrentUserHasAccessTo()->willReturn([$contactID]);
+    $leaveRequest = $this->createLeaveRequest($contactID);
+    $apiRequest = [
+      'params' => [
+        'leave_request_id' => $leaveRequest->id
+      ]
+    ];
+    $getBreakDownFieldHandler = new GetBreakDownFieldHandler($apiRequest, $leaveRequestRights->reveal());
+    $results = $this->sampleData;
+    $expectedParams = $this->sampleData;
+
+    $getBreakDownFieldHandler->process($results);
+    $this->assertEquals($expectedParams, $results);
+  }
+
+  public function testProcessForStaffRequestingBreakdownForAnotherStaff() {
+    //Staff with contact ID of 204 trying to access breakdown of staff with contact ID 206
+    $contactID = 204;
+    $staffID = 206;
+    $this->setPermissions();
+    $leaveRequestRights = $this->prophesize(LeaveRequestRightsService::class);
+    $leaveRequestRights->getLeaveContactsCurrentUserHasAccessTo()->willReturn([$contactID]);
+    $leaveRequest = $this->createLeaveRequest($staffID);
+    $apiRequest = [
+      'params' => [
+        'leave_request_id' => $leaveRequest->id
+      ]
+    ];
+    $getBreakDownFieldHandler = new GetBreakDownFieldHandler($apiRequest, $leaveRequestRights->reveal());
+    $results = $this->sampleData;
+    $expectedParams = $this->sampleData;
+    $expectedParams['values'][0]['amount'] = '';
+    $expectedParams['values'][1]['amount'] = '';
+    $expectedParams['values'][2]['amount'] = '';
+
+    $getBreakDownFieldHandler->process($results);
+    $this->assertEquals($expectedParams, $results);
+  }
+
+  public function testProcessForManagerRequestingBreakdownForManagee() {
+    //Manager trying to access breakdown for his managee
+    $staffID = 206;
+    $this->setPermissions(['manage leave and absences in ssp']);
+    $leaveRequestRights = $this->prophesize(LeaveRequestRightsService::class);
+    $leaveRequestRights->getLeaveContactsCurrentUserHasAccessTo()->willReturn([$staffID]);
+    $leaveRequest = $this->createLeaveRequest($staffID);
+    $apiRequest = [
+      'params' => [
+        'leave_request_id' => $leaveRequest->id
+      ]
+    ];
+    $getBreakDownFieldHandler = new GetBreakDownFieldHandler($apiRequest, $leaveRequestRights->reveal());
+    $results = $this->sampleData;
+    $expectedParams = $this->sampleData;
+
+    $getBreakDownFieldHandler->process($results);
+    $this->assertEquals($expectedParams, $results);
+  }
+
+  public function testProcessForManagerRequestingBreakdownForNonManagee() {
+    //Manager trying to access breakdown for non managee
+    $staffID = 204;
+    $staffID2 = 206;
+    $this->setPermissions(['manage leave and absences in ssp']);
+    $leaveRequestRights = $this->prophesize(LeaveRequestRightsService::class);
+    $leaveRequestRights->getLeaveContactsCurrentUserHasAccessTo()->willReturn([$staffID]);
+    $leaveRequest = $this->createLeaveRequest($staffID2);
+    $apiRequest = [
+      'params' => [
+        'leave_request_id' => $leaveRequest->id
+      ]
+    ];
+    $getBreakDownFieldHandler = new GetBreakDownFieldHandler($apiRequest, $leaveRequestRights->reveal());
+    $results = $this->sampleData;
+    $expectedParams = $this->sampleData;
+    $expectedParams['values'][0]['amount'] = '';
+    $expectedParams['values'][1]['amount'] = '';
+    $expectedParams['values'][2]['amount'] = '';
+
+    $getBreakDownFieldHandler->process($results);
+    $this->assertEquals($expectedParams, $results);
+  }
+
+  public function testProcessForAdmin() {
+    //Admin can access all restricted fields for a contaxt
+    $this->setPermissions(['administer leave and absences']);
+    $staffID = 206;
+    $leaveRequestRights = $this->prophesize(LeaveRequestRightsService::class);
+    $leaveRequestRights->getLeaveContactsCurrentUserHasAccessTo()->willReturn([]);
+    $leaveRequest = $this->createLeaveRequest($staffID);
+    $apiRequest = [
+      'params' => [
+        'leave_request_id' => $leaveRequest->id
+      ]
+    ];
+    $getBreakDownFieldHandler = new GetBreakDownFieldHandler($apiRequest, $leaveRequestRights->reveal());
+    $results = $this->sampleData;
+    $expectedParams = $this->sampleData;
+
+    $getBreakDownFieldHandler->process($results);
+    $this->assertEquals($expectedParams, $results);
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -992,7 +992,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     // This balance change will not be returned because it's not linked to
     // the leave request
     LeaveBalanceChangeFabricator::fabricate([
-      'source_id' => 100,
+      'source_id' => $expectedLeaveBalanceChanges[1]->source_id + 1,
       'source_type' => LeaveBalanceChange::SOURCE_LEAVE_REQUEST_DAY,
     ]);
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -3,6 +3,7 @@
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
 
 /**
  * Class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest
@@ -279,6 +280,38 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
 
     $leaveRightsService = $this->getLeaveRequestRightsForLeaveManagerAsCurrentUser();
     $this->assertTrue($leaveRightsService->canCancelToilWithPastDates($this->leaveContact, $absenceType->id));
+  }
+
+  public function testGetLeaveContactsCurrentUserHasAccessToWhenUserIsStaff() {
+    $staffMember1 = ContactFabricator::fabricate();
+    $staffMember2 = ContactFabricator::fabricate();
+    $this->registerCurrentLoggedInContactInSession($staffMember1['id']);
+    $leaveRequestRightsService = $this->getLeaveRightsService();
+    $accessibleContacts = $leaveRequestRightsService->getLeaveContactsCurrentUserHasAccessTo();
+    $this->assertEquals([$staffMember1['id']], $accessibleContacts);
+  }
+
+  public function testGetLeaveContactsCurrentUserHasAccessToWhenUserIsALeaveApprover() {
+    $manager = ContactFabricator::fabricate();
+    $staffMember1 = ContactFabricator::fabricate();
+    $staffMember2 = ContactFabricator::fabricate();
+    $this->registerCurrentLoggedInContactInSession($manager['id']);
+    $this->setContactAsLeaveApproverOf($manager, $staffMember2);
+    $leaveRequestRightsService = $this->getLeaveRightsService();
+    $accessibleContacts = $leaveRequestRightsService->getLeaveContactsCurrentUserHasAccessTo();
+    sort($accessibleContacts);
+    //The leave approver has access to his own contact id and that of his managees.
+    $this->assertEquals([$manager['id'],$staffMember2['id']], $accessibleContacts);
+  }
+
+  public function testGetLeaveContactsCurrentUserHasAccessToWhenUserIsAnAdmin() {
+    $staffMember1 = ContactFabricator::fabricate();
+    $staffMember2 = ContactFabricator::fabricate();
+    $leaveRequestRightsService = $this->getLeaveRequestRightsForAdminAsCurrentUser();
+    $accessibleContacts = $leaveRequestRightsService->getLeaveContactsCurrentUserHasAccessTo();
+    //In reality, An admin user has access to all contacts, but an empty array is returned in
+    //this case.
+    $this->assertEquals([], $accessibleContacts);
   }
 
   private function getLeaveRightsService($isAdmin = FALSE, $isManager = FALSE) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -282,7 +282,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     $this->assertTrue($leaveRightsService->canCancelToilWithPastDates($this->leaveContact, $absenceType->id));
   }
 
-  public function testGetLeaveContactsCurrentUserHasAccessToWhenUserIsStaff() {
+  public function testStaffMembersShouldOnlyHaveAccessToThemselves() {
     $staffMember1 = ContactFabricator::fabricate();
     $staffMember2 = ContactFabricator::fabricate();
     $this->registerCurrentLoggedInContactInSession($staffMember1['id']);
@@ -291,7 +291,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     $this->assertEquals([$staffMember1['id']], $accessibleContacts);
   }
 
-  public function testGetLeaveContactsCurrentUserHasAccessToWhenUserIsALeaveApprover() {
+  public function testGetLeaveApproverShouldOnlyHaveAccessToManagees() {
     $manager = ContactFabricator::fabricate();
     $staffMember1 = ContactFabricator::fabricate();
     $staffMember2 = ContactFabricator::fabricate();
@@ -304,7 +304,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     $this->assertEquals([$manager['id'],$staffMember2['id']], $accessibleContacts);
   }
 
-  public function testGetLeaveContactsCurrentUserHasAccessToWhenUserIsAnAdmin() {
+  public function testAdminShouldHaveAccessToAllContacts() {
     $staffMember1 = ContactFabricator::fabricate();
     $staffMember2 = ContactFabricator::fabricate();
     $leaveRequestRightsService = $this->getLeaveRequestRightsForAdminAsCurrentUser();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -921,11 +921,13 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $expectedValues = [
       [
         'id' => $leaveRequest1->id,
-        'dates' => $this->createLeaveRequestDatesArray($leaveRequest1)
+        'dates' => $this->createLeaveRequestDatesArray($leaveRequest1),
+        'contact_id' => $leaveRequest1->contact_id
       ],
       [
         'id' => $leaveRequest2->id,
-        'dates' => $this->createLeaveRequestDatesArray($leaveRequest2)
+        'dates' => $this->createLeaveRequestDatesArray($leaveRequest2),
+        'contact_id' => $leaveRequest2->contact_id
       ]
     ];
 
@@ -971,11 +973,13 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $expectedValues = [
       [
         'id' => $leaveRequest1->id,
-        'balance_change' => -1
+        'balance_change' => -1,
+        'contact_id' => $leaveRequest1->contact_id
       ],
       [
         'id' => $leaveRequest2->id,
-        'balance_change' => -1
+        'balance_change' => -1,
+        'contact_id' => $leaveRequest2->contact_id
       ]
     ];
 
@@ -1036,17 +1040,20 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       [
         'id' => $leaveRequest1->id,
         'balance_change' => -1,
-        'dates' => $this->createLeaveRequestDatesArray($leaveRequest1)
+        'dates' => $this->createLeaveRequestDatesArray($leaveRequest1),
+        'contact_id' => $leaveRequest1->contact_id
       ],
       [
         'id' => $leaveRequest2->id,
         'balance_change' => -1,
-        'dates' => $this->createLeaveRequestDatesArray($leaveRequest2)
+        'dates' => $this->createLeaveRequestDatesArray($leaveRequest2),
+        'contact_id' => $leaveRequest2->contact_id
       ],
       [
         'id' => $toilRequest->id,
         'balance_change' => 8,
-        'dates' => $this->createLeaveRequestDatesArray($toilRequest)
+        'dates' => $this->createLeaveRequestDatesArray($toilRequest),
+        'contact_id' => $toilRequest->contact_id
       ]
     ];
 
@@ -1092,11 +1099,13 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $expectedValues = [
       [
         'id' => $leaveRequest1->id,
-        'type_id' => $this->absenceType->id
+        'type_id' => $this->absenceType->id,
+        'contact_id' => $leaveRequest1->contact_id
       ],
       [
         'id' => $leaveRequest2->id,
-        'type_id' => $this->absenceType->id
+        'type_id' => $this->absenceType->id,
+        'contact_id' => $leaveRequest2->contact_id
       ]
     ];
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -1729,7 +1729,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
   public function testGetAndGetFullHidesRestrictedFieldsForUnAssignedContactForLoggedInLeaveManagerWhenUnassignedIsTrue() {
     $manager1 = ContactFabricator::fabricate();
     $this->registerCurrentLoggedInContactInSession($manager1['id']);
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API', 'manage leave and absences in ssp'];
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API'];
 
     $this->setLeaveApproverRelationshipTypes([
       'has Leaves Approved By',
@@ -3726,7 +3726,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $contact2 = ContactFabricator::fabricate();
 
     $this->registerCurrentLoggedInContactInSession($manager['id']);
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API', 'manage leave and absences in ssp'];
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API'];
 
     $this->setContactAsLeaveApproverOf($manager, $contact2);
 
@@ -4210,7 +4210,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $this->registerCurrentLoggedInContactInSession($manager['id']);
     $this->setContactAsLeaveApproverOf($manager, $contact2);
-    $this->setPermissions(['access AJAX API', 'manage leave and absences in ssp']);
+    $this->setPermissions(['access AJAX API']);
 
     //Contact one is not among the managees of the manager so the restricted fields
     //values will be hidden for the manager.

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -1726,10 +1726,10 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertNotEmpty($resultGetFull['values'][$leaveRequest1->id]);
   }
 
-  public function testGetAndGetFullReturnResultsForUnAssignedContactForLoggedInLeaveManagerWhenUnassignedIsTrue() {
+  public function testGetAndGetFullHidesRestrictedFieldsForUnAssignedContactForLoggedInLeaveManagerWhenUnassignedIsTrue() {
     $manager1 = ContactFabricator::fabricate();
     $this->registerCurrentLoggedInContactInSession($manager1['id']);
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API'];
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API', 'manage leave and absences in ssp'];
 
     $this->setLeaveApproverRelationshipTypes([
       'has Leaves Approved By',
@@ -1769,7 +1769,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'from_date' => CRM_Utils_Date::processDate('2016-01-05'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-05'),
       'from_date_type' => 1,
-      'to_date_type' => 1
+      'to_date_type' => 1,
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
     ], true);
 
     // The manager will see results for the contact with the inactive leave manager relationship.
@@ -1781,9 +1782,15 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals(1, $result['count']);
     $contactData = array_shift($result['values']);
     $this->assertEquals($staffMember2['id'], $contactData['contact_id']);
+    $this->assertEquals('', $contactData['toil_duration']);
+    $this->assertEquals('', $contactData['toil_to_accrue']);
+
     $this->assertEquals(1, $resultGetFull['count']);
     $contactData = array_shift($resultGetFull['values']);
     $this->assertEquals($staffMember2['id'], $contactData['contact_id']);
+    $this->assertEquals('', $contactData['toil_duration']);
+    $this->assertEquals('', $contactData['toil_to_accrue']);
+    $this->assertEquals('', $contactData['balance_change']);
   }
 
   public function testGetAndGetFullShouldReturnResultsForContactsManagedByLoggedInLeaveManagerWhenUnassignedIsFalse() {
@@ -3639,7 +3646,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     civicrm_api3('LeaveRequest', 'deletecomment', []);
   }
 
-  public function testGetAndGetFulShouldReturnResultsContactsOtherThanLoggedInUserWhenUserIsNotALeaveApproverOrAdmin() {
+  public function testGetAndGetFullShouldHideRestrictedFieldValuesForContactsOtherThanLoggedInUserWhenUserIsNotALeaveApproverOrAdmin() {
     $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();
 
@@ -3662,46 +3669,64 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       ]
     );
 
-    LeaveRequestFabricator::fabricateWithoutValidation([
+    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact1['id'],
       'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'from_date_type' => 1,
       'to_date_type' => 1,
-      'status_id' => 1
+      'status_id' => 1,
+      'toil_to_accrue' => 1,
+      'toil_duration' => 60,
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL,
     ], true);
 
-    LeaveRequestFabricator::fabricateWithoutValidation([
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact2['id'],
       'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-02-23'),
       'from_date_type' => 1,
       'to_date_type' => 1,
-      'status_id' => 1
+      'status_id' => 1,
+      'toil_to_accrue' => 1,
+      'toil_duration' => 30,
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL,
     ], true);
 
     //The logged in contact would be able to see results for the other contact too since the Leave ACL
-    //allows it.
+    //allows it but would not be able to view field values for restricted fields.
     $result = civicrm_api3('LeaveRequest', 'get', ['check_permissions' => true, 'sequential' => 1]);
     $this->assertEquals(2, $result['count']);
     $this->assertEquals($contact1['id'], $result['values'][0]['contact_id']);
+    $this->assertEquals($leaveRequest1->toil_to_accrue, $result['values'][0]['toil_to_accrue']);
+    $this->assertEquals($leaveRequest1->toil_duration, $result['values'][0]['toil_duration']);
+
     $this->assertEquals($contact2['id'], $result['values'][1]['contact_id']);
+    $this->assertEquals('', $result['values'][1]['toil_to_accrue']);
+    $this->assertEquals('', $result['values'][1]['toil_duration']);
 
     $result = civicrm_api3('LeaveRequest', 'getfull', ['check_permissions' => true, 'sequential' => 1]);
     $this->assertEquals(2, $result['count']);
     $this->assertEquals($contact1['id'], $result['values'][0]['contact_id']);
+    $this->assertEquals($leaveRequest1->toil_to_accrue, $result['values'][0]['toil_to_accrue']);
+    $this->assertEquals($leaveRequest1->toil_duration, $result['values'][0]['toil_duration']);
+    $this->assertNotEmpty($result['values'][0]['balance_change']);
+
     $this->assertEquals($contact2['id'], $result['values'][1]['contact_id']);
+    $this->assertEquals('', $result['values'][1]['toil_to_accrue']);
+    $this->assertEquals('', $result['values'][1]['toil_duration']);
+    $this->assertEquals('', $result['values'][1]['balance_change']);
   }
 
-  public function testGetAndGetFullReturnsDataForManageesAndNonManageesWhenLoggedInUserIsALeaveApprover() {
+  public function testGetAndGetFullHidesRestrictedFieldValuesForNonManageesWhenLoggedInUserIsALeaveApprover() {
     $manager = ContactFabricator::fabricate();
     $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();
 
     $this->registerCurrentLoggedInContactInSession($manager['id']);
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API'];
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API', 'manage leave and absences in ssp'];
 
     $this->setContactAsLeaveApproverOf($manager, $contact2);
 
@@ -3721,37 +3746,58 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       ]
     );
 
-    LeaveRequestFabricator::fabricateWithoutValidation([
+    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact1['id'],
       'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'from_date_type' => 1,
       'to_date_type' => 1,
-      'status_id' => 1
+      'status_id' => 1,
+      'toil_to_accrue' => 2,
+      'toil_duration' => 60,
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
     ], true);
 
-    LeaveRequestFabricator::fabricateWithoutValidation([
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact2['id'],
       'type_id' => $this->absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-02-23'),
       'from_date_type' => 1,
       'to_date_type' => 1,
-      'status_id' => 1
+      'status_id' => 1,
+      'toil_to_accrue' => 1,
+      'toil_duration' => 60,
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
     ], true);
 
     //Results will be returned for both leave contacts even though contact1 is not being managed by
-    //the logged in manager.
+    //the logged in manager but manager will not be able to view restricted field values for the contact
+    //which he's not a leave approver for.
     $result = civicrm_api3('LeaveRequest', 'get', ['check_permissions' => true, 'sequential' => 1]);
     $this->assertEquals(2, $result['count']);
+
     $this->assertEquals($contact1['id'], $result['values'][0]['contact_id']);
+    $this->assertEquals('', $result['values'][0]['toil_duration']);
+    $this->assertEquals('', $result['values'][0]['toil_to_accrue']);
+
     $this->assertEquals($contact2['id'], $result['values'][1]['contact_id']);
+    $this->assertEquals($leaveRequest2->toil_duration, $result['values'][1]['toil_duration']);
+    $this->assertEquals($leaveRequest2->toil_to_accrue, $result['values'][1]['toil_to_accrue']);
 
     $result = civicrm_api3('LeaveRequest', 'getfull', ['check_permissions' => true, 'sequential' => 1]);
     $this->assertEquals(2, $result['count']);
+
     $this->assertEquals($contact1['id'], $result['values'][0]['contact_id']);
+    $this->assertEquals('', $result['values'][0]['toil_duration']);
+    $this->assertEquals('', $result['values'][0]['toil_to_accrue']);
+    $this->assertEquals('', $result['values'][0]['balance_change']);
+
     $this->assertEquals($contact2['id'], $result['values'][1]['contact_id']);
+    $this->assertEquals($leaveRequest2->toil_duration, $result['values'][1]['toil_duration']);
+    $this->assertEquals($leaveRequest2->toil_to_accrue, $result['values'][1]['toil_to_accrue']);
+    $this->assertNotEmpty($result['values'][1]['balance_change']);
   }
 
   public function testGetAndGetFullReturnsAllDataWhenLoggedInUserHasViewAllContactsPermission() {
@@ -4089,7 +4135,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEmpty($result['values']);
   }
 
-  public function testGetBreakdownAlsoReturnsTheBreakdownOfAnotherStaffMemberWhenAStaffMemberTriesAccessingIt() {
+  public function testGetBreakdownHidesRestrictedFieldValuesOfAnotherStaffMemberWhenAStaffMemberTriesAccessingIt() {
     $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();
 
@@ -4110,12 +4156,15 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->registerCurrentLoggedInContactInSession($contact1['id']);
 
     // Contact1 should also be able to get the breakdown for a leave request of
-    // Contact2
+    // Contact2 but not restricted fields
     $result = civicrm_api3('LeaveRequest', 'getBreakdown', [
       'leave_request_id' => $leaveRequest->id,
       'check_permissions' => true,
     ]);
     $this->assertCount(3, $result['values']);
+    $this->assertEquals('', $result['values'][0]['amount']);
+    $this->assertEquals('', $result['values'][1]['amount']);
+    $this->assertEquals('', $result['values'][2]['amount']);
 
     $this->registerCurrentLoggedInContactInSession($contact2['id']);
 
@@ -4125,9 +4174,12 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'check_permissions' => true,
     ]);
     $this->assertCount(3, $result['values']);
+    $this->assertNotEmpty($result['values'][0]['amount']);
+    $this->assertNotEmpty($result['values'][1]['amount']);
+    $this->assertNotEmpty($result['values'][2]['amount']);
   }
 
-  public function testGetBreakdownShouldReturnsResultsForManageesAndNonManageesOfALeaveManager() {
+  public function testGetBreakdownHidesRestrictedFieldValuesForNonManageesOfALeaveManager() {
     $manager = ContactFabricator::fabricate();
     $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();
@@ -4158,19 +4210,27 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $this->registerCurrentLoggedInContactInSession($manager['id']);
     $this->setContactAsLeaveApproverOf($manager, $contact2);
-    $this->setPermissions(['access AJAX API']);
+    $this->setPermissions(['access AJAX API', 'manage leave and absences in ssp']);
 
+    //Contact one is not among the managees of the manager so the restricted fields
+    //values will be hidden for the manager.
     $result = civicrm_api3('LeaveRequest', 'getBreakdown', [
       'leave_request_id' => $leaveRequest1->id,
       'check_permissions' => true,
     ]);
     $this->assertCount(3, $result['values']);
+    $this->assertEquals('', $result['values'][0]['amount']);
+    $this->assertEquals('', $result['values'][1]['amount']);
+    $this->assertEquals('', $result['values'][2]['amount']);
 
     $result = civicrm_api3('LeaveRequest', 'getBreakdown', [
       'leave_request_id' => $leaveRequest2->id,
       'check_permissions' => true,
     ]);
     $this->assertCount(3, $result['values']);
+    $this->assertNotEmpty($result['values'][0]['amount']);
+    $this->assertNotEmpty($result['values'][1]['amount']);
+    $this->assertNotEmpty($result['values'][2]['amount']);
   }
 
   public function testGetBreakdownReturnsResultsIfAnAdminTriesToAccessTheBreakdownOfAnyLeaveRequest() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -922,12 +922,10 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       [
         'id' => $leaveRequest1->id,
         'dates' => $this->createLeaveRequestDatesArray($leaveRequest1),
-        'contact_id' => $leaveRequest1->contact_id
       ],
       [
         'id' => $leaveRequest2->id,
         'dates' => $this->createLeaveRequestDatesArray($leaveRequest2),
-        'contact_id' => $leaveRequest2->contact_id
       ]
     ];
 
@@ -974,12 +972,10 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       [
         'id' => $leaveRequest1->id,
         'balance_change' => -1,
-        'contact_id' => $leaveRequest1->contact_id
       ],
       [
         'id' => $leaveRequest2->id,
         'balance_change' => -1,
-        'contact_id' => $leaveRequest2->contact_id
       ]
     ];
 
@@ -1041,19 +1037,16 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
         'id' => $leaveRequest1->id,
         'balance_change' => -1,
         'dates' => $this->createLeaveRequestDatesArray($leaveRequest1),
-        'contact_id' => $leaveRequest1->contact_id
       ],
       [
         'id' => $leaveRequest2->id,
         'balance_change' => -1,
         'dates' => $this->createLeaveRequestDatesArray($leaveRequest2),
-        'contact_id' => $leaveRequest2->contact_id
       ],
       [
         'id' => $toilRequest->id,
         'balance_change' => 8,
         'dates' => $this->createLeaveRequestDatesArray($toilRequest),
-        'contact_id' => $toilRequest->contact_id
       ]
     ];
 
@@ -1100,12 +1093,10 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       [
         'id' => $leaveRequest1->id,
         'type_id' => $this->absenceType->id,
-        'contact_id' => $leaveRequest1->contact_id
       ],
       [
         'id' => $leaveRequest2->id,
         'type_id' => $this->absenceType->id,
-        'contact_id' => $leaveRequest2->contact_id
       ]
     ];
 
@@ -4610,7 +4601,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals($toDate->format('Y-m-d') ." 23:59:00", $leaveRequest->to_date);
   }
 
-  public function testGetAndGetFullReturnsDataForContactIdEvenWhenItsExcludedFromReturnParameters() {
+  public function testAContactCanViewRestrictedFieldsHeHasAccessToEvenWhenTheContactIdIsNotInTheReturnParameters() {
     $contact1 = ContactFabricator::fabricate();
     $this->registerCurrentLoggedInContactInSession($contact1['id']);
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API'];
@@ -4640,18 +4631,21 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     ]);
 
     $this->assertEquals(1, $result['count']);
-    $this->assertEquals($leaveRequest->contact_id, $result['values'][0]['contact_id']);
+    //type_id is a restricted field but contact has access
     $this->assertEquals($leaveRequest->type_id, $result['values'][0]['type_id']);
     $this->assertEquals($leaveRequest->status_id, $result['values'][0]['status_id']);
+    $this->assertArrayNotHasKey('contact_id', $result['values'][0]);
 
     $result = civicrm_api3('LeaveRequest', 'getfull', [
       'check_permissions' => true,
-      'sequential' => 1
+      'sequential' => 1,
+      'return' => ['status_id', 'type_id']
     ]);
     $this->assertEquals(1, $result['count']);
-    $this->assertEquals($contact1['id'], $result['values'][0]['contact_id']);
+    //type_id is a restricted field but contact has access
     $this->assertEquals($leaveRequest->type_id, $result['values'][0]['type_id']);
     $this->assertEquals($leaveRequest->status_id, $result['values'][0]['status_id']);
+    $this->assertArrayNotHasKey('contact_id', $result['values'][0]);
   }
 
   /**


### PR DESCRIPTION
## Overview
Based on the new requirements for the new Staff Calendar that allows a user to view leave requests for other user which was formerly impossible #2614 , Even though leave requests for other contacts can now be viewed, there are some sensitive/restricted fields that a user should not be able to see for contacts that he does not have access to. By having access to, I am referring to the Leave ACL rules which here means that a staff can only view these sensitive fields for his own leave requests only and for other's requests, a pre-determined configurable value is shown for these fields. For a manager he can only view these sensitive/restricted fields for the leave requests of his manages only while an Admin can view all fields for all contacts leave requests.

## Before
- A staff can view all fields for a leave requests that does not belong to the staff via the API
- A manager can view all fields for all leave requests of contacts that are not his managees via the API

## After
- A staff can only view true values for non restricted fields for a leave requests that does not belong to the staff via the API. For the restricted fields he only views a pre-determined value that is configurable.
- A manager can view can only view true values for non restricted  fields for all leave requests of contacts that are not his managees via the API. For the restricted fields he only views a pre-determined value that is configurable.


## Technical Details
- A new API wrapper class (`CRM_HRLeaveAndAbsences_API_Wrapper_LeaveRequestFieldsVisibility`) was created that filters these restricted field values based on handlers for each API action described in the `apiActions` property:

``` php
 protected $apiActions = [
    'getfull' => [
      'handler' => 'CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissions',
      'request_requires_contact_id' => TRUE
    ],
    'get' => [
      'handler' => 'CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissions',
      'request_requires_contact_id' => TRUE
    ],
    'getbreakdown' => [
      'handler' => 'CRM_HRLeaveAndAbsences_API_Handler_GetBreakDownFieldPermissions'
    ],
  ];
```
- The ACL permissions for a contact was implemented in restricting the field values.  
User with access to `administer leave and absences` i.e Admin Role was allowed access to all restricted fields. Users without this permission can only see restricted field values for the contacts they have access to. 

## Comments
- For the restricted fields, An empty string value was used for now till something else is decided. Also I restricted fields that I best thought were sensitive fields but since its configurable, more fields can be easily added and the values changed.
- A broken test [here](https://github.com/civicrm/civihr/blob/b77575ef21a8191d2ec2458bbc596f7d54b3bdf2/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php#L995) was also fixed. The test only fails on first install of the test database and does not fail subsequently. The reason for the failure is that the source_id for the balance change fabricated is hardcoded to 100 and when one of the leave dates created in the test function has an ID of 100 in the database, the test fails because at that point it seems as if the leave request is linked to the two original balance changes plus the extra one whose source ID is hardcoded to 100. The issue was fixed by picking the next available source_id after the balance change have been created for the leave dates.

## API Handler Usage
The API handlers created in this PR are re-usable and the concept can also be extended to other extensions. 
Before creating a new handler for an API action, please check and make sure that the existing handlers can be re-used for the API action, if it can't be re-used, create a new handler extending the `CRM_HRLeaveAndAbsences_API_Handler_LeaveFieldPermissions` class which is the parent class for the handlers. 
Implement the required abstract methods after extending this class. Of important note are the following methods to be extended:
`getRestrictedFields()` : This method allows the extending class to provide API fields whose values are to be restricted for users depending on some logic that will be implemented in the child class.
A sample implementation of this method is 
```php
  protected function getRestrictedFields() {
    $fields = [
      'amount' => [
        'restricted_value' => '',
        'level' => 1
      ],
    ];

    return $fields;
  }
```
The restricted value is the value that will replace the original field value while the level property indicates the level the field is in the nested array result set.
`getNewFieldValue($field, $value, $dataIdentifier)` : This method allows the extending class to define a logic with which to replace the field value when passed to it. For example the extending class can decide that only admins will have access to the original value while other roles will see the restricted value.
The $dataIdentifier parameter allows the extending class define the field value that should be passed to the function when a field value is about to be replaced. For example the `CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissions` class defines its Identifier key and level like below which means anytime a restricted field is to be replaced, the value of the contact_id is passed to the  getNewFieldValue function. This allows the class to make take decisions regarding the data.
```php
  /**
   * {@inheritdoc}
   */
  protected function getDataRowIdentifierKey() {
    return 'contact_id';
  }

  /**
   * {@inheritdoc}
   */
  protected function getDataRowIdentifierLevel() {
    return 1;
  }
```
The process method of the `CRM_HRLeaveAndAbsences_API_Handler_LeaveFieldPermissions` class contains the logic for processing the API result set and replacing restricted field values. This method should suffice for most API's, but can be overridden by extending class if need be.

There are also some cases where for example , some field must be present in the return parameters for the API result set  to be processed properly, For example for the Leave.get and Leave.getFull API's the contact_id parameter need to be included in the result set in order for the logic for replacing the field values to work properly, Please see how this was implemented [here](https://github.com/civicrm/civihr/blob/525cf84f7d77f6d0873b394a9960e89f98e39128/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Wrapper/LeaveRequestFieldsVisibility.php#L47) and [here](https://github.com/civicrm/civihr/blob/525cf84f7d77f6d0873b394a9960e89f98e39128/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Wrapper/LeaveRequestFieldsVisibility.php#L47)