### PR TITLE
PCHR-3613: Add upgrader to change site settings

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -24,6 +24,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1014;
   use CRM_HRCore_Upgrader_Steps_1015;
   use CRM_HRCore_Upgrader_Steps_1016;
+  use CRM_HRCore_Upgrader_Steps_1017;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1017.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1017.php
@@ -1,0 +1,26 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1017 {
+
+  /**
+   * Updates some site configuration
+   */
+  public function upgrade_1017() {
+    $this->up1017_setSettingValue('logging', TRUE);
+    $this->up1017_setSettingValue('max_attachments', 10);
+    $this->up1017_setSettingValue('maxFileSize', 10);
+
+    return TRUE;
+  }
+
+  /**
+   * Sets a CiviCRM setting value
+   *
+   * @param string $name
+   * @param mixed $value
+   */
+  private function up1017_setSettingValue($name, $value) {
+    civicrm_api3('Setting', 'create', [$name => $value]);
+  }
+
+}


### PR DESCRIPTION
## Overview

This PR updates some settings which are viewable at `/civicrm/admin/setting/misc`

## Before

- Logging was disabled by default
- Max upload size was 3 MB
- Max attachment file count was 3

![image](https://user-images.githubusercontent.com/6374064/40650290-db93ab54-632a-11e8-916c-ad2b0ad48563.png)

## After

- Logging is enable by default
- Max upload size is 10 MB
- Max attachment file count is 10

![image](https://user-images.githubusercontent.com/6374064/40649901-dc9098c4-6329-11e8-8607-df5e641d7cb0.png)
