### PR TITLE
PCHR-3460: UI Improvement for Option Groups

### DIFF
--- a/com.civicrm.hrjobroles/views/include/add_new_role.html
+++ b/com.civicrm.hrjobroles/views/include/add_new_role.html
@@ -86,7 +86,7 @@
                 <label for="newLocation" class="col-xs-4 control-label">Location:</label>
                 <div class="col-xs-6">
                   <div class="form-inline">
-                    <div class="crm_custom-select">
+                    <div class="crm_custom-select crm_custom-select--full">
                       <ui-select
                         prevent-animations
                         ng-model="jobroles.editData['new_role_id']['location']"
@@ -99,17 +99,19 @@
                         </ui-select-choices>
                       </ui-select>
                     </div>
-                    <a class="pointer">
-                      <i class="crm-i fa-wrench" ng-click="jobroles.openOptionsEditor('hrjc_location')"></i>
-                    </a>
                   </div>
+                </div>
+                <div class="col-xs-1 control-label">
+                  <a class="pointer">
+                    <i class="crm-i fa-wrench" ng-click="jobroles.openOptionsEditor('hrjc_location')"></i>
+                  </a>
                 </div>
               </div>
               <div class="form-group">
                 <label for="newRegion" class="col-xs-4 control-label">Region:</label>
                 <div class="col-xs-6">
                   <div class="form-inline">
-                    <div class="crm_custom-select">
+                    <div class="crm_custom-select crm_custom-select--full">
                       <ui-select
                         prevent-animations
                         ng-model="jobroles.editData['new_role_id']['region']"
@@ -122,17 +124,19 @@
                         </ui-select-choices>
                       </ui-select>
                     </div>
-                    <a class="pointer">
-                      <i class="crm-i fa-wrench" ng-click="jobroles.openOptionsEditor('hrjc_region')"></i>
-                    </a>
                   </div>
+                </div>
+                <div class="col-xs-1 control-label">
+                  <a class="pointer">
+                    <i class="crm-i fa-wrench" ng-click="jobroles.openOptionsEditor('hrjc_region')"></i>
+                  </a>
                 </div>
               </div>
               <div class="form-group">
                 <label for="newDepartment" class="col-xs-4 control-label">Department:</label>
                 <div class="col-xs-6">
                   <div class="form-inline">
-                    <div class="crm_custom-select">
+                    <div class="crm_custom-select crm_custom-select--full">
                       <ui-select
                         prevent-animations
                         ng-model="jobroles.editData['new_role_id']['department']"
@@ -144,17 +148,19 @@
                         </ui-select-choices>
                       </ui-select>
                     </div>
-                    <a class="pointer">
-                      <i class="crm-i fa-wrench" ng-click="jobroles.openOptionsEditor('hrjc_department')"></i>
-                    </a>
                   </div>
+                </div>
+                <div class="col-xs-1 control-label">
+                  <a class="pointer">
+                    <i class="crm-i fa-wrench" ng-click="jobroles.openOptionsEditor('hrjc_department')"></i>
+                  </a>
                 </div>
               </div>
               <div class="form-group">
                 <label for="newLevel" class="col-xs-4 control-label">Level:</label>
                 <div class="col-xs-6">
                   <div class="form-inline">
-                    <div class="crm_custom-select">
+                    <div class="crm_custom-select crm_custom-select--full">
                       <ui-select
                         prevent-animations
                         ng-model="jobroles.editData['new_role_id']['level']"
@@ -166,10 +172,12 @@
                         </ui-select-choices>
                       </ui-select>
                     </div>
-                    <a class="pointer">
-                      <i class="crm-i fa-wrench" ng-click="jobroles.openOptionsEditor('hrjc_level_type')"></i>
-                    </a>
                   </div>
+                </div>
+                <div class="col-xs-1 control-label">
+                  <a class="pointer">
+                    <i class="crm-i fa-wrench" ng-click="jobroles.openOptionsEditor('hrjc_level_type')"></i>
+                  </a>
                 </div>
               </div>
             </div>

--- a/com.civicrm.hrjobroles/views/include/job_role_panel.html
+++ b/com.civicrm.hrjobroles/views/include/job_role_panel.html
@@ -153,13 +153,13 @@
                 <label for="newLocation" class="col-sm-4 control-label">
                   Location:
                 </label>
-                <div class="col-sm-8">
+                <div class="col-sm-7">
                   <p class="form-control-static" ng-show="!editableForm.$visible">
                     {{jobroles.LocationsData[jobroles.editData[job_roles_data.id]['location']]['title'] || '-'}}
                   </p>
                   <span ng-show="editableForm.$visible">
                     <div class="form-inline">
-                      <div class="crm_custom-select">
+                      <div class="crm_custom-select crm_custom-select--full">
                         <ui-select
                           prevent-animations
                           ng-model="jobroles.editData[job_roles_data.id]['location']"
@@ -172,24 +172,26 @@
                           </ui-select-choices>
                         </ui-select>
                       </div>
-                      <a class="pointer">
-                        <i class="crm-i fa-wrench" ng-click="jobroles.openOptionsEditor('hrjc_location')"></i>
-                      </a>
                     </div>
                   </span>
+                </div>
+                <div class="col-sm-1 control-label" ng-show="editableForm.$visible">
+                  <a class="pointer">
+                    <i class="crm-i fa-wrench" ng-click="jobroles.openOptionsEditor('hrjc_location')"></i>
+                  </a>
                 </div>
               </div>
               <div class="form-group" ng-init="jobroles.initData(job_roles_data.id, 'region', job_roles_data.region)">
                 <label for="newRegion" class="col-sm-4 control-label">
                   Region:
                 </label>
-                <div class="col-sm-8">
+                <div class="col-sm-7">
                   <p class="form-control-static" ng-show="!editableForm.$visible">
                     {{jobroles.RegionsData[jobroles.editData[job_roles_data.id]['region']]['title'] || '-'}}
                   </p>
                   <span ng-show="editableForm.$visible">
                     <div class="form-inline">
-                      <div class="crm_custom-select">
+                      <div class="crm_custom-select crm_custom-select--full">
                         <ui-select
                           prevent-animations
                           ng-model="jobroles.editData[job_roles_data.id]['region']"
@@ -202,24 +204,26 @@
                           </ui-select-choices>
                         </ui-select>
                       </div>
-                      <a class="pointer">
-                        <i class="crm-i fa-wrench" ng-click="jobroles.openOptionsEditor('hrjc_region')"></i>
-                      </a>
                     </div>
                   </span>
+                </div>
+                <div class="col-sm-1 control-label" ng-show="editableForm.$visible">
+                  <a class="pointer">
+                      <i class="crm-i fa-wrench" ng-click="jobroles.openOptionsEditor('hrjc_region')"></i>
+                    </a>
                 </div>
               </div>
               <div class="form-group" ng-init="jobroles.initData(job_roles_data.id, 'department', job_roles_data.department)">
                 <label for="newDepartment" class="col-sm-4 control-label">
                   Department:
                 </label>
-                <div class="col-sm-8">
+                <div class="col-sm-7">
                   <p class="form-control-static" ng-show="!editableForm.$visible">
                     {{jobroles.DepartmentsData[jobroles.editData[job_roles_data.id]['department']]['title'] || '-'}}
                   </p>
                   <span ng-show="editableForm.$visible">
                     <div class="form-inline">
-                      <div class="crm_custom-select">
+                      <div class="crm_custom-select crm_custom-select--full">
                         <ui-select
                           prevent-animations
                           ng-model="jobroles.editData[job_roles_data.id]['department']"
@@ -232,24 +236,26 @@
                           </ui-select-choices>
                         </ui-select>
                       </div>
-                      <a class="pointer">
-                        <i class="crm-i fa-wrench" ng-click="jobroles.openOptionsEditor('hrjc_department')"></i>
-                      </a>
                     </div>
                   </span>
+                </div>
+                <div class="col-sm-1 control-label" ng-show="editableForm.$visible">
+                  <a class="pointer">
+                      <i class="crm-i fa-wrench" ng-click="jobroles.openOptionsEditor('hrjc_department')"></i>
+                    </a>
                 </div>
               </div>
               <div class="form-group" ng-init="jobroles.initData(job_roles_data.id, 'level', job_roles_data.level_type)">
                 <label for="newLevel" class="col-sm-4 control-label">
                   Level:
                 </label>
-                <div class="col-sm-8">
+                <div class="col-sm-7">
                   <p class="form-control-static" ng-show="!editableForm.$visible">
                     {{jobroles.LevelsData[jobroles.editData[job_roles_data.id]['level']]['title'] || '-'}}
                   </p>
                   <span ng-show="editableForm.$visible">
                     <div class="form-inline">
-                      <div class="crm_custom-select">
+                      <div class="crm_custom-select crm_custom-select--full">
                         <ui-select
                         prevent-animations
                         ng-model="jobroles.editData[job_roles_data.id]['level']"
@@ -262,11 +268,13 @@
                           </ui-select-choices>
                         </ui-select>
                       </div>
-                      <a class="pointer">
-                        <i class="crm-i fa-wrench" ng-click="jobroles.openOptionsEditor('hrjc_level_type')"></i>
-                      </a>
                     </div>
                   </span>
+                </div>
+                <div class="col-sm-1 control-label" ng-show="editableForm.$visible">
+                  <a class="pointer">
+                      <i class="crm-i fa-wrench" ng-click="jobroles.openOptionsEditor('hrjc_level_type')"></i>
+                    </a>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Overview
After adding tool icon for some of the option groups in Job Role, dropdown list for those options were not properly displayed. This fixed the issue.

## Before
![before_roles](https://user-images.githubusercontent.com/1507645/40487342-c8a54aa2-5f5b-11e8-9611-a4fd0ac20f54.gif)

## After
![after_roles](https://user-images.githubusercontent.com/1507645/40489439-0131f55a-5f61-11e8-9082-7e888d228b6a.gif)

## Technical Details
Initially css class `crm_custom-select--full` [which was removed](https://github.com/civicrm/civihr/pull/2546) has been restored and bootstrap `col` added for proper arrangement of elements.

```html
<div class="form-group">
   <label for="newDepartment" class="col-xs-4 control-label">Department:</label>
   <div class="col-xs-6">
      <div class="form-inline">
         <div class="crm_custom-select crm_custom-select--full">
             <ui-select
                  prevent-animations
                  ng-model="jobroles.editData['new_role_id']['department']"
                  theme="civihr-ui-select"
                  title="Choose a Department">
                     <ui-select-match prevent-animations allow-clear placeholder="Select a department">{{$select.selected.value.title}}</ui-select-match>
                    <ui-select-choices prevent-animations repeat="department.value.value as (key,department) in jobroles.DepartmentsData | filter: { value: { title: $select.search }}">
                        <div ng-bind-html="department.value.title | highlight: $select.search"></div>
                    </ui-select-choices>
             </ui-select>
          </div>
        </div>
   </div>
    <div class="col-xs-1">
          <a class="pointer">
               <i class="crm-i fa-wrench" ng-click="jobroles.openOptionsEditor('hrjc_department')"></i>
           </a>
     </div>
</div>
```
---
✅Manual Tests - passed
