### PR TITLE
PCHR-3743: Tool Icon Mouse Pointer Job Contract

### DIFF
--- a/hrjobcontract/views/modalChangeReason.html
+++ b/hrjobcontract/views/modalChangeReason.html
@@ -16,8 +16,8 @@
             </div>
           </div>
           <div class="col-sm-1 control-label">
-            <a class="pointer">
-              <i class="crm-i fa-wrench" ng-click="openRevisionChangeReasonEditor()"></i>
+            <a href ng-click="openRevisionChangeReasonEditor()">
+              <i class="crm-i fa-wrench"></i>
             </a>
           </div>
         </div>

--- a/hrjobcontract/views/modalForm.html
+++ b/hrjobcontract/views/modalForm.html
@@ -41,8 +41,8 @@
                   </div>
                 </div>
                 <div class="col-sm-1 control-label">
-                  <a class="pointer">
-                    <i class="crm-i fa-wrench" ng-click="openOptionsEditor('/civicrm/admin/options/hrjc_contract_type?reset=1', 'hrjobcontract_details_contract_type')"></i>
+                  <a href ng-click="openOptionsEditor('/civicrm/admin/options/hrjc_contract_type?reset=1', 'hrjobcontract_details_contract_type')">
+                    <i class="crm-i fa-wrench"></i>
                   </a>
                 </div>
               </div>
@@ -59,8 +59,8 @@
                   </div>
                 </div>
                 <div class="col-sm-1 control-label">
-                  <a class="pointer">
-                    <i class="crm-i fa-wrench" ng-click="openOptionsEditor('/civicrm/admin/options/hrjc_location?reset=1', 'hrjobcontract_details_location')"></i>
+                  <a href ng-click="openOptionsEditor('/civicrm/admin/options/hrjc_location?reset=1', 'hrjobcontract_details_location')">
+                    <i class="crm-i fa-wrench"></i>
                   </a>
                 </div>
               </div>
@@ -121,8 +121,8 @@
                   </div>
                 </div>
                 <div class="col-sm-1 control-label">
-                  <a class="pointer">
-                    <i class="crm-i fa-wrench" ng-click="openOptionsEditor('/civicrm/admin/options/hrjc_contract_end_reason?reset=1', 'hrjobcontract_details_end_reason')"></i>
+                  <a href ng-click="openOptionsEditor('/civicrm/admin/options/hrjc_contract_end_reason?reset=1', 'hrjobcontract_details_end_reason')">
+                    <i class="crm-i fa-wrench"></i>
                   </a>
                 </div>
               </div>
@@ -253,8 +253,8 @@
                   </div>
                 </div>
                 <div class="col-sm-1 control-label">
-                  <a class="pointer">
-                    <i class="crm-i fa-wrench" ng-click="openHoursLocationOptionsEditor()"></i>
+                  <a href ng-click="openHoursLocationOptionsEditor()">
+                    <i class="crm-i fa-wrench"></i>
                   </a>
                 </div>
               </div>
@@ -347,8 +347,8 @@
                 </div>
               </div>
               <div class="col-sm-1 control-label">
-                <a class="pointer">
-                  <i class="crm-i fa-wrench" ng-click="openPayScaleGradeOptionsEditor()"></i>
+                <a href ng-click="openPayScaleGradeOptionsEditor()">
+                  <i class="crm-i fa-wrench"></i>
                 </a>
               </div>
             </div>
@@ -436,8 +436,8 @@
                                 Benefit
                               </div>
                               <div class="col-sm-2">
-                                <a class="pointer">
-                                  <i class="crm-i fa-wrench" ng-click="openAnnualBenefitOptionsEditor()"></i>
+                                <a href ng-click="openAnnualBenefitOptionsEditor()">
+                                  <i class="crm-i fa-wrench"></i>
                                 </a>
                               </div>
                             </div>
@@ -517,8 +517,8 @@
                                 Deduction
                               </div>
                               <div class="col-sm-2">
-                                <a class="pointer">
-                                  <i class="crm-i fa-wrench" ng-click="openAnnualDeductionOptionsEditor()"></i>
+                                <a href ng-click="openAnnualDeductionOptionsEditor()">
+                                  <i class="crm-i fa-wrench"></i>
                                 </a>
                               </div>
                             </div>
@@ -712,8 +712,8 @@
                   </div>
                 </div>
                 <div class="col-sm-1 control-label">
-                  <a class="pointer">
-                    <i class="crm-i fa-wrench" ng-click="openOptionsEditor('/civicrm/admin/options/hrjc_insurance_plantype?reset=1', 'hrjobcontract_health_health_plan_type')"></i>
+                  <a href ng-click="openOptionsEditor('/civicrm/admin/options/hrjc_insurance_plantype?reset=1', 'hrjobcontract_health_health_plan_type')">
+                    <i class="crm-i fa-wrench"></i>
                   </a>
                 </div>
               </div>
@@ -790,8 +790,8 @@
                   </div>
                 </div>
                 <div class="col-sm-1 control-label">
-                  <a class="pointer">
-                    <i class="crm-i fa-wrench" ng-click="openOptionsEditor('/civicrm/admin/options/hrjc_insurance_plantype?reset=1', 'hrjobcontract_health_health_plan_type')"></i>
+                  <a href ng-click="openOptionsEditor('/civicrm/admin/options/hrjc_insurance_plantype?reset=1', 'hrjobcontract_health_health_plan_type')">
+                    <i class="crm-i fa-wrench"></i>
                   </a>
                 </div>
               </div>


### PR DESCRIPTION
## Overview
This PR fixes issue with mouse pointer in Job Contract for staff.

## Before
![before_jc](https://user-images.githubusercontent.com/1507645/40733466-a4dfdafc-642d-11e8-961d-12631ca10fcd.gif)


## After
![after_jc](https://user-images.githubusercontent.com/1507645/40733489-ad4f9524-642d-11e8-835d-9d690d8446c0.gif)


## Technical Details
The class pointer was not defined in the `hrjobcontract` extension css and thus removed. In place of the css, `href` markup was used. Sample snippet is shown below:
```html
<a href ng-click="openOptionsEditor('/civicrm/admin/options/hrjc_contract_type?reset=1', 'hrjobcontract_details_contract_type')">
  <i class="crm-i fa-wrench"></i>
</a>
```

---
✅Manual Tests - passed
