### PR TITLE
PCHR-3726: Disallow fetching other contact's TOIL requests via API

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissions.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissions.php
@@ -63,18 +63,6 @@ class  CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissions extends C
       'restricted_value' => '',
       'level' => 1
     ],
-    'toil_duration' => [
-      'restricted_value' => '',
-      'level' => 1
-    ],
-    'toil_to_accrue' => [
-      'restricted_value' => '',
-      'level' => 1
-    ],
-    'toil_expiry_date' => [
-      'restricted_value' => '',
-      'level' => 1
-    ],
     'sickness_reason' => [
       'restricted_value' => '',
       'level' => 1

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -1321,7 +1321,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
   }
 
   /**
-   *{@inheritdoc}
+   * This is the LeaveRequest Implementation of the addSelectWhereClause method. It allows leave
+   * requests to be filtered based on LeaveRequest ACL rules. The filtering is done basically
+   * for TOIL requests. A staff can not fetch TOIL requests for other contacts, A manager cannot
+   * fetch TOIL requests for contacts that are not managees but an Admin can fetch all TOIL requests.
+   * Requests other than TOIL requests are not restricted by this ACL rules.
    */
   public function addSelectWhereClause() {
     if (CRM_Core_Permission::check([['view all contacts', 'edit all contacts']])) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -14,6 +14,8 @@ use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_Hrjobcontract_BAO_HRJobContract as JobContract;
 use CRM_HRLeaveAndAbsences_Factory_LeaveDateAmountDeduction as LeaveDateAmountDeductionFactory;
 use CRM_HRLeaveAndAbsences_Service_ContactWorkPattern as ContactWorkPatternService;
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
+use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
 
 class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO_LeaveRequest {
 
@@ -1327,10 +1329,20 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     }
 
     $leaveTable =  CRM_HRLeaveAndAbsences_BAO_LeaveRequest::getTableName();
+    $leaveRequestRights = new LeaveRequestRightsService(new LeaveManagerService());
 
-    $query = "IN (SELECT DISTINCT contact_id FROM {$leaveTable})";
+    $accessibleContacts = $leaveRequestRights->getLeaveContactsCurrentUserHasAccessTo();
+    $contactsAccessIN = "'" . implode(', ', $accessibleContacts) . "'";
+    $notAccessibleLeaveRequestQuery = "SELECT id FROM {$leaveTable} 
+      WHERE contact_id NOT IN ($contactsAccessIN) AND request_type ='" . LeaveRequest::REQUEST_TYPE_TOIL . "'";
 
-    $clauses['contact_id'] = $query;
+    $query = "NOT IN ($notAccessibleLeaveRequestQuery)";
+
+    //Setting this to an empty array has same effect as allowing a contact have access to all
+    //contacts on the leave request table and the Civi default ACL will not be applied
+    $clauses['contact_id'] = [];
+    //Remove leave request ID's that the contact does not have access to
+    $clauses['id'] = $query;
 
     CRM_Utils_Hook::selectWhereClause($this, $clauses);
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissionsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissionsTest.php
@@ -95,10 +95,7 @@ class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extend
             'from_date_type' => '1',
             'to_date' => '2016-10-20 23:45:00',
             'to_date_type' => '1',
-            'toil_duration' => '200',
-            'toil_to_accrue' => '1',
-            'toil_expiry_date' => '2016-11-01',
-            'request_type' => 'toil',
+            'request_type' => 'leave',
             'is_deleted' => '0',
             'from_date_amount' => '0.00',
             'to_date_amount' => '0.00',
@@ -122,10 +119,7 @@ class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extend
             'from_date_type' => '1',
             'to_date' => '2016-12-15 23:45:00',
             'to_date_type' => '1',
-            'toil_duration' => '360',
-            'toil_to_accrue' => '2',
-            'toil_expiry_date' => '2016-12-31',
-            'request_type' => 'toil',
+            'request_type' => 'leave',
             'is_deleted' => '0',
             'from_date_amount' => '0.00',
             'to_date_amount' => '0.00',
@@ -191,7 +185,7 @@ class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extend
           ],
       ],
   ];
-  
+
   public function testProcessWhenUserIsNotAnAdminUser() {
     $this->setPermissions();
     //User has access to two leave contacts.
@@ -209,9 +203,6 @@ class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extend
     $expectedParams['values'][2]['from_date_amount'] = '';
     $expectedParams['values'][2]['to_date_amount'] = '';
     $expectedParams['values'][2]['balance_change'] = '';
-    $expectedParams['values'][2]['toil_duration'] = '';
-    $expectedParams['values'][2]['toil_to_accrue'] = '';
-    $expectedParams['values'][2]['toil_expiry_date'] = '';
     $expectedParams['values'][2]['type_id'] = '';
     $expectedParams['values'][4]['sickness_reason'] = '';
     $expectedParams['values'][4]['from_date_amount'] = '';
@@ -266,9 +257,6 @@ class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extend
     $expectedParams['values'][2]['from_date_amount'] = '';
     $expectedParams['values'][2]['to_date_amount'] = '';
     $expectedParams['values'][2]['balance_change'] = '';
-    $expectedParams['values'][2]['toil_duration'] = '';
-    $expectedParams['values'][2]['toil_to_accrue'] = '';
-    $expectedParams['values'][2]['toil_expiry_date'] = '';
     $expectedParams['values'][2]['type_id'] = '';
     $expectedParams['values'][4]['sickness_reason'] = '';
     $expectedParams['values'][4]['from_date_amount'] = '';

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -3892,6 +3892,63 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals($contact2['id'], $result['values'][0]['contact_id']);
   }
 
+  public function testGetAndGetFullShouldReturnToilRequestsForAllContactsWhenLoggedInUserIsAnAdmin() {
+    $admin = ContactFabricator::fabricate();
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    $this->registerCurrentLoggedInContactInSession($admin['id']);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API', 'view all contacts'];
+
+    HRJobContractFabricator::fabricate(
+      [ 'contact_id' => $contact2['id'] ],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => '2016-10-01'
+      ]
+    );
+
+    HRJobContractFabricator::fabricate(
+      [ 'contact_id' => $contact1['id'] ],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => '2016-10-01'
+      ]
+    );
+
+    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contact1['id'],
+      'type_id' => $this->absenceType->id,
+      'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
+      'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
+      'status_id' => 1,
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
+    ]);
+
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contact2['id'],
+      'type_id' => $this->absenceType->id,
+      'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
+      'to_date' =>  CRM_Utils_Date::processDate('2016-02-23'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
+      'status_id' => 1,
+      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
+    ]);
+
+    $result = civicrm_api3('LeaveRequest', 'get', ['check_permissions' => true, 'sequential' => 1]);
+    $this->assertEquals(2, $result['count']);
+    $this->assertEquals($contact1['id'], $result['values'][0]['contact_id']);
+    $this->assertEquals($contact2['id'], $result['values'][1]['contact_id']);
+
+    $result = civicrm_api3('LeaveRequest', 'getfull', ['check_permissions' => true, 'sequential' => 1]);
+    $this->assertEquals(2, $result['count']);
+    $this->assertEquals($contact1['id'], $result['values'][0]['contact_id']);
+    $this->assertEquals($contact2['id'], $result['values'][1]['contact_id']);
+  }
+
   public function testGetAndGetFullReturnsAllDataWhenLoggedInUserHasViewAllContactsPermission() {
     $adminID = 1;
     $contact1 = ContactFabricator::fabricate();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -1770,7 +1770,6 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'to_date' => CRM_Utils_Date::processDate('2016-01-05'),
       'from_date_type' => 1,
       'to_date_type' => 1,
-      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
     ], true);
 
     // The manager will see results for the contact with the inactive leave manager relationship.
@@ -1782,14 +1781,12 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals(1, $result['count']);
     $contactData = array_shift($result['values']);
     $this->assertEquals($staffMember2['id'], $contactData['contact_id']);
-    $this->assertEquals('', $contactData['toil_duration']);
-    $this->assertEquals('', $contactData['toil_to_accrue']);
+    $this->assertEquals('', $contactData['type_id']);
 
     $this->assertEquals(1, $resultGetFull['count']);
     $contactData = array_shift($resultGetFull['values']);
     $this->assertEquals($staffMember2['id'], $contactData['contact_id']);
-    $this->assertEquals('', $contactData['toil_duration']);
-    $this->assertEquals('', $contactData['toil_to_accrue']);
+    $this->assertEquals('', $contactData['type_id']);
     $this->assertEquals('', $contactData['balance_change']);
   }
 
@@ -3677,9 +3674,6 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'from_date_type' => 1,
       'to_date_type' => 1,
       'status_id' => 1,
-      'toil_to_accrue' => 1,
-      'toil_duration' => 60,
-      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL,
     ], true);
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
@@ -3690,9 +3684,6 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'from_date_type' => 1,
       'to_date_type' => 1,
       'status_id' => 1,
-      'toil_to_accrue' => 1,
-      'toil_duration' => 30,
-      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL,
     ], true);
 
     //The logged in contact would be able to see results for the other contact too since the Leave ACL
@@ -3700,23 +3691,19 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $result = civicrm_api3('LeaveRequest', 'get', ['check_permissions' => true, 'sequential' => 1]);
     $this->assertEquals(2, $result['count']);
     $this->assertEquals($contact1['id'], $result['values'][0]['contact_id']);
-    $this->assertEquals($leaveRequest1->toil_to_accrue, $result['values'][0]['toil_to_accrue']);
-    $this->assertEquals($leaveRequest1->toil_duration, $result['values'][0]['toil_duration']);
+    $this->assertEquals($leaveRequest1->type_id, $result['values'][0]['type_id']);
 
     $this->assertEquals($contact2['id'], $result['values'][1]['contact_id']);
-    $this->assertEquals('', $result['values'][1]['toil_to_accrue']);
-    $this->assertEquals('', $result['values'][1]['toil_duration']);
+    $this->assertEquals('', $result['values'][1]['type_id']);
 
     $result = civicrm_api3('LeaveRequest', 'getfull', ['check_permissions' => true, 'sequential' => 1]);
     $this->assertEquals(2, $result['count']);
     $this->assertEquals($contact1['id'], $result['values'][0]['contact_id']);
-    $this->assertEquals($leaveRequest1->toil_to_accrue, $result['values'][0]['toil_to_accrue']);
-    $this->assertEquals($leaveRequest1->toil_duration, $result['values'][0]['toil_duration']);
+    $this->assertEquals($leaveRequest1->type_id, $result['values'][0]['type_id']);
     $this->assertNotEmpty($result['values'][0]['balance_change']);
 
     $this->assertEquals($contact2['id'], $result['values'][1]['contact_id']);
-    $this->assertEquals('', $result['values'][1]['toil_to_accrue']);
-    $this->assertEquals('', $result['values'][1]['toil_duration']);
+    $this->assertEquals('', $result['values'][1]['type_id']);
     $this->assertEquals('', $result['values'][1]['balance_change']);
   }
 
@@ -3754,9 +3741,6 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'from_date_type' => 1,
       'to_date_type' => 1,
       'status_id' => 1,
-      'toil_to_accrue' => 2,
-      'toil_duration' => 60,
-      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
     ], true);
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
@@ -3767,9 +3751,6 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'from_date_type' => 1,
       'to_date_type' => 1,
       'status_id' => 1,
-      'toil_to_accrue' => 1,
-      'toil_duration' => 60,
-      'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
     ], true);
 
     //Results will be returned for both leave contacts even though contact1 is not being managed by
@@ -3779,24 +3760,20 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals(2, $result['count']);
 
     $this->assertEquals($contact1['id'], $result['values'][0]['contact_id']);
-    $this->assertEquals('', $result['values'][0]['toil_duration']);
-    $this->assertEquals('', $result['values'][0]['toil_to_accrue']);
+    $this->assertEquals('', $result['values'][0]['type_id']);
 
     $this->assertEquals($contact2['id'], $result['values'][1]['contact_id']);
-    $this->assertEquals($leaveRequest2->toil_duration, $result['values'][1]['toil_duration']);
-    $this->assertEquals($leaveRequest2->toil_to_accrue, $result['values'][1]['toil_to_accrue']);
+    $this->assertEquals($leaveRequest2->type_id, $result['values'][1]['type_id']);
 
     $result = civicrm_api3('LeaveRequest', 'getfull', ['check_permissions' => true, 'sequential' => 1]);
     $this->assertEquals(2, $result['count']);
 
     $this->assertEquals($contact1['id'], $result['values'][0]['contact_id']);
-    $this->assertEquals('', $result['values'][0]['toil_duration']);
-    $this->assertEquals('', $result['values'][0]['toil_to_accrue']);
+    $this->assertEquals('', $result['values'][0]['type_id']);
     $this->assertEquals('', $result['values'][0]['balance_change']);
 
     $this->assertEquals($contact2['id'], $result['values'][1]['contact_id']);
-    $this->assertEquals($leaveRequest2->toil_duration, $result['values'][1]['toil_duration']);
-    $this->assertEquals($leaveRequest2->toil_to_accrue, $result['values'][1]['toil_to_accrue']);
+    $this->assertEquals($leaveRequest2->type_id, $result['values'][1]['type_id']);
     $this->assertNotEmpty($result['values'][1]['balance_change']);
   }
 


### PR DESCRIPTION
## Overview
Currently, A contact can fetch TOIL requests for other contacts he does not have access to, For example a Manager can fetch TOIL requests for contacts other than his managees via the API.
Based on the requirement for the new Staff Calendar, this task makes sure that the Leave ACL rules is implemented for TOIL requests when fetching requests via the API, i.e
- The Staff can only fetch own TOIL requests
- Manager can only fetch  TOIL requests of managees
- Admin can fetch all TOIL requests.

## Before
- A contact can fetch TOIL requests for other contacts he does not have access to.

## After
- A contact can not fetch TOIL requests for contacts he does not have access to.

## Technical Details
- The LeaveRequest BAO implementation of the  `addSelectWhereClause` method by ensuring that TOIL Leave requests belonging to contacts that the contact does not have access to is excluded from the result set.


