### PR TITLE
PCHR-3724: Sync styles with Shoreditch

### DIFF
--- a/hrjobcontract/config.rb
+++ b/hrjobcontract/config.rb
@@ -17,7 +17,7 @@ javascripts_dir = "js"
 # relative_assets = true
 
 # To disable debugging comments that display the original location of your selectors. Uncomment:
-# line_comments = false
+line_comments = false
 
 
 # If you prefer the indented syntax, you might want to regenerate this

--- a/hrjobcontract/css/hrjc.css
+++ b/hrjobcontract/css/hrjc.css
@@ -1,5 +1,4 @@
 @charset "UTF-8";
-/* line 8, ../scss/hrjc.scss */
 #hrjob-contract {
   /**
    * Unset Eric Meyer's Reset CSS styles.
@@ -72,7 +71,6 @@
    * Ad-hoc customizations
    */
 }
-/* line 7, ../scss/civihr/modules/_unset.scss */
 #hrjob-contract html,
 #hrjob-contract body,
 #hrjob-contract div,
@@ -146,7 +144,6 @@
   border: initial;
   vertical-align: initial;
 }
-/* line 79, ../scss/civihr/modules/_unset.scss */
 #hrjob-contract ol,
 #hrjob-contract ul {
   padding-start: 40px;
@@ -154,48 +151,39 @@
   -webkit-padding-start: 40px;
   list-style: initial;
 }
-/* line 86, ../scss/civihr/modules/_unset.scss */
 #hrjob-contract blockquote,
 #hrjob-contract q {
   quotes: initial;
 }
-/* line 90, ../scss/civihr/modules/_unset.scss */
 #hrjob-contract blockquote:before,
 #hrjob-contract blockquote:after,
 #hrjob-contract q:before,
 #hrjob-contract q:after {
   content: initial;
 }
-/* line 98, ../scss/civihr/modules/_unset.scss */
 #hrjob-contract ins {
   text-decoration: initial;
 }
-/* line 101, ../scss/civihr/modules/_unset.scss */
 #hrjob-contract del {
   text-decoration: initial;
 }
-/* line 106, ../scss/civihr/modules/_unset.scss */
 #hrjob-contract table {
   border-collapse: initial;
   border-spacing: initial;
 }
-/* line 110, ../scss/civihr/modules/_unset.scss */
 #hrjob-contract table td, #hrjob-contract table th {
   color: inherit;
   font-size: inherit;
 }
-/* line 123, ../scss/civihr/modules/_unset.scss */
 #hrjob-contract input,
 #hrjob-contract select,
 #hrjob-contract textarea {
   font-family: initial;
 }
-/* line 128, ../scss/civihr/modules/_unset.scss */
 #hrjob-contract textarea {
   font-size: initial;
   line-height: initial;
 }
-/* line 32, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract article,
 #hrjob-contract aside,
 #hrjob-contract details,
@@ -211,7 +199,6 @@
 #hrjob-contract summary {
   display: block;
 }
-/* line 53, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract audio,
 #hrjob-contract canvas,
 #hrjob-contract progress,
@@ -219,53 +206,42 @@
   display: inline-block;
   vertical-align: baseline;
 }
-/* line 66, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract audio:not([controls]) {
   display: none;
   height: 0;
 }
-/* line 76, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract [hidden],
 #hrjob-contract template {
   display: none;
 }
-/* line 88, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract a {
   background-color: transparent;
 }
-/* line 96, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract a:active,
 #hrjob-contract a:hover {
   outline: 0;
 }
-/* line 108, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract abbr[title] {
   border-bottom: 1px dotted;
 }
-/* line 116, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract b,
 #hrjob-contract strong {
   font-weight: bold;
 }
-/* line 125, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract dfn {
   font-style: italic;
 }
-/* line 134, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract h1 {
   font-size: 2em;
   margin: 0.67em 0;
 }
-/* line 143, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract mark {
   background: #ff0;
   color: #000;
 }
-/* line 152, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract small {
   font-size: 80%;
 }
-/* line 160, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract sub,
 #hrjob-contract sup {
   font-size: 75%;
@@ -273,37 +249,29 @@
   position: relative;
   vertical-align: baseline;
 }
-/* line 168, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract sup {
   top: -0.5em;
 }
-/* line 172, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract sub {
   bottom: -0.25em;
 }
-/* line 183, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract img {
   border: 0;
 }
-/* line 191, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract svg:not(:root) {
   overflow: hidden;
 }
-/* line 202, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract figure {
   margin: 1em 40px;
 }
-/* line 210, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract hr {
   -moz-box-sizing: content-box;
   box-sizing: content-box;
   height: 0;
 }
-/* line 220, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract pre {
   overflow: auto;
 }
-/* line 228, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract code,
 #hrjob-contract kbd,
 #hrjob-contract pre,
@@ -311,7 +279,6 @@
   font-family: monospace, monospace;
   font-size: 1em;
 }
-/* line 251, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract button,
 #hrjob-contract input,
 #hrjob-contract optgroup,
@@ -321,16 +288,13 @@
   font: inherit;
   margin: 0;
 }
-/* line 265, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract button {
   overflow: visible;
 }
-/* line 276, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract button,
 #hrjob-contract select {
   text-transform: none;
 }
-/* line 289, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract button,
 #hrjob-contract input[type="button"],
 #hrjob-contract input[type="reset"],
@@ -338,75 +302,61 @@
   -webkit-appearance: button;
   cursor: pointer;
 }
-/* line 301, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract button[disabled],
 #hrjob-contract input[disabled] {
   cursor: default;
 }
-/* line 310, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract button::-moz-focus-inner,
 #hrjob-contract input::-moz-focus-inner {
   border: 0;
   padding: 0;
 }
-/* line 321, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract input {
   line-height: normal;
 }
-/* line 333, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract input[type="checkbox"],
 #hrjob-contract input[type="radio"] {
   box-sizing: border-box;
   padding: 0;
 }
-/* line 345, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract input[type="number"]::-webkit-inner-spin-button,
 #hrjob-contract input[type="number"]::-webkit-outer-spin-button {
   height: auto;
 }
-/* line 356, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract input[type="search"] {
   -webkit-appearance: textfield;
   -moz-box-sizing: content-box;
   -webkit-box-sizing: content-box;
   box-sizing: content-box;
 }
-/* line 369, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract input[type="search"]::-webkit-search-cancel-button,
 #hrjob-contract input[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
-/* line 378, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract fieldset {
   border: 1px solid #c0c0c0;
   margin: 0 2px;
   padding: 0.35em 0.625em 0.75em;
 }
-/* line 389, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract legend {
   border: 0;
   padding: 0;
 }
-/* line 398, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract textarea {
   overflow: auto;
 }
-/* line 407, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract optgroup {
   font-weight: bold;
 }
-/* line 418, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract table {
   border-collapse: collapse;
   border-spacing: 0;
 }
-/* line 423, ../scss/civihr/bootstrap/_normalize-custom.scss */
 #hrjob-contract td,
 #hrjob-contract th {
   padding: 0;
 }
 @media print {
-  /* line 9, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_print.scss */
   #hrjob-contract *,
   #hrjob-contract *:before,
   #hrjob-contract *:after {
@@ -415,78 +365,62 @@
     box-shadow: none !important;
     text-shadow: none !important;
   }
-  /* line 18, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_print.scss */
   #hrjob-contract a,
   #hrjob-contract a:visited {
     text-decoration: underline;
   }
-  /* line 23, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_print.scss */
   #hrjob-contract a[href]:after {
     content: " (" attr(href) ")";
   }
-  /* line 27, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_print.scss */
   #hrjob-contract abbr[title]:after {
     content: " (" attr(title) ")";
   }
-  /* line 33, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_print.scss */
   #hrjob-contract a[href^="#"]:after,
   #hrjob-contract a[href^="javascript:"]:after {
     content: "";
   }
-  /* line 38, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_print.scss */
   #hrjob-contract pre,
   #hrjob-contract blockquote {
     border: 1px solid #999;
     page-break-inside: avoid;
   }
-  /* line 44, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_print.scss */
   #hrjob-contract thead {
     display: table-header-group;
   }
-  /* line 48, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_print.scss */
   #hrjob-contract tr,
   #hrjob-contract img {
     page-break-inside: avoid;
   }
-  /* line 53, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_print.scss */
   #hrjob-contract img {
     max-width: 100% !important;
   }
-  /* line 57, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_print.scss */
   #hrjob-contract p,
   #hrjob-contract h2,
   #hrjob-contract h3 {
     orphans: 3;
     widows: 3;
   }
-  /* line 64, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_print.scss */
   #hrjob-contract h2,
   #hrjob-contract h3 {
     page-break-after: avoid;
   }
-  /* line 72, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_print.scss */
   #hrjob-contract .navbar {
     display: none;
   }
-  /* line 77, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_print.scss */
   #hrjob-contract .btn > .caret,
   #hrjob-contract .dropup > .btn > .caret {
     border-top-color: #000 !important;
   }
-  /* line 81, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_print.scss */
   #hrjob-contract .label {
     border: 1px solid #000;
   }
-  /* line 85, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_print.scss */
   #hrjob-contract .table {
     border-collapse: collapse !important;
   }
-  /* line 88, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_print.scss */
   #hrjob-contract .table td,
   #hrjob-contract .table th {
     background-color: #fff !important;
   }
-  /* line 94, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_print.scss */
   #hrjob-contract .table-bordered th,
   #hrjob-contract .table-bordered td {
     border: 1px solid #ddd !important;
@@ -494,10 +428,9 @@
 }
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: url("../fonts/bootstrap/glyphicons-halflings-regular.eot");
-  src: url("../fonts/bootstrap/glyphicons-halflings-regular.eot?#iefix") format("embedded-opentype"), url("../fonts/bootstrap/glyphicons-halflings-regular.woff") format("woff"), url("../fonts/bootstrap/glyphicons-halflings-regular.ttf") format("truetype"), url("../fonts/bootstrap/glyphicons-halflings-regular.svg#glyphicons_halflingsregular") format("svg");
+  src: url(font-path("../fonts/bootstrap/glyphicons-halflings-regular.eot"));
+  src: url(font-path("../fonts/bootstrap/glyphicons-halflings-regular.eot?#iefix")) format("embedded-opentype"), url(font-path("../fonts/bootstrap/glyphicons-halflings-regular.woff")) format("woff"), url(font-path("../fonts/bootstrap/glyphicons-halflings-regular.ttf")) format("truetype"), url(font-path("../fonts/bootstrap/glyphicons-halflings-regular.svg#glyphicons_halflingsregular")) format("svg");
 }
-/* line 26, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon {
   position: relative;
   top: 1px;
@@ -509,804 +442,604 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-/* line 39, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-asterisk:before {
   content: "\2a";
 }
-/* line 40, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-plus:before {
   content: "\2b";
 }
-/* line 42, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-euro:before,
 #hrjob-contract .glyphicon-eur:before {
   content: "\20ac";
 }
-/* line 43, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-minus:before {
   content: "\2212";
 }
-/* line 44, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-cloud:before {
   content: "\2601";
 }
-/* line 45, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-envelope:before {
   content: "\2709";
 }
-/* line 46, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-pencil:before {
   content: "\270f";
 }
-/* line 47, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-glass:before {
   content: "\e001";
 }
-/* line 48, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-music:before {
   content: "\e002";
 }
-/* line 49, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-search:before {
   content: "\e003";
 }
-/* line 50, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-heart:before {
   content: "\e005";
 }
-/* line 51, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-star:before {
   content: "\e006";
 }
-/* line 52, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-star-empty:before {
   content: "\e007";
 }
-/* line 53, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-user:before {
   content: "\e008";
 }
-/* line 54, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-film:before {
   content: "\e009";
 }
-/* line 55, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-th-large:before {
   content: "\e010";
 }
-/* line 56, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-th:before {
   content: "\e011";
 }
-/* line 57, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-th-list:before {
   content: "\e012";
 }
-/* line 58, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-ok:before {
   content: "\e013";
 }
-/* line 59, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-remove:before {
   content: "\e014";
 }
-/* line 60, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-zoom-in:before {
   content: "\e015";
 }
-/* line 61, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-zoom-out:before {
   content: "\e016";
 }
-/* line 62, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-off:before {
   content: "\e017";
 }
-/* line 63, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-signal:before {
   content: "\e018";
 }
-/* line 64, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-cog:before {
   content: "\e019";
 }
-/* line 65, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-trash:before {
   content: "\e020";
 }
-/* line 66, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-home:before {
   content: "\e021";
 }
-/* line 67, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-file:before {
   content: "\e022";
 }
-/* line 68, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-time:before {
   content: "\e023";
 }
-/* line 69, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-road:before {
   content: "\e024";
 }
-/* line 70, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-download-alt:before {
   content: "\e025";
 }
-/* line 71, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-download:before {
   content: "\e026";
 }
-/* line 72, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-upload:before {
   content: "\e027";
 }
-/* line 73, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-inbox:before {
   content: "\e028";
 }
-/* line 74, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-play-circle:before {
   content: "\e029";
 }
-/* line 75, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-repeat:before {
   content: "\e030";
 }
-/* line 76, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-refresh:before {
   content: "\e031";
 }
-/* line 77, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-list-alt:before {
   content: "\e032";
 }
-/* line 78, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-lock:before {
   content: "\e033";
 }
-/* line 79, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-flag:before {
   content: "\e034";
 }
-/* line 80, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-headphones:before {
   content: "\e035";
 }
-/* line 81, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-volume-off:before {
   content: "\e036";
 }
-/* line 82, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-volume-down:before {
   content: "\e037";
 }
-/* line 83, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-volume-up:before {
   content: "\e038";
 }
-/* line 84, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-qrcode:before {
   content: "\e039";
 }
-/* line 85, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-barcode:before {
   content: "\e040";
 }
-/* line 86, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-tag:before {
   content: "\e041";
 }
-/* line 87, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-tags:before {
   content: "\e042";
 }
-/* line 88, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-book:before {
   content: "\e043";
 }
-/* line 89, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-bookmark:before {
   content: "\e044";
 }
-/* line 90, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-print:before {
   content: "\e045";
 }
-/* line 91, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-camera:before {
   content: "\e046";
 }
-/* line 92, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-font:before {
   content: "\e047";
 }
-/* line 93, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-bold:before {
   content: "\e048";
 }
-/* line 94, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-italic:before {
   content: "\e049";
 }
-/* line 95, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-text-height:before {
   content: "\e050";
 }
-/* line 96, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-text-width:before {
   content: "\e051";
 }
-/* line 97, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-align-left:before {
   content: "\e052";
 }
-/* line 98, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-align-center:before {
   content: "\e053";
 }
-/* line 99, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-align-right:before {
   content: "\e054";
 }
-/* line 100, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-align-justify:before {
   content: "\e055";
 }
-/* line 101, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-list:before {
   content: "\e056";
 }
-/* line 102, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-indent-left:before {
   content: "\e057";
 }
-/* line 103, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-indent-right:before {
   content: "\e058";
 }
-/* line 104, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-facetime-video:before {
   content: "\e059";
 }
-/* line 105, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-picture:before {
   content: "\e060";
 }
-/* line 106, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-map-marker:before {
   content: "\e062";
 }
-/* line 107, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-adjust:before {
   content: "\e063";
 }
-/* line 108, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-tint:before {
   content: "\e064";
 }
-/* line 109, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-edit:before {
   content: "\e065";
 }
-/* line 110, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-share:before {
   content: "\e066";
 }
-/* line 111, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-check:before {
   content: "\e067";
 }
-/* line 112, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-move:before {
   content: "\e068";
 }
-/* line 113, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-step-backward:before {
   content: "\e069";
 }
-/* line 114, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-fast-backward:before {
   content: "\e070";
 }
-/* line 115, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-backward:before {
   content: "\e071";
 }
-/* line 116, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-play:before {
   content: "\e072";
 }
-/* line 117, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-pause:before {
   content: "\e073";
 }
-/* line 118, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-stop:before {
   content: "\e074";
 }
-/* line 119, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-forward:before {
   content: "\e075";
 }
-/* line 120, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-fast-forward:before {
   content: "\e076";
 }
-/* line 121, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-step-forward:before {
   content: "\e077";
 }
-/* line 122, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-eject:before {
   content: "\e078";
 }
-/* line 123, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-chevron-left:before {
   content: "\e079";
 }
-/* line 124, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-chevron-right:before {
   content: "\e080";
 }
-/* line 125, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-plus-sign:before {
   content: "\e081";
 }
-/* line 126, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-minus-sign:before {
   content: "\e082";
 }
-/* line 127, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-remove-sign:before {
   content: "\e083";
 }
-/* line 128, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-ok-sign:before {
   content: "\e084";
 }
-/* line 129, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-question-sign:before {
   content: "\e085";
 }
-/* line 130, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-info-sign:before {
   content: "\e086";
 }
-/* line 131, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-screenshot:before {
   content: "\e087";
 }
-/* line 132, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-remove-circle:before {
   content: "\e088";
 }
-/* line 133, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-ok-circle:before {
   content: "\e089";
 }
-/* line 134, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-ban-circle:before {
   content: "\e090";
 }
-/* line 135, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-arrow-left:before {
   content: "\e091";
 }
-/* line 136, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-arrow-right:before {
   content: "\e092";
 }
-/* line 137, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-arrow-up:before {
   content: "\e093";
 }
-/* line 138, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-arrow-down:before {
   content: "\e094";
 }
-/* line 139, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-share-alt:before {
   content: "\e095";
 }
-/* line 140, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-resize-full:before {
   content: "\e096";
 }
-/* line 141, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-resize-small:before {
   content: "\e097";
 }
-/* line 142, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-exclamation-sign:before {
   content: "\e101";
 }
-/* line 143, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-gift:before {
   content: "\e102";
 }
-/* line 144, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-leaf:before {
   content: "\e103";
 }
-/* line 145, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-fire:before {
   content: "\e104";
 }
-/* line 146, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-eye-open:before {
   content: "\e105";
 }
-/* line 147, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-eye-close:before {
   content: "\e106";
 }
-/* line 148, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-warning-sign:before {
   content: "\e107";
 }
-/* line 149, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-plane:before {
   content: "\e108";
 }
-/* line 150, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-calendar:before {
   content: "\e109";
 }
-/* line 151, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-random:before {
   content: "\e110";
 }
-/* line 152, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-comment:before {
   content: "\e111";
 }
-/* line 153, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-magnet:before {
   content: "\e112";
 }
-/* line 154, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-chevron-up:before {
   content: "\e113";
 }
-/* line 155, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-chevron-down:before {
   content: "\e114";
 }
-/* line 156, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-retweet:before {
   content: "\e115";
 }
-/* line 157, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-shopping-cart:before {
   content: "\e116";
 }
-/* line 158, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-folder-close:before {
   content: "\e117";
 }
-/* line 159, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-folder-open:before {
   content: "\e118";
 }
-/* line 160, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-resize-vertical:before {
   content: "\e119";
 }
-/* line 161, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-resize-horizontal:before {
   content: "\e120";
 }
-/* line 162, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-hdd:before {
   content: "\e121";
 }
-/* line 163, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-bullhorn:before {
   content: "\e122";
 }
-/* line 164, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-bell:before {
   content: "\e123";
 }
-/* line 165, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-certificate:before {
   content: "\e124";
 }
-/* line 166, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-thumbs-up:before {
   content: "\e125";
 }
-/* line 167, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-thumbs-down:before {
   content: "\e126";
 }
-/* line 168, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-hand-right:before {
   content: "\e127";
 }
-/* line 169, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-hand-left:before {
   content: "\e128";
 }
-/* line 170, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-hand-up:before {
   content: "\e129";
 }
-/* line 171, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-hand-down:before {
   content: "\e130";
 }
-/* line 172, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-circle-arrow-right:before {
   content: "\e131";
 }
-/* line 173, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-circle-arrow-left:before {
   content: "\e132";
 }
-/* line 174, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-circle-arrow-up:before {
   content: "\e133";
 }
-/* line 175, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-circle-arrow-down:before {
   content: "\e134";
 }
-/* line 176, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-globe:before {
   content: "\e135";
 }
-/* line 177, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-wrench:before {
   content: "\e136";
 }
-/* line 178, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-tasks:before {
   content: "\e137";
 }
-/* line 179, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-filter:before {
   content: "\e138";
 }
-/* line 180, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-briefcase:before {
   content: "\e139";
 }
-/* line 181, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-fullscreen:before {
   content: "\e140";
 }
-/* line 182, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-dashboard:before {
   content: "\e141";
 }
-/* line 183, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-paperclip:before {
   content: "\e142";
 }
-/* line 184, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-heart-empty:before {
   content: "\e143";
 }
-/* line 185, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-link:before {
   content: "\e144";
 }
-/* line 186, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-phone:before {
   content: "\e145";
 }
-/* line 187, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-pushpin:before {
   content: "\e146";
 }
-/* line 188, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-usd:before {
   content: "\e148";
 }
-/* line 189, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-gbp:before {
   content: "\e149";
 }
-/* line 190, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-sort:before {
   content: "\e150";
 }
-/* line 191, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-sort-by-alphabet:before {
   content: "\e151";
 }
-/* line 192, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-sort-by-alphabet-alt:before {
   content: "\e152";
 }
-/* line 193, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-sort-by-order:before {
   content: "\e153";
 }
-/* line 194, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-sort-by-order-alt:before {
   content: "\e154";
 }
-/* line 195, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-sort-by-attributes:before {
   content: "\e155";
 }
-/* line 196, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-sort-by-attributes-alt:before {
   content: "\e156";
 }
-/* line 197, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-unchecked:before {
   content: "\e157";
 }
-/* line 198, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-expand:before {
   content: "\e158";
 }
-/* line 199, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-collapse-down:before {
   content: "\e159";
 }
-/* line 200, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-collapse-up:before {
   content: "\e160";
 }
-/* line 201, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-log-in:before {
   content: "\e161";
 }
-/* line 202, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-flash:before {
   content: "\e162";
 }
-/* line 203, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-log-out:before {
   content: "\e163";
 }
-/* line 204, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-new-window:before {
   content: "\e164";
 }
-/* line 205, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-record:before {
   content: "\e165";
 }
-/* line 206, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-save:before {
   content: "\e166";
 }
-/* line 207, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-open:before {
   content: "\e167";
 }
-/* line 208, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-saved:before {
   content: "\e168";
 }
-/* line 209, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-import:before {
   content: "\e169";
 }
-/* line 210, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-export:before {
   content: "\e170";
 }
-/* line 211, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-send:before {
   content: "\e171";
 }
-/* line 212, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-floppy-disk:before {
   content: "\e172";
 }
-/* line 213, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-floppy-saved:before {
   content: "\e173";
 }
-/* line 214, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-floppy-remove:before {
   content: "\e174";
 }
-/* line 215, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-floppy-save:before {
   content: "\e175";
 }
-/* line 216, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-floppy-open:before {
   content: "\e176";
 }
-/* line 217, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-credit-card:before {
   content: "\e177";
 }
-/* line 218, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-transfer:before {
   content: "\e178";
 }
-/* line 219, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-cutlery:before {
   content: "\e179";
 }
-/* line 220, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-header:before {
   content: "\e180";
 }
-/* line 221, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-compressed:before {
   content: "\e181";
 }
-/* line 222, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-earphone:before {
   content: "\e182";
 }
-/* line 223, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-phone-alt:before {
   content: "\e183";
 }
-/* line 224, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-tower:before {
   content: "\e184";
 }
-/* line 225, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-stats:before {
   content: "\e185";
 }
-/* line 226, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-sd-video:before {
   content: "\e186";
 }
-/* line 227, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-hd-video:before {
   content: "\e187";
 }
-/* line 228, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-subtitles:before {
   content: "\e188";
 }
-/* line 229, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-sound-stereo:before {
   content: "\e189";
 }
-/* line 230, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-sound-dolby:before {
   content: "\e190";
 }
-/* line 231, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-sound-5-1:before {
   content: "\e191";
 }
-/* line 232, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-sound-6-1:before {
   content: "\e192";
 }
-/* line 233, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-sound-7-1:before {
   content: "\e193";
 }
-/* line 234, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-copyright-mark:before {
   content: "\e194";
 }
-/* line 235, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-registration-mark:before {
   content: "\e195";
 }
-/* line 236, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-cloud-download:before {
   content: "\e197";
 }
-/* line 237, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-cloud-upload:before {
   content: "\e198";
 }
-/* line 238, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-tree-conifer:before {
   content: "\e199";
 }
-/* line 239, ../scss/civihr/bootstrap/_glyphicons-custom.scss */
 #hrjob-contract .glyphicon-tree-deciduous:before {
   content: "\e200";
 }
@@ -1317,7 +1050,6 @@
   font-weight: normal;
   font-style: normal;
 }
-/* line 16, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa {
   display: inline-block;
   font: normal normal normal 14px/1 FontAwesome;
@@ -1326,44 +1058,35 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-/* line 25, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-lg {
   font-size: 1.33333333em;
   line-height: 0.75em;
   vertical-align: -15%;
 }
-/* line 30, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-2x {
   font-size: 2em;
 }
-/* line 33, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-3x {
   font-size: 3em;
 }
-/* line 36, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-4x {
   font-size: 4em;
 }
-/* line 39, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-5x {
   font-size: 5em;
 }
-/* line 42, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-fw {
   width: 1.28571429em;
   text-align: center;
 }
-/* line 46, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-ul {
   padding-left: 0;
   margin-left: 2.14285714em;
   list-style-type: none;
 }
-/* line 51, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-ul > li {
   position: relative;
 }
-/* line 54, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-li {
   position: absolute;
   left: -2.14285714em;
@@ -1371,33 +1094,26 @@
   top: 0.14285714em;
   text-align: center;
 }
-/* line 61, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-li.fa-lg {
   left: -1.85714286em;
 }
-/* line 64, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-border {
   padding: .2em .25em .15em;
   border: solid 0.08em #eeeeee;
   border-radius: .1em;
 }
-/* line 69, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .pull-right {
   float: right;
 }
-/* line 72, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .pull-left {
   float: left;
 }
-/* line 75, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa.pull-left {
   margin-right: .3em;
 }
-/* line 78, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa.pull-right {
   margin-left: .3em;
 }
-/* line 81, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-spin {
   -webkit-animation: fa-spin 2s infinite linear;
   animation: fa-spin 2s infinite linear;
@@ -1422,42 +1138,36 @@
     transform: rotate(359deg);
   }
 }
-/* line 105, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-rotate-90 {
   filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
   -webkit-transform: rotate(90deg);
   -ms-transform: rotate(90deg);
   transform: rotate(90deg);
 }
-/* line 111, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-rotate-180 {
   filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
 }
-/* line 117, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-rotate-270 {
   filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
   -webkit-transform: rotate(270deg);
   -ms-transform: rotate(270deg);
   transform: rotate(270deg);
 }
-/* line 123, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-flip-horizontal {
   filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1);
   -webkit-transform: scale(-1, 1);
   -ms-transform: scale(-1, 1);
   transform: scale(-1, 1);
 }
-/* line 129, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-flip-vertical {
   filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1);
   -webkit-transform: scale(1, -1);
   -ms-transform: scale(1, -1);
   transform: scale(1, -1);
 }
-/* line 135, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract :root .fa-rotate-90,
 #hrjob-contract :root .fa-rotate-180,
 #hrjob-contract :root .fa-rotate-270,
@@ -1465,7 +1175,6 @@
 #hrjob-contract :root .fa-flip-vertical {
   filter: none;
 }
-/* line 142, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-stack {
   position: relative;
   display: inline-block;
@@ -1474,7 +1183,6 @@
   line-height: 2em;
   vertical-align: middle;
 }
-/* line 150, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-stack-1x,
 #hrjob-contract .fa-stack-2x {
   position: absolute;
@@ -1482,1753 +1190,1330 @@
   width: 100%;
   text-align: center;
 }
-/* line 157, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-stack-1x {
   line-height: inherit;
 }
-/* line 160, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-stack-2x {
   font-size: 2em;
 }
-/* line 163, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-inverse {
   color: #ffffff;
 }
-/* line 168, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-glass:before {
   content: "\f000";
 }
-/* line 171, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-music:before {
   content: "\f001";
 }
-/* line 174, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-search:before {
   content: "\f002";
 }
-/* line 177, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-envelope-o:before {
   content: "\f003";
 }
-/* line 180, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-heart:before {
   content: "\f004";
 }
-/* line 183, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-star:before {
   content: "\f005";
 }
-/* line 186, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-star-o:before {
   content: "\f006";
 }
-/* line 189, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-user:before {
   content: "\f007";
 }
-/* line 192, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-film:before {
   content: "\f008";
 }
-/* line 195, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-th-large:before {
   content: "\f009";
 }
-/* line 198, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-th:before {
   content: "\f00a";
 }
-/* line 201, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-th-list:before {
   content: "\f00b";
 }
-/* line 204, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-check:before {
   content: "\f00c";
 }
-/* line 207, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-remove:before,
 #hrjob-contract .fa-close:before,
 #hrjob-contract .fa-times:before {
   content: "\f00d";
 }
-/* line 212, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-search-plus:before {
   content: "\f00e";
 }
-/* line 215, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-search-minus:before {
   content: "\f010";
 }
-/* line 218, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-power-off:before {
   content: "\f011";
 }
-/* line 221, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-signal:before {
   content: "\f012";
 }
-/* line 224, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-gear:before,
 #hrjob-contract .fa-cog:before {
   content: "\f013";
 }
-/* line 228, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-trash-o:before {
   content: "\f014";
 }
-/* line 231, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-home:before {
   content: "\f015";
 }
-/* line 234, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-file-o:before {
   content: "\f016";
 }
-/* line 237, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-clock-o:before {
   content: "\f017";
 }
-/* line 240, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-road:before {
   content: "\f018";
 }
-/* line 243, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-download:before {
   content: "\f019";
 }
-/* line 246, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-arrow-circle-o-down:before {
   content: "\f01a";
 }
-/* line 249, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-arrow-circle-o-up:before {
   content: "\f01b";
 }
-/* line 252, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-inbox:before {
   content: "\f01c";
 }
-/* line 255, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-play-circle-o:before {
   content: "\f01d";
 }
-/* line 258, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-rotate-right:before,
 #hrjob-contract .fa-repeat:before {
   content: "\f01e";
 }
-/* line 262, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-refresh:before {
   content: "\f021";
 }
-/* line 265, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-list-alt:before {
   content: "\f022";
 }
-/* line 268, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-lock:before {
   content: "\f023";
 }
-/* line 271, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-flag:before {
   content: "\f024";
 }
-/* line 274, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-headphones:before {
   content: "\f025";
 }
-/* line 277, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-volume-off:before {
   content: "\f026";
 }
-/* line 280, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-volume-down:before {
   content: "\f027";
 }
-/* line 283, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-volume-up:before {
   content: "\f028";
 }
-/* line 286, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-qrcode:before {
   content: "\f029";
 }
-/* line 289, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-barcode:before {
   content: "\f02a";
 }
-/* line 292, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-tag:before {
   content: "\f02b";
 }
-/* line 295, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-tags:before {
   content: "\f02c";
 }
-/* line 298, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-book:before {
   content: "\f02d";
 }
-/* line 301, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-bookmark:before {
   content: "\f02e";
 }
-/* line 304, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-print:before {
   content: "\f02f";
 }
-/* line 307, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-camera:before {
   content: "\f030";
 }
-/* line 310, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-font:before {
   content: "\f031";
 }
-/* line 313, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-bold:before {
   content: "\f032";
 }
-/* line 316, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-italic:before {
   content: "\f033";
 }
-/* line 319, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-text-height:before {
   content: "\f034";
 }
-/* line 322, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-text-width:before {
   content: "\f035";
 }
-/* line 325, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-align-left:before {
   content: "\f036";
 }
-/* line 328, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-align-center:before {
   content: "\f037";
 }
-/* line 331, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-align-right:before {
   content: "\f038";
 }
-/* line 334, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-align-justify:before {
   content: "\f039";
 }
-/* line 337, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-list:before {
   content: "\f03a";
 }
-/* line 340, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-dedent:before,
 #hrjob-contract .fa-outdent:before {
   content: "\f03b";
 }
-/* line 344, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-indent:before {
   content: "\f03c";
 }
-/* line 347, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-video-camera:before {
   content: "\f03d";
 }
-/* line 350, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-photo:before,
 #hrjob-contract .fa-image:before,
 #hrjob-contract .fa-picture-o:before {
   content: "\f03e";
 }
-/* line 355, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-pencil:before {
   content: "\f040";
 }
-/* line 358, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-map-marker:before {
   content: "\f041";
 }
-/* line 361, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-adjust:before {
   content: "\f042";
 }
-/* line 364, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-tint:before {
   content: "\f043";
 }
-/* line 367, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-edit:before,
 #hrjob-contract .fa-pencil-square-o:before {
   content: "\f044";
 }
-/* line 371, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-share-square-o:before {
   content: "\f045";
 }
-/* line 374, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-check-square-o:before {
   content: "\f046";
 }
-/* line 377, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-arrows:before {
   content: "\f047";
 }
-/* line 380, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-step-backward:before {
   content: "\f048";
 }
-/* line 383, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-fast-backward:before {
   content: "\f049";
 }
-/* line 386, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-backward:before {
   content: "\f04a";
 }
-/* line 389, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-play:before {
   content: "\f04b";
 }
-/* line 392, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-pause:before {
   content: "\f04c";
 }
-/* line 395, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-stop:before {
   content: "\f04d";
 }
-/* line 398, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-forward:before {
   content: "\f04e";
 }
-/* line 401, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-fast-forward:before {
   content: "\f050";
 }
-/* line 404, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-step-forward:before {
   content: "\f051";
 }
-/* line 407, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-eject:before {
   content: "\f052";
 }
-/* line 410, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-chevron-left:before {
   content: "\f053";
 }
-/* line 413, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-chevron-right:before {
   content: "\f054";
 }
-/* line 416, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-plus-circle:before {
   content: "\f055";
 }
-/* line 419, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-minus-circle:before {
   content: "\f056";
 }
-/* line 422, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-times-circle:before {
   content: "\f057";
 }
-/* line 425, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-check-circle:before {
   content: "\f058";
 }
-/* line 428, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-question-circle:before {
   content: "\f059";
 }
-/* line 431, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-info-circle:before {
   content: "\f05a";
 }
-/* line 434, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-crosshairs:before {
   content: "\f05b";
 }
-/* line 437, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-times-circle-o:before {
   content: "\f05c";
 }
-/* line 440, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-check-circle-o:before {
   content: "\f05d";
 }
-/* line 443, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-ban:before {
   content: "\f05e";
 }
-/* line 446, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-arrow-left:before {
   content: "\f060";
 }
-/* line 449, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-arrow-right:before {
   content: "\f061";
 }
-/* line 452, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-arrow-up:before {
   content: "\f062";
 }
-/* line 455, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-arrow-down:before {
   content: "\f063";
 }
-/* line 458, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-mail-forward:before,
 #hrjob-contract .fa-share:before {
   content: "\f064";
 }
-/* line 462, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-expand:before {
   content: "\f065";
 }
-/* line 465, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-compress:before {
   content: "\f066";
 }
-/* line 468, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-plus:before {
   content: "\f067";
 }
-/* line 471, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-minus:before {
   content: "\f068";
 }
-/* line 474, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-asterisk:before {
   content: "\f069";
 }
-/* line 477, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-exclamation-circle:before {
   content: "\f06a";
 }
-/* line 480, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-gift:before {
   content: "\f06b";
 }
-/* line 483, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-leaf:before {
   content: "\f06c";
 }
-/* line 486, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-fire:before {
   content: "\f06d";
 }
-/* line 489, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-eye:before {
   content: "\f06e";
 }
-/* line 492, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-eye-slash:before {
   content: "\f070";
 }
-/* line 495, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-warning:before,
 #hrjob-contract .fa-exclamation-triangle:before {
   content: "\f071";
 }
-/* line 499, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-plane:before {
   content: "\f072";
 }
-/* line 502, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-calendar:before {
   content: "\f073";
 }
-/* line 505, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-random:before {
   content: "\f074";
 }
-/* line 508, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-comment:before {
   content: "\f075";
 }
-/* line 511, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-magnet:before {
   content: "\f076";
 }
-/* line 514, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-chevron-up:before {
   content: "\f077";
 }
-/* line 517, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-chevron-down:before {
   content: "\f078";
 }
-/* line 520, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-retweet:before {
   content: "\f079";
 }
-/* line 523, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-shopping-cart:before {
   content: "\f07a";
 }
-/* line 526, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-folder:before {
   content: "\f07b";
 }
-/* line 529, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-folder-open:before {
   content: "\f07c";
 }
-/* line 532, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-arrows-v:before {
   content: "\f07d";
 }
-/* line 535, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-arrows-h:before {
   content: "\f07e";
 }
-/* line 538, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-bar-chart-o:before,
 #hrjob-contract .fa-bar-chart:before {
   content: "\f080";
 }
-/* line 542, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-twitter-square:before {
   content: "\f081";
 }
-/* line 545, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-facebook-square:before {
   content: "\f082";
 }
-/* line 548, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-camera-retro:before {
   content: "\f083";
 }
-/* line 551, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-key:before {
   content: "\f084";
 }
-/* line 554, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-gears:before,
 #hrjob-contract .fa-cogs:before {
   content: "\f085";
 }
-/* line 558, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-comments:before {
   content: "\f086";
 }
-/* line 561, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-thumbs-o-up:before {
   content: "\f087";
 }
-/* line 564, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-thumbs-o-down:before {
   content: "\f088";
 }
-/* line 567, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-star-half:before {
   content: "\f089";
 }
-/* line 570, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-heart-o:before {
   content: "\f08a";
 }
-/* line 573, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-sign-out:before {
   content: "\f08b";
 }
-/* line 576, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-linkedin-square:before {
   content: "\f08c";
 }
-/* line 579, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-thumb-tack:before {
   content: "\f08d";
 }
-/* line 582, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-external-link:before {
   content: "\f08e";
 }
-/* line 585, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-sign-in:before {
   content: "\f090";
 }
-/* line 588, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-trophy:before {
   content: "\f091";
 }
-/* line 591, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-github-square:before {
   content: "\f092";
 }
-/* line 594, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-upload:before {
   content: "\f093";
 }
-/* line 597, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-lemon-o:before {
   content: "\f094";
 }
-/* line 600, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-phone:before {
   content: "\f095";
 }
-/* line 603, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-square-o:before {
   content: "\f096";
 }
-/* line 606, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-bookmark-o:before {
   content: "\f097";
 }
-/* line 609, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-phone-square:before {
   content: "\f098";
 }
-/* line 612, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-twitter:before {
   content: "\f099";
 }
-/* line 615, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-facebook:before {
   content: "\f09a";
 }
-/* line 618, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-github:before {
   content: "\f09b";
 }
-/* line 621, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-unlock:before {
   content: "\f09c";
 }
-/* line 624, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-credit-card:before {
   content: "\f09d";
 }
-/* line 627, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-rss:before {
   content: "\f09e";
 }
-/* line 630, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-hdd-o:before {
   content: "\f0a0";
 }
-/* line 633, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-bullhorn:before {
   content: "\f0a1";
 }
-/* line 636, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-bell:before {
   content: "\f0f3";
 }
-/* line 639, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-certificate:before {
   content: "\f0a3";
 }
-/* line 642, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-hand-o-right:before {
   content: "\f0a4";
 }
-/* line 645, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-hand-o-left:before {
   content: "\f0a5";
 }
-/* line 648, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-hand-o-up:before {
   content: "\f0a6";
 }
-/* line 651, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-hand-o-down:before {
   content: "\f0a7";
 }
-/* line 654, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-arrow-circle-left:before {
   content: "\f0a8";
 }
-/* line 657, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-arrow-circle-right:before {
   content: "\f0a9";
 }
-/* line 660, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-arrow-circle-up:before {
   content: "\f0aa";
 }
-/* line 663, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-arrow-circle-down:before {
   content: "\f0ab";
 }
-/* line 666, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-globe:before {
   content: "\f0ac";
 }
-/* line 669, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-wrench:before {
   content: "\f0ad";
 }
-/* line 672, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-tasks:before {
   content: "\f0ae";
 }
-/* line 675, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-filter:before {
   content: "\f0b0";
 }
-/* line 678, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-briefcase:before {
   content: "\f0b1";
 }
-/* line 681, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-arrows-alt:before {
   content: "\f0b2";
 }
-/* line 684, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-group:before,
 #hrjob-contract .fa-users:before {
   content: "\f0c0";
 }
-/* line 688, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-chain:before,
 #hrjob-contract .fa-link:before {
   content: "\f0c1";
 }
-/* line 692, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-cloud:before {
   content: "\f0c2";
 }
-/* line 695, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-flask:before {
   content: "\f0c3";
 }
-/* line 698, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-cut:before,
 #hrjob-contract .fa-scissors:before {
   content: "\f0c4";
 }
-/* line 702, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-copy:before,
 #hrjob-contract .fa-files-o:before {
   content: "\f0c5";
 }
-/* line 706, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-paperclip:before {
   content: "\f0c6";
 }
-/* line 709, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-save:before,
 #hrjob-contract .fa-floppy-o:before {
   content: "\f0c7";
 }
-/* line 713, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-square:before {
   content: "\f0c8";
 }
-/* line 716, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-navicon:before,
 #hrjob-contract .fa-reorder:before,
 #hrjob-contract .fa-bars:before {
   content: "\f0c9";
 }
-/* line 721, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-list-ul:before {
   content: "\f0ca";
 }
-/* line 724, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-list-ol:before {
   content: "\f0cb";
 }
-/* line 727, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-strikethrough:before {
   content: "\f0cc";
 }
-/* line 730, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-underline:before {
   content: "\f0cd";
 }
-/* line 733, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-table:before {
   content: "\f0ce";
 }
-/* line 736, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-magic:before {
   content: "\f0d0";
 }
-/* line 739, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-truck:before {
   content: "\f0d1";
 }
-/* line 742, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-pinterest:before {
   content: "\f0d2";
 }
-/* line 745, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-pinterest-square:before {
   content: "\f0d3";
 }
-/* line 748, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-google-plus-square:before {
   content: "\f0d4";
 }
-/* line 751, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-google-plus:before {
   content: "\f0d5";
 }
-/* line 754, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-money:before {
   content: "\f0d6";
 }
-/* line 757, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-caret-down:before {
   content: "\f0d7";
 }
-/* line 760, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-caret-up:before {
   content: "\f0d8";
 }
-/* line 763, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-caret-left:before {
   content: "\f0d9";
 }
-/* line 766, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-caret-right:before {
   content: "\f0da";
 }
-/* line 769, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-columns:before {
   content: "\f0db";
 }
-/* line 772, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-unsorted:before,
 #hrjob-contract .fa-sort:before {
   content: "\f0dc";
 }
-/* line 776, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-sort-down:before,
 #hrjob-contract .fa-sort-desc:before {
   content: "\f0dd";
 }
-/* line 780, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-sort-up:before,
 #hrjob-contract .fa-sort-asc:before {
   content: "\f0de";
 }
-/* line 784, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-envelope:before {
   content: "\f0e0";
 }
-/* line 787, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-linkedin:before {
   content: "\f0e1";
 }
-/* line 790, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-rotate-left:before,
 #hrjob-contract .fa-undo:before {
   content: "\f0e2";
 }
-/* line 794, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-legal:before,
 #hrjob-contract .fa-gavel:before {
   content: "\f0e3";
 }
-/* line 798, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-dashboard:before,
 #hrjob-contract .fa-tachometer:before {
   content: "\f0e4";
 }
-/* line 802, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-comment-o:before {
   content: "\f0e5";
 }
-/* line 805, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-comments-o:before {
   content: "\f0e6";
 }
-/* line 808, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-flash:before,
 #hrjob-contract .fa-bolt:before {
   content: "\f0e7";
 }
-/* line 812, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-sitemap:before {
   content: "\f0e8";
 }
-/* line 815, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-umbrella:before {
   content: "\f0e9";
 }
-/* line 818, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-paste:before,
 #hrjob-contract .fa-clipboard:before {
   content: "\f0ea";
 }
-/* line 822, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-lightbulb-o:before {
   content: "\f0eb";
 }
-/* line 825, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-exchange:before {
   content: "\f0ec";
 }
-/* line 828, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-cloud-download:before {
   content: "\f0ed";
 }
-/* line 831, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-cloud-upload:before {
   content: "\f0ee";
 }
-/* line 834, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-user-md:before {
   content: "\f0f0";
 }
-/* line 837, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-stethoscope:before {
   content: "\f0f1";
 }
-/* line 840, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-suitcase:before {
   content: "\f0f2";
 }
-/* line 843, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-bell-o:before {
   content: "\f0a2";
 }
-/* line 846, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-coffee:before {
   content: "\f0f4";
 }
-/* line 849, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-cutlery:before {
   content: "\f0f5";
 }
-/* line 852, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-file-text-o:before {
   content: "\f0f6";
 }
-/* line 855, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-building-o:before {
   content: "\f0f7";
 }
-/* line 858, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-hospital-o:before {
   content: "\f0f8";
 }
-/* line 861, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-ambulance:before {
   content: "\f0f9";
 }
-/* line 864, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-medkit:before {
   content: "\f0fa";
 }
-/* line 867, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-fighter-jet:before {
   content: "\f0fb";
 }
-/* line 870, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-beer:before {
   content: "\f0fc";
 }
-/* line 873, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-h-square:before {
   content: "\f0fd";
 }
-/* line 876, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-plus-square:before {
   content: "\f0fe";
 }
-/* line 879, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-angle-double-left:before {
   content: "\f100";
 }
-/* line 882, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-angle-double-right:before {
   content: "\f101";
 }
-/* line 885, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-angle-double-up:before {
   content: "\f102";
 }
-/* line 888, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-angle-double-down:before {
   content: "\f103";
 }
-/* line 891, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-angle-left:before {
   content: "\f104";
 }
-/* line 894, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-angle-right:before {
   content: "\f105";
 }
-/* line 897, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-angle-up:before {
   content: "\f106";
 }
-/* line 900, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-angle-down:before {
   content: "\f107";
 }
-/* line 903, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-desktop:before {
   content: "\f108";
 }
-/* line 906, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-laptop:before {
   content: "\f109";
 }
-/* line 909, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-tablet:before {
   content: "\f10a";
 }
-/* line 912, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-mobile-phone:before,
 #hrjob-contract .fa-mobile:before {
   content: "\f10b";
 }
-/* line 916, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-circle-o:before {
   content: "\f10c";
 }
-/* line 919, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-quote-left:before {
   content: "\f10d";
 }
-/* line 922, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-quote-right:before {
   content: "\f10e";
 }
-/* line 925, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-spinner:before {
   content: "\f110";
 }
-/* line 928, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-circle:before {
   content: "\f111";
 }
-/* line 931, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-mail-reply:before,
 #hrjob-contract .fa-reply:before {
   content: "\f112";
 }
-/* line 935, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-github-alt:before {
   content: "\f113";
 }
-/* line 938, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-folder-o:before {
   content: "\f114";
 }
-/* line 941, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-folder-open-o:before {
   content: "\f115";
 }
-/* line 944, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-smile-o:before {
   content: "\f118";
 }
-/* line 947, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-frown-o:before {
   content: "\f119";
 }
-/* line 950, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-meh-o:before {
   content: "\f11a";
 }
-/* line 953, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-gamepad:before {
   content: "\f11b";
 }
-/* line 956, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-keyboard-o:before {
   content: "\f11c";
 }
-/* line 959, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-flag-o:before {
   content: "\f11d";
 }
-/* line 962, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-flag-checkered:before {
   content: "\f11e";
 }
-/* line 965, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-terminal:before {
   content: "\f120";
 }
-/* line 968, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-code:before {
   content: "\f121";
 }
-/* line 971, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-mail-reply-all:before,
 #hrjob-contract .fa-reply-all:before {
   content: "\f122";
 }
-/* line 975, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-star-half-empty:before,
 #hrjob-contract .fa-star-half-full:before,
 #hrjob-contract .fa-star-half-o:before {
   content: "\f123";
 }
-/* line 980, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-location-arrow:before {
   content: "\f124";
 }
-/* line 983, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-crop:before {
   content: "\f125";
 }
-/* line 986, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-code-fork:before {
   content: "\f126";
 }
-/* line 989, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-unlink:before,
 #hrjob-contract .fa-chain-broken:before {
   content: "\f127";
 }
-/* line 993, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-question:before {
   content: "\f128";
 }
-/* line 996, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-info:before {
   content: "\f129";
 }
-/* line 999, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-exclamation:before {
   content: "\f12a";
 }
-/* line 1002, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-superscript:before {
   content: "\f12b";
 }
-/* line 1005, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-subscript:before {
   content: "\f12c";
 }
-/* line 1008, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-eraser:before {
   content: "\f12d";
 }
-/* line 1011, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-puzzle-piece:before {
   content: "\f12e";
 }
-/* line 1014, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-microphone:before {
   content: "\f130";
 }
-/* line 1017, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-microphone-slash:before {
   content: "\f131";
 }
-/* line 1020, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-shield:before {
   content: "\f132";
 }
-/* line 1023, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-calendar-o:before {
   content: "\f133";
 }
-/* line 1026, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-fire-extinguisher:before {
   content: "\f134";
 }
-/* line 1029, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-rocket:before {
   content: "\f135";
 }
-/* line 1032, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-maxcdn:before {
   content: "\f136";
 }
-/* line 1035, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-chevron-circle-left:before {
   content: "\f137";
 }
-/* line 1038, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-chevron-circle-right:before {
   content: "\f138";
 }
-/* line 1041, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-chevron-circle-up:before {
   content: "\f139";
 }
-/* line 1044, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-chevron-circle-down:before {
   content: "\f13a";
 }
-/* line 1047, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-html5:before {
   content: "\f13b";
 }
-/* line 1050, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-css3:before {
   content: "\f13c";
 }
-/* line 1053, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-anchor:before {
   content: "\f13d";
 }
-/* line 1056, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-unlock-alt:before {
   content: "\f13e";
 }
-/* line 1059, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-bullseye:before {
   content: "\f140";
 }
-/* line 1062, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-ellipsis-h:before {
   content: "\f141";
 }
-/* line 1065, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-ellipsis-v:before {
   content: "\f142";
 }
-/* line 1068, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-rss-square:before {
   content: "\f143";
 }
-/* line 1071, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-play-circle:before {
   content: "\f144";
 }
-/* line 1074, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-ticket:before {
   content: "\f145";
 }
-/* line 1077, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-minus-square:before {
   content: "\f146";
 }
-/* line 1080, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-minus-square-o:before {
   content: "\f147";
 }
-/* line 1083, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-level-up:before {
   content: "\f148";
 }
-/* line 1086, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-level-down:before {
   content: "\f149";
 }
-/* line 1089, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-check-square:before {
   content: "\f14a";
 }
-/* line 1092, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-pencil-square:before {
   content: "\f14b";
 }
-/* line 1095, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-external-link-square:before {
   content: "\f14c";
 }
-/* line 1098, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-share-square:before {
   content: "\f14d";
 }
-/* line 1101, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-compass:before {
   content: "\f14e";
 }
-/* line 1104, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-toggle-down:before,
 #hrjob-contract .fa-caret-square-o-down:before {
   content: "\f150";
 }
-/* line 1108, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-toggle-up:before,
 #hrjob-contract .fa-caret-square-o-up:before {
   content: "\f151";
 }
-/* line 1112, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-toggle-right:before,
 #hrjob-contract .fa-caret-square-o-right:before {
   content: "\f152";
 }
-/* line 1116, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-euro:before,
 #hrjob-contract .fa-eur:before {
   content: "\f153";
 }
-/* line 1120, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-gbp:before {
   content: "\f154";
 }
-/* line 1123, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-dollar:before,
 #hrjob-contract .fa-usd:before {
   content: "\f155";
 }
-/* line 1127, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-rupee:before,
 #hrjob-contract .fa-inr:before {
   content: "\f156";
 }
-/* line 1131, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-cny:before,
 #hrjob-contract .fa-rmb:before,
 #hrjob-contract .fa-yen:before,
 #hrjob-contract .fa-jpy:before {
   content: "\f157";
 }
-/* line 1137, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-ruble:before,
 #hrjob-contract .fa-rouble:before,
 #hrjob-contract .fa-rub:before {
   content: "\f158";
 }
-/* line 1142, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-won:before,
 #hrjob-contract .fa-krw:before {
   content: "\f159";
 }
-/* line 1146, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-bitcoin:before,
 #hrjob-contract .fa-btc:before {
   content: "\f15a";
 }
-/* line 1150, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-file:before {
   content: "\f15b";
 }
-/* line 1153, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-file-text:before {
   content: "\f15c";
 }
-/* line 1156, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-sort-alpha-asc:before {
   content: "\f15d";
 }
-/* line 1159, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-sort-alpha-desc:before {
   content: "\f15e";
 }
-/* line 1162, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-sort-amount-asc:before {
   content: "\f160";
 }
-/* line 1165, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-sort-amount-desc:before {
   content: "\f161";
 }
-/* line 1168, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-sort-numeric-asc:before {
   content: "\f162";
 }
-/* line 1171, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-sort-numeric-desc:before {
   content: "\f163";
 }
-/* line 1174, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-thumbs-up:before {
   content: "\f164";
 }
-/* line 1177, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-thumbs-down:before {
   content: "\f165";
 }
-/* line 1180, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-youtube-square:before {
   content: "\f166";
 }
-/* line 1183, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-youtube:before {
   content: "\f167";
 }
-/* line 1186, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-xing:before {
   content: "\f168";
 }
-/* line 1189, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-xing-square:before {
   content: "\f169";
 }
-/* line 1192, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-youtube-play:before {
   content: "\f16a";
 }
-/* line 1195, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-dropbox:before {
   content: "\f16b";
 }
-/* line 1198, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-stack-overflow:before {
   content: "\f16c";
 }
-/* line 1201, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-instagram:before {
   content: "\f16d";
 }
-/* line 1204, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-flickr:before {
   content: "\f16e";
 }
-/* line 1207, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-adn:before {
   content: "\f170";
 }
-/* line 1210, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-bitbucket:before {
   content: "\f171";
 }
-/* line 1213, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-bitbucket-square:before {
   content: "\f172";
 }
-/* line 1216, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-tumblr:before {
   content: "\f173";
 }
-/* line 1219, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-tumblr-square:before {
   content: "\f174";
 }
-/* line 1222, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-long-arrow-down:before {
   content: "\f175";
 }
-/* line 1225, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-long-arrow-up:before {
   content: "\f176";
 }
-/* line 1228, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-long-arrow-left:before {
   content: "\f177";
 }
-/* line 1231, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-long-arrow-right:before {
   content: "\f178";
 }
-/* line 1234, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-apple:before {
   content: "\f179";
 }
-/* line 1237, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-windows:before {
   content: "\f17a";
 }
-/* line 1240, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-android:before {
   content: "\f17b";
 }
-/* line 1243, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-linux:before {
   content: "\f17c";
 }
-/* line 1246, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-dribbble:before {
   content: "\f17d";
 }
-/* line 1249, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-skype:before {
   content: "\f17e";
 }
-/* line 1252, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-foursquare:before {
   content: "\f180";
 }
-/* line 1255, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-trello:before {
   content: "\f181";
 }
-/* line 1258, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-female:before {
   content: "\f182";
 }
-/* line 1261, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-male:before {
   content: "\f183";
 }
-/* line 1264, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-gittip:before {
   content: "\f184";
 }
-/* line 1267, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-sun-o:before {
   content: "\f185";
 }
-/* line 1270, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-moon-o:before {
   content: "\f186";
 }
-/* line 1273, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-archive:before {
   content: "\f187";
 }
-/* line 1276, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-bug:before {
   content: "\f188";
 }
-/* line 1279, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-vk:before {
   content: "\f189";
 }
-/* line 1282, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-weibo:before {
   content: "\f18a";
 }
-/* line 1285, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-renren:before {
   content: "\f18b";
 }
-/* line 1288, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-pagelines:before {
   content: "\f18c";
 }
-/* line 1291, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-stack-exchange:before {
   content: "\f18d";
 }
-/* line 1294, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-arrow-circle-o-right:before {
   content: "\f18e";
 }
-/* line 1297, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-arrow-circle-o-left:before {
   content: "\f190";
 }
-/* line 1300, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-toggle-left:before,
 #hrjob-contract .fa-caret-square-o-left:before {
   content: "\f191";
 }
-/* line 1304, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-dot-circle-o:before {
   content: "\f192";
 }
-/* line 1307, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-wheelchair:before {
   content: "\f193";
 }
-/* line 1310, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-vimeo-square:before {
   content: "\f194";
 }
-/* line 1313, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-turkish-lira:before,
 #hrjob-contract .fa-try:before {
   content: "\f195";
 }
-/* line 1317, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-plus-square-o:before {
   content: "\f196";
 }
-/* line 1320, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-space-shuttle:before {
   content: "\f197";
 }
-/* line 1323, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-slack:before {
   content: "\f198";
 }
-/* line 1326, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-envelope-square:before {
   content: "\f199";
 }
-/* line 1329, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-wordpress:before {
   content: "\f19a";
 }
-/* line 1332, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-openid:before {
   content: "\f19b";
 }
-/* line 1335, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-institution:before,
 #hrjob-contract .fa-bank:before,
 #hrjob-contract .fa-university:before {
   content: "\f19c";
 }
-/* line 1340, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-mortar-board:before,
 #hrjob-contract .fa-graduation-cap:before {
   content: "\f19d";
 }
-/* line 1344, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-yahoo:before {
   content: "\f19e";
 }
-/* line 1347, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-google:before {
   content: "\f1a0";
 }
-/* line 1350, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-reddit:before {
   content: "\f1a1";
 }
-/* line 1353, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-reddit-square:before {
   content: "\f1a2";
 }
-/* line 1356, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-stumbleupon-circle:before {
   content: "\f1a3";
 }
-/* line 1359, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-stumbleupon:before {
   content: "\f1a4";
 }
-/* line 1362, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-delicious:before {
   content: "\f1a5";
 }
-/* line 1365, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-digg:before {
   content: "\f1a6";
 }
-/* line 1368, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-pied-piper:before {
   content: "\f1a7";
 }
-/* line 1371, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-pied-piper-alt:before {
   content: "\f1a8";
 }
-/* line 1374, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-drupal:before {
   content: "\f1a9";
 }
-/* line 1377, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-joomla:before {
   content: "\f1aa";
 }
-/* line 1380, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-language:before {
   content: "\f1ab";
 }
-/* line 1383, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-fax:before {
   content: "\f1ac";
 }
-/* line 1386, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-building:before {
   content: "\f1ad";
 }
-/* line 1389, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-child:before {
   content: "\f1ae";
 }
-/* line 1392, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-paw:before {
   content: "\f1b0";
 }
-/* line 1395, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-spoon:before {
   content: "\f1b1";
 }
-/* line 1398, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-cube:before {
   content: "\f1b2";
 }
-/* line 1401, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-cubes:before {
   content: "\f1b3";
 }
-/* line 1404, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-behance:before {
   content: "\f1b4";
 }
-/* line 1407, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-behance-square:before {
   content: "\f1b5";
 }
-/* line 1410, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-steam:before {
   content: "\f1b6";
 }
-/* line 1413, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-steam-square:before {
   content: "\f1b7";
 }
-/* line 1416, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-recycle:before {
   content: "\f1b8";
 }
-/* line 1419, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-automobile:before,
 #hrjob-contract .fa-car:before {
   content: "\f1b9";
 }
-/* line 1423, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-cab:before,
 #hrjob-contract .fa-taxi:before {
   content: "\f1ba";
 }
-/* line 1427, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-tree:before {
   content: "\f1bb";
 }
-/* line 1430, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-spotify:before {
   content: "\f1bc";
 }
-/* line 1433, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-deviantart:before {
   content: "\f1bd";
 }
-/* line 1436, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-soundcloud:before {
   content: "\f1be";
 }
-/* line 1439, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-database:before {
   content: "\f1c0";
 }
-/* line 1442, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-file-pdf-o:before {
   content: "\f1c1";
 }
-/* line 1445, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-file-word-o:before {
   content: "\f1c2";
 }
-/* line 1448, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-file-excel-o:before {
   content: "\f1c3";
 }
-/* line 1451, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-file-powerpoint-o:before {
   content: "\f1c4";
 }
-/* line 1454, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-file-photo-o:before,
 #hrjob-contract .fa-file-picture-o:before,
 #hrjob-contract .fa-file-image-o:before {
   content: "\f1c5";
 }
-/* line 1459, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-file-zip-o:before,
 #hrjob-contract .fa-file-archive-o:before {
   content: "\f1c6";
 }
-/* line 1463, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-file-sound-o:before,
 #hrjob-contract .fa-file-audio-o:before {
   content: "\f1c7";
 }
-/* line 1467, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-file-movie-o:before,
 #hrjob-contract .fa-file-video-o:before {
   content: "\f1c8";
 }
-/* line 1471, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-file-code-o:before {
   content: "\f1c9";
 }
-/* line 1474, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-vine:before {
   content: "\f1ca";
 }
-/* line 1477, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-codepen:before {
   content: "\f1cb";
 }
-/* line 1480, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-jsfiddle:before {
   content: "\f1cc";
 }
-/* line 1483, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-life-bouy:before,
 #hrjob-contract .fa-life-buoy:before,
 #hrjob-contract .fa-life-saver:before,
@@ -3236,264 +2521,202 @@
 #hrjob-contract .fa-life-ring:before {
   content: "\f1cd";
 }
-/* line 1490, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-circle-o-notch:before {
   content: "\f1ce";
 }
-/* line 1493, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-ra:before,
 #hrjob-contract .fa-rebel:before {
   content: "\f1d0";
 }
-/* line 1497, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-ge:before,
 #hrjob-contract .fa-empire:before {
   content: "\f1d1";
 }
-/* line 1501, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-git-square:before {
   content: "\f1d2";
 }
-/* line 1504, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-git:before {
   content: "\f1d3";
 }
-/* line 1507, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-hacker-news:before {
   content: "\f1d4";
 }
-/* line 1510, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-tencent-weibo:before {
   content: "\f1d5";
 }
-/* line 1513, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-qq:before {
   content: "\f1d6";
 }
-/* line 1516, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-wechat:before,
 #hrjob-contract .fa-weixin:before {
   content: "\f1d7";
 }
-/* line 1520, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-send:before,
 #hrjob-contract .fa-paper-plane:before {
   content: "\f1d8";
 }
-/* line 1524, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-send-o:before,
 #hrjob-contract .fa-paper-plane-o:before {
   content: "\f1d9";
 }
-/* line 1528, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-history:before {
   content: "\f1da";
 }
-/* line 1531, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-circle-thin:before {
   content: "\f1db";
 }
-/* line 1534, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-header:before {
   content: "\f1dc";
 }
-/* line 1537, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-paragraph:before {
   content: "\f1dd";
 }
-/* line 1540, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-sliders:before {
   content: "\f1de";
 }
-/* line 1543, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-share-alt:before {
   content: "\f1e0";
 }
-/* line 1546, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-share-alt-square:before {
   content: "\f1e1";
 }
-/* line 1549, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-bomb:before {
   content: "\f1e2";
 }
-/* line 1552, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-soccer-ball-o:before,
 #hrjob-contract .fa-futbol-o:before {
   content: "\f1e3";
 }
-/* line 1556, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-tty:before {
   content: "\f1e4";
 }
-/* line 1559, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-binoculars:before {
   content: "\f1e5";
 }
-/* line 1562, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-plug:before {
   content: "\f1e6";
 }
-/* line 1565, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-slideshare:before {
   content: "\f1e7";
 }
-/* line 1568, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-twitch:before {
   content: "\f1e8";
 }
-/* line 1571, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-yelp:before {
   content: "\f1e9";
 }
-/* line 1574, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-newspaper-o:before {
   content: "\f1ea";
 }
-/* line 1577, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-wifi:before {
   content: "\f1eb";
 }
-/* line 1580, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-calculator:before {
   content: "\f1ec";
 }
-/* line 1583, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-paypal:before {
   content: "\f1ed";
 }
-/* line 1586, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-google-wallet:before {
   content: "\f1ee";
 }
-/* line 1589, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-cc-visa:before {
   content: "\f1f0";
 }
-/* line 1592, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-cc-mastercard:before {
   content: "\f1f1";
 }
-/* line 1595, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-cc-discover:before {
   content: "\f1f2";
 }
-/* line 1598, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-cc-amex:before {
   content: "\f1f3";
 }
-/* line 1601, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-cc-paypal:before {
   content: "\f1f4";
 }
-/* line 1604, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-cc-stripe:before {
   content: "\f1f5";
 }
-/* line 1607, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-bell-slash:before {
   content: "\f1f6";
 }
-/* line 1610, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-bell-slash-o:before {
   content: "\f1f7";
 }
-/* line 1613, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-trash:before {
   content: "\f1f8";
 }
-/* line 1616, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-copyright:before {
   content: "\f1f9";
 }
-/* line 1619, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-at:before {
   content: "\f1fa";
 }
-/* line 1622, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-eyedropper:before {
   content: "\f1fb";
 }
-/* line 1625, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-paint-brush:before {
   content: "\f1fc";
 }
-/* line 1628, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-birthday-cake:before {
   content: "\f1fd";
 }
-/* line 1631, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-area-chart:before {
   content: "\f1fe";
 }
-/* line 1634, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-pie-chart:before {
   content: "\f200";
 }
-/* line 1637, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-line-chart:before {
   content: "\f201";
 }
-/* line 1640, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-lastfm:before {
   content: "\f202";
 }
-/* line 1643, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-lastfm-square:before {
   content: "\f203";
 }
-/* line 1646, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-toggle-off:before {
   content: "\f204";
 }
-/* line 1649, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-toggle-on:before {
   content: "\f205";
 }
-/* line 1652, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-bicycle:before {
   content: "\f206";
 }
-/* line 1655, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-bus:before {
   content: "\f207";
 }
-/* line 1658, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-ioxhost:before {
   content: "\f208";
 }
-/* line 1661, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-angellist:before {
   content: "\f209";
 }
-/* line 1664, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-cc:before {
   content: "\f20a";
 }
-/* line 1667, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-shekel:before,
 #hrjob-contract .fa-sheqel:before,
 #hrjob-contract .fa-ils:before {
   content: "\f20b";
 }
-/* line 1672, ../scss/civihr/modules/_fontawesome.scss */
 #hrjob-contract .fa-meanpath:before {
   content: "\f20c";
 }
-/* line 12, ../scss/civihr/bootstrap/_scaffolding-custom.scss */
 #hrjob-contract * {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
-/* line 15, ../scss/civihr/bootstrap/_scaffolding-custom.scss */
 #hrjob-contract *:before,
 #hrjob-contract *:after {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
-/* line 26, ../scss/civihr/bootstrap/_scaffolding-custom.scss */
 #hrjob-contract .container-fluid,
 #hrjob-contract .container {
   font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -3501,7 +2724,6 @@
   line-height: 1.42857143;
   color: #4D4D69;
 }
-/* line 35, ../scss/civihr/bootstrap/_scaffolding-custom.scss */
 #hrjob-contract input,
 #hrjob-contract button,
 #hrjob-contract select,
@@ -3511,40 +2733,32 @@
   font-size: inherit;
   line-height: inherit;
 }
-/* line 48, ../scss/civihr/bootstrap/_scaffolding-custom.scss */
 #hrjob-contract a {
   color: #0071BD;
   text-decoration: none;
 }
-/* line 52, ../scss/civihr/bootstrap/_scaffolding-custom.scss */
 #hrjob-contract a:hover, #hrjob-contract a:focus {
   color: #005c99;
   text-decoration: none;
 }
-/* line 58, ../scss/civihr/bootstrap/_scaffolding-custom.scss */
 #hrjob-contract a:focus {
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
-/* line 69, ../scss/civihr/bootstrap/_scaffolding-custom.scss */
 #hrjob-contract figure {
   margin: 0;
 }
-/* line 76, ../scss/civihr/bootstrap/_scaffolding-custom.scss */
 #hrjob-contract img {
   vertical-align: middle;
 }
-/* line 81, ../scss/civihr/bootstrap/_scaffolding-custom.scss */
 #hrjob-contract .img-responsive {
   display: block;
   max-width: 100%;
   height: auto;
 }
-/* line 86, ../scss/civihr/bootstrap/_scaffolding-custom.scss */
 #hrjob-contract .img-rounded {
   border-radius: 4px;
 }
-/* line 93, ../scss/civihr/bootstrap/_scaffolding-custom.scss */
 #hrjob-contract .img-thumbnail {
   padding: 4px;
   line-height: 1.42857143;
@@ -3558,18 +2772,15 @@
   max-width: 100%;
   height: auto;
 }
-/* line 106, ../scss/civihr/bootstrap/_scaffolding-custom.scss */
 #hrjob-contract .img-circle {
   border-radius: 50%;
 }
-/* line 113, ../scss/civihr/bootstrap/_scaffolding-custom.scss */
 #hrjob-contract hr {
   margin-top: 18px;
   margin-bottom: 18px;
   border: 0;
   border-top: 1px solid #D3DEE2;
 }
-/* line 125, ../scss/civihr/bootstrap/_scaffolding-custom.scss */
 #hrjob-contract .sr-only {
   position: absolute;
   width: 1px;
@@ -3580,7 +2791,6 @@
   clip: rect(0, 0, 0, 0);
   border: 0;
 }
-/* line 141, ../scss/civihr/bootstrap/_scaffolding-custom.scss */
 #hrjob-contract .sr-only-focusable:active, #hrjob-contract .sr-only-focusable:focus {
   position: static;
   width: auto;
@@ -3589,7 +2799,6 @@
   overflow: visible;
   clip: auto;
 }
-/* line 9, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract h1, #hrjob-contract h2, #hrjob-contract h3, #hrjob-contract h4, #hrjob-contract h5, #hrjob-contract h6,
 #hrjob-contract .h1, #hrjob-contract .h2, #hrjob-contract .h3, #hrjob-contract .h4, #hrjob-contract .h5, #hrjob-contract .h6 {
   font-family: inherit;
@@ -3597,7 +2806,6 @@
   line-height: 1.1;
   color: #464354;
 }
-/* line 16, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract h1 small,
 #hrjob-contract h1 .small, #hrjob-contract h2 small,
 #hrjob-contract h2 .small, #hrjob-contract h3 small,
@@ -3616,14 +2824,12 @@
   line-height: 1;
   color: #E8EEF0;
 }
-/* line 24, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract h1, #hrjob-contract .h1,
 #hrjob-contract h2, #hrjob-contract .h2,
 #hrjob-contract h3, #hrjob-contract .h3 {
   margin-top: 18px;
   margin-bottom: 9px;
 }
-/* line 30, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract h1 small,
 #hrjob-contract h1 .small, #hrjob-contract .h1 small,
 #hrjob-contract .h1 .small,
@@ -3635,14 +2841,12 @@
 #hrjob-contract .h3 .small {
   font-size: 65%;
 }
-/* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract h4, #hrjob-contract .h4,
 #hrjob-contract h5, #hrjob-contract .h5,
 #hrjob-contract h6, #hrjob-contract .h6 {
   margin-top: 9px;
   margin-bottom: 9px;
 }
-/* line 41, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract h4 small,
 #hrjob-contract h4 .small, #hrjob-contract .h4 small,
 #hrjob-contract .h4 .small,
@@ -3654,35 +2858,27 @@
 #hrjob-contract .h6 .small {
   font-size: 75%;
 }
-/* line 47, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract h1, #hrjob-contract .h1 {
   font-size: 24px;
 }
-/* line 48, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract h2, #hrjob-contract .h2 {
   font-size: 18px;
 }
-/* line 49, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract h3, #hrjob-contract .h3 {
   font-size: 13px;
 }
-/* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract h4, #hrjob-contract .h4 {
   font-size: 13px;
 }
-/* line 51, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract h5, #hrjob-contract .h5 {
   font-size: 13px;
 }
-/* line 52, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract h6, #hrjob-contract .h6 {
   font-size: 12px;
 }
-/* line 58, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract p {
   margin: 0 0 9px;
 }
-/* line 62, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract .lead {
   margin-bottom: 18px;
   font-size: 14px;
@@ -3690,217 +2886,171 @@
   line-height: 1.4;
 }
 @media (min-width: 768px) {
-  /* line 62, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
   #hrjob-contract .lead {
     font-size: 19.5px;
   }
 }
-/* line 78, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract small,
 #hrjob-contract .small {
   font-size: 92%;
 }
-/* line 83, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract mark,
 #hrjob-contract .mark {
   background-color: #fcf8e3;
   padding: .2em;
 }
-/* line 90, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract .text-left {
   text-align: left;
 }
-/* line 91, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract .text-right {
   text-align: right;
 }
-/* line 92, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract .text-center {
   text-align: center;
 }
-/* line 93, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract .text-justify {
   text-align: justify;
 }
-/* line 94, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract .text-nowrap {
   white-space: nowrap;
 }
-/* line 97, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract .text-lowercase {
   text-transform: lowercase;
 }
-/* line 98, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract .text-uppercase, #hrjob-contract .initialism {
   text-transform: uppercase;
 }
-/* line 99, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract .text-capitalize {
   text-transform: capitalize;
 }
-/* line 102, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract .text-muted {
   color: #9494A5;
 }
-/* line 5, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss */
 #hrjob-contract .text-primary {
   color: #0071BD;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss */
 #hrjob-contract a.text-primary:hover,
 #hrjob-contract a.text-primary:focus {
   color: #00538a;
 }
-/* line 5, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss */
 #hrjob-contract .text-success {
   color: #4d994d;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss */
 #hrjob-contract a.text-success:hover,
 #hrjob-contract a.text-success:focus {
   color: #3c773c;
 }
-/* line 5, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss */
 #hrjob-contract .text-info {
   color: #31708f;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss */
 #hrjob-contract a.text-info:hover,
 #hrjob-contract a.text-info:focus {
   color: #245269;
 }
-/* line 5, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss */
 #hrjob-contract .text-warning {
   color: #bf5900;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss */
 #hrjob-contract a.text-warning:hover,
 #hrjob-contract a.text-warning:focus {
   color: #8c4100;
 }
-/* line 5, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss */
 #hrjob-contract .text-danger {
   color: #CF3458;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss */
 #hrjob-contract a.text-danger:hover,
 #hrjob-contract a.text-danger:focus {
   color: #a82846;
 }
-/* line 119, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract .bg-primary {
   color: #fff;
 }
-/* line 5, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_background-variant.scss */
 #hrjob-contract .bg-primary {
   background-color: #0071BD;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_background-variant.scss */
 #hrjob-contract a.bg-primary:hover,
 #hrjob-contract a.bg-primary:focus {
   background-color: #00538a;
 }
-/* line 5, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_background-variant.scss */
 #hrjob-contract .bg-success {
   background-color: #dff0d8;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_background-variant.scss */
 #hrjob-contract a.bg-success:hover,
 #hrjob-contract a.bg-success:focus {
   background-color: #c1e2b3;
 }
-/* line 5, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_background-variant.scss */
 #hrjob-contract .bg-info {
   background-color: #d9edf7;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_background-variant.scss */
 #hrjob-contract a.bg-info:hover,
 #hrjob-contract a.bg-info:focus {
   background-color: #afd9ee;
 }
-/* line 5, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_background-variant.scss */
 #hrjob-contract .bg-warning {
   background-color: #fcf8e3;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_background-variant.scss */
 #hrjob-contract a.bg-warning:hover,
 #hrjob-contract a.bg-warning:focus {
   background-color: #f7ecb5;
 }
-/* line 5, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_background-variant.scss */
 #hrjob-contract .bg-danger {
   background-color: #f2dede;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_background-variant.scss */
 #hrjob-contract a.bg-danger:hover,
 #hrjob-contract a.bg-danger:focus {
   background-color: #e4b9b9;
 }
-/* line 138, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract .page-header {
   padding-bottom: 8px;
   margin: 36px 0 18px;
   border-bottom: 1px solid #F3F6F7;
 }
-/* line 149, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract ul,
 #hrjob-contract ol {
   margin-top: 0;
   margin-bottom: 9px;
 }
-/* line 153, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract ul ul,
 #hrjob-contract ul ol,
 #hrjob-contract ol ul,
 #hrjob-contract ol ol {
   margin-bottom: 0;
 }
-/* line 167, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract .list-unstyled {
   padding-left: 0;
   list-style: none;
 }
-/* line 173, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract .list-inline {
   padding-left: 0;
   list-style: none;
   margin-left: -5px;
 }
-/* line 177, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract .list-inline > li {
   display: inline-block;
   padding-left: 5px;
   padding-right: 5px;
 }
-/* line 185, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract dl {
   margin-top: 0;
   margin-bottom: 18px;
 }
-/* line 189, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract dt,
 #hrjob-contract dd {
   line-height: 1.42857143;
 }
-/* line 193, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract dt {
   font-weight: bold;
 }
-/* line 196, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract dd {
   margin-left: 0;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .dl-horizontal dd:before, #hrjob-contract .dl-horizontal dd:after {
   content: " ";
   display: table;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .dl-horizontal dd:after {
   clear: both;
 }
 @media (min-width: 768px) {
-  /* line 211, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
   #hrjob-contract .dl-horizontal dt {
     float: left;
     width: 160px;
@@ -3910,35 +3060,29 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  /* line 218, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
   #hrjob-contract .dl-horizontal dd {
     margin-left: 180px;
   }
 }
-/* line 229, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract abbr[title],
 #hrjob-contract abbr[data-original-title] {
   cursor: help;
   border-bottom: 1px dotted #E8EEF0;
 }
-/* line 235, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract .initialism {
   font-size: 90%;
 }
-/* line 241, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract blockquote {
   padding: 9px 18px;
   margin: 0 0 18px;
   font-size: 16.25px;
   border-left: 5px solid #F3F6F7;
 }
-/* line 250, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract blockquote p:last-child,
 #hrjob-contract blockquote ul:last-child,
 #hrjob-contract blockquote ol:last-child {
   margin-bottom: 0;
 }
-/* line 257, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract blockquote footer,
 #hrjob-contract blockquote small,
 #hrjob-contract blockquote .small {
@@ -3947,13 +3091,11 @@
   line-height: 1.42857143;
   color: #E8EEF0;
 }
-/* line 265, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract blockquote footer:before,
 #hrjob-contract blockquote small:before,
 #hrjob-contract blockquote .small:before {
   content: '\2014 \00A0';
 }
-/* line 274, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract .blockquote-reverse,
 #hrjob-contract blockquote.pull-right {
   padding-right: 15px;
@@ -3962,7 +3104,6 @@
   border-left: 0;
   text-align: right;
 }
-/* line 286, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract .blockquote-reverse footer:before,
 #hrjob-contract .blockquote-reverse small:before,
 #hrjob-contract .blockquote-reverse .small:before,
@@ -3971,7 +3112,6 @@
 #hrjob-contract blockquote.pull-right .small:before {
   content: '';
 }
-/* line 287, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract .blockquote-reverse footer:after,
 #hrjob-contract .blockquote-reverse small:after,
 #hrjob-contract .blockquote-reverse .small:after,
@@ -3980,20 +3120,17 @@
 #hrjob-contract blockquote.pull-right .small:after {
   content: '\00A0 \2014';
 }
-/* line 294, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_type.scss */
 #hrjob-contract address {
   margin-bottom: 18px;
   font-style: normal;
   line-height: 1.42857143;
 }
-/* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_code.scss */
 #hrjob-contract code,
 #hrjob-contract kbd,
 #hrjob-contract pre,
 #hrjob-contract samp {
   font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
 }
-/* line 15, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_code.scss */
 #hrjob-contract code {
   padding: 2px 4px;
   font-size: 90%;
@@ -4001,7 +3138,6 @@
   background-color: #f9f2f4;
   border-radius: 2px;
 }
-/* line 24, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_code.scss */
 #hrjob-contract kbd {
   padding: 2px 4px;
   font-size: 90%;
@@ -4010,14 +3146,12 @@
   border-radius: 2px;
   box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
 }
-/* line 32, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_code.scss */
 #hrjob-contract kbd kbd {
   padding: 0;
   font-size: 100%;
   font-weight: bold;
   box-shadow: none;
 }
-/* line 41, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_code.scss */
 #hrjob-contract pre {
   display: block;
   padding: 8.5px;
@@ -4031,7 +3165,6 @@
   border: 1px solid #ccc;
   border-radius: 2px;
 }
-/* line 55, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_code.scss */
 #hrjob-contract pre code {
   padding: 0;
   font-size: inherit;
@@ -4040,942 +3173,715 @@
   background-color: transparent;
   border-radius: 0;
 }
-/* line 66, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_code.scss */
 #hrjob-contract .pre-scrollable {
   max-height: 340px;
   overflow-y: scroll;
 }
-/* line 10, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_grid.scss */
 #hrjob-contract .container {
   margin-right: auto;
   margin-left: auto;
   padding-left: 15px;
   padding-right: 15px;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .container:before, #hrjob-contract .container:after {
   content: " ";
   display: table;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .container:after {
   clear: both;
 }
 @media (min-width: 768px) {
-  /* line 10, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_grid.scss */
   #hrjob-contract .container {
     width: 750px;
   }
 }
 @media (min-width: 992px) {
-  /* line 10, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_grid.scss */
   #hrjob-contract .container {
     width: 970px;
   }
 }
 @media (min-width: 1200px) {
-  /* line 10, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_grid.scss */
   #hrjob-contract .container {
     width: 1170px;
   }
 }
-/* line 30, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_grid.scss */
 #hrjob-contract .container-fluid {
   margin-right: auto;
   margin-left: auto;
   padding-left: 15px;
   padding-right: 15px;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .container-fluid:before, #hrjob-contract .container-fluid:after {
   content: " ";
   display: table;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .container-fluid:after {
   clear: both;
 }
-/* line 39, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_grid.scss */
 #hrjob-contract .row {
   margin-left: -15px;
   margin-right: -15px;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .row:before, #hrjob-contract .row:after {
   content: " ";
   display: table;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .row:after {
   clear: both;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-1, #hrjob-contract .col-sm-1, #hrjob-contract .col-md-1, #hrjob-contract .col-lg-1, #hrjob-contract .col-xs-2, #hrjob-contract .col-sm-2, #hrjob-contract .col-md-2, #hrjob-contract .col-lg-2, #hrjob-contract .col-xs-3, #hrjob-contract .col-sm-3, #hrjob-contract .col-md-3, #hrjob-contract .col-lg-3, #hrjob-contract .col-xs-4, #hrjob-contract .col-sm-4, #hrjob-contract .col-md-4, #hrjob-contract .col-lg-4, #hrjob-contract .col-xs-5, #hrjob-contract .col-sm-5, #hrjob-contract .col-md-5, #hrjob-contract .col-lg-5, #hrjob-contract .col-xs-6, #hrjob-contract .col-sm-6, #hrjob-contract .col-md-6, #hrjob-contract .col-lg-6, #hrjob-contract .col-xs-7, #hrjob-contract .col-sm-7, #hrjob-contract .col-md-7, #hrjob-contract .col-lg-7, #hrjob-contract .col-xs-8, #hrjob-contract .col-sm-8, #hrjob-contract .col-md-8, #hrjob-contract .col-lg-8, #hrjob-contract .col-xs-9, #hrjob-contract .col-sm-9, #hrjob-contract .col-md-9, #hrjob-contract .col-lg-9, #hrjob-contract .col-xs-10, #hrjob-contract .col-sm-10, #hrjob-contract .col-md-10, #hrjob-contract .col-lg-10, #hrjob-contract .col-xs-11, #hrjob-contract .col-sm-11, #hrjob-contract .col-md-11, #hrjob-contract .col-lg-11, #hrjob-contract .col-xs-12, #hrjob-contract .col-sm-12, #hrjob-contract .col-md-12, #hrjob-contract .col-lg-12 {
   position: relative;
   min-height: 1px;
   padding-left: 15px;
   padding-right: 15px;
 }
-/* line 27, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-1, #hrjob-contract .col-xs-2, #hrjob-contract .col-xs-3, #hrjob-contract .col-xs-4, #hrjob-contract .col-xs-5, #hrjob-contract .col-xs-6, #hrjob-contract .col-xs-7, #hrjob-contract .col-xs-8, #hrjob-contract .col-xs-9, #hrjob-contract .col-xs-10, #hrjob-contract .col-xs-11, #hrjob-contract .col-xs-12 {
   float: left;
 }
-/* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-1 {
   width: 8.33333333%;
 }
-/* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-2 {
   width: 16.66666667%;
 }
-/* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-3 {
   width: 25%;
 }
-/* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-4 {
   width: 33.33333333%;
 }
-/* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-5 {
   width: 41.66666667%;
 }
-/* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-6 {
   width: 50%;
 }
-/* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-7 {
   width: 58.33333333%;
 }
-/* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-8 {
   width: 66.66666667%;
 }
-/* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-9 {
   width: 75%;
 }
-/* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-10 {
   width: 83.33333333%;
 }
-/* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-11 {
   width: 91.66666667%;
 }
-/* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-12 {
   width: 100%;
 }
-/* line 55, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-pull-0 {
   right: auto;
 }
-/* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-pull-1 {
   right: 8.33333333%;
 }
-/* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-pull-2 {
   right: 16.66666667%;
 }
-/* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-pull-3 {
   right: 25%;
 }
-/* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-pull-4 {
   right: 33.33333333%;
 }
-/* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-pull-5 {
   right: 41.66666667%;
 }
-/* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-pull-6 {
   right: 50%;
 }
-/* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-pull-7 {
   right: 58.33333333%;
 }
-/* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-pull-8 {
   right: 66.66666667%;
 }
-/* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-pull-9 {
   right: 75%;
 }
-/* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-pull-10 {
   right: 83.33333333%;
 }
-/* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-pull-11 {
   right: 91.66666667%;
 }
-/* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-pull-12 {
   right: 100%;
 }
-/* line 45, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-push-0 {
   left: auto;
 }
-/* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-push-1 {
   left: 8.33333333%;
 }
-/* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-push-2 {
   left: 16.66666667%;
 }
-/* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-push-3 {
   left: 25%;
 }
-/* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-push-4 {
   left: 33.33333333%;
 }
-/* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-push-5 {
   left: 41.66666667%;
 }
-/* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-push-6 {
   left: 50%;
 }
-/* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-push-7 {
   left: 58.33333333%;
 }
-/* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-push-8 {
   left: 66.66666667%;
 }
-/* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-push-9 {
   left: 75%;
 }
-/* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-push-10 {
   left: 83.33333333%;
 }
-/* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-push-11 {
   left: 91.66666667%;
 }
-/* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-push-12 {
   left: 100%;
 }
-/* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-offset-0 {
   margin-left: 0%;
 }
-/* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-offset-1 {
   margin-left: 8.33333333%;
 }
-/* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-offset-2 {
   margin-left: 16.66666667%;
 }
-/* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-offset-3 {
   margin-left: 25%;
 }
-/* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-offset-4 {
   margin-left: 33.33333333%;
 }
-/* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-offset-5 {
   margin-left: 41.66666667%;
 }
-/* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-offset-6 {
   margin-left: 50%;
 }
-/* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-offset-7 {
   margin-left: 58.33333333%;
 }
-/* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-offset-8 {
   margin-left: 66.66666667%;
 }
-/* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-offset-9 {
   margin-left: 75%;
 }
-/* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-offset-10 {
   margin-left: 83.33333333%;
 }
-/* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-offset-11 {
   margin-left: 91.66666667%;
 }
-/* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
 #hrjob-contract .col-xs-offset-12 {
   margin-left: 100%;
 }
 @media (min-width: 768px) {
-  /* line 27, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-1, #hrjob-contract .col-sm-2, #hrjob-contract .col-sm-3, #hrjob-contract .col-sm-4, #hrjob-contract .col-sm-5, #hrjob-contract .col-sm-6, #hrjob-contract .col-sm-7, #hrjob-contract .col-sm-8, #hrjob-contract .col-sm-9, #hrjob-contract .col-sm-10, #hrjob-contract .col-sm-11, #hrjob-contract .col-sm-12 {
     float: left;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-1 {
     width: 8.33333333%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-2 {
     width: 16.66666667%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-3 {
     width: 25%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-4 {
     width: 33.33333333%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-5 {
     width: 41.66666667%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-6 {
     width: 50%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-7 {
     width: 58.33333333%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-8 {
     width: 66.66666667%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-9 {
     width: 75%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-10 {
     width: 83.33333333%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-11 {
     width: 91.66666667%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-12 {
     width: 100%;
   }
-  /* line 55, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-pull-0 {
     right: auto;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-pull-1 {
     right: 8.33333333%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-pull-2 {
     right: 16.66666667%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-pull-3 {
     right: 25%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-pull-4 {
     right: 33.33333333%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-pull-5 {
     right: 41.66666667%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-pull-6 {
     right: 50%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-pull-7 {
     right: 58.33333333%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-pull-8 {
     right: 66.66666667%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-pull-9 {
     right: 75%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-pull-10 {
     right: 83.33333333%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-pull-11 {
     right: 91.66666667%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-pull-12 {
     right: 100%;
   }
-  /* line 45, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-push-0 {
     left: auto;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-push-1 {
     left: 8.33333333%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-push-2 {
     left: 16.66666667%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-push-3 {
     left: 25%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-push-4 {
     left: 33.33333333%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-push-5 {
     left: 41.66666667%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-push-6 {
     left: 50%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-push-7 {
     left: 58.33333333%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-push-8 {
     left: 66.66666667%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-push-9 {
     left: 75%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-push-10 {
     left: 83.33333333%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-push-11 {
     left: 91.66666667%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-push-12 {
     left: 100%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-offset-0 {
     margin-left: 0%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-offset-1 {
     margin-left: 8.33333333%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-offset-2 {
     margin-left: 16.66666667%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-offset-3 {
     margin-left: 25%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-offset-4 {
     margin-left: 33.33333333%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-offset-5 {
     margin-left: 41.66666667%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-offset-6 {
     margin-left: 50%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-offset-7 {
     margin-left: 58.33333333%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-offset-8 {
     margin-left: 66.66666667%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-offset-9 {
     margin-left: 75%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-offset-10 {
     margin-left: 83.33333333%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-offset-11 {
     margin-left: 91.66666667%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-sm-offset-12 {
     margin-left: 100%;
   }
 }
 @media (min-width: 992px) {
-  /* line 27, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-1, #hrjob-contract .col-md-2, #hrjob-contract .col-md-3, #hrjob-contract .col-md-4, #hrjob-contract .col-md-5, #hrjob-contract .col-md-6, #hrjob-contract .col-md-7, #hrjob-contract .col-md-8, #hrjob-contract .col-md-9, #hrjob-contract .col-md-10, #hrjob-contract .col-md-11, #hrjob-contract .col-md-12 {
     float: left;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-1 {
     width: 8.33333333%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-2 {
     width: 16.66666667%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-3 {
     width: 25%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-4 {
     width: 33.33333333%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-5 {
     width: 41.66666667%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-6 {
     width: 50%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-7 {
     width: 58.33333333%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-8 {
     width: 66.66666667%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-9 {
     width: 75%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-10 {
     width: 83.33333333%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-11 {
     width: 91.66666667%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-12 {
     width: 100%;
   }
-  /* line 55, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-pull-0 {
     right: auto;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-pull-1 {
     right: 8.33333333%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-pull-2 {
     right: 16.66666667%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-pull-3 {
     right: 25%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-pull-4 {
     right: 33.33333333%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-pull-5 {
     right: 41.66666667%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-pull-6 {
     right: 50%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-pull-7 {
     right: 58.33333333%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-pull-8 {
     right: 66.66666667%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-pull-9 {
     right: 75%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-pull-10 {
     right: 83.33333333%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-pull-11 {
     right: 91.66666667%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-pull-12 {
     right: 100%;
   }
-  /* line 45, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-push-0 {
     left: auto;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-push-1 {
     left: 8.33333333%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-push-2 {
     left: 16.66666667%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-push-3 {
     left: 25%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-push-4 {
     left: 33.33333333%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-push-5 {
     left: 41.66666667%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-push-6 {
     left: 50%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-push-7 {
     left: 58.33333333%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-push-8 {
     left: 66.66666667%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-push-9 {
     left: 75%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-push-10 {
     left: 83.33333333%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-push-11 {
     left: 91.66666667%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-push-12 {
     left: 100%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-offset-0 {
     margin-left: 0%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-offset-1 {
     margin-left: 8.33333333%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-offset-2 {
     margin-left: 16.66666667%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-offset-3 {
     margin-left: 25%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-offset-4 {
     margin-left: 33.33333333%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-offset-5 {
     margin-left: 41.66666667%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-offset-6 {
     margin-left: 50%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-offset-7 {
     margin-left: 58.33333333%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-offset-8 {
     margin-left: 66.66666667%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-offset-9 {
     margin-left: 75%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-offset-10 {
     margin-left: 83.33333333%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-offset-11 {
     margin-left: 91.66666667%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-md-offset-12 {
     margin-left: 100%;
   }
 }
 @media (min-width: 1200px) {
-  /* line 27, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-1, #hrjob-contract .col-lg-2, #hrjob-contract .col-lg-3, #hrjob-contract .col-lg-4, #hrjob-contract .col-lg-5, #hrjob-contract .col-lg-6, #hrjob-contract .col-lg-7, #hrjob-contract .col-lg-8, #hrjob-contract .col-lg-9, #hrjob-contract .col-lg-10, #hrjob-contract .col-lg-11, #hrjob-contract .col-lg-12 {
     float: left;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-1 {
     width: 8.33333333%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-2 {
     width: 16.66666667%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-3 {
     width: 25%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-4 {
     width: 33.33333333%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-5 {
     width: 41.66666667%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-6 {
     width: 50%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-7 {
     width: 58.33333333%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-8 {
     width: 66.66666667%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-9 {
     width: 75%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-10 {
     width: 83.33333333%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-11 {
     width: 91.66666667%;
   }
-  /* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-12 {
     width: 100%;
   }
-  /* line 55, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-pull-0 {
     right: auto;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-pull-1 {
     right: 8.33333333%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-pull-2 {
     right: 16.66666667%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-pull-3 {
     right: 25%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-pull-4 {
     right: 33.33333333%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-pull-5 {
     right: 41.66666667%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-pull-6 {
     right: 50%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-pull-7 {
     right: 58.33333333%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-pull-8 {
     right: 66.66666667%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-pull-9 {
     right: 75%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-pull-10 {
     right: 83.33333333%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-pull-11 {
     right: 91.66666667%;
   }
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-pull-12 {
     right: 100%;
   }
-  /* line 45, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-push-0 {
     left: auto;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-push-1 {
     left: 8.33333333%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-push-2 {
     left: 16.66666667%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-push-3 {
     left: 25%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-push-4 {
     left: 33.33333333%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-push-5 {
     left: 41.66666667%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-push-6 {
     left: 50%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-push-7 {
     left: 58.33333333%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-push-8 {
     left: 66.66666667%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-push-9 {
     left: 75%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-push-10 {
     left: 83.33333333%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-push-11 {
     left: 91.66666667%;
   }
-  /* line 40, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-push-12 {
     left: 100%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-offset-0 {
     margin-left: 0%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-offset-1 {
     margin-left: 8.33333333%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-offset-2 {
     margin-left: 16.66666667%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-offset-3 {
     margin-left: 25%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-offset-4 {
     margin-left: 33.33333333%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-offset-5 {
     margin-left: 41.66666667%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-offset-6 {
     margin-left: 50%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-offset-7 {
     margin-left: 58.33333333%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-offset-8 {
     margin-left: 66.66666667%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-offset-9 {
     margin-left: 75%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-offset-10 {
     margin-left: 83.33333333%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-offset-11 {
     margin-left: 91.66666667%;
   }
-  /* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_grid-framework.scss */
   #hrjob-contract .col-lg-offset-12 {
     margin-left: 100%;
   }
 }
-/* line 6, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
 #hrjob-contract table {
   background-color: #FFFFFF;
 }
-/* line 9, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
 #hrjob-contract caption {
   padding-top: 11px 8px 10px;
   padding-bottom: 11px 8px 10px;
   color: #9494A5;
   text-align: left;
 }
-/* line 15, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
 #hrjob-contract th {
   text-align: left;
 }
-/* line 22, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
 #hrjob-contract .table {
   width: 100%;
   max-width: 100%;
   margin-bottom: 18px;
 }
-/* line 31, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
 #hrjob-contract .table > thead > tr > th,
 #hrjob-contract .table > thead > tr > td,
 #hrjob-contract .table > tbody > tr > th,
@@ -4987,12 +3893,10 @@
   vertical-align: top;
   border-top: 1px solid #E8EEF0;
 }
-/* line 41, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
 #hrjob-contract .table > thead > tr > th {
   vertical-align: bottom;
   border-bottom: 2px solid #E8EEF0;
 }
-/* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
 #hrjob-contract .table > caption + thead > tr:first-child > th,
 #hrjob-contract .table > caption + thead > tr:first-child > td,
 #hrjob-contract .table > colgroup + thead > tr:first-child > th,
@@ -5001,15 +3905,12 @@
 #hrjob-contract .table > thead:first-child > tr:first-child > td {
   border-top: 0;
 }
-/* line 57, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
 #hrjob-contract .table > tbody + tbody {
   border-top: 2px solid #E8EEF0;
 }
-/* line 62, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
 #hrjob-contract .table .table {
   background-color: #E8EEF0;
 }
-/* line 75, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
 #hrjob-contract .table-condensed > thead > tr > th,
 #hrjob-contract .table-condensed > thead > tr > td,
 #hrjob-contract .table-condensed > tbody > tr > th,
@@ -5018,11 +3919,9 @@
 #hrjob-contract .table-condensed > tfoot > tr > td {
   padding: 5px;
 }
-/* line 88, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
 #hrjob-contract .table-bordered {
   border: 1px solid #E8EEF0;
 }
-/* line 94, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
 #hrjob-contract .table-bordered > thead > tr > th,
 #hrjob-contract .table-bordered > thead > tr > td,
 #hrjob-contract .table-bordered > tbody > tr > th,
@@ -5031,33 +3930,27 @@
 #hrjob-contract .table-bordered > tfoot > tr > td {
   border: 1px solid #E8EEF0;
 }
-/* line 101, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
 #hrjob-contract .table-bordered > thead > tr > th,
 #hrjob-contract .table-bordered > thead > tr > td {
   border-bottom-width: 2px;
 }
-/* line 114, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
 #hrjob-contract .table-striped > tbody > tr:nth-of-type(odd) {
   background-color: #FFFFFF;
 }
-/* line 125, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
 #hrjob-contract .table-hover > tbody > tr:hover {
   background-color: #f5f5f5;
 }
-/* line 135, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
 #hrjob-contract table col[class*="col-"] {
   position: static;
   float: none;
   display: table-column;
 }
-/* line 143, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
 #hrjob-contract table td[class*="col-"],
 #hrjob-contract table th[class*="col-"] {
   position: static;
   float: none;
   display: table-cell;
 }
-/* line 9, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_table-row.scss */
 #hrjob-contract .table > thead > tr > td.active,
 #hrjob-contract .table > thead > tr > th.active, #hrjob-contract .table > thead > tr.active > td, #hrjob-contract .table > thead > tr.active > th,
 #hrjob-contract .table > tbody > tr > td.active,
@@ -5070,12 +3963,10 @@
 #hrjob-contract .table > tfoot > tr.active > th {
   background-color: #f5f5f5;
 }
-/* line 20, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_table-row.scss */
 #hrjob-contract .table-hover > tbody > tr > td.active:hover,
 #hrjob-contract .table-hover > tbody > tr > th.active:hover, #hrjob-contract .table-hover > tbody > tr.active:hover > td, #hrjob-contract .table-hover > tbody > tr:hover > .active, #hrjob-contract .table-hover > tbody > tr.active:hover > th {
   background-color: #e8e8e8;
 }
-/* line 9, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_table-row.scss */
 #hrjob-contract .table > thead > tr > td.success,
 #hrjob-contract .table > thead > tr > th.success, #hrjob-contract .table > thead > tr.success > td, #hrjob-contract .table > thead > tr.success > th,
 #hrjob-contract .table > tbody > tr > td.success,
@@ -5088,12 +3979,10 @@
 #hrjob-contract .table > tfoot > tr.success > th {
   background-color: #dff0d8;
 }
-/* line 20, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_table-row.scss */
 #hrjob-contract .table-hover > tbody > tr > td.success:hover,
 #hrjob-contract .table-hover > tbody > tr > th.success:hover, #hrjob-contract .table-hover > tbody > tr.success:hover > td, #hrjob-contract .table-hover > tbody > tr:hover > .success, #hrjob-contract .table-hover > tbody > tr.success:hover > th {
   background-color: #d0e9c6;
 }
-/* line 9, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_table-row.scss */
 #hrjob-contract .table > thead > tr > td.info,
 #hrjob-contract .table > thead > tr > th.info, #hrjob-contract .table > thead > tr.info > td, #hrjob-contract .table > thead > tr.info > th,
 #hrjob-contract .table > tbody > tr > td.info,
@@ -5106,12 +3995,10 @@
 #hrjob-contract .table > tfoot > tr.info > th {
   background-color: #d9edf7;
 }
-/* line 20, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_table-row.scss */
 #hrjob-contract .table-hover > tbody > tr > td.info:hover,
 #hrjob-contract .table-hover > tbody > tr > th.info:hover, #hrjob-contract .table-hover > tbody > tr.info:hover > td, #hrjob-contract .table-hover > tbody > tr:hover > .info, #hrjob-contract .table-hover > tbody > tr.info:hover > th {
   background-color: #c4e3f3;
 }
-/* line 9, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_table-row.scss */
 #hrjob-contract .table > thead > tr > td.warning,
 #hrjob-contract .table > thead > tr > th.warning, #hrjob-contract .table > thead > tr.warning > td, #hrjob-contract .table > thead > tr.warning > th,
 #hrjob-contract .table > tbody > tr > td.warning,
@@ -5124,12 +4011,10 @@
 #hrjob-contract .table > tfoot > tr.warning > th {
   background-color: #fcf8e3;
 }
-/* line 20, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_table-row.scss */
 #hrjob-contract .table-hover > tbody > tr > td.warning:hover,
 #hrjob-contract .table-hover > tbody > tr > th.warning:hover, #hrjob-contract .table-hover > tbody > tr.warning:hover > td, #hrjob-contract .table-hover > tbody > tr:hover > .warning, #hrjob-contract .table-hover > tbody > tr.warning:hover > th {
   background-color: #faf2cc;
 }
-/* line 9, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_table-row.scss */
 #hrjob-contract .table > thead > tr > td.danger,
 #hrjob-contract .table > thead > tr > th.danger, #hrjob-contract .table > thead > tr.danger > td, #hrjob-contract .table > thead > tr.danger > th,
 #hrjob-contract .table > tbody > tr > td.danger,
@@ -5142,18 +4027,15 @@
 #hrjob-contract .table > tfoot > tr.danger > th {
   background-color: #f2dede;
 }
-/* line 20, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_table-row.scss */
 #hrjob-contract .table-hover > tbody > tr > td.danger:hover,
 #hrjob-contract .table-hover > tbody > tr > th.danger:hover, #hrjob-contract .table-hover > tbody > tr.danger:hover > td, #hrjob-contract .table-hover > tbody > tr:hover > .danger, #hrjob-contract .table-hover > tbody > tr.danger:hover > th {
   background-color: #ebcccc;
 }
-/* line 171, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
 #hrjob-contract .table-responsive {
   overflow-x: auto;
   min-height: 0.01%;
 }
 @media screen and (max-width: 767px) {
-  /* line 171, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
   #hrjob-contract .table-responsive {
     width: 100%;
     margin-bottom: 13.5px;
@@ -5161,11 +4043,9 @@
     -ms-overflow-style: -ms-autohiding-scrollbar;
     border: 1px solid #E8EEF0;
   }
-  /* line 183, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
   #hrjob-contract .table-responsive > .table {
     margin-bottom: 0;
   }
-  /* line 191, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
   #hrjob-contract .table-responsive > .table > thead > tr > th,
   #hrjob-contract .table-responsive > .table > thead > tr > td,
   #hrjob-contract .table-responsive > .table > tbody > tr > th,
@@ -5174,11 +4054,9 @@
   #hrjob-contract .table-responsive > .table > tfoot > tr > td {
     white-space: nowrap;
   }
-  /* line 200, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
   #hrjob-contract .table-responsive > .table-bordered {
     border: 0;
   }
-  /* line 208, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
   #hrjob-contract .table-responsive > .table-bordered > thead > tr > th:first-child,
   #hrjob-contract .table-responsive > .table-bordered > thead > tr > td:first-child,
   #hrjob-contract .table-responsive > .table-bordered > tbody > tr > th:first-child,
@@ -5187,7 +4065,6 @@
   #hrjob-contract .table-responsive > .table-bordered > tfoot > tr > td:first-child {
     border-left: 0;
   }
-  /* line 212, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
   #hrjob-contract .table-responsive > .table-bordered > thead > tr > th:last-child,
   #hrjob-contract .table-responsive > .table-bordered > thead > tr > td:last-child,
   #hrjob-contract .table-responsive > .table-bordered > tbody > tr > th:last-child,
@@ -5196,7 +4073,6 @@
   #hrjob-contract .table-responsive > .table-bordered > tfoot > tr > td:last-child {
     border-right: 0;
   }
-  /* line 225, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss */
   #hrjob-contract .table-responsive > .table-bordered > tbody > tr:last-child > th,
   #hrjob-contract .table-responsive > .table-bordered > tbody > tr:last-child > td,
   #hrjob-contract .table-responsive > .table-bordered > tfoot > tr:last-child > th,
@@ -5204,14 +4080,12 @@
     border-bottom: 0;
   }
 }
-/* line 10, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract fieldset {
   padding: 0;
   margin: 0;
   border: 0;
   min-width: 0;
 }
-/* line 20, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract legend {
   display: block;
   width: 100%;
@@ -5223,7 +4097,6 @@
   border: 0;
   border-bottom: 1px solid #e5e5e5;
 }
-/* line 32, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract label, #hrjob-contract .checkbox-label,
 #hrjob-contract .radio-label {
   display: inline-block;
@@ -5231,41 +4104,34 @@
   margin-bottom: 5px;
   font-weight: bold;
 }
-/* line 47, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract input[type="search"] {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
-/* line 52, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract input[type="radio"],
 #hrjob-contract input[type="checkbox"] {
   margin: 4px 0 0;
   margin-top: 1px \9;
   line-height: normal;
 }
-/* line 59, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract input[type="file"] {
   display: block;
 }
-/* line 64, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract input[type="range"] {
   display: block;
   width: 100%;
 }
-/* line 70, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract select[multiple],
 #hrjob-contract select[size] {
   height: auto;
 }
-/* line 76, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract input[type="file"]:focus,
 #hrjob-contract input[type="radio"]:focus,
 #hrjob-contract input[type="checkbox"]:focus {
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
-/* line 83, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract output {
   display: block;
   padding-top: 7px;
@@ -5273,7 +4139,6 @@
   line-height: 1.42857143;
   color: #4D4D69;
 }
-/* line 114, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-control {
   display: block;
   width: 100%;
@@ -5292,57 +4157,46 @@
   -o-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
   transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
 }
-/* line 57, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract .form-control:focus {
   border-color: #66afe9;
   outline: 0;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
 }
-/* line 103, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_vendor-prefixes.scss */
 #hrjob-contract .form-control::-moz-placeholder {
   color: #9494A5;
   opacity: 1;
 }
-/* line 107, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_vendor-prefixes.scss */
 #hrjob-contract .form-control:-ms-input-placeholder {
   color: #9494A5;
 }
-/* line 108, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_vendor-prefixes.scss */
 #hrjob-contract .form-control::-webkit-input-placeholder {
   color: #9494A5;
 }
-/* line 136, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-control::-ms-expand {
   border: 0;
   background-color: transparent;
 }
-/* line 146, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-control[disabled], #hrjob-contract .form-control[readonly], fieldset[disabled] #hrjob-contract .form-control {
   background-color: #F3F6F7;
   opacity: 1;
 }
-/* line 153, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-control[disabled], fieldset[disabled] #hrjob-contract .form-control {
   cursor: not-allowed;
 }
-/* line 162, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract textarea.form-control {
   height: auto;
 }
-/* line 174, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract input[type="search"] {
   -webkit-appearance: none;
 }
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
-  /* line 193, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract input[type="date"].form-control,
   #hrjob-contract input[type="time"].form-control,
   #hrjob-contract input[type="datetime-local"].form-control,
   #hrjob-contract input[type="month"].form-control {
     line-height: 32px;
   }
-  /* line 197, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract input[type="date"].input-sm, #hrjob-contract .input-group-sm > input[type="date"].form-control,
   #hrjob-contract .input-group-sm > input[type="date"].input-group-addon,
   #hrjob-contract .input-group-sm > .input-group-btn > input[type="date"].btn, .input-group-sm #hrjob-contract input[type="date"],
@@ -5363,7 +4217,6 @@
   #hrjob-contract input[type="month"] {
     line-height: 30px;
   }
-  /* line 202, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract input[type="date"].input-lg, #hrjob-contract .input-group-lg > input[type="date"].form-control,
   #hrjob-contract .input-group-lg > input[type="date"].input-group-addon,
   #hrjob-contract .input-group-lg > .input-group-btn > input[type="date"].btn, .input-group-lg #hrjob-contract input[type="date"],
@@ -5385,11 +4238,9 @@
     line-height: 45px;
   }
 }
-/* line 215, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-group {
   margin-bottom: 15px;
 }
-/* line 224, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .radio,
 #hrjob-contract .checkbox {
   position: relative;
@@ -5397,7 +4248,6 @@
   margin-top: 10px;
   margin-bottom: 10px;
 }
-/* line 231, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .radio label, #hrjob-contract .radio .checkbox-label,
 #hrjob-contract .radio .radio-label,
 #hrjob-contract .checkbox label,
@@ -5409,7 +4259,6 @@
   font-weight: normal;
   cursor: pointer;
 }
-/* line 239, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .radio input[type="radio"],
 #hrjob-contract .radio-inline input[type="radio"],
 #hrjob-contract .checkbox input[type="checkbox"],
@@ -5418,12 +4267,10 @@
   margin-left: -20px;
   margin-top: 4px \9;
 }
-/* line 248, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .radio + .radio,
 #hrjob-contract .checkbox + .checkbox {
   margin-top: -5px;
 }
-/* line 254, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .radio-inline,
 #hrjob-contract .checkbox-inline {
   position: relative;
@@ -5434,26 +4281,22 @@
   font-weight: normal;
   cursor: pointer;
 }
-/* line 264, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .radio-inline + .radio-inline,
 #hrjob-contract .checkbox-inline + .checkbox-inline {
   margin-top: 0;
   margin-left: 10px;
 }
-/* line 276, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract input[type="radio"][disabled], #hrjob-contract input[type="radio"].disabled, fieldset[disabled] #hrjob-contract input[type="radio"],
 #hrjob-contract input[type="checkbox"][disabled],
 #hrjob-contract input[type="checkbox"].disabled, fieldset[disabled]
 #hrjob-contract input[type="checkbox"] {
   cursor: not-allowed;
 }
-/* line 285, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .radio-inline.disabled, fieldset[disabled] #hrjob-contract .radio-inline,
 #hrjob-contract .checkbox-inline.disabled, fieldset[disabled]
 #hrjob-contract .checkbox-inline {
   cursor: not-allowed;
 }
-/* line 295, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .radio.disabled label, #hrjob-contract .radio.disabled .checkbox-label,
 #hrjob-contract .radio.disabled .radio-label, fieldset[disabled] #hrjob-contract .radio label, fieldset[disabled] #hrjob-contract .radio .checkbox-label,
 fieldset[disabled] #hrjob-contract .radio .radio-label,
@@ -5466,14 +4309,12 @@ fieldset[disabled]
 #hrjob-contract .checkbox .radio-label {
   cursor: not-allowed;
 }
-/* line 307, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-control-static {
   padding-top: 7px;
   padding-bottom: 7px;
   margin-bottom: 0;
   min-height: 31px;
 }
-/* line 315, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-control-static.input-lg, #hrjob-contract .input-group-lg > .form-control-static.form-control,
 #hrjob-contract .input-group-lg > .form-control-static.input-group-addon,
 #hrjob-contract .input-group-lg > .input-group-btn > .form-control-static.btn, #hrjob-contract .form-control-static.input-sm, #hrjob-contract .input-group-sm > .form-control-static.form-control,
@@ -5482,7 +4323,6 @@ fieldset[disabled]
   padding-left: 0;
   padding-right: 0;
 }
-/* line 71, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract .input-sm, #hrjob-contract .input-group-sm > .form-control,
 #hrjob-contract .input-group-sm > .input-group-addon,
 #hrjob-contract .input-group-sm > .input-group-btn > .btn {
@@ -5492,14 +4332,12 @@ fieldset[disabled]
   line-height: 1.5;
   border-radius: 2px;
 }
-/* line 79, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract select.input-sm, #hrjob-contract .input-group-sm > select.form-control,
 #hrjob-contract .input-group-sm > select.input-group-addon,
 #hrjob-contract .input-group-sm > .input-group-btn > select.btn {
   height: 30px;
   line-height: 30px;
 }
-/* line 84, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract textarea.input-sm, #hrjob-contract .input-group-sm > textarea.form-control,
 #hrjob-contract .input-group-sm > textarea.input-group-addon,
 #hrjob-contract .input-group-sm > .input-group-btn > textarea.btn,
@@ -5509,7 +4347,6 @@ fieldset[disabled]
 #hrjob-contract .input-group-sm > .input-group-btn > select[multiple].btn {
   height: auto;
 }
-/* line 333, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-group-sm .form-control {
   height: 30px;
   padding: 5px 10px;
@@ -5517,17 +4354,14 @@ fieldset[disabled]
   line-height: 1.5;
   border-radius: 2px;
 }
-/* line 340, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-group-sm select.form-control {
   height: 30px;
   line-height: 30px;
 }
-/* line 344, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-group-sm textarea.form-control,
 #hrjob-contract .form-group-sm select[multiple].form-control {
   height: auto;
 }
-/* line 348, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-group-sm .form-control-static {
   height: 30px;
   min-height: 30px;
@@ -5535,7 +4369,6 @@ fieldset[disabled]
   font-size: 12px;
   line-height: 1.5;
 }
-/* line 71, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract .input-lg, #hrjob-contract .input-group-lg > .form-control,
 #hrjob-contract .input-group-lg > .input-group-addon,
 #hrjob-contract .input-group-lg > .input-group-btn > .btn {
@@ -5545,14 +4378,12 @@ fieldset[disabled]
   line-height: 1.3333333;
   border-radius: 4px;
 }
-/* line 79, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract select.input-lg, #hrjob-contract .input-group-lg > select.form-control,
 #hrjob-contract .input-group-lg > select.input-group-addon,
 #hrjob-contract .input-group-lg > .input-group-btn > select.btn {
   height: 45px;
   line-height: 45px;
 }
-/* line 84, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract textarea.input-lg, #hrjob-contract .input-group-lg > textarea.form-control,
 #hrjob-contract .input-group-lg > textarea.input-group-addon,
 #hrjob-contract .input-group-lg > .input-group-btn > textarea.btn,
@@ -5562,7 +4393,6 @@ fieldset[disabled]
 #hrjob-contract .input-group-lg > .input-group-btn > select[multiple].btn {
   height: auto;
 }
-/* line 359, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-group-lg .form-control {
   height: 45px;
   padding: 10px 16px;
@@ -5570,17 +4400,14 @@ fieldset[disabled]
   line-height: 1.3333333;
   border-radius: 4px;
 }
-/* line 366, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-group-lg select.form-control {
   height: 45px;
   line-height: 45px;
 }
-/* line 370, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-group-lg textarea.form-control,
 #hrjob-contract .form-group-lg select[multiple].form-control {
   height: auto;
 }
-/* line 374, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-group-lg .form-control-static {
   height: 45px;
   min-height: 35px;
@@ -5588,15 +4415,12 @@ fieldset[disabled]
   font-size: 17px;
   line-height: 1.3333333;
 }
-/* line 388, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .has-feedback {
   position: relative;
 }
-/* line 393, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .has-feedback .form-control {
   padding-right: 40px;
 }
-/* line 398, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-control-feedback {
   position: absolute;
   top: 0;
@@ -5609,7 +4433,6 @@ fieldset[disabled]
   text-align: center;
   pointer-events: none;
 }
-/* line 410, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .input-lg + .form-control-feedback, #hrjob-contract .input-group-lg > .form-control + .form-control-feedback,
 #hrjob-contract .input-group-lg > .input-group-addon + .form-control-feedback,
 #hrjob-contract .input-group-lg > .input-group-btn > .btn + .form-control-feedback,
@@ -5619,7 +4442,6 @@ fieldset[disabled]
   height: 45px;
   line-height: 45px;
 }
-/* line 417, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .input-sm + .form-control-feedback, #hrjob-contract .input-group-sm > .form-control + .form-control-feedback,
 #hrjob-contract .input-group-sm > .input-group-addon + .form-control-feedback,
 #hrjob-contract .input-group-sm > .input-group-btn > .btn + .form-control-feedback,
@@ -5629,7 +4451,6 @@ fieldset[disabled]
   height: 30px;
   line-height: 30px;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract .has-success .help-block,
 #hrjob-contract .has-success .control-label,
 #hrjob-contract .has-success .radio,
@@ -5642,29 +4463,24 @@ fieldset[disabled]
 #hrjob-contract .has-success.checkbox-inline .radio-label {
   color: #4d994d;
 }
-/* line 21, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract .has-success .form-control {
   border-color: #4d994d;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
 }
-/* line 24, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract .has-success .form-control:focus {
   border-color: #3c773c;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #89c389;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #89c389;
 }
-/* line 31, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract .has-success .input-group-addon {
   color: #4d994d;
   border-color: #4d994d;
   background-color: #dff0d8;
 }
-/* line 37, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract .has-success .form-control-feedback {
   color: #4d994d;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract .has-warning .help-block,
 #hrjob-contract .has-warning .control-label,
 #hrjob-contract .has-warning .radio,
@@ -5677,29 +4493,24 @@ fieldset[disabled]
 #hrjob-contract .has-warning.checkbox-inline .radio-label {
   color: #bf5900;
 }
-/* line 21, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract .has-warning .form-control {
   border-color: #bf5900;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
 }
-/* line 24, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract .has-warning .form-control:focus {
   border-color: #8c4100;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ff8b26;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ff8b26;
 }
-/* line 31, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract .has-warning .input-group-addon {
   color: #bf5900;
   border-color: #bf5900;
   background-color: #fcf8e3;
 }
-/* line 37, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract .has-warning .form-control-feedback {
   color: #bf5900;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract .has-error .help-block,
 #hrjob-contract .has-error .control-label,
 #hrjob-contract .has-error .radio,
@@ -5712,39 +4523,32 @@ fieldset[disabled]
 #hrjob-contract .has-error.checkbox-inline .radio-label {
   color: #CF3458;
 }
-/* line 21, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract .has-error .form-control {
   border-color: #CF3458;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
 }
-/* line 24, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract .has-error .form-control:focus {
   border-color: #a82846;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #e3869c;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #e3869c;
 }
-/* line 31, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract .has-error .input-group-addon {
   color: #CF3458;
   border-color: #CF3458;
   background-color: #f2dede;
 }
-/* line 37, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_forms.scss */
 #hrjob-contract .has-error .form-control-feedback {
   color: #CF3458;
 }
-/* line 439, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .has-feedback label ~ .form-control-feedback, #hrjob-contract .has-feedback .checkbox-label ~ .form-control-feedback,
 #hrjob-contract .has-feedback .radio-label ~ .form-control-feedback {
   top: 23px;
 }
-/* line 442, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .has-feedback label.sr-only ~ .form-control-feedback, #hrjob-contract .has-feedback .sr-only.checkbox-label ~ .form-control-feedback,
 #hrjob-contract .has-feedback .sr-only.radio-label ~ .form-control-feedback {
   top: 0;
 }
-/* line 453, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .help-block {
   display: block;
   margin-top: 5px;
@@ -5752,43 +4556,35 @@ fieldset[disabled]
   color: #8b8baa;
 }
 @media (min-width: 768px) {
-  /* line 478, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .form-inline .form-group {
     display: inline-block;
     margin-bottom: 0;
     vertical-align: middle;
   }
-  /* line 485, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .form-inline .form-control {
     display: inline-block;
     width: auto;
     vertical-align: middle;
   }
-  /* line 492, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .form-inline .form-control-static {
     display: inline-block;
   }
-  /* line 496, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .form-inline .input-group {
     display: inline-table;
     vertical-align: middle;
   }
-  /* line 500, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .form-inline .input-group .input-group-addon,
   #hrjob-contract .form-inline .input-group .input-group-btn,
   #hrjob-contract .form-inline .input-group .form-control {
     width: auto;
   }
-  /* line 508, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .form-inline .input-group > .form-control {
     width: 100%;
   }
-  /* line 512, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .form-inline .control-label {
     margin-bottom: 0;
     vertical-align: middle;
   }
-  /* line 519, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .form-inline .radio,
   #hrjob-contract .form-inline .checkbox {
     display: inline-block;
@@ -5796,7 +4592,6 @@ fieldset[disabled]
     margin-bottom: 0;
     vertical-align: middle;
   }
-  /* line 526, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .form-inline .radio label, #hrjob-contract .form-inline .radio .checkbox-label,
   #hrjob-contract .form-inline .radio .radio-label,
   #hrjob-contract .form-inline .checkbox label,
@@ -5804,18 +4599,15 @@ fieldset[disabled]
   #hrjob-contract .form-inline .checkbox .radio-label {
     padding-left: 0;
   }
-  /* line 530, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .form-inline .radio input[type="radio"],
   #hrjob-contract .form-inline .checkbox input[type="checkbox"] {
     position: relative;
     margin-left: 0;
   }
-  /* line 537, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .form-inline .has-feedback .form-control-feedback {
     top: 0;
   }
 }
-/* line 559, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-horizontal .radio,
 #hrjob-contract .form-horizontal .checkbox,
 #hrjob-contract .form-horizontal .radio-inline,
@@ -5824,52 +4616,43 @@ fieldset[disabled]
   margin-bottom: 0;
   padding-top: 7px;
 }
-/* line 569, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-horizontal .radio,
 #hrjob-contract .form-horizontal .checkbox {
   min-height: 25px;
 }
-/* line 575, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-horizontal .form-group {
   margin-left: -15px;
   margin-right: -15px;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .form-horizontal .form-group:before, #hrjob-contract .form-horizontal .form-group:after {
   content: " ";
   display: table;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .form-horizontal .form-group:after {
   clear: both;
 }
 @media (min-width: 768px) {
-  /* line 582, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .form-horizontal .control-label {
     text-align: right;
     margin-bottom: 0;
     padding-top: 7px;
   }
 }
-/* line 593, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
 #hrjob-contract .form-horizontal .has-feedback .form-control-feedback {
   right: 15px;
 }
 @media (min-width: 768px) {
-  /* line 603, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .form-horizontal .form-group-lg .control-label {
     padding-top: 11px;
     font-size: 17px;
   }
 }
 @media (min-width: 768px) {
-  /* line 611, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .form-horizontal .form-group-sm .control-label {
     padding-top: 6px;
     font-size: 12px;
   }
 }
-/* line 9, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn {
   display: inline-block;
   margin-bottom: 0;
@@ -5890,24 +4673,20 @@ fieldset[disabled]
   -ms-user-select: none;
   user-select: none;
 }
-/* line 26, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn:focus, #hrjob-contract .btn.focus, #hrjob-contract .btn:active:focus, #hrjob-contract .btn:active.focus, #hrjob-contract .btn.active:focus, #hrjob-contract .btn.active.focus {
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
-/* line 32, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn:hover, #hrjob-contract .btn:focus, #hrjob-contract .btn.focus {
   color: #333;
   text-decoration: none;
 }
-/* line 39, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn:active, #hrjob-contract .btn.active {
   outline: 0;
   background-image: none;
   -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
 }
-/* line 46, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn.disabled, #hrjob-contract .btn[disabled], fieldset[disabled] #hrjob-contract .btn {
   cursor: not-allowed;
   opacity: 0.65;
@@ -5915,365 +4694,298 @@ fieldset[disabled]
   -webkit-box-shadow: none;
   box-shadow: none;
 }
-/* line 58, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract a.btn.disabled, fieldset[disabled] #hrjob-contract a.btn {
   pointer-events: none;
 }
-/* line 68, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn-default {
   color: #333;
   background-color: #fff;
   border-color: #ccc;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-default:focus, #hrjob-contract .btn-default.focus {
   color: #333;
   background-color: #e6e6e6;
   border-color: #8c8c8c;
 }
-/* line 17, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-default:hover {
   color: #333;
   background-color: #e6e6e6;
   border-color: #adadad;
 }
-/* line 22, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-default:active, #hrjob-contract .btn-default.active, .open > #hrjob-contract .btn-default.dropdown-toggle {
   color: #333;
   background-color: #e6e6e6;
   border-color: #adadad;
 }
-/* line 29, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-default:active:hover, #hrjob-contract .btn-default:active:focus, #hrjob-contract .btn-default:active.focus, #hrjob-contract .btn-default.active:hover, #hrjob-contract .btn-default.active:focus, #hrjob-contract .btn-default.active.focus, .open > #hrjob-contract .btn-default.dropdown-toggle:hover, .open > #hrjob-contract .btn-default.dropdown-toggle:focus, .open > #hrjob-contract .btn-default.dropdown-toggle.focus {
   color: #333;
   background-color: #d4d4d4;
   border-color: #8c8c8c;
 }
-/* line 37, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-default:active, #hrjob-contract .btn-default.active, .open > #hrjob-contract .btn-default.dropdown-toggle {
   background-image: none;
 }
-/* line 45, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-default.disabled:hover, #hrjob-contract .btn-default.disabled:focus, #hrjob-contract .btn-default.disabled.focus, #hrjob-contract .btn-default[disabled]:hover, #hrjob-contract .btn-default[disabled]:focus, #hrjob-contract .btn-default[disabled].focus, fieldset[disabled] #hrjob-contract .btn-default:hover, fieldset[disabled] #hrjob-contract .btn-default:focus, fieldset[disabled] #hrjob-contract .btn-default.focus {
   background-color: #fff;
   border-color: #ccc;
 }
-/* line 53, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-default .badge {
   color: #fff;
   background-color: #333;
 }
-/* line 71, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn-primary {
   color: #fff;
   background-color: #0071BD;
   border-color: #0062a4;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-primary:focus, #hrjob-contract .btn-primary.focus {
   color: #fff;
   background-color: #00538a;
   border-color: #001624;
 }
-/* line 17, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-primary:hover {
   color: #fff;
   background-color: #00538a;
   border-color: #003d66;
 }
-/* line 22, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-primary:active, #hrjob-contract .btn-primary.active, .open > #hrjob-contract .btn-primary.dropdown-toggle {
   color: #fff;
   background-color: #00538a;
   border-color: #003d66;
 }
-/* line 29, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-primary:active:hover, #hrjob-contract .btn-primary:active:focus, #hrjob-contract .btn-primary:active.focus, #hrjob-contract .btn-primary.active:hover, #hrjob-contract .btn-primary.active:focus, #hrjob-contract .btn-primary.active.focus, .open > #hrjob-contract .btn-primary.dropdown-toggle:hover, .open > #hrjob-contract .btn-primary.dropdown-toggle:focus, .open > #hrjob-contract .btn-primary.dropdown-toggle.focus {
   color: #fff;
   background-color: #003d66;
   border-color: #001624;
 }
-/* line 37, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-primary:active, #hrjob-contract .btn-primary.active, .open > #hrjob-contract .btn-primary.dropdown-toggle {
   background-image: none;
 }
-/* line 45, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-primary.disabled:hover, #hrjob-contract .btn-primary.disabled:focus, #hrjob-contract .btn-primary.disabled.focus, #hrjob-contract .btn-primary[disabled]:hover, #hrjob-contract .btn-primary[disabled]:focus, #hrjob-contract .btn-primary[disabled].focus, fieldset[disabled] #hrjob-contract .btn-primary:hover, fieldset[disabled] #hrjob-contract .btn-primary:focus, fieldset[disabled] #hrjob-contract .btn-primary.focus {
   background-color: #0071BD;
   border-color: #0062a4;
 }
-/* line 53, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-primary .badge {
   color: #0071BD;
   background-color: #fff;
 }
-/* line 75, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn-success {
   color: #fff;
   background-color: #44CB7E;
   border-color: #35c071;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-success:focus, #hrjob-contract .btn-success.focus {
   color: #fff;
   background-color: #30ac65;
   border-color: #1a5c36;
 }
-/* line 17, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-success:hover {
   color: #fff;
   background-color: #30ac65;
   border-color: #289055;
 }
-/* line 22, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-success:active, #hrjob-contract .btn-success.active, .open > #hrjob-contract .btn-success.dropdown-toggle {
   color: #fff;
   background-color: #30ac65;
   border-color: #289055;
 }
-/* line 29, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-success:active:hover, #hrjob-contract .btn-success:active:focus, #hrjob-contract .btn-success:active.focus, #hrjob-contract .btn-success.active:hover, #hrjob-contract .btn-success.active:focus, #hrjob-contract .btn-success.active.focus, .open > #hrjob-contract .btn-success.dropdown-toggle:hover, .open > #hrjob-contract .btn-success.dropdown-toggle:focus, .open > #hrjob-contract .btn-success.dropdown-toggle.focus {
   color: #fff;
   background-color: #289055;
   border-color: #1a5c36;
 }
-/* line 37, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-success:active, #hrjob-contract .btn-success.active, .open > #hrjob-contract .btn-success.dropdown-toggle {
   background-image: none;
 }
-/* line 45, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-success.disabled:hover, #hrjob-contract .btn-success.disabled:focus, #hrjob-contract .btn-success.disabled.focus, #hrjob-contract .btn-success[disabled]:hover, #hrjob-contract .btn-success[disabled]:focus, #hrjob-contract .btn-success[disabled].focus, fieldset[disabled] #hrjob-contract .btn-success:hover, fieldset[disabled] #hrjob-contract .btn-success:focus, fieldset[disabled] #hrjob-contract .btn-success.focus {
   background-color: #44CB7E;
   border-color: #35c071;
 }
-/* line 53, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-success .badge {
   color: #44CB7E;
   background-color: #fff;
 }
-/* line 79, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn-info {
   color: #fff;
   background-color: #5bc0de;
   border-color: #46b8da;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-info:focus, #hrjob-contract .btn-info.focus {
   color: #fff;
   background-color: #31b0d5;
   border-color: #1b6d85;
 }
-/* line 17, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-info:hover {
   color: #fff;
   background-color: #31b0d5;
   border-color: #269abc;
 }
-/* line 22, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-info:active, #hrjob-contract .btn-info.active, .open > #hrjob-contract .btn-info.dropdown-toggle {
   color: #fff;
   background-color: #31b0d5;
   border-color: #269abc;
 }
-/* line 29, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-info:active:hover, #hrjob-contract .btn-info:active:focus, #hrjob-contract .btn-info:active.focus, #hrjob-contract .btn-info.active:hover, #hrjob-contract .btn-info.active:focus, #hrjob-contract .btn-info.active.focus, .open > #hrjob-contract .btn-info.dropdown-toggle:hover, .open > #hrjob-contract .btn-info.dropdown-toggle:focus, .open > #hrjob-contract .btn-info.dropdown-toggle.focus {
   color: #fff;
   background-color: #269abc;
   border-color: #1b6d85;
 }
-/* line 37, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-info:active, #hrjob-contract .btn-info.active, .open > #hrjob-contract .btn-info.dropdown-toggle {
   background-image: none;
 }
-/* line 45, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-info.disabled:hover, #hrjob-contract .btn-info.disabled:focus, #hrjob-contract .btn-info.disabled.focus, #hrjob-contract .btn-info[disabled]:hover, #hrjob-contract .btn-info[disabled]:focus, #hrjob-contract .btn-info[disabled].focus, fieldset[disabled] #hrjob-contract .btn-info:hover, fieldset[disabled] #hrjob-contract .btn-info:focus, fieldset[disabled] #hrjob-contract .btn-info.focus {
   background-color: #5bc0de;
   border-color: #46b8da;
 }
-/* line 53, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-info .badge {
   color: #5bc0de;
   background-color: #fff;
 }
-/* line 83, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn-warning {
   color: #fff;
   background-color: #E6AB5E;
   border-color: #e39f48;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-warning:focus, #hrjob-contract .btn-warning.focus {
   color: #fff;
   background-color: #df9432;
   border-color: #945e17;
 }
-/* line 17, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-warning:hover {
   color: #fff;
   background-color: #df9432;
   border-color: #cd8220;
 }
-/* line 22, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-warning:active, #hrjob-contract .btn-warning.active, .open > #hrjob-contract .btn-warning.dropdown-toggle {
   color: #fff;
   background-color: #df9432;
   border-color: #cd8220;
 }
-/* line 29, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-warning:active:hover, #hrjob-contract .btn-warning:active:focus, #hrjob-contract .btn-warning:active.focus, #hrjob-contract .btn-warning.active:hover, #hrjob-contract .btn-warning.active:focus, #hrjob-contract .btn-warning.active.focus, .open > #hrjob-contract .btn-warning.dropdown-toggle:hover, .open > #hrjob-contract .btn-warning.dropdown-toggle:focus, .open > #hrjob-contract .btn-warning.dropdown-toggle.focus {
   color: #fff;
   background-color: #cd8220;
   border-color: #945e17;
 }
-/* line 37, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-warning:active, #hrjob-contract .btn-warning.active, .open > #hrjob-contract .btn-warning.dropdown-toggle {
   background-image: none;
 }
-/* line 45, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-warning.disabled:hover, #hrjob-contract .btn-warning.disabled:focus, #hrjob-contract .btn-warning.disabled.focus, #hrjob-contract .btn-warning[disabled]:hover, #hrjob-contract .btn-warning[disabled]:focus, #hrjob-contract .btn-warning[disabled].focus, fieldset[disabled] #hrjob-contract .btn-warning:hover, fieldset[disabled] #hrjob-contract .btn-warning:focus, fieldset[disabled] #hrjob-contract .btn-warning.focus {
   background-color: #E6AB5E;
   border-color: #e39f48;
 }
-/* line 53, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-warning .badge {
   color: #E6AB5E;
   background-color: #fff;
 }
-/* line 87, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn-danger {
   color: #fff;
   background-color: #CF3458;
   border-color: #bd2d4e;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-danger:focus, #hrjob-contract .btn-danger.focus {
   color: #fff;
   background-color: #a82846;
   border-color: #561423;
 }
-/* line 17, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-danger:hover {
   color: #fff;
   background-color: #a82846;
   border-color: #8b213a;
 }
-/* line 22, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-danger:active, #hrjob-contract .btn-danger.active, .open > #hrjob-contract .btn-danger.dropdown-toggle {
   color: #fff;
   background-color: #a82846;
   border-color: #8b213a;
 }
-/* line 29, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-danger:active:hover, #hrjob-contract .btn-danger:active:focus, #hrjob-contract .btn-danger:active.focus, #hrjob-contract .btn-danger.active:hover, #hrjob-contract .btn-danger.active:focus, #hrjob-contract .btn-danger.active.focus, .open > #hrjob-contract .btn-danger.dropdown-toggle:hover, .open > #hrjob-contract .btn-danger.dropdown-toggle:focus, .open > #hrjob-contract .btn-danger.dropdown-toggle.focus {
   color: #fff;
   background-color: #8b213a;
   border-color: #561423;
 }
-/* line 37, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-danger:active, #hrjob-contract .btn-danger.active, .open > #hrjob-contract .btn-danger.dropdown-toggle {
   background-image: none;
 }
-/* line 45, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-danger.disabled:hover, #hrjob-contract .btn-danger.disabled:focus, #hrjob-contract .btn-danger.disabled.focus, #hrjob-contract .btn-danger[disabled]:hover, #hrjob-contract .btn-danger[disabled]:focus, #hrjob-contract .btn-danger[disabled].focus, fieldset[disabled] #hrjob-contract .btn-danger:hover, fieldset[disabled] #hrjob-contract .btn-danger:focus, fieldset[disabled] #hrjob-contract .btn-danger.focus {
   background-color: #CF3458;
   border-color: #bd2d4e;
 }
-/* line 53, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_buttons.scss */
 #hrjob-contract .btn-danger .badge {
   color: #CF3458;
   background-color: #fff;
 }
-/* line 96, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn-link {
   color: #0071BD;
   font-weight: normal;
   border-radius: 0;
 }
-/* line 101, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn-link, #hrjob-contract .btn-link:active, #hrjob-contract .btn-link.active, #hrjob-contract .btn-link[disabled], fieldset[disabled] #hrjob-contract .btn-link {
   background-color: transparent;
   -webkit-box-shadow: none;
   box-shadow: none;
 }
-/* line 109, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn-link, #hrjob-contract .btn-link:hover, #hrjob-contract .btn-link:focus, #hrjob-contract .btn-link:active {
   border-color: transparent;
 }
-/* line 115, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn-link:hover, #hrjob-contract .btn-link:focus {
   color: #005c99;
   text-decoration: none;
   background-color: transparent;
 }
-/* line 123, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn-link[disabled]:hover, #hrjob-contract .btn-link[disabled]:focus, fieldset[disabled] #hrjob-contract .btn-link:hover, fieldset[disabled] #hrjob-contract .btn-link:focus {
   color: #E8EEF0;
   text-decoration: none;
 }
-/* line 135, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn-lg, #hrjob-contract .btn-group-lg > .btn {
   padding: 10px 16px;
   font-size: 17px;
   line-height: 1.3333333;
   border-radius: 4px;
 }
-/* line 139, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn-sm, #hrjob-contract .btn-group-sm > .btn {
   padding: 5px 10px;
   font-size: 12px;
   line-height: 1.5;
   border-radius: 2px;
 }
-/* line 143, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn-xs, #hrjob-contract .btn-group-xs > .btn {
   padding: 3px 8px;
   font-size: 12px;
   line-height: 1.5;
   border-radius: 2px;
 }
-/* line 151, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn-block {
   display: block;
   width: 100%;
 }
-/* line 157, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract .btn-block + .btn-block {
   margin-top: 5px;
 }
-/* line 165, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_buttons.scss */
 #hrjob-contract input[type="submit"].btn-block,
 #hrjob-contract input[type="reset"].btn-block,
 #hrjob-contract input[type="button"].btn-block {
   width: 100%;
 }
-/* line 10, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_component-animations.scss */
 #hrjob-contract .fade {
   opacity: 0;
   -webkit-transition: opacity 0.15s linear;
   -o-transition: opacity 0.15s linear;
   transition: opacity 0.15s linear;
 }
-/* line 13, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_component-animations.scss */
 #hrjob-contract .fade.in {
   opacity: 1;
 }
-/* line 18, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_component-animations.scss */
 #hrjob-contract .collapse {
   display: none;
 }
-/* line 21, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_component-animations.scss */
 #hrjob-contract .collapse.in {
   display: block;
 }
-/* line 26, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_component-animations.scss */
 #hrjob-contract tr.collapse.in {
   display: table-row;
 }
-/* line 28, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_component-animations.scss */
 #hrjob-contract tbody.collapse.in {
   display: table-row-group;
 }
-/* line 30, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_component-animations.scss */
 #hrjob-contract .collapsing {
   position: relative;
   height: 0;
@@ -6285,7 +4997,6 @@ fieldset[disabled]
   -webkit-transition-timing-function: ease;
   transition-timing-function: ease;
 }
-/* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .caret {
   display: inline-block;
   width: 0;
@@ -6297,16 +5008,13 @@ fieldset[disabled]
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
 }
-/* line 20, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .dropup,
 #hrjob-contract .dropdown {
   position: relative;
 }
-/* line 26, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .dropdown-toggle:focus {
   outline: 0;
 }
-/* line 31, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .dropdown-menu {
   position: absolute;
   top: 100%;
@@ -6328,19 +5036,16 @@ fieldset[disabled]
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
   background-clip: padding-box;
 }
-/* line 54, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .dropdown-menu.pull-right {
   right: 0;
   left: auto;
 }
-/* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .dropdown-menu .divider {
   height: 1px;
   margin: 8px 0;
   overflow: hidden;
   background-color: #e5e5e5;
 }
-/* line 65, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .dropdown-menu > li > a {
   display: block;
   padding: 3px 20px;
@@ -6350,24 +5055,20 @@ fieldset[disabled]
   color: #4D4D69;
   white-space: nowrap;
 }
-/* line 78, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .dropdown-menu > li > a:hover, #hrjob-contract .dropdown-menu > li > a:focus {
   text-decoration: none;
   color: #42425a;
   background-color: #f5f5f5;
 }
-/* line 88, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .dropdown-menu > .active > a, #hrjob-contract .dropdown-menu > .active > a:hover, #hrjob-contract .dropdown-menu > .active > a:focus {
   color: #fff;
   text-decoration: none;
   outline: 0;
   background-color: #0071BD;
 }
-/* line 103, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .dropdown-menu > .disabled > a, #hrjob-contract .dropdown-menu > .disabled > a:hover, #hrjob-contract .dropdown-menu > .disabled > a:focus {
   color: #E8EEF0;
 }
-/* line 110, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .dropdown-menu > .disabled > a:hover, #hrjob-contract .dropdown-menu > .disabled > a:focus {
   text-decoration: none;
   background-color: transparent;
@@ -6375,25 +5076,20 @@ fieldset[disabled]
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
   cursor: not-allowed;
 }
-/* line 123, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .open > .dropdown-menu {
   display: block;
 }
-/* line 128, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .open > a {
   outline: 0;
 }
-/* line 137, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .dropdown-menu-right {
   left: auto;
   right: 0;
 }
-/* line 147, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .dropdown-menu-left {
   left: 0;
   right: auto;
 }
-/* line 153, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .dropdown-header {
   display: block;
   padding: 3px 20px;
@@ -6402,7 +5098,6 @@ fieldset[disabled]
   color: #E8EEF0;
   white-space: nowrap;
 }
-/* line 163, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .dropdown-backdrop {
   position: fixed;
   left: 0;
@@ -6411,12 +5106,10 @@ fieldset[disabled]
   top: 0;
   z-index: 990;
 }
-/* line 173, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .pull-right > .dropdown-menu {
   right: 0;
   left: auto;
 }
-/* line 186, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .dropup .caret,
 #hrjob-contract .navbar-fixed-bottom .dropdown .caret {
   border-top: 0;
@@ -6424,7 +5117,6 @@ fieldset[disabled]
   border-bottom: 4px solid \9;
   content: "";
 }
-/* line 193, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
 #hrjob-contract .dropup .dropdown-menu,
 #hrjob-contract .navbar-fixed-bottom .dropdown .dropdown-menu {
   top: auto;
@@ -6432,31 +5124,26 @@ fieldset[disabled]
   margin-bottom: 2px;
 }
 @media (min-width: 768px) {
-  /* line 207, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
   #hrjob-contract .navbar-right .dropdown-menu {
     right: 0;
     left: auto;
   }
-  /* line 212, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss */
   #hrjob-contract .navbar-right .dropdown-menu-left {
     left: 0;
     right: auto;
   }
 }
-/* line 6, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group,
 #hrjob-contract .btn-group-vertical {
   position: relative;
   display: inline-block;
   vertical-align: middle;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group > .btn,
 #hrjob-contract .btn-group-vertical > .btn {
   position: relative;
   float: left;
 }
-/* line 15, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group > .btn:hover, #hrjob-contract .btn-group > .btn:focus, #hrjob-contract .btn-group > .btn:active, #hrjob-contract .btn-group > .btn.active,
 #hrjob-contract .btn-group-vertical > .btn:hover,
 #hrjob-contract .btn-group-vertical > .btn:focus,
@@ -6464,115 +5151,92 @@ fieldset[disabled]
 #hrjob-contract .btn-group-vertical > .btn.active {
   z-index: 2;
 }
-/* line 26, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group .btn + .btn,
 #hrjob-contract .btn-group .btn + .btn-group,
 #hrjob-contract .btn-group .btn-group + .btn,
 #hrjob-contract .btn-group .btn-group + .btn-group {
   margin-left: -1px;
 }
-/* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-toolbar {
   margin-left: -5px;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .btn-toolbar:before, #hrjob-contract .btn-toolbar:after {
   content: " ";
   display: table;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .btn-toolbar:after {
   clear: both;
 }
-/* line 39, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-toolbar .btn,
 #hrjob-contract .btn-toolbar .btn-group,
 #hrjob-contract .btn-toolbar .input-group {
   float: left;
 }
-/* line 44, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-toolbar > .btn,
 #hrjob-contract .btn-toolbar > .btn-group,
 #hrjob-contract .btn-toolbar > .input-group {
   margin-left: 5px;
 }
-/* line 51, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group > .btn:not(:first-child):not(:last-child):not(.dropdown-toggle) {
   border-radius: 0;
 }
-/* line 56, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group > .btn:first-child {
   margin-left: 0;
 }
-/* line 58, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group > .btn:first-child:not(:last-child):not(.dropdown-toggle) {
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
 }
-/* line 63, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group > .btn:last-child:not(:first-child),
 #hrjob-contract .btn-group > .dropdown-toggle:not(:first-child) {
   border-bottom-left-radius: 0;
   border-top-left-radius: 0;
 }
-/* line 69, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group > .btn-group {
   float: left;
 }
-/* line 72, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group > .btn-group:not(:first-child):not(:last-child) > .btn {
   border-radius: 0;
 }
-/* line 76, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group > .btn-group:first-child:not(:last-child) > .btn:last-child,
 #hrjob-contract .btn-group > .btn-group:first-child:not(:last-child) > .dropdown-toggle {
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
 }
-/* line 81, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group > .btn-group:last-child:not(:first-child) > .btn:first-child {
   border-bottom-left-radius: 0;
   border-top-left-radius: 0;
 }
-/* line 86, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group .dropdown-toggle:active,
 #hrjob-contract .btn-group.open .dropdown-toggle {
   outline: 0;
 }
-/* line 105, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group > .btn + .dropdown-toggle {
   padding-left: 8px;
   padding-right: 8px;
 }
-/* line 109, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group > .btn-lg + .dropdown-toggle, #hrjob-contract .btn-group-lg.btn-group > .btn + .dropdown-toggle {
   padding-left: 12px;
   padding-right: 12px;
 }
-/* line 116, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group.open .dropdown-toggle {
   -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
 }
-/* line 120, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group.open .dropdown-toggle.btn-link {
   -webkit-box-shadow: none;
   box-shadow: none;
 }
-/* line 127, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn .caret {
   margin-left: 0;
 }
-/* line 131, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-lg .caret, #hrjob-contract .btn-group-lg > .btn .caret {
   border-width: 5px 5px 0;
   border-bottom-width: 0;
 }
-/* line 136, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .dropup .btn-lg .caret, #hrjob-contract .dropup .btn-group-lg > .btn .caret {
   border-width: 0 5px 5px;
 }
-/* line 145, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group-vertical > .btn,
 #hrjob-contract .btn-group-vertical > .btn-group,
 #hrjob-contract .btn-group-vertical > .btn-group > .btn {
@@ -6581,20 +5245,16 @@ fieldset[disabled]
   width: 100%;
   max-width: 100%;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .btn-group-vertical > .btn-group:before, #hrjob-contract .btn-group-vertical > .btn-group:after {
   content: " ";
   display: table;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .btn-group-vertical > .btn-group:after {
   clear: both;
 }
-/* line 157, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group-vertical > .btn-group > .btn {
   float: none;
 }
-/* line 162, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group-vertical > .btn + .btn,
 #hrjob-contract .btn-group-vertical > .btn + .btn-group,
 #hrjob-contract .btn-group-vertical > .btn-group + .btn,
@@ -6602,62 +5262,51 @@ fieldset[disabled]
   margin-top: -1px;
   margin-left: 0;
 }
-/* line 172, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group-vertical > .btn:not(:first-child):not(:last-child) {
   border-radius: 0;
 }
-/* line 175, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group-vertical > .btn:first-child:not(:last-child) {
   border-top-right-radius: 2px;
   border-top-left-radius: 2px;
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0;
 }
-/* line 179, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group-vertical > .btn:last-child:not(:first-child) {
   border-top-right-radius: 0;
   border-top-left-radius: 0;
   border-bottom-right-radius: 2px;
   border-bottom-left-radius: 2px;
 }
-/* line 184, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .btn {
   border-radius: 0;
 }
-/* line 188, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group-vertical > .btn-group:first-child:not(:last-child) > .btn:last-child,
 #hrjob-contract .btn-group-vertical > .btn-group:first-child:not(:last-child) > .dropdown-toggle {
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0;
 }
-/* line 193, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group-vertical > .btn-group:last-child:not(:first-child) > .btn:first-child {
   border-top-right-radius: 0;
   border-top-left-radius: 0;
 }
-/* line 201, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group-justified {
   display: table;
   width: 100%;
   table-layout: fixed;
   border-collapse: separate;
 }
-/* line 206, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group-justified > .btn,
 #hrjob-contract .btn-group-justified > .btn-group {
   float: none;
   display: table-cell;
   width: 1%;
 }
-/* line 212, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group-justified > .btn-group .btn {
   width: 100%;
 }
-/* line 216, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract .btn-group-justified > .btn-group .dropdown-menu {
   left: auto;
 }
-/* line 237, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_button-groups.scss */
 #hrjob-contract [data-toggle="buttons"] > .btn input[type="radio"],
 #hrjob-contract [data-toggle="buttons"] > .btn input[type="checkbox"],
 #hrjob-contract [data-toggle="buttons"] > .btn-group > .btn input[type="radio"],
@@ -6666,19 +5315,16 @@ fieldset[disabled]
   clip: rect(0, 0, 0, 0);
   pointer-events: none;
 }
-/* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group {
   position: relative;
   display: table;
   border-collapse: separate;
 }
-/* line 13, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group[class*="col-"] {
   float: none;
   padding-left: 0;
   padding-right: 0;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group .form-control {
   position: relative;
   z-index: 2;
@@ -6686,30 +5332,25 @@ fieldset[disabled]
   width: 100%;
   margin-bottom: 0;
 }
-/* line 33, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group .form-control:focus {
   z-index: 3;
 }
-/* line 58, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group-addon,
 #hrjob-contract .input-group-btn,
 #hrjob-contract .input-group .form-control {
   display: table-cell;
 }
-/* line 63, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group-addon:not(:first-child):not(:last-child),
 #hrjob-contract .input-group-btn:not(:first-child):not(:last-child),
 #hrjob-contract .input-group .form-control:not(:first-child):not(:last-child) {
   border-radius: 0;
 }
-/* line 68, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group-addon,
 #hrjob-contract .input-group-btn {
   width: 1%;
   white-space: nowrap;
   vertical-align: middle;
 }
-/* line 77, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group-addon {
   padding: 6px 12px;
   font-size: 13px;
@@ -6721,7 +5362,6 @@ fieldset[disabled]
   border: 1px solid #C2CFD8;
   border-radius: 2px;
 }
-/* line 89, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group-addon.input-sm,
 #hrjob-contract .input-group-sm > .input-group-addon,
 #hrjob-contract .input-group-sm > .input-group-btn > .input-group-addon.btn {
@@ -6729,7 +5369,6 @@ fieldset[disabled]
   font-size: 12px;
   border-radius: 2px;
 }
-/* line 94, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group-addon.input-lg,
 #hrjob-contract .input-group-lg > .input-group-addon,
 #hrjob-contract .input-group-lg > .input-group-btn > .input-group-addon.btn {
@@ -6737,12 +5376,10 @@ fieldset[disabled]
   font-size: 17px;
   border-radius: 4px;
 }
-/* line 101, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group-addon input[type="radio"],
 #hrjob-contract .input-group-addon input[type="checkbox"] {
   margin-top: 0;
 }
-/* line 108, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group .form-control:first-child,
 #hrjob-contract .input-group-addon:first-child,
 #hrjob-contract .input-group-btn:first-child > .btn,
@@ -6753,11 +5390,9 @@ fieldset[disabled]
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
 }
-/* line 117, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group-addon:first-child {
   border-right: 0;
 }
-/* line 120, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group .form-control:last-child,
 #hrjob-contract .input-group-addon:last-child,
 #hrjob-contract .input-group-btn:last-child > .btn,
@@ -6768,118 +5403,95 @@ fieldset[disabled]
   border-bottom-left-radius: 0;
   border-top-left-radius: 0;
 }
-/* line 129, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group-addon:last-child {
   border-left: 0;
 }
-/* line 135, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group-btn {
   position: relative;
   font-size: 0;
   white-space: nowrap;
 }
-/* line 144, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group-btn > .btn {
   position: relative;
 }
-/* line 146, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group-btn > .btn + .btn {
   margin-left: -1px;
 }
-/* line 150, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group-btn > .btn:hover, #hrjob-contract .input-group-btn > .btn:focus, #hrjob-contract .input-group-btn > .btn:active {
   z-index: 2;
 }
-/* line 159, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group-btn:first-child > .btn,
 #hrjob-contract .input-group-btn:first-child > .btn-group {
   margin-right: -1px;
 }
-/* line 165, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_input-groups.scss */
 #hrjob-contract .input-group-btn:last-child > .btn,
 #hrjob-contract .input-group-btn:last-child > .btn-group {
   z-index: 2;
   margin-left: -1px;
 }
-/* line 9, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav {
   margin-bottom: 0;
   padding-left: 0;
   list-style: none;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .nav:before, #hrjob-contract .nav:after {
   content: " ";
   display: table;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .nav:after {
   clear: both;
 }
-/* line 15, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav > li {
   position: relative;
   display: block;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav > li > a {
   position: relative;
   display: block;
   padding: 10px 15px;
 }
-/* line 23, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav > li > a:hover, #hrjob-contract .nav > li > a:focus {
   text-decoration: none;
   background-color: #F3F6F7;
 }
-/* line 31, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav > li.disabled > a {
   color: #E8EEF0;
 }
-/* line 34, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav > li.disabled > a:hover, #hrjob-contract .nav > li.disabled > a:focus {
   color: #E8EEF0;
   text-decoration: none;
   background-color: transparent;
   cursor: not-allowed;
 }
-/* line 46, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav .open > a, #hrjob-contract .nav .open > a:hover, #hrjob-contract .nav .open > a:focus {
   background-color: #F3F6F7;
   border-color: #0071BD;
 }
-/* line 59, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav .nav-divider {
   height: 1px;
   margin: 8px 0;
   overflow: hidden;
   background-color: #e5e5e5;
 }
-/* line 66, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav > li > a > img {
   max-width: none;
 }
-/* line 76, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav-tabs {
   border-bottom: 1px solid #D3DEE2;
 }
-/* line 78, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav-tabs > li {
   float: left;
   margin-bottom: -1px;
 }
-/* line 84, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav-tabs > li > a {
   margin-right: 2px;
   line-height: 1.42857143;
   border: 1px solid transparent;
   border-radius: 2px 2px 0 0;
 }
-/* line 89, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav-tabs > li > a:hover {
   border-color: #F3F6F7 #F3F6F7 #D3DEE2;
 }
-/* line 96, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav-tabs > li.active > a, #hrjob-contract .nav-tabs > li.active > a:hover, #hrjob-contract .nav-tabs > li.active > a:focus {
   color: #464354;
   background-color: #F3F6F7;
@@ -6887,71 +5499,56 @@ fieldset[disabled]
   border-bottom-color: transparent;
   cursor: default;
 }
-/* line 118, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav-pills > li {
   float: left;
 }
-/* line 122, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav-pills > li > a {
   border-radius: 2px;
 }
-/* line 125, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav-pills > li + li {
   margin-left: 2px;
 }
-/* line 131, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav-pills > li.active > a, #hrjob-contract .nav-pills > li.active > a:hover, #hrjob-contract .nav-pills > li.active > a:focus {
   color: #fff;
   background-color: #0071BD;
 }
-/* line 144, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav-stacked > li {
   float: none;
 }
-/* line 146, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav-stacked > li + li {
   margin-top: 2px;
   margin-left: 0;
 }
-/* line 160, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav-justified, #hrjob-contract .nav-tabs.nav-justified {
   width: 100%;
 }
-/* line 163, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav-justified > li, #hrjob-contract .nav-tabs.nav-justified > li {
   float: none;
 }
-/* line 165, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav-justified > li > a, #hrjob-contract .nav-tabs.nav-justified > li > a {
   text-align: center;
   margin-bottom: 5px;
 }
-/* line 171, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav-justified > .dropdown .dropdown-menu {
   top: auto;
   left: auto;
 }
 @media (min-width: 768px) {
-  /* line 177, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
   #hrjob-contract .nav-justified > li, #hrjob-contract .nav-tabs.nav-justified > li {
     display: table-cell;
     width: 1%;
   }
-  /* line 180, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
   #hrjob-contract .nav-justified > li > a, #hrjob-contract .nav-tabs.nav-justified > li > a {
     margin-bottom: 0;
   }
 }
-/* line 190, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav-tabs-justified, #hrjob-contract .nav-tabs.nav-justified {
   border-bottom: 0;
 }
-/* line 193, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav-tabs-justified > li > a, #hrjob-contract .nav-tabs.nav-justified > li > a {
   margin-right: 0;
   border-radius: 2px;
 }
-/* line 199, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav-tabs-justified > .active > a, #hrjob-contract .nav-tabs.nav-justified > .active > a,
 #hrjob-contract .nav-tabs-justified > .active > a:hover,
 #hrjob-contract .nav-tabs.nav-justified > .active > a:hover,
@@ -6960,12 +5557,10 @@ fieldset[disabled]
   border: 1px solid #ddd;
 }
 @media (min-width: 768px) {
-  /* line 206, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
   #hrjob-contract .nav-tabs-justified > li > a, #hrjob-contract .nav-tabs.nav-justified > li > a {
     border-bottom: 1px solid #ddd;
     border-radius: 2px 2px 0 0;
   }
-  /* line 210, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
   #hrjob-contract .nav-tabs-justified > .active > a, #hrjob-contract .nav-tabs.nav-justified > .active > a,
   #hrjob-contract .nav-tabs-justified > .active > a:hover,
   #hrjob-contract .nav-tabs.nav-justified > .active > a:hover,
@@ -6974,58 +5569,47 @@ fieldset[disabled]
     border-bottom-color: #E8EEF0;
   }
 }
-/* line 224, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .tab-content > .tab-pane {
   display: none;
 }
-/* line 227, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .tab-content > .active {
   display: block;
 }
-/* line 237, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navs.scss */
 #hrjob-contract .nav-tabs .dropdown-menu {
   margin-top: -1px;
   border-top-right-radius: 0;
   border-top-left-radius: 0;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar {
   position: relative;
   min-height: 50px;
   margin-bottom: 18px;
   border: 1px solid transparent;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .navbar:before, #hrjob-contract .navbar:after {
   content: " ";
   display: table;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .navbar:after {
   clear: both;
 }
 @media (min-width: 768px) {
-  /* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar {
     border-radius: 2px;
   }
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .navbar-header:before, #hrjob-contract .navbar-header:after {
   content: " ";
   display: table;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .navbar-header:after {
   clear: both;
 }
 @media (min-width: 768px) {
-  /* line 31, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-header {
     float: left;
   }
 }
-/* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-collapse {
   overflow-x: visible;
   padding-right: 15px;
@@ -7034,56 +5618,46 @@ fieldset[disabled]
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
   -webkit-overflow-scrolling: touch;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .navbar-collapse:before, #hrjob-contract .navbar-collapse:after {
   content: " ";
   display: table;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .navbar-collapse:after {
   clear: both;
 }
-/* line 59, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-collapse.in {
   overflow-y: auto;
 }
 @media (min-width: 768px) {
-  /* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-collapse {
     width: auto;
     border-top: 0;
     box-shadow: none;
   }
-  /* line 68, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-collapse.collapse {
     display: block !important;
     height: auto !important;
     padding-bottom: 0;
     overflow: visible !important;
   }
-  /* line 75, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-collapse.in {
     overflow-y: visible;
   }
-  /* line 81, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   .navbar-fixed-top #hrjob-contract .navbar-collapse, .navbar-static-top #hrjob-contract .navbar-collapse, .navbar-fixed-bottom #hrjob-contract .navbar-collapse {
     padding-left: 0;
     padding-right: 0;
   }
 }
-/* line 92, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-fixed-top .navbar-collapse,
 #hrjob-contract .navbar-fixed-bottom .navbar-collapse {
   max-height: 340px;
 }
 @media (max-device-width: 480px) and (orientation: landscape) {
-  /* line 92, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-fixed-top .navbar-collapse,
   #hrjob-contract .navbar-fixed-bottom .navbar-collapse {
     max-height: 200px;
   }
 }
-/* line 108, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .container > .navbar-header,
 #hrjob-contract .container > .navbar-collapse,
 #hrjob-contract .container-fluid > .navbar-header,
@@ -7092,7 +5666,6 @@ fieldset[disabled]
   margin-left: -15px;
 }
 @media (min-width: 768px) {
-  /* line 108, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .container > .navbar-header,
   #hrjob-contract .container > .navbar-collapse,
   #hrjob-contract .container-fluid > .navbar-header,
@@ -7101,18 +5674,15 @@ fieldset[disabled]
     margin-left: 0;
   }
 }
-/* line 128, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-static-top {
   z-index: 1000;
   border-width: 0 0 1px;
 }
 @media (min-width: 768px) {
-  /* line 128, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-static-top {
     border-radius: 0;
   }
 }
-/* line 138, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-fixed-top,
 #hrjob-contract .navbar-fixed-bottom {
   position: fixed;
@@ -7121,24 +5691,20 @@ fieldset[disabled]
   z-index: 1030;
 }
 @media (min-width: 768px) {
-  /* line 138, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-fixed-top,
   #hrjob-contract .navbar-fixed-bottom {
     border-radius: 0;
   }
 }
-/* line 150, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-fixed-top {
   top: 0;
   border-width: 0 0 1px;
 }
-/* line 154, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-fixed-bottom {
   bottom: 0;
   margin-bottom: 0;
   border-width: 1px 0 0;
 }
-/* line 163, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-brand {
   float: left;
   padding: 16px 15px;
@@ -7146,21 +5712,17 @@ fieldset[disabled]
   line-height: 18px;
   height: 50px;
 }
-/* line 170, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-brand:hover, #hrjob-contract .navbar-brand:focus {
   text-decoration: none;
 }
-/* line 175, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-brand > img {
   display: block;
 }
 @media (min-width: 768px) {
-  /* line 180, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   .navbar > .container #hrjob-contract .navbar-brand, .navbar > .container-fluid #hrjob-contract .navbar-brand {
     margin-left: -15px;
   }
 }
-/* line 193, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-toggle {
   position: relative;
   float: right;
@@ -7173,39 +5735,32 @@ fieldset[disabled]
   border: 1px solid transparent;
   border-radius: 2px;
 }
-/* line 206, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-toggle:focus {
   outline: 0;
 }
-/* line 211, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-toggle .icon-bar {
   display: block;
   width: 22px;
   height: 2px;
   border-radius: 1px;
 }
-/* line 217, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-toggle .icon-bar + .icon-bar {
   margin-top: 4px;
 }
 @media (min-width: 768px) {
-  /* line 193, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-toggle {
     display: none;
   }
 }
-/* line 232, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-nav {
   margin: 8px -15px;
 }
-/* line 235, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-nav > li > a {
   padding-top: 10px;
   padding-bottom: 10px;
   line-height: 18px;
 }
 @media (max-width: 767px) {
-  /* line 243, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-nav .open .dropdown-menu {
     position: static;
     float: none;
@@ -7215,37 +5770,30 @@ fieldset[disabled]
     border: 0;
     box-shadow: none;
   }
-  /* line 251, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-nav .open .dropdown-menu > li > a,
   #hrjob-contract .navbar-nav .open .dropdown-menu .dropdown-header {
     padding: 5px 15px 5px 25px;
   }
-  /* line 255, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-nav .open .dropdown-menu > li > a {
     line-height: 18px;
   }
-  /* line 257, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-nav .open .dropdown-menu > li > a:hover, #hrjob-contract .navbar-nav .open .dropdown-menu > li > a:focus {
     background-image: none;
   }
 }
 @media (min-width: 768px) {
-  /* line 232, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-nav {
     float: left;
     margin: 0;
   }
-  /* line 270, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-nav > li {
     float: left;
   }
-  /* line 272, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-nav > li > a {
     padding-top: 16px;
     padding-bottom: 16px;
   }
 }
-/* line 286, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-form {
   margin-left: -15px;
   margin-right: -15px;
@@ -7258,43 +5806,35 @@ fieldset[disabled]
   margin-bottom: 9px;
 }
 @media (min-width: 768px) {
-  /* line 478, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .navbar-form .form-group {
     display: inline-block;
     margin-bottom: 0;
     vertical-align: middle;
   }
-  /* line 485, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .navbar-form .form-control {
     display: inline-block;
     width: auto;
     vertical-align: middle;
   }
-  /* line 492, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .navbar-form .form-control-static {
     display: inline-block;
   }
-  /* line 496, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .navbar-form .input-group {
     display: inline-table;
     vertical-align: middle;
   }
-  /* line 500, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .navbar-form .input-group .input-group-addon,
   #hrjob-contract .navbar-form .input-group .input-group-btn,
   #hrjob-contract .navbar-form .input-group .form-control {
     width: auto;
   }
-  /* line 508, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .navbar-form .input-group > .form-control {
     width: 100%;
   }
-  /* line 512, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .navbar-form .control-label {
     margin-bottom: 0;
     vertical-align: middle;
   }
-  /* line 519, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .navbar-form .radio,
   #hrjob-contract .navbar-form .checkbox {
     display: inline-block;
@@ -7302,7 +5842,6 @@ fieldset[disabled]
     margin-bottom: 0;
     vertical-align: middle;
   }
-  /* line 526, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .navbar-form .radio label, #hrjob-contract .navbar-form .radio .checkbox-label,
   #hrjob-contract .navbar-form .radio .radio-label,
   #hrjob-contract .navbar-form .checkbox label,
@@ -7310,29 +5849,24 @@ fieldset[disabled]
   #hrjob-contract .navbar-form .checkbox .radio-label {
     padding-left: 0;
   }
-  /* line 530, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .navbar-form .radio input[type="radio"],
   #hrjob-contract .navbar-form .checkbox input[type="checkbox"] {
     position: relative;
     margin-left: 0;
   }
-  /* line 537, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_forms.scss */
   #hrjob-contract .navbar-form .has-feedback .form-control-feedback {
     top: 0;
   }
 }
 @media (max-width: 767px) {
-  /* line 298, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-form .form-group {
     margin-bottom: 5px;
   }
-  /* line 302, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-form .form-group:last-child {
     margin-bottom: 0;
   }
 }
 @media (min-width: 768px) {
-  /* line 286, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-form {
     width: auto;
     border: 0;
@@ -7344,13 +5878,11 @@ fieldset[disabled]
     box-shadow: none;
   }
 }
-/* line 327, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-nav > li > .dropdown-menu {
   margin-top: 0;
   border-top-right-radius: 0;
   border-top-left-radius: 0;
 }
-/* line 332, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-fixed-bottom .navbar-nav > li > .dropdown-menu {
   margin-bottom: 0;
   border-top-right-radius: 2px;
@@ -7358,28 +5890,23 @@ fieldset[disabled]
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0;
 }
-/* line 343, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-btn {
   margin-top: 9px;
   margin-bottom: 9px;
 }
-/* line 346, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-btn.btn-sm, #hrjob-contract .btn-group-sm > .navbar-btn.btn {
   margin-top: 10px;
   margin-bottom: 10px;
 }
-/* line 349, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-btn.btn-xs, #hrjob-contract .btn-group-xs > .navbar-btn.btn {
   margin-top: 14px;
   margin-bottom: 14px;
 }
-/* line 359, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-text {
   margin-top: 16px;
   margin-bottom: 16px;
 }
 @media (min-width: 768px) {
-  /* line 359, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-text {
     float: left;
     margin-left: 15px;
@@ -7387,229 +5914,179 @@ fieldset[disabled]
   }
 }
 @media (min-width: 768px) {
-  /* line 379, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-left {
     float: left !important;
   }
-  /* line 382, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-right {
     float: right !important;
     margin-right: -15px;
   }
-  /* line 386, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-right ~ .navbar-right {
     margin-right: 0;
   }
 }
-/* line 397, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-default {
   background-color: #f8f8f8;
   border-color: #e7e7e7;
 }
-/* line 401, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-default .navbar-brand {
   color: #777;
 }
-/* line 403, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-default .navbar-brand:hover, #hrjob-contract .navbar-default .navbar-brand:focus {
   color: #5e5e5e;
   background-color: transparent;
 }
-/* line 410, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-default .navbar-text {
   color: #777;
 }
-/* line 415, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-default .navbar-nav > li > a {
   color: #777;
 }
-/* line 418, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-default .navbar-nav > li > a:hover, #hrjob-contract .navbar-default .navbar-nav > li > a:focus {
   color: #333;
   background-color: transparent;
 }
-/* line 425, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-default .navbar-nav > .active > a, #hrjob-contract .navbar-default .navbar-nav > .active > a:hover, #hrjob-contract .navbar-default .navbar-nav > .active > a:focus {
   color: #555;
   background-color: #e7e7e7;
 }
-/* line 433, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-default .navbar-nav > .disabled > a, #hrjob-contract .navbar-default .navbar-nav > .disabled > a:hover, #hrjob-contract .navbar-default .navbar-nav > .disabled > a:focus {
   color: #ccc;
   background-color: transparent;
 }
-/* line 442, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-default .navbar-toggle {
   border-color: #ddd;
 }
-/* line 444, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-default .navbar-toggle:hover, #hrjob-contract .navbar-default .navbar-toggle:focus {
   background-color: #ddd;
 }
-/* line 448, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-default .navbar-toggle .icon-bar {
   background-color: #888;
 }
-/* line 453, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-default .navbar-collapse,
 #hrjob-contract .navbar-default .navbar-form {
   border-color: #e7e7e7;
 }
-/* line 462, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-default .navbar-nav > .open > a, #hrjob-contract .navbar-default .navbar-nav > .open > a:hover, #hrjob-contract .navbar-default .navbar-nav > .open > a:focus {
   background-color: #e7e7e7;
   color: #555;
 }
 @media (max-width: 767px) {
-  /* line 473, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-default .navbar-nav .open .dropdown-menu > li > a {
     color: #777;
   }
-  /* line 475, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-default .navbar-nav .open .dropdown-menu > li > a:hover, #hrjob-contract .navbar-default .navbar-nav .open .dropdown-menu > li > a:focus {
     color: #333;
     background-color: transparent;
   }
-  /* line 482, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-default .navbar-nav .open .dropdown-menu > .active > a, #hrjob-contract .navbar-default .navbar-nav .open .dropdown-menu > .active > a:hover, #hrjob-contract .navbar-default .navbar-nav .open .dropdown-menu > .active > a:focus {
     color: #555;
     background-color: #e7e7e7;
   }
-  /* line 490, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a, #hrjob-contract .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:hover, #hrjob-contract .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:focus {
     color: #ccc;
     background-color: transparent;
   }
 }
-/* line 506, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-default .navbar-link {
   color: #777;
 }
-/* line 508, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-default .navbar-link:hover {
   color: #333;
 }
-/* line 513, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-default .btn-link {
   color: #777;
 }
-/* line 515, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-default .btn-link:hover, #hrjob-contract .navbar-default .btn-link:focus {
   color: #333;
 }
-/* line 521, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-default .btn-link[disabled]:hover, #hrjob-contract .navbar-default .btn-link[disabled]:focus, fieldset[disabled] #hrjob-contract .navbar-default .btn-link:hover, fieldset[disabled] #hrjob-contract .navbar-default .btn-link:focus {
   color: #ccc;
 }
-/* line 531, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-inverse {
   background-color: #222;
   border-color: #090909;
 }
-/* line 535, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-inverse .navbar-brand {
   color: white;
 }
-/* line 537, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-inverse .navbar-brand:hover, #hrjob-contract .navbar-inverse .navbar-brand:focus {
   color: #fff;
   background-color: transparent;
 }
-/* line 544, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-inverse .navbar-text {
   color: white;
 }
-/* line 549, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-inverse .navbar-nav > li > a {
   color: white;
 }
-/* line 552, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-inverse .navbar-nav > li > a:hover, #hrjob-contract .navbar-inverse .navbar-nav > li > a:focus {
   color: #fff;
   background-color: transparent;
 }
-/* line 559, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-inverse .navbar-nav > .active > a, #hrjob-contract .navbar-inverse .navbar-nav > .active > a:hover, #hrjob-contract .navbar-inverse .navbar-nav > .active > a:focus {
   color: #fff;
   background-color: #090909;
 }
-/* line 567, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-inverse .navbar-nav > .disabled > a, #hrjob-contract .navbar-inverse .navbar-nav > .disabled > a:hover, #hrjob-contract .navbar-inverse .navbar-nav > .disabled > a:focus {
   color: #444;
   background-color: transparent;
 }
-/* line 577, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-inverse .navbar-toggle {
   border-color: #333;
 }
-/* line 579, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-inverse .navbar-toggle:hover, #hrjob-contract .navbar-inverse .navbar-toggle:focus {
   background-color: #333;
 }
-/* line 583, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-inverse .navbar-toggle .icon-bar {
   background-color: #fff;
 }
-/* line 588, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-inverse .navbar-collapse,
 #hrjob-contract .navbar-inverse .navbar-form {
   border-color: #101010;
 }
-/* line 596, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-inverse .navbar-nav > .open > a, #hrjob-contract .navbar-inverse .navbar-nav > .open > a:hover, #hrjob-contract .navbar-inverse .navbar-nav > .open > a:focus {
   background-color: #090909;
   color: #fff;
 }
 @media (max-width: 767px) {
-  /* line 607, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-inverse .navbar-nav .open .dropdown-menu > .dropdown-header {
     border-color: #090909;
   }
-  /* line 610, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-inverse .navbar-nav .open .dropdown-menu .divider {
     background-color: #090909;
   }
-  /* line 613, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-inverse .navbar-nav .open .dropdown-menu > li > a {
     color: white;
   }
-  /* line 615, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:hover, #hrjob-contract .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:focus {
     color: #fff;
     background-color: transparent;
   }
-  /* line 622, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a, #hrjob-contract .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a:hover, #hrjob-contract .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a:focus {
     color: #fff;
     background-color: #090909;
   }
-  /* line 630, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
   #hrjob-contract .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a, #hrjob-contract .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a:hover, #hrjob-contract .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a:focus {
     color: #444;
     background-color: transparent;
   }
 }
-/* line 641, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-inverse .navbar-link {
   color: white;
 }
-/* line 643, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-inverse .navbar-link:hover {
   color: #fff;
 }
-/* line 648, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-inverse .btn-link {
   color: white;
 }
-/* line 650, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-inverse .btn-link:hover, #hrjob-contract .navbar-inverse .btn-link:focus {
   color: #fff;
 }
-/* line 656, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_navbar.scss */
 #hrjob-contract .navbar-inverse .btn-link[disabled]:hover, #hrjob-contract .navbar-inverse .btn-link[disabled]:focus, fieldset[disabled] #hrjob-contract .navbar-inverse .btn-link:hover, fieldset[disabled] #hrjob-contract .navbar-inverse .btn-link:focus {
   color: #444;
 }
-/* line 6, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_breadcrumbs.scss */
 #hrjob-contract .breadcrumb {
   padding: 8px 15px;
   margin-bottom: 18px;
@@ -7617,32 +6094,26 @@ fieldset[disabled]
   background-color: #f5f5f5;
   border-radius: 2px;
 }
-/* line 13, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_breadcrumbs.scss */
 #hrjob-contract .breadcrumb > li {
   display: inline-block;
 }
-/* line 16, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_breadcrumbs.scss */
 #hrjob-contract .breadcrumb > li + li:before {
   content: "/ ";
   padding: 0 5px;
   color: #ccc;
 }
-/* line 25, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_breadcrumbs.scss */
 #hrjob-contract .breadcrumb > .active {
   color: #E8EEF0;
 }
-/* line 4, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_pagination.scss */
 #hrjob-contract .pagination {
   display: inline-block;
   padding-left: 0;
   margin: 18px 0;
   border-radius: 2px;
 }
-/* line 10, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_pagination.scss */
 #hrjob-contract .pagination > li {
   display: inline;
 }
-/* line 12, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_pagination.scss */
 #hrjob-contract .pagination > li > a,
 #hrjob-contract .pagination > li > span {
   position: relative;
@@ -7655,20 +6126,17 @@ fieldset[disabled]
   border: 1px solid #ddd;
   margin-left: -1px;
 }
-/* line 25, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_pagination.scss */
 #hrjob-contract .pagination > li:first-child > a,
 #hrjob-contract .pagination > li:first-child > span {
   margin-left: 0;
   border-bottom-left-radius: 2px;
   border-top-left-radius: 2px;
 }
-/* line 32, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_pagination.scss */
 #hrjob-contract .pagination > li:last-child > a,
 #hrjob-contract .pagination > li:last-child > span {
   border-bottom-right-radius: 2px;
   border-top-right-radius: 2px;
 }
-/* line 41, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_pagination.scss */
 #hrjob-contract .pagination > li > a:hover, #hrjob-contract .pagination > li > a:focus,
 #hrjob-contract .pagination > li > span:hover,
 #hrjob-contract .pagination > li > span:focus {
@@ -7677,7 +6145,6 @@ fieldset[disabled]
   background-color: #F3F6F7;
   border-color: #ddd;
 }
-/* line 52, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_pagination.scss */
 #hrjob-contract .pagination > .active > a, #hrjob-contract .pagination > .active > a:hover, #hrjob-contract .pagination > .active > a:focus,
 #hrjob-contract .pagination > .active > span,
 #hrjob-contract .pagination > .active > span:hover,
@@ -7688,7 +6155,6 @@ fieldset[disabled]
   border-color: #0071BD;
   cursor: default;
 }
-/* line 64, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_pagination.scss */
 #hrjob-contract .pagination > .disabled > span,
 #hrjob-contract .pagination > .disabled > span:hover,
 #hrjob-contract .pagination > .disabled > span:focus,
@@ -7700,65 +6166,54 @@ fieldset[disabled]
   border-color: #ddd;
   cursor: not-allowed;
 }
-/* line 5, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_pagination.scss */
 #hrjob-contract .pagination-lg > li > a,
 #hrjob-contract .pagination-lg > li > span {
   padding: 10px 16px;
   font-size: 17px;
   line-height: 1.3333333;
 }
-/* line 12, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_pagination.scss */
 #hrjob-contract .pagination-lg > li:first-child > a,
 #hrjob-contract .pagination-lg > li:first-child > span {
   border-bottom-left-radius: 4px;
   border-top-left-radius: 4px;
 }
-/* line 18, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_pagination.scss */
 #hrjob-contract .pagination-lg > li:last-child > a,
 #hrjob-contract .pagination-lg > li:last-child > span {
   border-bottom-right-radius: 4px;
   border-top-right-radius: 4px;
 }
-/* line 5, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_pagination.scss */
 #hrjob-contract .pagination-sm > li > a,
 #hrjob-contract .pagination-sm > li > span {
   padding: 5px 10px;
   font-size: 12px;
   line-height: 1.5;
 }
-/* line 12, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_pagination.scss */
 #hrjob-contract .pagination-sm > li:first-child > a,
 #hrjob-contract .pagination-sm > li:first-child > span {
   border-bottom-left-radius: 2px;
   border-top-left-radius: 2px;
 }
-/* line 18, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_pagination.scss */
 #hrjob-contract .pagination-sm > li:last-child > a,
 #hrjob-contract .pagination-sm > li:last-child > span {
   border-bottom-right-radius: 2px;
   border-top-right-radius: 2px;
 }
-/* line 6, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_pager.scss */
 #hrjob-contract .pager {
   padding-left: 0;
   margin: 18px 0;
   list-style: none;
   text-align: center;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .pager:before, #hrjob-contract .pager:after {
   content: " ";
   display: table;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .pager:after {
   clear: both;
 }
-/* line 12, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_pager.scss */
 #hrjob-contract .pager li {
   display: inline;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_pager.scss */
 #hrjob-contract .pager li > a,
 #hrjob-contract .pager li > span {
   display: inline-block;
@@ -7767,23 +6222,19 @@ fieldset[disabled]
   border: 1px solid #ddd;
   border-radius: 15px;
 }
-/* line 23, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_pager.scss */
 #hrjob-contract .pager li > a:hover,
 #hrjob-contract .pager li > a:focus {
   text-decoration: none;
   background-color: #F3F6F7;
 }
-/* line 31, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_pager.scss */
 #hrjob-contract .pager .next > a,
 #hrjob-contract .pager .next > span {
   float: right;
 }
-/* line 38, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_pager.scss */
 #hrjob-contract .pager .previous > a,
 #hrjob-contract .pager .previous > span {
   float: left;
 }
-/* line 45, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_pager.scss */
 #hrjob-contract .pager .disabled > a,
 #hrjob-contract .pager .disabled > a:hover,
 #hrjob-contract .pager .disabled > a:focus,
@@ -7792,7 +6243,6 @@ fieldset[disabled]
   background-color: #fff;
   cursor: not-allowed;
 }
-/* line 5, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_labels.scss */
 #hrjob-contract .label {
   display: inline;
   padding: .2em .6em .3em;
@@ -7805,70 +6255,54 @@ fieldset[disabled]
   vertical-align: baseline;
   border-radius: .25em;
 }
-/* line 20, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_labels.scss */
 #hrjob-contract .label:empty {
   display: none;
 }
-/* line 25, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_labels.scss */
 .btn #hrjob-contract .label {
   position: relative;
   top: -1px;
 }
-/* line 33, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_labels.scss */
 #hrjob-contract a.label:hover, #hrjob-contract a.label:focus {
   color: #fff;
   text-decoration: none;
   cursor: pointer;
 }
-/* line 44, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_labels.scss */
 #hrjob-contract .label-default {
   background-color: #E8EEF0;
 }
-/* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_labels.scss */
 #hrjob-contract .label-default[href]:hover, #hrjob-contract .label-default[href]:focus {
   background-color: #c9d7dc;
 }
-/* line 48, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_labels.scss */
 #hrjob-contract .label-primary {
   background-color: #0071BD;
 }
-/* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_labels.scss */
 #hrjob-contract .label-primary[href]:hover, #hrjob-contract .label-primary[href]:focus {
   background-color: #00538a;
 }
-/* line 52, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_labels.scss */
 #hrjob-contract .label-success {
   background-color: #44CB7E;
 }
-/* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_labels.scss */
 #hrjob-contract .label-success[href]:hover, #hrjob-contract .label-success[href]:focus {
   background-color: #30ac65;
 }
-/* line 56, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_labels.scss */
 #hrjob-contract .label-info {
   background-color: #5bc0de;
 }
-/* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_labels.scss */
 #hrjob-contract .label-info[href]:hover, #hrjob-contract .label-info[href]:focus {
   background-color: #31b0d5;
 }
-/* line 60, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_labels.scss */
 #hrjob-contract .label-warning {
   background-color: #E6AB5E;
 }
-/* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_labels.scss */
 #hrjob-contract .label-warning[href]:hover, #hrjob-contract .label-warning[href]:focus {
   background-color: #df9432;
 }
-/* line 64, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_labels.scss */
 #hrjob-contract .label-danger {
   background-color: #CF3458;
 }
-/* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_labels.scss */
 #hrjob-contract .label-danger[href]:hover, #hrjob-contract .label-danger[href]:focus {
   background-color: #a82846;
 }
-/* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_badges.scss */
 #hrjob-contract .badge {
   display: inline-block;
   min-width: 10px;
@@ -7883,44 +6317,35 @@ fieldset[disabled]
   background-color: #E8EEF0;
   border-radius: 10px;
 }
-/* line 22, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_badges.scss */
 #hrjob-contract .badge:empty {
   display: none;
 }
-/* line 27, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_badges.scss */
 .btn #hrjob-contract .badge {
   position: relative;
   top: -1px;
 }
-/* line 32, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_badges.scss */
 .btn-xs #hrjob-contract .badge, #hrjob-contract .btn-group-xs > .btn #hrjob-contract .badge, .btn-group-xs > .btn #hrjob-contract .badge {
   top: 0;
   padding: 1px 5px;
 }
-/* line 41, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_badges.scss */
 .list-group-item.active > #hrjob-contract .badge, .nav-pills > .active > a > #hrjob-contract .badge {
   color: #0071BD;
   background-color: #fff;
 }
-/* line 47, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_badges.scss */
 .list-group-item > #hrjob-contract .badge {
   float: right;
 }
-/* line 51, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_badges.scss */
 .list-group-item > #hrjob-contract .badge + #hrjob-contract .badge {
   margin-right: 5px;
 }
-/* line 55, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_badges.scss */
 .nav-pills > li > a > #hrjob-contract .badge {
   margin-left: 3px;
 }
-/* line 62, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_badges.scss */
 #hrjob-contract a.badge:hover, #hrjob-contract a.badge:focus {
   color: #fff;
   text-decoration: none;
   cursor: pointer;
 }
-/* line 6, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_jumbotron.scss */
 #hrjob-contract .jumbotron {
   padding-top: 30px;
   padding-bottom: 30px;
@@ -7928,49 +6353,40 @@ fieldset[disabled]
   color: inherit;
   background-color: #F3F6F7;
 }
-/* line 13, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_jumbotron.scss */
 #hrjob-contract .jumbotron h1,
 #hrjob-contract .jumbotron .h1 {
   color: inherit;
 }
-/* line 18, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_jumbotron.scss */
 #hrjob-contract .jumbotron p {
   margin-bottom: 15px;
   font-size: 20px;
   font-weight: 200;
 }
-/* line 24, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_jumbotron.scss */
 #hrjob-contract .jumbotron > hr {
   border-top-color: #d4dfe3;
 }
-/* line 28, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_jumbotron.scss */
 .container #hrjob-contract .jumbotron, .container-fluid #hrjob-contract .jumbotron {
   border-radius: 4px;
   padding-left: 15px;
   padding-right: 15px;
 }
-/* line 35, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_jumbotron.scss */
 #hrjob-contract .jumbotron .container {
   max-width: 100%;
 }
 @media screen and (min-width: 768px) {
-  /* line 6, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_jumbotron.scss */
   #hrjob-contract .jumbotron {
     padding-top: 48px;
     padding-bottom: 48px;
   }
-  /* line 43, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_jumbotron.scss */
   .container #hrjob-contract .jumbotron, .container-fluid #hrjob-contract .jumbotron {
     padding-left: 60px;
     padding-right: 60px;
   }
-  /* line 49, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_jumbotron.scss */
   #hrjob-contract .jumbotron h1,
   #hrjob-contract .jumbotron .h1 {
     font-size: 59px;
   }
 }
-/* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_thumbnails.scss */
 #hrjob-contract .thumbnail {
   display: block;
   padding: 4px;
@@ -7983,7 +6399,6 @@ fieldset[disabled]
   -o-transition: border 0.2s ease-in-out;
   transition: border 0.2s ease-in-out;
 }
-/* line 17, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_thumbnails.scss */
 #hrjob-contract .thumbnail > img,
 #hrjob-contract .thumbnail a > img {
   display: block;
@@ -7992,48 +6407,39 @@ fieldset[disabled]
   margin-left: auto;
   margin-right: auto;
 }
-/* line 27, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_thumbnails.scss */
 #hrjob-contract .thumbnail .caption {
   padding: 9px;
   color: #4D4D69;
 }
-/* line 34, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_thumbnails.scss */
 #hrjob-contract a.thumbnail:hover,
 #hrjob-contract a.thumbnail:focus,
 #hrjob-contract a.thumbnail.active {
   border-color: #0071BD;
 }
-/* line 9, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_alerts.scss */
 #hrjob-contract .alert {
   padding: 15px;
   margin-bottom: 18px;
   border: 1px solid transparent;
   border-radius: 2px;
 }
-/* line 16, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_alerts.scss */
 #hrjob-contract .alert h4 {
   margin-top: 0;
   color: inherit;
 }
-/* line 23, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_alerts.scss */
 #hrjob-contract .alert .alert-link {
   font-weight: 600;
 }
-/* line 28, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_alerts.scss */
 #hrjob-contract .alert > p,
 #hrjob-contract .alert > ul {
   margin-bottom: 0;
 }
-/* line 33, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_alerts.scss */
 #hrjob-contract .alert > p + p {
   margin-top: 5px;
 }
-/* line 42, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_alerts.scss */
 #hrjob-contract .alert-dismissable,
 #hrjob-contract .alert-dismissible {
   padding-right: 35px;
 }
-/* line 47, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_alerts.scss */
 #hrjob-contract .alert-dismissable .close,
 #hrjob-contract .alert-dismissible .close {
   position: relative;
@@ -8041,59 +6447,47 @@ fieldset[disabled]
   right: -21px;
   color: inherit;
 }
-/* line 59, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_alerts.scss */
 #hrjob-contract .alert-success {
   background-color: #dff0d8;
   border-color: #d6e9c6;
   color: #4d994d;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_alerts.scss */
 #hrjob-contract .alert-success hr {
   border-top-color: #c9e2b3;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_alerts.scss */
 #hrjob-contract .alert-success .alert-link {
   color: #3c773c;
 }
-/* line 63, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_alerts.scss */
 #hrjob-contract .alert-info {
   background-color: #d9edf7;
   border-color: #bce8f1;
   color: #31708f;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_alerts.scss */
 #hrjob-contract .alert-info hr {
   border-top-color: #a6e1ec;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_alerts.scss */
 #hrjob-contract .alert-info .alert-link {
   color: #245269;
 }
-/* line 67, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_alerts.scss */
 #hrjob-contract .alert-warning {
   background-color: #fcf8e3;
   border-color: #faebcc;
   color: #bf5900;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_alerts.scss */
 #hrjob-contract .alert-warning hr {
   border-top-color: #f7e1b5;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_alerts.scss */
 #hrjob-contract .alert-warning .alert-link {
   color: #8c4100;
 }
-/* line 71, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_alerts.scss */
 #hrjob-contract .alert-danger {
   background-color: #f2dede;
   border-color: #ebccd1;
   color: #CF3458;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_alerts.scss */
 #hrjob-contract .alert-danger hr {
   border-top-color: #e4b9c0;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_alerts.scss */
 #hrjob-contract .alert-danger .alert-link {
   color: #a82846;
 }
@@ -8113,7 +6507,6 @@ fieldset[disabled]
     background-position: 0 0;
   }
 }
-/* line 26, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_progress-bars.scss */
 #hrjob-contract .progress {
   overflow: hidden;
   height: 18px;
@@ -8123,7 +6516,6 @@ fieldset[disabled]
   -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
 }
-/* line 36, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_progress-bars.scss */
 #hrjob-contract .progress-bar {
   float: left;
   width: 0%;
@@ -8139,7 +6531,6 @@ fieldset[disabled]
   -o-transition: width 0.6s ease;
   transition: width 0.6s ease;
 }
-/* line 54, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_progress-bars.scss */
 #hrjob-contract .progress-striped .progress-bar,
 #hrjob-contract .progress-bar-striped {
   background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
@@ -8147,120 +6538,96 @@ fieldset[disabled]
   background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-size: 40px 40px;
 }
-/* line 64, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_progress-bars.scss */
 #hrjob-contract .progress.active .progress-bar,
 #hrjob-contract .progress-bar.active {
   -webkit-animation: progress-bar-stripes 2s linear infinite;
   -o-animation: progress-bar-stripes 2s linear infinite;
   animation: progress-bar-stripes 2s linear infinite;
 }
-/* line 73, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_progress-bars.scss */
 #hrjob-contract .progress-bar-success {
   background-color: #44CB7E;
 }
-/* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_progress-bar.scss */
 .progress-striped #hrjob-contract .progress-bar-success {
   background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
 }
-/* line 77, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_progress-bars.scss */
 #hrjob-contract .progress-bar-info {
   background-color: #5bc0de;
 }
-/* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_progress-bar.scss */
 .progress-striped #hrjob-contract .progress-bar-info {
   background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
 }
-/* line 81, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_progress-bars.scss */
 #hrjob-contract .progress-bar-warning {
   background-color: #E6AB5E;
 }
-/* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_progress-bar.scss */
 .progress-striped #hrjob-contract .progress-bar-warning {
   background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
 }
-/* line 85, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_progress-bars.scss */
 #hrjob-contract .progress-bar-danger {
   background-color: #CF3458;
 }
-/* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_progress-bar.scss */
 .progress-striped #hrjob-contract .progress-bar-danger {
   background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
 }
-/* line 1, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_media.scss */
 #hrjob-contract .media {
   margin-top: 15px;
 }
-/* line 5, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_media.scss */
 #hrjob-contract .media:first-child {
   margin-top: 0;
 }
-/* line 10, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_media.scss */
 #hrjob-contract .media,
 #hrjob-contract .media-body {
   zoom: 1;
   overflow: hidden;
 }
-/* line 16, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_media.scss */
 #hrjob-contract .media-body {
   width: 10000px;
 }
-/* line 20, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_media.scss */
 #hrjob-contract .media-object {
   display: block;
 }
-/* line 24, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_media.scss */
 #hrjob-contract .media-object.img-thumbnail {
   max-width: none;
 }
-/* line 29, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_media.scss */
 #hrjob-contract .media-right,
 #hrjob-contract .media > .pull-right {
   padding-left: 10px;
 }
-/* line 34, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_media.scss */
 #hrjob-contract .media-left,
 #hrjob-contract .media > .pull-left {
   padding-right: 10px;
 }
-/* line 39, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_media.scss */
 #hrjob-contract .media-left,
 #hrjob-contract .media-right,
 #hrjob-contract .media-body {
   display: table-cell;
   vertical-align: top;
 }
-/* line 46, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_media.scss */
 #hrjob-contract .media-middle {
   vertical-align: middle;
 }
-/* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_media.scss */
 #hrjob-contract .media-bottom {
   vertical-align: bottom;
 }
-/* line 55, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_media.scss */
 #hrjob-contract .media-heading {
   margin-top: 0;
   margin-bottom: 5px;
 }
-/* line 63, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_media.scss */
 #hrjob-contract .media-list {
   padding-left: 0;
   list-style: none;
 }
-/* line 10, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_list-group.scss */
 #hrjob-contract .list-group {
   margin-bottom: 20px;
   padding-left: 0;
 }
-/* line 21, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_list-group.scss */
 #hrjob-contract .list-group-item {
   position: relative;
   display: block;
@@ -8269,28 +6636,23 @@ fieldset[disabled]
   background-color: #fff;
   border: 1px solid #ddd;
 }
-/* line 31, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_list-group.scss */
 #hrjob-contract .list-group-item:first-child {
   border-top-right-radius: 2px;
   border-top-left-radius: 2px;
 }
-/* line 34, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_list-group.scss */
 #hrjob-contract .list-group-item:last-child {
   margin-bottom: 0;
   border-bottom-right-radius: 2px;
   border-bottom-left-radius: 2px;
 }
-/* line 46, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_list-group.scss */
 #hrjob-contract a.list-group-item,
 #hrjob-contract button.list-group-item {
   color: #555;
 }
-/* line 50, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_list-group.scss */
 #hrjob-contract a.list-group-item .list-group-item-heading,
 #hrjob-contract button.list-group-item .list-group-item-heading {
   color: #333;
 }
-/* line 55, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_list-group.scss */
 #hrjob-contract a.list-group-item:hover, #hrjob-contract a.list-group-item:focus,
 #hrjob-contract button.list-group-item:hover,
 #hrjob-contract button.list-group-item:focus {
@@ -8298,33 +6660,27 @@ fieldset[disabled]
   color: #555;
   background-color: #f5f5f5;
 }
-/* line 63, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_list-group.scss */
 #hrjob-contract button.list-group-item {
   width: 100%;
   text-align: left;
 }
-/* line 70, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_list-group.scss */
 #hrjob-contract .list-group-item.disabled, #hrjob-contract .list-group-item.disabled:hover, #hrjob-contract .list-group-item.disabled:focus {
   background-color: #F3F6F7;
   color: #E8EEF0;
   cursor: not-allowed;
 }
-/* line 78, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_list-group.scss */
 #hrjob-contract .list-group-item.disabled .list-group-item-heading, #hrjob-contract .list-group-item.disabled:hover .list-group-item-heading, #hrjob-contract .list-group-item.disabled:focus .list-group-item-heading {
   color: inherit;
 }
-/* line 81, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_list-group.scss */
 #hrjob-contract .list-group-item.disabled .list-group-item-text, #hrjob-contract .list-group-item.disabled:hover .list-group-item-text, #hrjob-contract .list-group-item.disabled:focus .list-group-item-text {
   color: #E8EEF0;
 }
-/* line 87, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_list-group.scss */
 #hrjob-contract .list-group-item.active, #hrjob-contract .list-group-item.active:hover, #hrjob-contract .list-group-item.active:focus {
   z-index: 2;
   color: #fff;
   background-color: #0071BD;
   border-color: #0071BD;
 }
-/* line 96, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_list-group.scss */
 #hrjob-contract .list-group-item.active .list-group-item-heading,
 #hrjob-contract .list-group-item.active .list-group-item-heading > small,
 #hrjob-contract .list-group-item.active .list-group-item-heading > .small, #hrjob-contract .list-group-item.active:hover .list-group-item-heading,
@@ -8334,33 +6690,27 @@ fieldset[disabled]
 #hrjob-contract .list-group-item.active:focus .list-group-item-heading > .small {
   color: inherit;
 }
-/* line 101, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_list-group.scss */
 #hrjob-contract .list-group-item.active .list-group-item-text, #hrjob-contract .list-group-item.active:hover .list-group-item-text, #hrjob-contract .list-group-item.active:focus .list-group-item-text {
   color: #8ad0ff;
 }
-/* line 4, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract .list-group-item-success {
   color: #4d994d;
   background-color: #dff0d8;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract a.list-group-item-success,
 #hrjob-contract button.list-group-item-success {
   color: #4d994d;
 }
-/* line 15, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract a.list-group-item-success .list-group-item-heading,
 #hrjob-contract button.list-group-item-success .list-group-item-heading {
   color: inherit;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract a.list-group-item-success:hover, #hrjob-contract a.list-group-item-success:focus,
 #hrjob-contract button.list-group-item-success:hover,
 #hrjob-contract button.list-group-item-success:focus {
   color: #4d994d;
   background-color: #d0e9c6;
 }
-/* line 24, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract a.list-group-item-success.active, #hrjob-contract a.list-group-item-success.active:hover, #hrjob-contract a.list-group-item-success.active:focus,
 #hrjob-contract button.list-group-item-success.active,
 #hrjob-contract button.list-group-item-success.active:hover,
@@ -8369,29 +6719,24 @@ fieldset[disabled]
   background-color: #4d994d;
   border-color: #4d994d;
 }
-/* line 4, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract .list-group-item-info {
   color: #31708f;
   background-color: #d9edf7;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract a.list-group-item-info,
 #hrjob-contract button.list-group-item-info {
   color: #31708f;
 }
-/* line 15, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract a.list-group-item-info .list-group-item-heading,
 #hrjob-contract button.list-group-item-info .list-group-item-heading {
   color: inherit;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract a.list-group-item-info:hover, #hrjob-contract a.list-group-item-info:focus,
 #hrjob-contract button.list-group-item-info:hover,
 #hrjob-contract button.list-group-item-info:focus {
   color: #31708f;
   background-color: #c4e3f3;
 }
-/* line 24, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract a.list-group-item-info.active, #hrjob-contract a.list-group-item-info.active:hover, #hrjob-contract a.list-group-item-info.active:focus,
 #hrjob-contract button.list-group-item-info.active,
 #hrjob-contract button.list-group-item-info.active:hover,
@@ -8400,29 +6745,24 @@ fieldset[disabled]
   background-color: #31708f;
   border-color: #31708f;
 }
-/* line 4, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract .list-group-item-warning {
   color: #bf5900;
   background-color: #fcf8e3;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract a.list-group-item-warning,
 #hrjob-contract button.list-group-item-warning {
   color: #bf5900;
 }
-/* line 15, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract a.list-group-item-warning .list-group-item-heading,
 #hrjob-contract button.list-group-item-warning .list-group-item-heading {
   color: inherit;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract a.list-group-item-warning:hover, #hrjob-contract a.list-group-item-warning:focus,
 #hrjob-contract button.list-group-item-warning:hover,
 #hrjob-contract button.list-group-item-warning:focus {
   color: #bf5900;
   background-color: #faf2cc;
 }
-/* line 24, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract a.list-group-item-warning.active, #hrjob-contract a.list-group-item-warning.active:hover, #hrjob-contract a.list-group-item-warning.active:focus,
 #hrjob-contract button.list-group-item-warning.active,
 #hrjob-contract button.list-group-item-warning.active:hover,
@@ -8431,29 +6771,24 @@ fieldset[disabled]
   background-color: #bf5900;
   border-color: #bf5900;
 }
-/* line 4, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract .list-group-item-danger {
   color: #CF3458;
   background-color: #f2dede;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract a.list-group-item-danger,
 #hrjob-contract button.list-group-item-danger {
   color: #CF3458;
 }
-/* line 15, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract a.list-group-item-danger .list-group-item-heading,
 #hrjob-contract button.list-group-item-danger .list-group-item-heading {
   color: inherit;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract a.list-group-item-danger:hover, #hrjob-contract a.list-group-item-danger:focus,
 #hrjob-contract button.list-group-item-danger:hover,
 #hrjob-contract button.list-group-item-danger:focus {
   color: #CF3458;
   background-color: #ebcccc;
 }
-/* line 24, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_list-group.scss */
 #hrjob-contract a.list-group-item-danger.active, #hrjob-contract a.list-group-item-danger.active:hover, #hrjob-contract a.list-group-item-danger.active:focus,
 #hrjob-contract button.list-group-item-danger.active,
 #hrjob-contract button.list-group-item-danger.active:hover,
@@ -8462,17 +6797,14 @@ fieldset[disabled]
   background-color: #CF3458;
   border-color: #CF3458;
 }
-/* line 123, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_list-group.scss */
 #hrjob-contract .list-group-item-heading {
   margin-top: 0;
   margin-bottom: 5px;
 }
-/* line 127, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_list-group.scss */
 #hrjob-contract .list-group-item-text {
   margin-bottom: 0;
   line-height: 1.3;
 }
-/* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel {
   margin-bottom: 18px;
   background-color: #FFFFFF;
@@ -8481,38 +6813,31 @@ fieldset[disabled]
   -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
 }
-/* line 16, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-body {
   padding: 20px;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .panel-body:before, #hrjob-contract .panel-body:after {
   content: " ";
   display: table;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .panel-body:after {
   clear: both;
 }
-/* line 22, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-heading {
   padding: 15px 19px 14px;
   border-bottom: 1px solid transparent;
   border-top-right-radius: 1px;
   border-top-left-radius: 1px;
 }
-/* line 27, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-heading > .dropdown .dropdown-toggle {
   color: inherit;
 }
-/* line 33, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-title {
   margin-top: 0;
   margin-bottom: 0;
   font-size: 15px;
   color: inherit;
 }
-/* line 39, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-title > a,
 #hrjob-contract .panel-title > small,
 #hrjob-contract .panel-title > .small,
@@ -8520,7 +6845,6 @@ fieldset[disabled]
 #hrjob-contract .panel-title > .small > a {
   color: inherit;
 }
-/* line 49, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-footer {
   padding: 15px 19px 14px;
   background-color: #FFFFFF;
@@ -8528,64 +6852,53 @@ fieldset[disabled]
   border-bottom-right-radius: 1px;
   border-bottom-left-radius: 1px;
 }
-/* line 63, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .list-group,
 #hrjob-contract .panel > .panel-collapse > .list-group {
   margin-bottom: 0;
 }
-/* line 67, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .list-group .list-group-item,
 #hrjob-contract .panel > .panel-collapse > .list-group .list-group-item {
   border-width: 1px 0;
   border-radius: 0;
 }
-/* line 74, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .list-group:first-child .list-group-item:first-child,
 #hrjob-contract .panel > .panel-collapse > .list-group:first-child .list-group-item:first-child {
   border-top: 0;
   border-top-right-radius: 1px;
   border-top-left-radius: 1px;
 }
-/* line 82, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .list-group:last-child .list-group-item:last-child,
 #hrjob-contract .panel > .panel-collapse > .list-group:last-child .list-group-item:last-child {
   border-bottom: 0;
   border-bottom-right-radius: 1px;
   border-bottom-left-radius: 1px;
 }
-/* line 89, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .panel-heading + .panel-collapse > .list-group .list-group-item:first-child {
   border-top-right-radius: 0;
   border-top-left-radius: 0;
 }
-/* line 96, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-heading + .list-group .list-group-item:first-child {
   border-top-width: 0;
 }
-/* line 100, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .list-group + .panel-footer {
   border-top-width: 0;
 }
-/* line 110, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .table,
 #hrjob-contract .panel > .table-responsive > .table,
 #hrjob-contract .panel > .panel-collapse > .table {
   margin-bottom: 0;
 }
-/* line 115, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .table caption,
 #hrjob-contract .panel > .table-responsive > .table caption,
 #hrjob-contract .panel > .panel-collapse > .table caption {
   padding-left: 20px;
   padding-right: 20px;
 }
-/* line 121, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .table:first-child,
 #hrjob-contract .panel > .table-responsive:first-child > .table:first-child {
   border-top-right-radius: 1px;
   border-top-left-radius: 1px;
 }
-/* line 127, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .table:first-child > thead:first-child > tr:first-child,
 #hrjob-contract .panel > .table:first-child > tbody:first-child > tr:first-child,
 #hrjob-contract .panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child,
@@ -8593,7 +6906,6 @@ fieldset[disabled]
   border-top-left-radius: 1px;
   border-top-right-radius: 1px;
 }
-/* line 131, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .table:first-child > thead:first-child > tr:first-child td:first-child,
 #hrjob-contract .panel > .table:first-child > thead:first-child > tr:first-child th:first-child,
 #hrjob-contract .panel > .table:first-child > tbody:first-child > tr:first-child td:first-child,
@@ -8604,7 +6916,6 @@ fieldset[disabled]
 #hrjob-contract .panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child th:first-child {
   border-top-left-radius: 1px;
 }
-/* line 135, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .table:first-child > thead:first-child > tr:first-child td:last-child,
 #hrjob-contract .panel > .table:first-child > thead:first-child > tr:first-child th:last-child,
 #hrjob-contract .panel > .table:first-child > tbody:first-child > tr:first-child td:last-child,
@@ -8615,13 +6926,11 @@ fieldset[disabled]
 #hrjob-contract .panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child th:last-child {
   border-top-right-radius: 1px;
 }
-/* line 143, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .table:last-child,
 #hrjob-contract .panel > .table-responsive:last-child > .table:last-child {
   border-bottom-right-radius: 1px;
   border-bottom-left-radius: 1px;
 }
-/* line 149, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .table:last-child > tbody:last-child > tr:last-child,
 #hrjob-contract .panel > .table:last-child > tfoot:last-child > tr:last-child,
 #hrjob-contract .panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child,
@@ -8629,7 +6938,6 @@ fieldset[disabled]
   border-bottom-left-radius: 1px;
   border-bottom-right-radius: 1px;
 }
-/* line 153, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .table:last-child > tbody:last-child > tr:last-child td:first-child,
 #hrjob-contract .panel > .table:last-child > tbody:last-child > tr:last-child th:first-child,
 #hrjob-contract .panel > .table:last-child > tfoot:last-child > tr:last-child td:first-child,
@@ -8640,7 +6948,6 @@ fieldset[disabled]
 #hrjob-contract .panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child th:first-child {
   border-bottom-left-radius: 1px;
 }
-/* line 157, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .table:last-child > tbody:last-child > tr:last-child td:last-child,
 #hrjob-contract .panel > .table:last-child > tbody:last-child > tr:last-child th:last-child,
 #hrjob-contract .panel > .table:last-child > tfoot:last-child > tr:last-child td:last-child,
@@ -8651,24 +6958,20 @@ fieldset[disabled]
 #hrjob-contract .panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child th:last-child {
   border-bottom-right-radius: 1px;
 }
-/* line 164, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .panel-body + .table,
 #hrjob-contract .panel > .panel-body + .table-responsive,
 #hrjob-contract .panel > .table + .panel-body,
 #hrjob-contract .panel > .table-responsive + .panel-body {
   border-top: 1px solid #E8EEF0;
 }
-/* line 170, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .table > tbody:first-child > tr:first-child th,
 #hrjob-contract .panel > .table > tbody:first-child > tr:first-child td {
   border-top: 0;
 }
-/* line 174, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .table-bordered,
 #hrjob-contract .panel > .table-responsive > .table-bordered {
   border: 0;
 }
-/* line 181, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .table-bordered > thead > tr > th:first-child,
 #hrjob-contract .panel > .table-bordered > thead > tr > td:first-child,
 #hrjob-contract .panel > .table-bordered > tbody > tr > th:first-child,
@@ -8683,7 +6986,6 @@ fieldset[disabled]
 #hrjob-contract .panel > .table-responsive > .table-bordered > tfoot > tr > td:first-child {
   border-left: 0;
 }
-/* line 185, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .table-bordered > thead > tr > th:last-child,
 #hrjob-contract .panel > .table-bordered > thead > tr > td:last-child,
 #hrjob-contract .panel > .table-bordered > tbody > tr > th:last-child,
@@ -8698,7 +7000,6 @@ fieldset[disabled]
 #hrjob-contract .panel > .table-responsive > .table-bordered > tfoot > tr > td:last-child {
   border-right: 0;
 }
-/* line 194, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .table-bordered > thead > tr:first-child > td,
 #hrjob-contract .panel > .table-bordered > thead > tr:first-child > th,
 #hrjob-contract .panel > .table-bordered > tbody > tr:first-child > td,
@@ -8709,7 +7010,6 @@ fieldset[disabled]
 #hrjob-contract .panel > .table-responsive > .table-bordered > tbody > tr:first-child > th {
   border-bottom: 0;
 }
-/* line 203, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .table-bordered > tbody > tr:last-child > td,
 #hrjob-contract .panel > .table-bordered > tbody > tr:last-child > th,
 #hrjob-contract .panel > .table-bordered > tfoot > tr:last-child > td,
@@ -8720,180 +7020,141 @@ fieldset[disabled]
 #hrjob-contract .panel > .table-responsive > .table-bordered > tfoot > tr:last-child > th {
   border-bottom: 0;
 }
-/* line 210, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel > .table-responsive {
   border: 0;
   margin-bottom: 0;
 }
-/* line 222, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-group {
   margin-bottom: 18px;
 }
-/* line 226, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-group .panel {
   margin-bottom: 0;
   border-radius: 2px;
 }
-/* line 230, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-group .panel + .panel {
   margin-top: 5px;
 }
-/* line 235, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-group .panel-heading {
   border-bottom: 0;
 }
-/* line 238, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-group .panel-heading + .panel-collapse > .panel-body,
 #hrjob-contract .panel-group .panel-heading + .panel-collapse > .list-group {
   border-top: 1px solid #ddd;
 }
-/* line 244, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-group .panel-footer {
   border-top: 0;
 }
-/* line 246, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-group .panel-footer + .panel-collapse .panel-body {
   border-bottom: 1px solid #ddd;
 }
-/* line 254, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-default {
   border-color: #D3DEE2;
 }
-/* line 6, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-default > .panel-heading {
   color: #4D4D69;
   background-color: #F3F6F7;
   border-color: #D3DEE2;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-default > .panel-heading + .panel-collapse > .panel-body {
   border-top-color: #D3DEE2;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-default > .panel-heading .badge {
   color: #F3F6F7;
   background-color: #4D4D69;
 }
-/* line 20, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-default > .panel-footer + .panel-collapse > .panel-body {
   border-bottom-color: #D3DEE2;
 }
-/* line 257, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-primary {
   border-color: #0071BD;
 }
-/* line 6, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-primary > .panel-heading {
   color: #fff;
   background-color: #0071BD;
   border-color: #0071BD;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-primary > .panel-heading + .panel-collapse > .panel-body {
   border-top-color: #0071BD;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-primary > .panel-heading .badge {
   color: #0071BD;
   background-color: #fff;
 }
-/* line 20, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-primary > .panel-footer + .panel-collapse > .panel-body {
   border-bottom-color: #0071BD;
 }
-/* line 260, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-success {
   border-color: #d6e9c6;
 }
-/* line 6, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-success > .panel-heading {
   color: #4d994d;
   background-color: #dff0d8;
   border-color: #d6e9c6;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-success > .panel-heading + .panel-collapse > .panel-body {
   border-top-color: #d6e9c6;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-success > .panel-heading .badge {
   color: #dff0d8;
   background-color: #4d994d;
 }
-/* line 20, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-success > .panel-footer + .panel-collapse > .panel-body {
   border-bottom-color: #d6e9c6;
 }
-/* line 263, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-info {
   border-color: #bce8f1;
 }
-/* line 6, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-info > .panel-heading {
   color: #31708f;
   background-color: #d9edf7;
   border-color: #bce8f1;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-info > .panel-heading + .panel-collapse > .panel-body {
   border-top-color: #bce8f1;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-info > .panel-heading .badge {
   color: #d9edf7;
   background-color: #31708f;
 }
-/* line 20, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-info > .panel-footer + .panel-collapse > .panel-body {
   border-bottom-color: #bce8f1;
 }
-/* line 266, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-warning {
   border-color: #faebcc;
 }
-/* line 6, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-warning > .panel-heading {
   color: #bf5900;
   background-color: #fcf8e3;
   border-color: #faebcc;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-warning > .panel-heading + .panel-collapse > .panel-body {
   border-top-color: #faebcc;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-warning > .panel-heading .badge {
   color: #fcf8e3;
   background-color: #bf5900;
 }
-/* line 20, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-warning > .panel-footer + .panel-collapse > .panel-body {
   border-bottom-color: #faebcc;
 }
-/* line 269, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_panels.scss */
 #hrjob-contract .panel-danger {
   border-color: #ebccd1;
 }
-/* line 6, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-danger > .panel-heading {
   color: #CF3458;
   background-color: #f2dede;
   border-color: #ebccd1;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-danger > .panel-heading + .panel-collapse > .panel-body {
   border-top-color: #ebccd1;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-danger > .panel-heading .badge {
   color: #f2dede;
   background-color: #CF3458;
 }
-/* line 20, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_panels.scss */
 #hrjob-contract .panel-danger > .panel-footer + .panel-collapse > .panel-body {
   border-bottom-color: #ebccd1;
 }
-/* line 5, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-embed.scss */
 #hrjob-contract .embed-responsive {
   position: relative;
   display: block;
@@ -8901,7 +7162,6 @@ fieldset[disabled]
   padding: 0;
   overflow: hidden;
 }
-/* line 12, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-embed.scss */
 #hrjob-contract .embed-responsive .embed-responsive-item,
 #hrjob-contract .embed-responsive iframe,
 #hrjob-contract .embed-responsive embed,
@@ -8915,15 +7175,12 @@ fieldset[disabled]
   width: 100%;
   border: 0;
 }
-/* line 28, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-embed.scss */
 #hrjob-contract .embed-responsive-16by9 {
   padding-bottom: 56.25%;
 }
-/* line 33, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-embed.scss */
 #hrjob-contract .embed-responsive-4by3 {
   padding-bottom: 75%;
 }
-/* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_wells.scss */
 #hrjob-contract .well {
   min-height: 20px;
   padding: 19px;
@@ -8934,22 +7191,18 @@ fieldset[disabled]
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
 }
-/* line 15, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_wells.scss */
 #hrjob-contract .well blockquote {
   border-color: #ddd;
   border-color: rgba(0, 0, 0, 0.15);
 }
-/* line 22, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_wells.scss */
 #hrjob-contract .well-lg {
   padding: 24px;
   border-radius: 4px;
 }
-/* line 26, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_wells.scss */
 #hrjob-contract .well-sm {
   padding: 9px;
   border-radius: 2px;
 }
-/* line 6, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_close.scss */
 #hrjob-contract .close {
   float: right;
   font-size: 19.5px;
@@ -8960,7 +7213,6 @@ fieldset[disabled]
   opacity: 0.2;
   filter: alpha(opacity=20);
 }
-/* line 15, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_close.scss */
 #hrjob-contract .close:hover, #hrjob-contract .close:focus {
   color: #000;
   text-decoration: none;
@@ -8968,7 +7220,6 @@ fieldset[disabled]
   opacity: 0.5;
   filter: alpha(opacity=50);
 }
-/* line 30, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_close.scss */
 #hrjob-contract button.close {
   padding: 0;
   cursor: pointer;
@@ -8976,11 +7227,9 @@ fieldset[disabled]
   border: 0;
   -webkit-appearance: none;
 }
-/* line 15, ../scss/civihr/bootstrap/_modals-custom.scss */
 .modal-open {
   overflow: hidden;
 }
-/* line 21, ../scss/civihr/bootstrap/_modals-custom.scss */
 #hrjob-contract .modal {
   display: none;
   overflow: hidden;
@@ -8993,7 +7242,6 @@ fieldset[disabled]
   -webkit-overflow-scrolling: touch;
   outline: 0;
 }
-/* line 37, ../scss/civihr/bootstrap/_modals-custom.scss */
 #hrjob-contract .modal.fade .modal-dialog {
   -webkit-transform: translate(0, -25%);
   -ms-transform: translate(0, -25%);
@@ -9004,25 +7252,21 @@ fieldset[disabled]
   -o-transition: -o-transform 0.3s ease-out;
   transition: transform 0.3s ease-out;
 }
-/* line 41, ../scss/civihr/bootstrap/_modals-custom.scss */
 #hrjob-contract .modal.in .modal-dialog {
   -webkit-transform: translate(0, 0);
   -ms-transform: translate(0, 0);
   -o-transform: translate(0, 0);
   transform: translate(0, 0);
 }
-/* line 43, ../scss/civihr/bootstrap/_modals-custom.scss */
 #hrjob-contract .modal-open .modal {
   overflow-x: hidden;
   overflow-y: auto;
 }
-/* line 49, ../scss/civihr/bootstrap/_modals-custom.scss */
 #hrjob-contract .modal-dialog {
   position: relative;
   width: auto;
   margin: 10px;
 }
-/* line 56, ../scss/civihr/bootstrap/_modals-custom.scss */
 #hrjob-contract .modal-content {
   position: relative;
   background-color: #fff;
@@ -9034,7 +7278,6 @@ fieldset[disabled]
   background-clip: padding-box;
   outline: 0;
 }
-/* line 69, ../scss/civihr/bootstrap/_modals-custom.scss */
 #hrjob-contract .modal-backdrop {
   position: fixed;
   top: 0;
@@ -9043,62 +7286,50 @@ fieldset[disabled]
   left: 0;
   background-color: #000;
 }
-/* line 77, ../scss/civihr/bootstrap/_modals-custom.scss */
 #hrjob-contract .modal-backdrop.fade {
   opacity: 0;
   filter: alpha(opacity=0);
 }
-/* line 78, ../scss/civihr/bootstrap/_modals-custom.scss */
 #hrjob-contract .modal-backdrop.in {
   opacity: 0.5;
   filter: alpha(opacity=50);
 }
-/* line 83, ../scss/civihr/bootstrap/_modals-custom.scss */
 #hrjob-contract .modal-header {
   padding: 15px;
   border-bottom: 1px solid #e5e5e5;
   min-height: 16.42857143px;
 }
-/* line 90, ../scss/civihr/bootstrap/_modals-custom.scss */
 #hrjob-contract .modal-title {
   margin: 0;
   line-height: 1.42857143;
 }
-/* line 97, ../scss/civihr/bootstrap/_modals-custom.scss */
 #hrjob-contract .modal-body {
   position: relative;
   padding: 15px;
 }
-/* line 103, ../scss/civihr/bootstrap/_modals-custom.scss */
 #hrjob-contract .modal-footer {
   background: #F3F6F7;
   padding: 15px;
   text-align: right;
   border-top: 1px solid #e5e5e5;
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .modal-footer:before, #hrjob-contract .modal-footer:after {
   content: " ";
   display: table;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .modal-footer:after {
   clear: both;
 }
-/* line 111, ../scss/civihr/bootstrap/_modals-custom.scss */
 #hrjob-contract .modal-footer .btn + .btn {
   margin-left: 5px;
   margin-bottom: 0;
 }
-/* line 116, ../scss/civihr/bootstrap/_modals-custom.scss */
 #hrjob-contract .modal-footer .btn-group .btn + .btn {
   margin-left: -1px;
 }
-/* line 120, ../scss/civihr/bootstrap/_modals-custom.scss */
 #hrjob-contract .modal-footer .btn-block + .btn-block {
   margin-left: 0;
 }
-/* line 126, ../scss/civihr/bootstrap/_modals-custom.scss */
 #hrjob-contract .modal-scrollbar-measure {
   position: absolute;
   top: -9999px;
@@ -9107,28 +7338,23 @@ fieldset[disabled]
   overflow: scroll;
 }
 @media (min-width: 768px) {
-  /* line 137, ../scss/civihr/bootstrap/_modals-custom.scss */
   #hrjob-contract .modal-dialog {
     width: 600px;
     margin: 30px auto;
   }
-  /* line 141, ../scss/civihr/bootstrap/_modals-custom.scss */
   #hrjob-contract .modal-content {
     -webkit-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
   }
-  /* line 146, ../scss/civihr/bootstrap/_modals-custom.scss */
   #hrjob-contract .modal-sm {
     width: 300px;
   }
 }
 @media (min-width: 992px) {
-  /* line 150, ../scss/civihr/bootstrap/_modals-custom.scss */
   #hrjob-contract .modal-lg {
     width: 900px;
   }
 }
-/* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tooltip.scss */
 #hrjob-contract .tooltip {
   position: absolute;
   z-index: 1070;
@@ -9152,32 +7378,26 @@ fieldset[disabled]
   opacity: 0;
   filter: alpha(opacity=0);
 }
-/* line 18, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tooltip.scss */
 #hrjob-contract .tooltip.in {
   opacity: 0.9;
   filter: alpha(opacity=90);
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tooltip.scss */
 #hrjob-contract .tooltip.top {
   margin-top: -3px;
   padding: 5px 0;
 }
-/* line 20, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tooltip.scss */
 #hrjob-contract .tooltip.right {
   margin-left: 3px;
   padding: 0 5px;
 }
-/* line 21, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tooltip.scss */
 #hrjob-contract .tooltip.bottom {
   margin-top: 3px;
   padding: 5px 0;
 }
-/* line 22, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tooltip.scss */
 #hrjob-contract .tooltip.left {
   margin-left: -3px;
   padding: 0 5px;
 }
-/* line 26, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tooltip.scss */
 #hrjob-contract .tooltip-inner {
   max-width: 200px;
   padding: 3px 8px;
@@ -9186,7 +7406,6 @@ fieldset[disabled]
   background-color: #000;
   border-radius: 2px;
 }
-/* line 36, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tooltip.scss */
 #hrjob-contract .tooltip-arrow {
   position: absolute;
   width: 0;
@@ -9194,7 +7413,6 @@ fieldset[disabled]
   border-color: transparent;
   border-style: solid;
 }
-/* line 45, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tooltip.scss */
 #hrjob-contract .tooltip.top .tooltip-arrow {
   bottom: 0;
   left: 50%;
@@ -9202,7 +7420,6 @@ fieldset[disabled]
   border-width: 5px 5px 0;
   border-top-color: #000;
 }
-/* line 52, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tooltip.scss */
 #hrjob-contract .tooltip.top-left .tooltip-arrow {
   bottom: 0;
   right: 5px;
@@ -9210,7 +7427,6 @@ fieldset[disabled]
   border-width: 5px 5px 0;
   border-top-color: #000;
 }
-/* line 59, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tooltip.scss */
 #hrjob-contract .tooltip.top-right .tooltip-arrow {
   bottom: 0;
   left: 5px;
@@ -9218,7 +7434,6 @@ fieldset[disabled]
   border-width: 5px 5px 0;
   border-top-color: #000;
 }
-/* line 66, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tooltip.scss */
 #hrjob-contract .tooltip.right .tooltip-arrow {
   top: 50%;
   left: 0;
@@ -9226,7 +7441,6 @@ fieldset[disabled]
   border-width: 5px 5px 5px 0;
   border-right-color: #000;
 }
-/* line 73, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tooltip.scss */
 #hrjob-contract .tooltip.left .tooltip-arrow {
   top: 50%;
   right: 0;
@@ -9234,7 +7448,6 @@ fieldset[disabled]
   border-width: 5px 0 5px 5px;
   border-left-color: #000;
 }
-/* line 80, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tooltip.scss */
 #hrjob-contract .tooltip.bottom .tooltip-arrow {
   top: 0;
   left: 50%;
@@ -9242,7 +7455,6 @@ fieldset[disabled]
   border-width: 0 5px 5px;
   border-bottom-color: #000;
 }
-/* line 87, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tooltip.scss */
 #hrjob-contract .tooltip.bottom-left .tooltip-arrow {
   top: 0;
   right: 5px;
@@ -9250,7 +7462,6 @@ fieldset[disabled]
   border-width: 0 5px 5px;
   border-bottom-color: #000;
 }
-/* line 94, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tooltip.scss */
 #hrjob-contract .tooltip.bottom-right .tooltip-arrow {
   top: 0;
   left: 5px;
@@ -9258,7 +7469,6 @@ fieldset[disabled]
   border-width: 0 5px 5px;
   border-bottom-color: #000;
 }
-/* line 6, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_popovers.scss */
 #hrjob-contract .popover {
   position: absolute;
   top: 0;
@@ -9291,23 +7501,18 @@ fieldset[disabled]
   -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
 }
-/* line 27, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_popovers.scss */
 #hrjob-contract .popover.top {
   margin-top: -10px;
 }
-/* line 28, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_popovers.scss */
 #hrjob-contract .popover.right {
   margin-left: 10px;
 }
-/* line 29, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_popovers.scss */
 #hrjob-contract .popover.bottom {
   margin-top: 10px;
 }
-/* line 30, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_popovers.scss */
 #hrjob-contract .popover.left {
   margin-left: -10px;
 }
-/* line 33, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_popovers.scss */
 #hrjob-contract .popover-title {
   margin: 0;
   padding: 8px 14px;
@@ -9316,11 +7521,9 @@ fieldset[disabled]
   border-bottom: 1px solid #ebebeb;
   border-radius: 3px 3px 0 0;
 }
-/* line 42, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_popovers.scss */
 #hrjob-contract .popover-content {
   padding: 9px 14px;
 }
-/* line 51, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_popovers.scss */
 #hrjob-contract .popover > .arrow, #hrjob-contract .popover > .arrow:after {
   position: absolute;
   display: block;
@@ -9329,16 +7532,13 @@ fieldset[disabled]
   border-color: transparent;
   border-style: solid;
 }
-/* line 61, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_popovers.scss */
 #hrjob-contract .popover > .arrow {
   border-width: 11px;
 }
-/* line 64, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_popovers.scss */
 #hrjob-contract .popover > .arrow:after {
   border-width: 10px;
   content: "";
 }
-/* line 70, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_popovers.scss */
 #hrjob-contract .popover.top > .arrow {
   left: 50%;
   margin-left: -11px;
@@ -9347,7 +7547,6 @@ fieldset[disabled]
   border-top-color: rgba(0, 0, 0, 0.25);
   bottom: -11px;
 }
-/* line 77, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_popovers.scss */
 #hrjob-contract .popover.top > .arrow:after {
   content: " ";
   bottom: 1px;
@@ -9355,7 +7554,6 @@ fieldset[disabled]
   border-bottom-width: 0;
   border-top-color: #fff;
 }
-/* line 85, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_popovers.scss */
 #hrjob-contract .popover.right > .arrow {
   top: 50%;
   left: -11px;
@@ -9364,7 +7562,6 @@ fieldset[disabled]
   border-right-color: #999999;
   border-right-color: rgba(0, 0, 0, 0.25);
 }
-/* line 92, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_popovers.scss */
 #hrjob-contract .popover.right > .arrow:after {
   content: " ";
   left: 1px;
@@ -9372,7 +7569,6 @@ fieldset[disabled]
   border-left-width: 0;
   border-right-color: #fff;
 }
-/* line 100, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_popovers.scss */
 #hrjob-contract .popover.bottom > .arrow {
   left: 50%;
   margin-left: -11px;
@@ -9381,7 +7577,6 @@ fieldset[disabled]
   border-bottom-color: rgba(0, 0, 0, 0.25);
   top: -11px;
 }
-/* line 107, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_popovers.scss */
 #hrjob-contract .popover.bottom > .arrow:after {
   content: " ";
   top: 1px;
@@ -9389,7 +7584,6 @@ fieldset[disabled]
   border-top-width: 0;
   border-bottom-color: #fff;
 }
-/* line 116, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_popovers.scss */
 #hrjob-contract .popover.left > .arrow {
   top: 50%;
   right: -11px;
@@ -9398,7 +7592,6 @@ fieldset[disabled]
   border-left-color: #999999;
   border-left-color: rgba(0, 0, 0, 0.25);
 }
-/* line 123, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_popovers.scss */
 #hrjob-contract .popover.left > .arrow:after {
   content: " ";
   right: 1px;
@@ -9406,17 +7599,14 @@ fieldset[disabled]
   border-left-color: #fff;
   bottom: -10px;
 }
-/* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel {
   position: relative;
 }
-/* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-inner {
   position: relative;
   overflow: hidden;
   width: 100%;
 }
-/* line 16, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-inner > .item {
   display: none;
   position: relative;
@@ -9424,7 +7614,6 @@ fieldset[disabled]
   -o-transition: 0.6s ease-in-out left;
   transition: 0.6s ease-in-out left;
 }
-/* line 22, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-inner > .item > img,
 #hrjob-contract .carousel-inner > .item > a > img {
   display: block;
@@ -9433,7 +7622,6 @@ fieldset[disabled]
   line-height: 1;
 }
 @media all and (transform-3d), (-webkit-transform-3d) {
-  /* line 16, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
   #hrjob-contract .carousel-inner > .item {
     -webkit-transition: -webkit-transform 0.6s ease-in-out;
     -moz-transition: -moz-transform 0.6s ease-in-out;
@@ -9446,64 +7634,52 @@ fieldset[disabled]
     -moz-perspective: 1000px;
     perspective: 1000px;
   }
-  /* line 34, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
   #hrjob-contract .carousel-inner > .item.next, #hrjob-contract .carousel-inner > .item.active.right {
     -webkit-transform: translate3d(100%, 0, 0);
     transform: translate3d(100%, 0, 0);
     left: 0;
   }
-  /* line 39, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
   #hrjob-contract .carousel-inner > .item.prev, #hrjob-contract .carousel-inner > .item.active.left {
     -webkit-transform: translate3d(-100%, 0, 0);
     transform: translate3d(-100%, 0, 0);
     left: 0;
   }
-  /* line 44, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
   #hrjob-contract .carousel-inner > .item.next.left, #hrjob-contract .carousel-inner > .item.prev.right, #hrjob-contract .carousel-inner > .item.active {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0);
     left: 0;
   }
 }
-/* line 53, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-inner > .active,
 #hrjob-contract .carousel-inner > .next,
 #hrjob-contract .carousel-inner > .prev {
   display: block;
 }
-/* line 59, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-inner > .active {
   left: 0;
 }
-/* line 63, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-inner > .next,
 #hrjob-contract .carousel-inner > .prev {
   position: absolute;
   top: 0;
   width: 100%;
 }
-/* line 70, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-inner > .next {
   left: 100%;
 }
-/* line 73, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-inner > .prev {
   left: -100%;
 }
-/* line 76, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-inner > .next.left,
 #hrjob-contract .carousel-inner > .prev.right {
   left: 0;
 }
-/* line 81, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-inner > .active.left {
   left: -100%;
 }
-/* line 84, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-inner > .active.right {
   left: 100%;
 }
-/* line 93, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-control {
   position: absolute;
   top: 0;
@@ -9518,7 +7694,6 @@ fieldset[disabled]
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
   background-color: transparent;
 }
-/* line 109, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-control.left {
   background-image: -webkit-linear-gradient(left, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%);
   background-image: -o-linear-gradient(left, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%);
@@ -9526,7 +7701,6 @@ fieldset[disabled]
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#80000000', endColorstr='#00000000', GradientType=1);
 }
-/* line 112, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-control.right {
   left: auto;
   right: 0;
@@ -9536,7 +7710,6 @@ fieldset[disabled]
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#80000000', GradientType=1);
 }
-/* line 119, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-control:hover, #hrjob-contract .carousel-control:focus {
   outline: 0;
   color: #fff;
@@ -9544,7 +7717,6 @@ fieldset[disabled]
   opacity: 0.9;
   filter: alpha(opacity=90);
 }
-/* line 128, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-control .icon-prev,
 #hrjob-contract .carousel-control .icon-next,
 #hrjob-contract .carousel-control .glyphicon-chevron-left,
@@ -9555,19 +7727,16 @@ fieldset[disabled]
   z-index: 5;
   display: inline-block;
 }
-/* line 138, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-control .icon-prev,
 #hrjob-contract .carousel-control .glyphicon-chevron-left {
   left: 50%;
   margin-left: -10px;
 }
-/* line 143, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-control .icon-next,
 #hrjob-contract .carousel-control .glyphicon-chevron-right {
   right: 50%;
   margin-right: -10px;
 }
-/* line 148, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-control .icon-prev,
 #hrjob-contract .carousel-control .icon-next {
   width: 20px;
@@ -9575,15 +7744,12 @@ fieldset[disabled]
   line-height: 1;
   font-family: serif;
 }
-/* line 158, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-control .icon-prev:before {
   content: '\2039';
 }
-/* line 163, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-control .icon-next:before {
   content: '\203a';
 }
-/* line 174, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-indicators {
   position: absolute;
   bottom: 10px;
@@ -9595,7 +7761,6 @@ fieldset[disabled]
   list-style: none;
   text-align: center;
 }
-/* line 185, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-indicators li {
   display: inline-block;
   width: 10px;
@@ -9608,14 +7773,12 @@ fieldset[disabled]
   background-color: #000 \9;
   background-color: transparent;
 }
-/* line 207, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-indicators .active {
   margin: 0;
   width: 12px;
   height: 12px;
   background-color: #fff;
 }
-/* line 218, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-caption {
   position: absolute;
   left: 15%;
@@ -9628,12 +7791,10 @@ fieldset[disabled]
   text-align: center;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
 }
-/* line 229, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
 #hrjob-contract .carousel-caption .btn {
   text-shadow: none;
 }
 @media screen and (min-width: 768px) {
-  /* line 240, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
   #hrjob-contract .carousel-control .glyphicon-chevron-left,
   #hrjob-contract .carousel-control .glyphicon-chevron-right,
   #hrjob-contract .carousel-control .icon-prev,
@@ -9643,63 +7804,50 @@ fieldset[disabled]
     margin-top: -10px;
     font-size: 30px;
   }
-  /* line 249, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
   #hrjob-contract .carousel-control .glyphicon-chevron-left,
   #hrjob-contract .carousel-control .icon-prev {
     margin-left: -10px;
   }
-  /* line 253, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
   #hrjob-contract .carousel-control .glyphicon-chevron-right,
   #hrjob-contract .carousel-control .icon-next {
     margin-right: -10px;
   }
-  /* line 260, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
   #hrjob-contract .carousel-caption {
     left: 20%;
     right: 20%;
     padding-bottom: 30px;
   }
-  /* line 267, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_carousel.scss */
   #hrjob-contract .carousel-indicators {
     bottom: 20px;
   }
 }
-/* line 14, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .clearfix:before, #hrjob-contract .clearfix:after {
   content: " ";
   display: table;
 }
-/* line 19, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_clearfix.scss */
 #hrjob-contract .clearfix:after {
   clear: both;
 }
-/* line 12, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_utilities.scss */
 #hrjob-contract .center-block {
   display: block;
   margin-left: auto;
   margin-right: auto;
 }
-/* line 15, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_utilities.scss */
 #hrjob-contract .pull-right {
   float: right !important;
 }
-/* line 18, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_utilities.scss */
 #hrjob-contract .pull-left {
   float: left !important;
 }
-/* line 27, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_utilities.scss */
 #hrjob-contract .hide {
   display: none !important;
 }
-/* line 30, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_utilities.scss */
 #hrjob-contract .show {
   display: block !important;
 }
-/* line 33, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_utilities.scss */
 #hrjob-contract .invisible {
   visibility: hidden;
 }
-/* line 36, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_utilities.scss */
 #hrjob-contract .text-hide {
   font: 0/0 a;
   color: transparent;
@@ -9707,34 +7855,27 @@ fieldset[disabled]
   background-color: transparent;
   border: 0;
 }
-/* line 45, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_utilities.scss */
 #hrjob-contract .hidden {
   display: none !important;
 }
-/* line 53, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_utilities.scss */
 #hrjob-contract .affix {
   position: fixed;
 }
 @-ms-viewport {
   width: device-width;
 }
-/* line 18, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
 #hrjob-contract .visible-xs {
   display: none !important;
 }
-/* line 18, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
 #hrjob-contract .visible-sm {
   display: none !important;
 }
-/* line 18, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
 #hrjob-contract .visible-md {
   display: none !important;
 }
-/* line 18, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
 #hrjob-contract .visible-lg {
   display: none !important;
 }
-/* line 36, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-utilities.scss */
 #hrjob-contract .visible-xs-block,
 #hrjob-contract .visible-xs-inline,
 #hrjob-contract .visible-xs-inline-block,
@@ -9750,232 +7891,188 @@ fieldset[disabled]
   display: none !important;
 }
 @media (max-width: 767px) {
-  /* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract .visible-xs {
     display: block !important;
   }
-  /* line 10, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract table.visible-xs {
     display: table !important;
   }
-  /* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract tr.visible-xs {
     display: table-row !important;
   }
-  /* line 12, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract th.visible-xs,
   #hrjob-contract td.visible-xs {
     display: table-cell !important;
   }
 }
 @media (max-width: 767px) {
-  /* line 54, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-utilities.scss */
   #hrjob-contract .visible-xs-block {
     display: block !important;
   }
 }
 @media (max-width: 767px) {
-  /* line 59, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-utilities.scss */
   #hrjob-contract .visible-xs-inline {
     display: inline !important;
   }
 }
 @media (max-width: 767px) {
-  /* line 64, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-utilities.scss */
   #hrjob-contract .visible-xs-inline-block {
     display: inline-block !important;
   }
 }
 @media (min-width: 768px) and (max-width: 991px) {
-  /* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract .visible-sm {
     display: block !important;
   }
-  /* line 10, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract table.visible-sm {
     display: table !important;
   }
-  /* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract tr.visible-sm {
     display: table-row !important;
   }
-  /* line 12, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract th.visible-sm,
   #hrjob-contract td.visible-sm {
     display: table-cell !important;
   }
 }
 @media (min-width: 768px) and (max-width: 991px) {
-  /* line 73, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-utilities.scss */
   #hrjob-contract .visible-sm-block {
     display: block !important;
   }
 }
 @media (min-width: 768px) and (max-width: 991px) {
-  /* line 78, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-utilities.scss */
   #hrjob-contract .visible-sm-inline {
     display: inline !important;
   }
 }
 @media (min-width: 768px) and (max-width: 991px) {
-  /* line 83, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-utilities.scss */
   #hrjob-contract .visible-sm-inline-block {
     display: inline-block !important;
   }
 }
 @media (min-width: 992px) and (max-width: 1199px) {
-  /* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract .visible-md {
     display: block !important;
   }
-  /* line 10, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract table.visible-md {
     display: table !important;
   }
-  /* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract tr.visible-md {
     display: table-row !important;
   }
-  /* line 12, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract th.visible-md,
   #hrjob-contract td.visible-md {
     display: table-cell !important;
   }
 }
 @media (min-width: 992px) and (max-width: 1199px) {
-  /* line 92, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-utilities.scss */
   #hrjob-contract .visible-md-block {
     display: block !important;
   }
 }
 @media (min-width: 992px) and (max-width: 1199px) {
-  /* line 97, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-utilities.scss */
   #hrjob-contract .visible-md-inline {
     display: inline !important;
   }
 }
 @media (min-width: 992px) and (max-width: 1199px) {
-  /* line 102, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-utilities.scss */
   #hrjob-contract .visible-md-inline-block {
     display: inline-block !important;
   }
 }
 @media (min-width: 1200px) {
-  /* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract .visible-lg {
     display: block !important;
   }
-  /* line 10, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract table.visible-lg {
     display: table !important;
   }
-  /* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract tr.visible-lg {
     display: table-row !important;
   }
-  /* line 12, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract th.visible-lg,
   #hrjob-contract td.visible-lg {
     display: table-cell !important;
   }
 }
 @media (min-width: 1200px) {
-  /* line 111, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-utilities.scss */
   #hrjob-contract .visible-lg-block {
     display: block !important;
   }
 }
 @media (min-width: 1200px) {
-  /* line 116, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-utilities.scss */
   #hrjob-contract .visible-lg-inline {
     display: inline !important;
   }
 }
 @media (min-width: 1200px) {
-  /* line 121, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-utilities.scss */
   #hrjob-contract .visible-lg-inline-block {
     display: inline-block !important;
   }
 }
 @media (max-width: 767px) {
-  /* line 18, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract .hidden-xs {
     display: none !important;
   }
 }
 @media (min-width: 768px) and (max-width: 991px) {
-  /* line 18, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract .hidden-sm {
     display: none !important;
   }
 }
 @media (min-width: 992px) and (max-width: 1199px) {
-  /* line 18, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract .hidden-md {
     display: none !important;
   }
 }
 @media (min-width: 1200px) {
-  /* line 18, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract .hidden-lg {
     display: none !important;
   }
 }
-/* line 18, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
 #hrjob-contract .visible-print {
   display: none !important;
 }
 @media print {
-  /* line 7, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract .visible-print {
     display: block !important;
   }
-  /* line 10, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract table.visible-print {
     display: table !important;
   }
-  /* line 11, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract tr.visible-print {
     display: table-row !important;
   }
-  /* line 12, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract th.visible-print,
   #hrjob-contract td.visible-print {
     display: table-cell !important;
   }
 }
-/* line 155, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-utilities.scss */
 #hrjob-contract .visible-print-block {
   display: none !important;
 }
 @media print {
-  /* line 155, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-utilities.scss */
   #hrjob-contract .visible-print-block {
     display: block !important;
   }
 }
-/* line 162, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-utilities.scss */
 #hrjob-contract .visible-print-inline {
   display: none !important;
 }
 @media print {
-  /* line 162, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-utilities.scss */
   #hrjob-contract .visible-print-inline {
     display: inline !important;
   }
 }
-/* line 169, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-utilities.scss */
 #hrjob-contract .visible-print-inline-block {
   display: none !important;
 }
 @media print {
-  /* line 169, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_responsive-utilities.scss */
   #hrjob-contract .visible-print-inline-block {
     display: inline-block !important;
   }
 }
 @media print {
-  /* line 18, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss */
   #hrjob-contract .hidden-print {
     display: none !important;
   }
@@ -10022,7 +8119,6 @@ fieldset[disabled]
   font-weight: 700;
   font-style: italic;
 }
-/* line 1, ../scss/civihr/modules/_angular.scss */
 #hrjob-contract [ng\:cloak],
 #hrjob-contract [ng-cloak],
 #hrjob-contract [data-ng-cloak],
@@ -10031,24 +8127,19 @@ fieldset[disabled]
 #hrjob-contract .x-ng-cloak {
   display: none !important;
 }
-/* line 1, ../scss/civihr/modules/_utils.scss */
 #hrjob-contract .text-normal {
   font-weight: normal;
 }
-/* line 5, ../scss/civihr/modules/_utils.scss */
 #hrjob-contract .cursor-pointer {
   cursor: pointer;
 }
-/* line 9, ../scss/civihr/modules/_utils.scss */
 #hrjob-contract .shadow-global {
   -webkit-box-shadow: 1px 4px 15px 0px rgba(0, 0, 0, 0.1);
   box-shadow: 1px 4px 15px 0px rgba(0, 0, 0, 0.1);
 }
-/* line 10, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-highlight {
   font-weight: 600;
 }
-/* line 14, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-offscreen {
   clip: rect(0 0 0 0) !important;
   width: 1px !important;
@@ -10062,44 +8153,34 @@ fieldset[disabled]
   left: 0px !important;
   top: 0px !important;
 }
-/* line 31, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ng-dirty.ng-invalid > a.select2-choice {
   border-color: #D44950;
 }
-/* line 35, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .select2-result-single {
   padding-left: 0;
 }
-/* line 39, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .select2-locked > .select2-search-choice-close {
   display: none;
 }
-/* line 43, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .select-locked > .ui-select-match-close {
   display: none;
 }
-/* line 47, ../scss/civihr/modules/_select.scss */
 #hrjob-contract body > .select2-container.open {
   z-index: 9999;
   /* The z-index Select2 applies to the select2-drop */
 }
-/* line 54, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .selectize-input.selectize-focus {
   border-color: #007FBB !important;
 }
-/* line 59, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .selectize-control > .selectize-input > input {
   width: 100%;
 }
-/* line 64, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .selectize-control > .selectize-dropdown {
   width: 100%;
 }
-/* line 69, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ng-dirty.ng-invalid > div.selectize-input {
   border-color: #D44950;
 }
-/* line 77, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .btn-default-focus {
   color: #333;
   background-color: #EBEBEB;
@@ -10109,11 +8190,9 @@ fieldset[disabled]
   outline-offset: -2px;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
 }
-/* line 87, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-bootstrap .ui-select-toggle {
   position: relative;
 }
-/* line 91, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-bootstrap .ui-select-toggle > .caret {
   position: absolute;
   height: 10px;
@@ -10121,30 +8200,25 @@ fieldset[disabled]
   right: 10px;
   margin-top: -2px;
 }
-/* line 100, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .input-group > .ui-select-bootstrap.dropdown {
   /* Instead of relative */
   position: static;
 }
-/* line 105, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .input-group > .ui-select-bootstrap > input.ui-select-search.form-control {
   border-radius: 2px;
   /* FIXME hardcoded value :-/ */
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
 }
-/* line 111, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-bootstrap > .ui-select-match > .btn {
   /* Instead of center because of .btn */
   text-align: left !important;
 }
-/* line 116, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-bootstrap > .ui-select-match > .caret {
   position: absolute;
   top: 45%;
   right: 15px;
 }
-/* line 123, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-bootstrap > .ui-select-choices {
   width: 100%;
   height: auto;
@@ -10152,17 +8226,14 @@ fieldset[disabled]
   overflow-x: hidden;
   margin-top: -1px;
 }
-/* line 131, ../scss/civihr/modules/_select.scss */
 #hrjob-contract body > .ui-select-bootstrap.open {
   z-index: 1000;
   /* Standard Bootstrap dropdown z-index */
 }
-/* line 135, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-multiple.ui-select-bootstrap {
   height: auto;
   padding: 3px 3px 0 3px;
 }
-/* line 140, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-multiple.ui-select-bootstrap input.ui-select-search {
   background-color: transparent !important;
   /* To prevent double background when disabled */
@@ -10171,21 +8242,17 @@ fieldset[disabled]
   height: 1.666666em;
   margin-bottom: 3px;
 }
-/* line 148, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-multiple.ui-select-bootstrap .ui-select-match .close {
   font-size: 1.6em;
   line-height: 0.75;
 }
-/* line 153, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-multiple.ui-select-bootstrap .ui-select-match-item {
   outline: 0;
   margin: 0 3px 3px 0;
 }
-/* line 158, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-multiple .ui-select-match-item {
   position: relative;
 }
-/* line 162, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-multiple .ui-select-match-item.dropping-before:before {
   content: "";
   position: absolute;
@@ -10195,7 +8262,6 @@ fieldset[disabled]
   margin-right: 2px;
   border-left: 1px solid #428bca;
 }
-/* line 172, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-multiple .ui-select-match-item.dropping-after:after {
   content: "";
   position: absolute;
@@ -10205,7 +8271,6 @@ fieldset[disabled]
   margin-left: 2px;
   border-right: 1px solid #428bca;
 }
-/* line 182, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-bootstrap .ui-select-choices-row > a {
   display: block;
   padding: 3px 20px;
@@ -10215,36 +8280,30 @@ fieldset[disabled]
   color: #333;
   white-space: nowrap;
 }
-/* line 192, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-bootstrap .ui-select-choices-row > a:hover, #hrjob-contract .ui-select-bootstrap .ui-select-choices-row > a:focus {
   text-decoration: none;
   color: #262626;
   background-color: #f5f5f5;
 }
-/* line 198, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-bootstrap .ui-select-choices-row.active > a {
   color: #fff;
   text-decoration: none;
   outline: 0;
   background-color: #428bca;
 }
-/* line 205, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-bootstrap .ui-select-choices-row.disabled > a,
 #hrjob-contract .ui-select-bootstrap .ui-select-choices-row.active.disabled > a {
   color: #777;
   cursor: not-allowed;
   background-color: #fff;
 }
-/* line 213, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-match.ng-hide-add,
 #hrjob-contract .ui-select-search.ng-hide-add {
   display: none !important;
 }
-/* line 219, ../scss/civihr/modules/_select.scss */
 #hrjob-contract .ui-select-bootstrap.ng-dirty.ng-invalid > button.btn.ui-select-match {
   border-color: #D44950;
 }
-/* line 10, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .ta-hidden-input {
   width: 1px;
   height: 1px;
@@ -10257,7 +8316,6 @@ fieldset[disabled]
   opacity: 0;
   overflow: hidden;
 }
-/* line 24, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .ta-root.focussed > .ta-scroll-window.form-control {
   border-color: #66afe9;
   outline: 0;
@@ -10265,7 +8323,6 @@ fieldset[disabled]
   -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
 }
-/* line 32, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .ta-editor.ta-html, #hrjob-contract .ta-scroll-window.form-control {
   min-height: 300px;
   height: auto;
@@ -10273,28 +8330,23 @@ fieldset[disabled]
   font-family: inherit;
   font-size: 100%;
 }
-/* line 40, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .ta-scroll-window.form-control {
   position: relative;
   padding: 0;
 }
-/* line 45, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .ta-scroll-window > .ta-bind {
   height: auto;
   min-height: 300px;
   padding: 6px 12px;
 }
-/* line 51, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .ta-editor:focus {
   user-select: text;
 }
-/* line 56, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .ta-resizer-handle-overlay {
   z-index: 100;
   position: absolute;
   display: none;
 }
-/* line 62, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .ta-resizer-handle-overlay > .ta-resizer-handle-info {
   position: absolute;
   bottom: 16px;
@@ -10304,7 +8356,6 @@ fieldset[disabled]
   padding: 0 4px;
   opacity: 0.7;
 }
-/* line 72, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .ta-resizer-handle-overlay > .ta-resizer-handle-background {
   position: absolute;
   bottom: 5px;
@@ -10314,34 +8365,29 @@ fieldset[disabled]
   border: 1px solid black;
   background-color: rgba(0, 0, 0, 0.2);
 }
-/* line 82, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .ta-resizer-handle-overlay > .ta-resizer-handle-corner {
   width: 10px;
   height: 10px;
   position: absolute;
 }
-/* line 88, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .ta-resizer-handle-overlay > .ta-resizer-handle-corner-tl {
   top: 0;
   left: 0;
   border-left: 1px solid black;
   border-top: 1px solid black;
 }
-/* line 95, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .ta-resizer-handle-overlay > .ta-resizer-handle-corner-tr {
   top: 0;
   right: 0;
   border-right: 1px solid black;
   border-top: 1px solid black;
 }
-/* line 102, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .ta-resizer-handle-overlay > .ta-resizer-handle-corner-bl {
   bottom: 0;
   left: 0;
   border-left: 1px solid black;
   border-bottom: 1px solid black;
 }
-/* line 109, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .ta-resizer-handle-overlay > .ta-resizer-handle-corner-br {
   bottom: 0;
   right: 0;
@@ -10349,7 +8395,6 @@ fieldset[disabled]
   cursor: se-resize;
   background-color: white;
 }
-/* line 118, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .popover {
   position: absolute;
   top: 0;
@@ -10372,15 +8417,12 @@ fieldset[disabled]
   -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
 }
-/* line 140, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .popover.top {
   margin-top: -10px;
 }
-/* line 143, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .popover.bottom {
   margin-top: 10px;
 }
-/* line 146, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .popover-title {
   padding: 8px 14px;
   margin: 0;
@@ -10389,11 +8431,9 @@ fieldset[disabled]
   border-bottom: 1px solid #ebebeb;
   border-radius: 5px 5px 0 0;
 }
-/* line 154, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .popover-content {
   padding: 9px 14px;
 }
-/* line 157, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .popover > .arrow,
 #hrjob-contract .popover > .arrow:after {
   position: absolute;
@@ -10403,16 +8443,13 @@ fieldset[disabled]
   border-color: transparent;
   border-style: solid;
 }
-/* line 166, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .popover > .arrow {
   border-width: 11px;
 }
-/* line 169, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .popover > .arrow:after {
   content: "";
   border-width: 10px;
 }
-/* line 173, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .popover.top > .arrow {
   bottom: -11px;
   left: 50%;
@@ -10421,7 +8458,6 @@ fieldset[disabled]
   border-top-color: rgba(0, 0, 0, 0.25);
   border-bottom-width: 0;
 }
-/* line 181, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .popover.top > .arrow:after {
   bottom: 1px;
   margin-left: -10px;
@@ -10429,7 +8465,6 @@ fieldset[disabled]
   border-top-color: #fff;
   border-bottom-width: 0;
 }
-/* line 188, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .popover.bottom > .arrow {
   top: -11px;
   left: 50%;
@@ -10438,7 +8473,6 @@ fieldset[disabled]
   border-bottom-color: #999;
   border-bottom-color: rgba(0, 0, 0, 0.25);
 }
-/* line 196, ../scss/civihr/modules/_textangular.scss */
 #hrjob-contract .popover.bottom > .arrow:after {
   top: 1px;
   margin-left: -10px;
@@ -10470,7 +8504,6 @@ fieldset[disabled]
     opacity: 1;
   }
 }
-/* line 8, ../scss/civihr/modules/_animate.scss */
 #hrjob-contract .fade-in {
   -webkit-animation: fadeIn 0.5s;
   -o-animation: fadeIn 0.5s;
@@ -10516,49 +8549,39 @@ fieldset[disabled]
     opacity: 1;
   }
 }
-/* line 21, ../scss/civihr/modules/_animate.scss */
 #hrjob-contract .fade-in-up {
   -webkit-animation: fadeInUp 0.5s;
   -o-animation: fadeInUp 0.5s;
   animation: fadeInUp 0.5s;
 }
-/* line 5, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss */
 #hrjob-contract .text-success-light {
   color: #44CB7E;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss */
 #hrjob-contract a.text-success-light:hover,
 #hrjob-contract a.text-success-light:focus {
   color: #30ac65;
 }
-/* line 5, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss */
 #hrjob-contract .text-info-light {
   color: #5bc0de;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss */
 #hrjob-contract a.text-info-light:hover,
 #hrjob-contract a.text-info-light:focus {
   color: #31b0d5;
 }
-/* line 5, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss */
 #hrjob-contract .text-warning-light {
   color: #E6AB5E;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss */
 #hrjob-contract a.text-warning-light:hover,
 #hrjob-contract a.text-warning-light:focus {
   color: #df9432;
 }
-/* line 5, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss */
 #hrjob-contract .text-danger-light {
   color: #CF3458;
 }
-/* line 8, ../../../../../../../../../../../../.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss */
 #hrjob-contract a.text-danger-light:hover,
 #hrjob-contract a.text-danger-light:focus {
   color: #a82846;
 }
-/* line 6, ../scss/civihr/partials/_typography.scss */
 #hrjob-contract .header-bar {
   -webkit-box-shadow: 1px 4px 15px 0px rgba(0, 0, 0, 0.1);
   box-shadow: 1px 4px 15px 0px rgba(0, 0, 0, 0.1);
@@ -10570,113 +8593,88 @@ fieldset[disabled]
   padding: 11px 20px 10px;
   max-width: 100%;
 }
-/* line 18, ../scss/civihr/partials/_typography.scss */
 #hrjob-contract .header-bar.header-bar-primary {
   background-color: #0071BD;
   color: #fff;
 }
-/* line 22, ../scss/civihr/partials/_typography.scss */
 #hrjob-contract .header-bar.header-bar-primary a {
   color: #fff;
 }
-/* line 25, ../scss/civihr/partials/_typography.scss */
 #hrjob-contract .header-bar.header-bar-primary a:hover, #hrjob-contract .header-bar.header-bar-primary a:active {
   color: #e6e6e6;
 }
-/* line 32, ../scss/civihr/partials/_typography.scss */
 #hrjob-contract .header-bar.header-bar-success {
   background-color: #44CB7E;
   color: #fff;
 }
-/* line 37, ../scss/civihr/partials/_typography.scss */
 #hrjob-contract .header-bar.header-bar-info {
   background-color: #5bc0de;
   color: #fff;
 }
-/* line 42, ../scss/civihr/partials/_typography.scss */
 #hrjob-contract .header-bar.header-bar-warning {
   background-color: #CF3458;
   color: #fff;
 }
-/* line 47, ../scss/civihr/partials/_typography.scss */
 #hrjob-contract .header-bar.header-bar-danger {
   background-color: #CF3458;
   color: #fff;
 }
-/* line 51, ../scss/civihr/partials/_typography.scss */
 #hrjob-contract .header-bar.header-bar-danger a {
   color: #fff;
 }
-/* line 54, ../scss/civihr/partials/_typography.scss */
 #hrjob-contract .header-bar.header-bar-danger a:hover, #hrjob-contract .header-bar.header-bar-danger a:active {
   color: #e6e6e6;
 }
-/* line 61, ../scss/civihr/partials/_typography.scss */
 #hrjob-contract .header-bar.header-bar-danger-light {
   background-color: #e6807f;
   color: #fff;
 }
-/* line 66, ../scss/civihr/partials/_typography.scss */
 #hrjob-contract .header-bar.header-bar-dark {
   background-color: #5d6779;
   color: #fff;
 }
-/* line 72, ../scss/civihr/partials/_typography.scss */
 #hrjob-contract a[disabled]:not(.btn) {
   color: #4D4D69;
 }
-/* line 75, ../scss/civihr/partials/_typography.scss */
 #hrjob-contract a[disabled]:not(.btn):hover {
   cursor: default;
 }
-/* line 80, ../scss/civihr/partials/_typography.scss */
 #hrjob-contract a:active,
 #hrjob-contract a:focus {
   outline: 0;
 }
-/* line 2, ../scss/civihr/partials/_global.scss */
 #hrjob-contract hr {
   margin-bottom: 20px;
   margin-top: 20px;
 }
-/* line 1, ../scss/civihr/partials/_badge.scss */
 #hrjob-contract .badge {
   font-size: 11px;
   padding: 3px 7px 4px;
 }
-/* line 5, ../scss/civihr/partials/_badge.scss */
 #hrjob-contract .badge.badge-primary {
   background-color: #0071BD !important;
 }
-/* line 9, ../scss/civihr/partials/_badge.scss */
 #hrjob-contract .badge.badge-secondary {
   background-color: #f4f7f8 !important;
 }
-/* line 13, ../scss/civihr/partials/_badge.scss */
 #hrjob-contract .badge.badge-success {
   background-color: #44CB7E !important;
 }
-/* line 17, ../scss/civihr/partials/_badge.scss */
 #hrjob-contract .badge.badge-info {
   background-color: #5bc0de !important;
 }
-/* line 21, ../scss/civihr/partials/_badge.scss */
 #hrjob-contract .badge.badge-warning {
   background-color: #E6AB5E !important;
 }
-/* line 25, ../scss/civihr/partials/_badge.scss */
 #hrjob-contract .badge.badge-dark {
   background-color: #5d6779 !important;
 }
-/* line 29, ../scss/civihr/partials/_badge.scss */
 #hrjob-contract .badge.badge-danger {
   background-color: #CF3458 !important;
 }
-/* line 33, ../scss/civihr/partials/_badge.scss */
 #hrjob-contract .badge.badge-danger-light {
   background-color: #e6807f !important;
 }
-/* line 1, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .btn {
   -moz-border-radius: 2px;
   -webkit-border-radius: 2px;
@@ -10684,73 +8682,59 @@ fieldset[disabled]
   font-weight: normal;
   text-transform: uppercase;
 }
-/* line 8, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .btn.btn-primary:hover {
   background-color: #005c99;
   border-color: #005c99;
 }
-/* line 14, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .btn.btn-success {
   color: #464354;
 }
-/* line 17, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .btn.btn-success:hover {
   background-color: #33b86c;
   border-color: #33b86c;
   color: #000000;
 }
-/* line 26, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .btn.btn-info:hover {
   background-color: #3db5d8;
   border-color: #3db5d8;
 }
-/* line 32, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .btn.btn-warning {
   color: #464354;
 }
-/* line 35, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .btn.btn-warning:hover {
   background-color: #e19b3f;
   border-color: #e19b3f;
   color: #000000;
 }
-/* line 44, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .btn.btn-danger:hover {
   background-color: #b52b4b;
   border-color: #b52b4b;
 }
-/* line 50, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .btn.disabled, #hrjob-contract .btn[disabled], fieldset[disabled] #hrjob-contract .btn {
   cursor: not-allowed;
   opacity: 1;
   filter: alpha(opacity=100);
 }
-/* line 58, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .btn-link {
   font-weight: 600;
 }
-/* line 62, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .btn-gray {
   color: #4D4D69;
   background-color: #fff;
   border-color: #4D4D69;
 }
-/* line 67, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .btn-gray:hover, #hrjob-contract .btn-gray:focus, #hrjob-contract .btn-gray.btn-focus {
   background-color: #3e3e54;
   color: #fff;
 }
-/* line 74, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .btn-gray.active {
   background-color: #3e3e54;
   color: #fff;
 }
-/* line 78, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .btn-gray.active:hover, #hrjob-contract .btn-gray.active:focus, #hrjob-contract .btn-gray.active.btn-focus {
   background-color: #3e3e54;
   color: #fff;
 }
-/* line 87, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .btn-collapse {
   background: none;
   border: 0 none;
@@ -10761,23 +8745,19 @@ fieldset[disabled]
   text-transform: none;
   vertical-align: baseline;
 }
-/* line 97, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .btn-collapse:hover {
   color: #373e4b;
 }
-/* line 101, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .btn-collapse:active {
   -webkit-box-shadow: none;
   box-shadow: none;
 }
-/* line 105, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .btn-collapse .fa {
   margin-right: 3px;
   font-size: 9px;
   position: relative;
   top: -1px;
 }
-/* line 113, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .hrjc-context-menu-toggle {
   color: #464354;
   padding: 0px 10px;
@@ -10785,25 +8765,20 @@ fieldset[disabled]
   display: inline-block;
   font-size: 14px;
 }
-/* line 120, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .hrjc-context-menu-toggle:hover {
   color: #0071BD;
 }
-/* line 126, ../scss/civihr/partials/_buttons.scss */
 #hrjob-contract .btn-group.open .hrjc-context-menu-toggle.dropdown-toggle {
   -webkit-box-shadow: none;
   box-shadow: none;
 }
-/* line 1, ../scss/civihr/partials/_dropdowns.scss */
 #hrjob-contract .dropdown-menu {
   padding: 0;
 }
-/* line 4, ../scss/civihr/partials/_dropdowns.scss */
 #hrjob-contract .dropdown-menu > li > a {
   padding: 8px 14px;
   line-height: 18px;
 }
-/* line 9, ../scss/civihr/partials/_dropdowns.scss */
 #hrjob-contract .dropdown-menu [class^="fa-"],
 #hrjob-contract .dropdown-menu [class^="glyphicon-"],
 #hrjob-contract .dropdown-menu [class*=" fa-"],
@@ -10811,7 +8786,6 @@ fieldset[disabled]
   text-align: center;
   width: 1.25em;
 }
-/* line 3, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract input[type='radio'],
 #hrjob-contract input[type='checkbox'],
 #hrjob-contract .radio input[type='radio'],
@@ -10820,69 +8794,54 @@ fieldset[disabled]
 #hrjob-contract .checkbox-inline input[type='checkbox'] {
   margin-top: 2px;
 }
-/* line 12, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .form-control-file {
   padding: 6px 12px;
 }
-/* line 16, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .form-control-static {
   padding-bottom: 8px;
   padding-top: 6px;
 }
-/* line 22, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .form-control-static .subfield {
   display: block;
 }
-/* line 28, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .form-horizontal .control-label {
   text-align: left;
 }
-/* line 31, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .form-horizontal .control-label.control-label-line-2 {
   margin-top: -3px;
   padding-top: 0;
 }
-/* line 37, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .form-horizontal .has-feedback {
   /* stylelint-disable selector-max-compound-selectors */
   /* stylelint-enable selector-max-compound-selectors */
 }
-/* line 39, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .form-horizontal .has-feedback select + .form-control-feedback {
   right: 28px;
 }
-/* line 43, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .form-horizontal .has-feedback [uib-datepicker-popup] + .form-control-feedback {
   right: 41px;
 }
-/* line 47, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .form-horizontal .has-feedback .form-inline {
   float: left;
   position: relative;
 }
-/* line 51, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .form-horizontal .has-feedback .form-inline select + .form-control-feedback {
   right: 10px;
 }
-/* line 59, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .form-horizontal .well .form-group {
   margin-bottom: 0;
 }
-/* line 62, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .form-horizontal .well .form-group + .form-group {
   /* stylelint-disable-line selector-max-compound-selectors */
   margin-top: 15px;
 }
-/* line 69, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .text-required {
   color: #f00;
 }
-/* line 74, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .form-group.required .control-label::after {
   color: #f00;
   content: '*';
 }
-/* line 80, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .control-label,
 #hrjob-contract .checkbox-inline,
 #hrjob-contract .radio-inline,
@@ -10891,114 +8850,91 @@ fieldset[disabled]
   color: #464354;
   font-weight: 600;
 }
-/* line 89, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .checkbox-label,
 #hrjob-contract .radio-label {
   /* stylelint-disable-line scss/at-extend-no-missing-placeholder */
 }
-/* line 94, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .drop-zone {
   background-color: #F3F6F7;
   border: 1px dashed #C2CFD8;
   color: #464354;
 }
-/* line 100, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .ui-select-placeholder,
 #hrjob-contract .ui-select-match-text {
   font-weight: normal;
   text-transform: none;
 }
-/* line 106, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .ui-select-match-text {
   color: #4D4D69;
 }
-/* line 110, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .ui-select-toggle[disabled] {
   background-color: #F3F6F7;
   opacity: 1;
 }
-/* line 114, ../scss/civihr/partials/_forms.scss */
 #hrjob-contract .ui-select-toggle[disabled]:hover, #hrjob-contract .ui-select-toggle[disabled]:focus, #hrjob-contract .ui-select-toggle[disabled]:active {
   background-color: #F3F6F7;
 }
-/* line 1, ../scss/civihr/partials/_iframe.scss */
 #hrjob-contract .hrjc-iframe {
   opacity: 0;
 }
-/* line 4, ../scss/civihr/partials/_iframe.scss */
 #hrjob-contract .hrjc-iframe.hrjc-iframe-ready {
   -webkit-transition: opacity 0.5s;
   -o-transition: opacity 0.5s;
   transition: opacity 0.5s;
   opacity: 1;
 }
-/* line 1, ../scss/civihr/partials/_modals.scss */
 #hrjob-contract .modal-header {
   background-color: #F3F6F7;
 }
-/* line 4, ../scss/civihr/partials/_modals.scss */
 #hrjob-contract .modal-header .close {
   color: #464354;
   font-size: 18px;
   margin-top: 3px;
   opacity: 1;
 }
-/* line 10, ../scss/civihr/partials/_modals.scss */
 #hrjob-contract .modal-header .close:hover {
   color: #000000;
 }
-/* line 16, ../scss/civihr/partials/_modals.scss */
 #hrjob-contract .modal-body {
   background-color: #FFFFFF;
 }
-/* line 21, ../scss/civihr/partials/_modals.scss */
 #hrjob-contract .modal-progress .modal-body {
   overflow: hidden;
   padding-top: 25px;
 }
-/* line 26, ../scss/civihr/partials/_modals.scss */
 #hrjob-contract .modal-progress .progress {
   margin-bottom: 2px;
 }
-/* line 30, ../scss/civihr/partials/_modals.scss */
 #hrjob-contract .modal-progress .progress-bar {
   min-width: 2.5em;
 }
-/* line 35, ../scss/civihr/partials/_modals.scss */
 #hrjob-contract .modal-title {
   font-size: 18px;
 }
-/* line 42, ../scss/civihr/partials/_modals.scss */
 #hrjob-contract .modal-content .form-horizontal .row,
 #hrjob-contract .modal-content .form-horizontal .form-group {
   margin-left: -15px;
   margin-right: -15px;
 }
-/* line 50, ../scss/civihr/partials/_modals.scss */
 #hrjob-contract .modal-content .form-horizontal .modal-body {
   padding-bottom: 0;
 }
-/* line 55, ../scss/civihr/partials/_modals.scss */
 #hrjob-contract .modal-content [class^="col-"],
 #hrjob-contract .modal-content [class*=" col-"] {
   padding-left: 15px;
   padding-right: 15px;
 }
 @media (min-width: 768px) {
-  /* line 65, ../scss/civihr/partials/_modals.scss */
   #hrjob-contract .modal-dialog {
     margin: 60px auto;
   }
 }
-/* line 1, ../scss/civihr/partials/_page-contact.scss */
 #hrjob-contract .hrjc-page-contact {
   padding: 20px;
 }
-/* line 1, ../scss/civihr/partials/_pagination.scss */
 #hrjob-contract .pagination {
   margin-top: 23px;
 }
-/* line 1, ../scss/civihr/partials/_panels.scss */
 #hrjob-contract .panel {
   display: block;
   position: static;
@@ -11008,115 +8944,92 @@ fieldset[disabled]
   -webkit-box-shadow: 1px 4px 15px 0px rgba(0, 0, 0, 0.1);
   box-shadow: 1px 4px 15px 0px rgba(0, 0, 0, 0.1);
 }
-/* line 10, ../scss/civihr/partials/_panels.scss */
 #hrjob-contract .panel-heading {
   color: #464354;
   font-weight: 600;
 }
-/* line 14, ../scss/civihr/partials/_panels.scss */
 #hrjob-contract .panel-heading .btn-group.btn-group-sm {
   margin-top: -2px;
   margin-bottom: -3px;
 }
-/* line 17, ../scss/civihr/partials/_panels.scss */
 #hrjob-contract .panel-heading .btn-group.btn-group-sm > .btn {
   padding: 5px 13px;
   text-transform: none;
 }
-/* line 23, ../scss/civihr/partials/_panels.scss */
 #hrjob-contract .panel-heading .btn-collapse {
   margin: 4px 0 2px;
 }
-/* line 30, ../scss/civihr/partials/_panels.scss */
 #hrjob-contract .panel-filter {
   margin-bottom: 0;
 }
-/* line 34, ../scss/civihr/partials/_panels.scss */
 #hrjob-contract .panel-filter__filter {
   font-weight: normal;
 }
-/* line 37, ../scss/civihr/partials/_panels.scss */
 #hrjob-contract .panel-filter__filter:first-child {
   border-radius: 2px 0 0 2px;
 }
-/* line 41, ../scss/civihr/partials/_panels.scss */
 #hrjob-contract .panel-filter__filter:last-child {
   border-radius: 0 2px 2px 0;
 }
-/* line 48, ../scss/civihr/partials/_panels.scss */
 #hrjob-contract .panel-title {
   font-size: 18px;
   line-height: 1.42857143;
 }
-/* line 53, ../scss/civihr/partials/_panels.scss */
 #hrjob-contract .panel-light {
   border: 0 none;
   -webkit-box-shadow: 0 0 0 0;
   box-shadow: 0 0 0 0;
 }
-/* line 57, ../scss/civihr/partials/_panels.scss */
 #hrjob-contract .panel-light > .panel-heading {
   border-bottom: 0 none;
   padding: 12px 20px 13px;
 }
-/* line 62, ../scss/civihr/partials/_panels.scss */
 #hrjob-contract .panel-light > .panel-footer {
   border-top: 1px solid #E8EEF0;
   padding: 16px 20px;
 }
-/* line 69, ../scss/civihr/partials/_panels.scss */
 #hrjob-contract .panel-secondary > .panel-body,
 #hrjob-contract .panel-secondary .list-group,
 #hrjob-contract .panel-secondary .list-group-item {
   background-color: #f4f7f8;
 }
-/* line 4, ../scss/civihr/partials/_select.scss */
 #hrjob-contract .ui-select-bootstrap .ui-select-choices-row:not(.active) > a small {
   color: #586277;
 }
-/* line 10, ../scss/civihr/partials/_select.scss */
 #hrjob-contract .ui-select-bootstrap input {
   font-weight: normal;
 }
-/* line 14, ../scss/civihr/partials/_select.scss */
 #hrjob-contract .ui-select-bootstrap .ui-select-toggle {
   padding-right: 30px;
 }
-/* line 18, ../scss/civihr/partials/_select.scss */
 #hrjob-contract .ui-select-bootstrap.ui-select-multiple {
   min-height: 32px;
   padding: 2px 2px 0 2px;
 }
-/* line 22, ../scss/civihr/partials/_select.scss */
 #hrjob-contract .ui-select-bootstrap.ui-select-multiple input.ui-select-search {
   height: 1.9em;
   text-indent: 10px;
 }
-/* line 27, ../scss/civihr/partials/_select.scss */
 #hrjob-contract .ui-select-bootstrap.ui-select-multiple .ui-select-match .close {
   line-height: 0.8;
 }
-/* line 31, ../scss/civihr/partials/_select.scss */
 #hrjob-contract .ui-select-bootstrap.ui-select-multiple .ui-select-match-item {
   border-color: #0071BD;
   margin: 0 2px 2px 1px;
   padding: 2px 8px;
   text-transform: none;
 }
-/* line 7, ../scss/civihr/partials/_tables.scss */
 #hrjob-contract .table > tbody > tr > td .hrjc-context-menu-toggle,
 #hrjob-contract .table > tfoot > tr > td .hrjc-context-menu-toggle {
   margin: -2px 0;
   position: relative;
   top: 1px;
 }
-/* line 13, ../scss/civihr/partials/_tables.scss */
 #hrjob-contract .table > tbody > tr > td.checkbox,
 #hrjob-contract .table > tfoot > tr > td.checkbox {
   padding: 11px 8px 10px;
   text-align: left;
 }
-/* line 24, ../scss/civihr/partials/_tables.scss */
 #hrjob-contract .table > thead > tr > th,
 #hrjob-contract .table > thead > tr > th.checkbox {
   border: 0 none;
@@ -11128,7 +9041,6 @@ fieldset[disabled]
   text-align: left;
   text-transform: none;
 }
-/* line 37, ../scss/civihr/partials/_tables.scss */
 #hrjob-contract .table > thead > tr > th label, #hrjob-contract .table > thead > tr > th .checkbox-label,
 #hrjob-contract .table > thead > tr > th .radio-label,
 #hrjob-contract .table > thead > tr > th.checkbox label,
@@ -11136,16 +9048,13 @@ fieldset[disabled]
 #hrjob-contract .table > thead > tr > th.checkbox .radio-label {
   font-weight: 600;
 }
-/* line 42, ../scss/civihr/partials/_tables.scss */
 #hrjob-contract .table > thead > tr > td {
   border-top: 0 none;
 }
-/* line 1, ../scss/civihr/partials/_tooltip.scss */
 #hrjob-contract .tooltip-inner {
   text-align: left;
   width: 350px;
 }
-/* line 1, ../scss/civihr/partials/_wells.scss */
 #hrjob-contract .well {
   -webkit-box-shadow: none;
   box-shadow: none;
@@ -11174,51 +9083,41 @@ fieldset[disabled]
     opacity: 1;
   }
 }
-/* line 6, ../scss/hrjc/modules/_animate.scss */
 #hrjob-contract .hrjc-btn-add-contract {
   opacity: 0;
 }
-/* line 10, ../scss/hrjc/modules/_animate.scss */
 #hrjob-contract .hrjc-btn-add-contract.ng-active {
   -webkit-transition: all linear 0.2s;
   transition: all linear 0.2s;
   opacity: 1;
 }
-/* line 17, ../scss/hrjc/modules/_animate.scss */
 #hrjob-contract .hrjc-list-contract-item > * {
   opacity: 0;
 }
-/* line 21, ../scss/hrjc/modules/_animate.scss */
 #hrjob-contract .hrjc-list-contract-item.ng-active > * {
   -webkit-transition: all linear 0.2s;
   transition: all linear 0.2s;
   opacity: 1;
 }
-/* line 27, ../scss/hrjc/modules/_animate.scss */
 #hrjob-contract .hrjc-list-contract-item .hrjc-loader {
   opacity: 1;
 }
-/* line 1, ../scss/hrjc/modules/_ui-bootstrap.scss */
 #hrjob-contract .ng-animate.item:not(.left):not(.right) {
   -webkit-transition: 0s ease-in-out left;
   transition: 0s ease-in-out left;
 }
-/* line 5, ../scss/hrjc/modules/_ui-bootstrap.scss */
 #hrjob-contract .uib-datepicker .uib-title {
   width: 100%;
 }
-/* line 8, ../scss/hrjc/modules/_ui-bootstrap.scss */
 #hrjob-contract .uib-day button,
 #hrjob-contract .uib-month button,
 #hrjob-contract .uib-year button {
   min-width: 100%;
 }
-/* line 13, ../scss/hrjc/modules/_ui-bootstrap.scss */
 #hrjob-contract .uib-left,
 #hrjob-contract .uib-right {
   width: 100%;
 }
-/* line 17, ../scss/hrjc/modules/_ui-bootstrap.scss */
 #hrjob-contract .uib-position-measure {
   display: block !important;
   visibility: hidden !important;
@@ -11226,7 +9125,6 @@ fieldset[disabled]
   top: -9999px !important;
   left: -9999px !important;
 }
-/* line 24, ../scss/hrjc/modules/_ui-bootstrap.scss */
 #hrjob-contract .uib-position-scrollbar-measure {
   position: absolute !important;
   top: -9999px !important;
@@ -11234,21 +9132,17 @@ fieldset[disabled]
   height: 50px !important;
   overflow: scroll !important;
 }
-/* line 31, ../scss/hrjc/modules/_ui-bootstrap.scss */
 #hrjob-contract .uib-position-body-scrollbar-measure {
   overflow: scroll !important;
 }
-/* line 34, ../scss/hrjc/modules/_ui-bootstrap.scss */
 #hrjob-contract .uib-datepicker-popup.dropdown-menu {
   display: block;
   float: none;
   margin: 0;
 }
-/* line 39, ../scss/hrjc/modules/_ui-bootstrap.scss */
 #hrjob-contract .uib-button-bar {
   padding: 10px 9px 2px;
 }
-/* line 42, ../scss/hrjc/modules/_ui-bootstrap.scss */
 #hrjob-contract [uib-tooltip-popup].tooltip.top-left > .tooltip-arrow,
 #hrjob-contract [uib-tooltip-popup].tooltip.top-right > .tooltip-arrow,
 #hrjob-contract [uib-tooltip-popup].tooltip.bottom-left > .tooltip-arrow,
@@ -11303,97 +9197,78 @@ fieldset[disabled]
   right: auto;
   margin: 0;
 }
-/* line 96, ../scss/hrjc/modules/_ui-bootstrap.scss */
 #hrjob-contract [uib-popover-popup].popover,
 #hrjob-contract [uib-popover-html-popup].popover,
 #hrjob-contract [uib-popover-template-popup].popover {
   display: block !important;
 }
-/* line 101, ../scss/hrjc/modules/_ui-bootstrap.scss */
 #hrjob-contract .uib-time input {
   width: 50px;
 }
-/* line 104, ../scss/hrjc/modules/_ui-bootstrap.scss */
 #hrjob-contract [uib-typeahead-popup].dropdown-menu {
   display: block;
 }
-/* line 107, ../scss/hrjc/modules/_ui-bootstrap.scss */
 #hrjob-contract .uib-tab a:hover {
   color: #0071BD;
 }
-/* line 3, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn-group-action .dropdown-menu .checkbox {
   font-size: 12px;
   margin-bottom: 5px;
   margin-top: 5px;
   padding: 0px 10px;
 }
-/* line 9, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn-group-action .dropdown-menu .checkbox input[type="checkbox"] {
   margin-top: 1px;
 }
-/* line 13, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn-group-action .dropdown-menu .checkbox label, #hrjob-contract .btn-group-action .dropdown-menu .checkbox .checkbox-label,
 #hrjob-contract .btn-group-action .dropdown-menu .checkbox .radio-label {
   min-height: 17px;
 }
-/* line 22, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn.btn-success {
   color: #464354;
 }
-/* line 25, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn.btn-success:hover {
   color: #000000;
 }
-/* line 30, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn.btn-warning {
   color: #464354;
 }
-/* line 33, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn.btn-warning:hover {
   color: #000000;
 }
-/* line 38, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn.disabled, #hrjob-contract .btn[disabled], fieldset[disabled] #hrjob-contract .btn {
   cursor: not-allowed;
   opacity: 1;
   filter: alpha(opacity=100);
 }
-/* line 44, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn.disabled.btn-primary, #hrjob-contract .btn[disabled].btn-primary, fieldset[disabled] #hrjob-contract .btn.btn-primary {
   background-color: #57bbff;
   border-color: #57bbff;
 }
-/* line 48, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn.disabled.btn-success, #hrjob-contract .btn[disabled].btn-success, fieldset[disabled] #hrjob-contract .btn.btn-success {
   background-color: #bcecd1;
   border-color: #bcecd1;
   color: #908ca4;
 }
-/* line 53, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn.disabled.btn-warning, #hrjob-contract .btn[disabled].btn-warning, fieldset[disabled] #hrjob-contract .btn.btn-warning {
   background-color: #fbf0e2;
   border-color: #fbf0e2;
   color: #908ca4;
 }
-/* line 58, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn.disabled.btn-danger, #hrjob-contract .btn[disabled].btn-danger, fieldset[disabled] #hrjob-contract .btn.btn-danger {
   background-color: #ecb0be;
   border-color: #ecb0be;
 }
-/* line 76, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn-danger-outline {
   background-color: transparent;
   border-color: #CF3458;
   color: #464354;
 }
-/* line 81, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn-danger-outline:hover:not(.disabled):not([disabled]), #hrjob-contract .btn-danger-outline:focus:not(.disabled):not([disabled]) {
   background-color: #b52b4b;
   border-color: #b52b4b;
   color: #FFFFFF;
 }
-/* line 88, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn-danger-outline.disabled, #hrjob-contract .btn-danger-outline[disabled], fieldset[disabled] #hrjob-contract .btn-danger-outline {
   border-color: #ecb0be;
   color: #908ca4;
@@ -11401,19 +9276,16 @@ fieldset[disabled]
   opacity: 1;
   filter: alpha(opacity=100);
 }
-/* line 76, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn-primary-outline {
   background-color: transparent;
   border-color: #0071BD;
   color: #464354;
 }
-/* line 81, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn-primary-outline:hover:not(.disabled):not([disabled]), #hrjob-contract .btn-primary-outline:focus:not(.disabled):not([disabled]) {
   background-color: #005c99;
   border-color: #005c99;
   color: #FFFFFF;
 }
-/* line 88, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn-primary-outline.disabled, #hrjob-contract .btn-primary-outline[disabled], fieldset[disabled] #hrjob-contract .btn-primary-outline {
   border-color: #57bbff;
   color: #908ca4;
@@ -11421,19 +9293,16 @@ fieldset[disabled]
   opacity: 1;
   filter: alpha(opacity=100);
 }
-/* line 76, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn-secondary-outline {
   background-color: transparent;
   border-color: #4D4D69;
   color: #464354;
 }
-/* line 81, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn-secondary-outline:hover:not(.disabled):not([disabled]), #hrjob-contract .btn-secondary-outline:focus:not(.disabled):not([disabled]) {
   background-color: #3e3e54;
   border-color: #3e3e54;
   color: #FFFFFF;
 }
-/* line 88, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn-secondary-outline.disabled, #hrjob-contract .btn-secondary-outline[disabled], fieldset[disabled] #hrjob-contract .btn-secondary-outline {
   border-color: #9a9ab5;
   color: #908ca4;
@@ -11441,19 +9310,16 @@ fieldset[disabled]
   opacity: 1;
   filter: alpha(opacity=100);
 }
-/* line 76, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn-success-outline {
   background-color: transparent;
   border-color: #44CB7E;
   color: #464354;
 }
-/* line 81, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn-success-outline:hover:not(.disabled):not([disabled]), #hrjob-contract .btn-success-outline:focus:not(.disabled):not([disabled]) {
   background-color: #33b86c;
   border-color: #33b86c;
   color: #000000;
 }
-/* line 88, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn-success-outline.disabled, #hrjob-contract .btn-success-outline[disabled], fieldset[disabled] #hrjob-contract .btn-success-outline {
   border-color: #bcecd1;
   color: #908ca4;
@@ -11461,19 +9327,16 @@ fieldset[disabled]
   opacity: 1;
   filter: alpha(opacity=100);
 }
-/* line 76, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn-warning-outline {
   background-color: transparent;
   border-color: #E6AB5E;
   color: #464354;
 }
-/* line 81, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn-warning-outline:hover:not(.disabled):not([disabled]), #hrjob-contract .btn-warning-outline:focus:not(.disabled):not([disabled]) {
   background-color: #e19b3f;
   border-color: #e19b3f;
   color: #000000;
 }
-/* line 88, ../scss/hrjc/partials/_buttons.scss */
 #hrjob-contract .btn-warning-outline.disabled, #hrjob-contract .btn-warning-outline[disabled], fieldset[disabled] #hrjob-contract .btn-warning-outline {
   border-color: #fbf0e2;
   color: #908ca4;
@@ -11481,12 +9344,10 @@ fieldset[disabled]
   opacity: 1;
   filter: alpha(opacity=100);
 }
-/* line 1, ../scss/hrjc/partials/_collapse.scss */
 #hrjob-contract .hrjc-contract-details {
   padding-bottom: 10px;
   padding-top: 10px;
 }
-/* line 8, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .chr_custom-select {
   background: #ffffff;
   border-radius: 2px;
@@ -11496,7 +9357,6 @@ fieldset[disabled]
   position: relative;
   vertical-align: top;
 }
-/* line 17, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .chr_custom-select > select {
   background: transparent;
   padding: 6px 44px 6px 12px;
@@ -11507,11 +9367,9 @@ fieldset[disabled]
   -webkit-appearance: none;
   -webkit-border-radius: 0px;
 }
-/* line 28, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .chr_custom-select > select::-ms-expand {
   display: none;
 }
-/* line 33, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .chr_custom-select:after {
   content: '\f0d7';
   border-left: 1px solid #C2CFD8;
@@ -11527,93 +9385,74 @@ fieldset[disabled]
   line-height: 33px;
   -webkit-font-smoothing: antialiased;
 }
-/* line 51, ../scss/hrjc/partials/_forms.scss */
 .ie9 #hrjob-contract .chr_custom-select > select {
   padding-right: 10px;
 }
-/* line 55, ../scss/hrjc/partials/_forms.scss */
 .ie9 #hrjob-contract .chr_custom-select:after {
   display: none;
 }
-/* line 61, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .chr_custom-select--full {
   display: block;
   width: auto;
 }
-/* line 66, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .chr_custom-select--transparent {
   background: transparent;
 }
-/* line 69, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .chr_custom-select--transparent option {
   background: #ffffff;
 }
-/* line 78, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .has-feedback .chr_custom-select > select {
   padding-right: 44px;
 }
-/* line 81, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .has-feedback .chr_custom-select > select + .form-control-feedback {
   right: 27px !important;
 }
-/* line 88, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .input-group-addon {
   border-left: 0 !important;
   cursor: pointer;
   width: 0;
 }
-/* line 93, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .input-group-addon a {
   color: #333333;
 }
-/* line 103, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .form-horizontal .control-label.control-label-checkbox {
   padding-top: 0;
 }
-/* line 114, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .form-group.required.has-has-feedback .control-label, #hrjob-contract .form-group.required.has-error .control-label, #hrjob-contract .form-group.required.has-success .control-label {
   color: #464354;
 }
-/* line 119, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .form-group.required .control-label:after {
   color: #CF3458;
   margin-left: 5px;
 }
-/* line 126, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .form-inline .form-control {
   vertical-align: top;
 }
-/* line 131, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .form-control {
   -webkit-box-shadow: inset 0 0 3px 0 rgba(0, 0, 0, 0.2);
   box-shadow: inset 0 0 3px 0 rgba(0, 0, 0, 0.2);
 }
-/* line 134, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .form-control:focus {
   -webkit-box-shadow: inset 0 0 3px 0 rgba(0, 0, 0, 0.2);
   box-shadow: inset 0 0 3px 0 rgba(0, 0, 0, 0.2);
   border-color: #0071BD;
 }
-/* line 139, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .form-control .input-group-addon,
 #hrjob-contract .form-control .input-group-btn,
 #hrjob-contract .form-control .input-group .form-control {
   display: table-cell;
   border-radius: #C2CFD8;
 }
-/* line 149, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .ui-select-match .btn-default,
 #hrjob-contract .ui-select-container + .input-group-btn .btn-default {
   border-color: #C2CFD8;
   border-radius: #C2CFD8 0 0 #C2CFD8;
 }
-/* line 153, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .ui-select-match .btn-default:hover, #hrjob-contract .ui-select-match .btn-default:focus,
 #hrjob-contract .ui-select-container + .input-group-btn .btn-default:hover,
 #hrjob-contract .ui-select-container + .input-group-btn .btn-default:focus {
   background-color: #FFFFFF;
 }
-/* line 157, ../scss/hrjc/partials/_forms.scss */
 #hrjob-contract .ui-select-match .btn-default:hover i,
 #hrjob-contract .ui-select-match .btn-default:hover .fa, #hrjob-contract .ui-select-match .btn-default:focus i,
 #hrjob-contract .ui-select-match .btn-default:focus .fa,
@@ -11623,36 +9462,29 @@ fieldset[disabled]
 #hrjob-contract .ui-select-container + .input-group-btn .btn-default:focus .fa {
   color: #333;
 }
-/* line 2, ../scss/hrjc/partials/_history.scss */
 #hrjob-contract .hrjc-history .btn-group-action {
   margin-top: -31px;
 }
-/* line 6, ../scss/hrjc/partials/_history.scss */
 #hrjob-contract .hrjc-history .table {
   margin-bottom: 0;
 }
-/* line 1, ../scss/hrjc/partials/_list.scss */
 #hrjob-contract .hrjc-list-contract {
   list-style: none;
   margin: 0;
   padding: 0;
 }
-/* line 12, ../scss/hrjc/partials/_list.scss */
 #hrjob-contract .hrjc-list-contract-item {
   min-height: 108px;
 }
-/* line 15, ../scss/hrjc/partials/_list.scss */
 #hrjob-contract .hrjc-list-contract-item .tab-content {
   margin-bottom: 20px;
 }
-/* line 19, ../scss/hrjc/partials/_list.scss */
 #hrjob-contract .hrjc-list-contract-item .btn-collapse {
   color: #4D4D69;
   font-size: 12px;
   font-weight: normal;
   text-transform: none;
 }
-/* line 1, ../scss/hrjc/partials/_loader.scss */
 #hrjob-contract .hrjc-loader {
   left: 50%;
   margin-top: 1%;
@@ -11660,52 +9492,42 @@ fieldset[disabled]
   top: 50%;
   z-index: 1000;
 }
-/* line 3, ../scss/hrjc/partials/_modals.scss */
 #hrjob-contract .modal-revision .modal-header .btn-group-action {
   float: right;
   margin-right: 20px;
   margin-top: -2px;
 }
-/* line 10, ../scss/hrjc/partials/_modals.scss */
 #hrjob-contract .modal-revision .table {
   font-size: 13px;
 }
-/* line 13, ../scss/hrjc/partials/_modals.scss */
 #hrjob-contract .modal-revision .table .table {
   background-color: transparent;
   font-size: 12px;
 }
-/* line 17, ../scss/hrjc/partials/_modals.scss */
 #hrjob-contract .modal-revision .table .table th {
   font-size: 12px;
 }
-/* line 23, ../scss/hrjc/partials/_modals.scss */
 #hrjob-contract .modal-revision .pagination {
   margin-top: 10px;
   margin-bottom: 10px;
 }
-/* line 31, ../scss/hrjc/partials/_modals.scss */
 #hrjob-contract .modal-contract .modal-body {
   background-color: #fff;
 }
 @media (min-width: 992px) {
-  /* line 37, ../scss/hrjc/partials/_modals.scss */
   #hrjob-contract .modal-revision .modal-dialog {
     width: 1140px;
   }
 }
-/* line 1, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .nav-tabs {
   border-bottom: 0 none;
 }
-/* line 4, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .nav-tabs > li > a {
   border-top-right-radius: 2px;
   border-top-left-radius: 2px;
   font-size: 13px;
   font-weight: 600;
 }
-/* line 12, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tab-content > .tab-pane {
   background-color: #F3F6F7;
   -moz-border-radius: 2px;
@@ -11715,406 +9537,324 @@ fieldset[disabled]
   border-style: solid;
   border-width: 1px;
 }
-/* line 16, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tab-content > .tab-pane:first-child {
   -moz-border-radius: 0 2px 2px 2px;
   -webkit-border-radius: 0;
   border-radius: 0 2px 2px 2px;
 }
-/* line 29, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tabs-below > .nav-tabs {
   border-top: 1px solid #D3DEE2;
 }
-/* line 32, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tabs-below > .nav-tabs > li {
   margin-top: -1px;
   margin-bottom: 0;
 }
-/* line 36, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tabs-below > .nav-tabs > li > a {
   -moz-border-radius: 0 0 2px 2px;
   -webkit-border-radius: 0;
   border-radius: 0 0 2px 2px;
 }
-/* line 39, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tabs-below > .nav-tabs > li > a:hover, #hrjob-contract .tabs-below > .nav-tabs > li > a:focus {
   border-top-color: #D3DEE2;
   border-bottom-color: transparent;
 }
-/* line 46, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tabs-below > .nav-tabs > .active a, #hrjob-contract .tabs-below > .nav-tabs > .active a:hover, #hrjob-contract .tabs-below > .nav-tabs > .active a:focus {
   border-color: transparent #D3DEE2 #D3DEE2 #D3DEE2;
 }
-/* line 54, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tabs-left > .nav-tabs, #hrjob-contract .tabs-right > .nav-tabs {
   width: 18%;
 }
-/* line 57, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tabs-left > .nav-tabs > li, #hrjob-contract .tabs-right > .nav-tabs > li {
   float: none;
 }
-/* line 60, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tabs-left > .nav-tabs > li > a, #hrjob-contract .tabs-right > .nav-tabs > li > a {
   min-width: 74px;
   margin-right: 0;
   margin-bottom: 3px;
   padding: 15px;
 }
-/* line 69, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tabs-left > .tab-content, #hrjob-contract .tabs-right > .tab-content {
   width: 82%;
 }
-/* line 75, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tabs-left > .nav-tabs {
   float: left;
   margin-left: 0;
   border-right: 1px solid #D3DEE2;
   margin-right: -1px;
 }
-/* line 81, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tabs-left > .nav-tabs > li > a {
   margin-right: -1px;
   -moz-border-radius: 2px 0 0 2px;
   -webkit-border-radius: 2px;
   border-radius: 2px 0 0 2px;
 }
-/* line 85, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tabs-left > .nav-tabs > li > a:hover, #hrjob-contract .tabs-left > .nav-tabs > li > a:focus {
   border-color: #F3F6F7 #D3DEE2 #F3F6F7 #F3F6F7;
 }
-/* line 91, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tabs-left > .nav-tabs > .active a, #hrjob-contract .tabs-left > .nav-tabs > .active a:hover, #hrjob-contract .tabs-left > .nav-tabs > .active a:focus {
   border-color: #D3DEE2 transparent #D3DEE2 #D3DEE2;
   *border-right-color: #fff;
 }
-/* line 98, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tabs-left > .tab-content {
   float: left;
 }
-/* line 104, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tabs-right > .nav-tabs {
   float: right;
   margin-right: 0px;
   border-left: 1px solid #D3DEE2;
   margin-left: -1px;
 }
-/* line 110, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tabs-right > .nav-tabs > li > a {
   margin-left: -1px;
   -moz-border-radius: 0 2px 2px 0;
   -webkit-border-radius: 0;
   border-radius: 0 2px 2px 0;
 }
-/* line 114, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tabs-right > .nav-tabs > li > a:hover, #hrjob-contract .tabs-right > .nav-tabs > li > a:focus {
   border-color: #F3F6F7 #F3F6F7 #F3F6F7 #D3DEE2;
 }
-/* line 120, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tabs-right > .nav-tabs > .active a, #hrjob-contract .tabs-right > .nav-tabs > .active a:hover, #hrjob-contract .tabs-right > .nav-tabs > .active a:focus {
   border-color: #D3DEE2 #D3DEE2 #D3DEE2 transparent;
   *border-left-color: #fff;
 }
-/* line 127, ../scss/hrjc/partials/_navs.scss */
 #hrjob-contract .tabs-right > .tab-content {
   float: right;
 }
-/* line 1, ../scss/hrjc/partials/_panels.scss */
 #hrjob-contract .hrjc-panel-action {
   padding-bottom: 2px;
   padding-top: 10px;
 }
-/* line 7, ../scss/hrjc/partials/_panels.scss */
 #hrjob-contract .hrjc-panel-action .badge {
   margin-top: 6px;
 }
-/* line 11, ../scss/hrjc/partials/_panels.scss */
 #hrjob-contract .hrjc-panel-action .btn {
   margin-left: 7px;
   padding-bottom: 8px;
   padding-top: 8px;
 }
-/* line 19, ../scss/hrjc/partials/_panels.scss */
 #hrjob-contract .hrjc-panel-action .btn .glyphicon {
   margin-right: 3px;
 }
-/* line 23, ../scss/hrjc/partials/_panels.scss */
 #hrjob-contract .hrjc-panel-action .btn.btn-sm, #hrjob-contract .hrjc-panel-action .btn-group-sm > .btn {
   padding: 4px;
   margin-right: -10px;
   margin-left: 0;
 }
-/* line 29, ../scss/hrjc/partials/_panels.scss */
 #hrjob-contract .hrjc-panel-action .btn:first-child {
   margin-left: 0;
 }
-/* line 34, ../scss/hrjc/partials/_panels.scss */
 #hrjob-contract .hrjc-panel-action .form-control-static {
   text-transform: none;
   font-weight: normal;
 }
-/* line 39, ../scss/hrjc/partials/_panels.scss */
 #hrjob-contract .hrjc-panel-action .form-group {
   margin-bottom: 0;
 }
-/* line 43, ../scss/hrjc/partials/_panels.scss */
 #hrjob-contract .hrjc-panel-action .row,
 #hrjob-contract .hrjc-panel-action .form-horizontal .form-group {
   margin-left: -5px;
   margin-right: -5px;
 }
-/* line 53, ../scss/hrjc/partials/_panels.scss */
 #hrjob-contract .hrjc-panel-action > .hrjc-row-action .control-label {
   font-size: 16px;
 }
-/* line 57, ../scss/hrjc/partials/_panels.scss */
 #hrjob-contract .hrjc-panel-action > .hrjc-row-action .form-control-static {
   font-size: 14px;
   padding-bottom: 6px;
   padding-top: 10px;
 }
-/* line 67, ../scss/hrjc/partials/_panels.scss */
 #hrjob-contract .hrjc-panel-action > .hrjc-row-info .control-label,
 #hrjob-contract .hrjc-panel-action > .hrjc-row-info .form-control-static {
   color: #4D4D69;
 }
-/* line 72, ../scss/hrjc/partials/_panels.scss */
 #hrjob-contract .hrjc-panel-action > .hrjc-row-info .badge {
   font-size: 12px;
   padding: 3px 8px;
 }
-/* line 78, ../scss/hrjc/partials/_panels.scss */
 #hrjob-contract .hrjc-panel-action [class^="col-"],
 #hrjob-contract .hrjc-panel-action [class*=" col-"] {
   padding-left: 5px;
   padding-right: 5px;
 }
-/* line 86, ../scss/hrjc/partials/_panels.scss */
 #hrjob-contract .hrjc-panel-action hr {
   margin-bottom: 2px;
   margin-top: 10px;
 }
-/* line 93, ../scss/hrjc/partials/_panels.scss */
 #hrjob-contract .hrjc-panel-action + .panel-body {
   padding-bottom: 10px;
   padding-top: 10px;
 }
-/* line 1, ../scss/hrjc/partials/_summary.scss */
 #hrjob-contract .hrjc-summary-container {
   min-height: 387px;
 }
-/* line 5, ../scss/hrjc/partials/_summary.scss */
 #hrjob-contract .hrjc-summary {
   padding: 20px 20px 10px 20px;
 }
-/* line 9, ../scss/hrjc/partials/_summary.scss */
 #hrjob-contract .hrjc-summary .form-control-static .subfield:not(:first-child) {
   margin-top: 8px;
 }
-/* line 14, ../scss/hrjc/partials/_summary.scss */
 #hrjob-contract .hrjc-summary .form-group {
   margin-bottom: 10px;
 }
-/* line 18, ../scss/hrjc/partials/_summary.scss */
 #hrjob-contract .hrjc-summary strong {
   color: #464354;
 }
-/* line 1, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .hrjc-table-pay {
   table-layout: fixed;
 }
-/* line 4, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .hrjc-table-pay .col-action {
   width: 48px;
 }
-/* line 16, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .hrjc-table-pay .col-index {
   width: 35px;
 }
-/* line 28, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .hrjc-table-pay .action {
   vertical-align: middle;
 }
-/* line 32, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .hrjc-table-pay .index {
   font-weight: bold;
   vertical-align: middle;
 }
-/* line 38, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .hrjc-table-upload {
   table-layout: fixed;
 }
-/* line 41, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .hrjc-table-upload .btn-xs, #hrjob-contract .hrjc-table-upload .btn-group-xs > .btn {
   font-size: 11px;
 }
-/* line 45, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .hrjc-table-upload td {
   overflow: hidden;
   text-overflow: ellipsis;
 }
-/* line 50, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .hrjc-table-upload .col-index {
   width: 32px;
 }
-/* line 54, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .hrjc-table-upload .col-size {
   width: 80px;
 }
-/* line 58, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .hrjc-table-upload .col-action {
   width: 95px;
 }
-/* line 62, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .hrjc-table-upload .progress {
   margin-bottom: 0;
 }
-/* line 69, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .hrjc-table-sort > thead > tr,
 #hrjob-contract .hrjc-table-sort > tbody > tr:nth-child(even) {
   background-color: #F3F6F7;
 }
-/* line 74, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .hrjc-table-sort th > a {
   color: #464354;
   padding-right: 15px;
   position: relative;
 }
-/* line 79, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .hrjc-table-sort th > a .fa {
   position: absolute;
   right: 0;
   top: 50%;
   margin-top: -6px;
 }
-/* line 89, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .table-responsive::-webkit-scrollbar-track {
   background-color: #E8EEF0;
 }
-/* line 93, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .table-responsive::-webkit-scrollbar {
   height: 10px;
   background-color: #4D4D69;
 }
-/* line 98, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .table-responsive::-webkit-scrollbar-thumb {
   border-radius: 10px;
   background-color: #4D4D69;
 }
-/* line 106, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .hrjc-table-revision-list .btn-group-action {
   min-width: 80px;
   vertical-align: baseline;
 }
-/* line 110, ../scss/hrjc/partials/_tables.scss */
 #hrjob-contract .hrjc-table-revision-list .btn-group-action .glyphicon-search {
   font-size: 11px;
 }
-/* line 1, ../scss/hrjc/partials/_wizard.scss */
 #hrjob-contract .hrjc-wizard {
   /** Wizard - Tab - General **/
 }
-/* line 7, ../scss/hrjc/partials/_wizard.scss */
 #hrjob-contract .hrjc-wizard .tabs-left > .tab-content {
   float: left;
   margin-bottom: 20px;
 }
-/* line 11, ../scss/hrjc/partials/_wizard.scss */
 #hrjob-contract .hrjc-wizard .tabs-left > .tab-content > .tab-pane {
   min-height: 365px;
   padding: 15px;
 }
-/* line 18, ../scss/hrjc/partials/_wizard.scss */
 #hrjob-contract .hrjc-wizard .tooltip-inner {
   max-width: 350px;
   width: 350px;
 }
-/* line 23, ../scss/hrjc/partials/_wizard.scss */
 #hrjob-contract .hrjc-wizard h4:not(.modal-title) {
   font-size: 16px;
   margin-top: 0;
 }
-/* line 27, ../scss/hrjc/partials/_wizard.scss */
 #hrjob-contract .hrjc-wizard h4:not(.modal-title) + hr {
   margin-top: 16px;
 }
-/* line 33, ../scss/hrjc/partials/_wizard.scss */
 #hrjob-contract .hrjc-wizard .input-inline-xs {
   max-width: 42px;
 }
-/* line 37, ../scss/hrjc/partials/_wizard.scss */
 #hrjob-contract .hrjc-wizard .input-inline-sm {
   max-width: 100px;
 }
-/* line 41, ../scss/hrjc/partials/_wizard.scss */
 #hrjob-contract .hrjc-wizard .input-inline-lg {
   max-width: 420px;
 }
-/* line 1, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
+
 #hrjob-contract [uib-datepicker-popup] {
   border-color: #C2CFD8;
 }
-/* line 4, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 #hrjob-contract [uib-datepicker-popup] .form-control {
   border-color: #C2CFD8;
 }
-/* line 10, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 #hrjob-contract [uib-datepicker-popup-wrap] + .input-group-btn > button {
   border-color: #C2CFD8;
   color: #C2CFD8;
 }
-/* line 16, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 #hrjob-contract .uib-left,
 #hrjob-contract .uib-right,
 #hrjob-contract .uib-title {
   border: 0;
   color: #464354;
 }
-/* line 22, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 #hrjob-contract .uib-left:hover,
 #hrjob-contract .uib-right:hover,
 #hrjob-contract .uib-title:hover {
   background: transparent;
 }
-/* line 29, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 #hrjob-contract .uib-left i,
 #hrjob-contract .uib-right i {
   font-weight: 300;
 }
-/* line 35, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 #hrjob-contract .uib-title strong {
   font-size: 12px;
   font-weight: 700;
 }
-/* line 41, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 #hrjob-contract .uib-daypicker {
   outline: 0;
 }
-/* line 44, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 #hrjob-contract .uib-daypicker th {
   background: #FFFFFF;
   color: #586277;
   padding: 7px;
   vertical-align: middle;
 }
-/* line 51, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 #hrjob-contract .uib-daypicker tbody {
   background: transparent;
   border-top: 0;
   box-shadow: 0;
 }
-/* line 58, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 #hrjob-contract .uib-day,
 #hrjob-contract .uib-month,
 #hrjob-contract .uib-year {
   padding: 7px;
 }
-/* line 63, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 #hrjob-contract .uib-day .text-muted,
 #hrjob-contract .uib-month .text-muted,
 #hrjob-contract .uib-year .text-muted {
   color: #dcdddd;
 }
-/* line 67, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 #hrjob-contract .uib-day .text-info,
 #hrjob-contract .uib-month .text-info,
 #hrjob-contract .uib-year .text-info {
@@ -12122,7 +9862,6 @@ fieldset[disabled]
   border-radius: 50%;
   color: #0071BD;
 }
-/* line 73, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 #hrjob-contract .uib-day .btn-default,
 #hrjob-contract .uib-month .btn-default,
 #hrjob-contract .uib-year .btn-default {
@@ -12133,13 +9872,11 @@ fieldset[disabled]
   min-width: 0;
   padding: 7px;
 }
-/* line 81, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 #hrjob-contract .uib-day .btn-default span,
 #hrjob-contract .uib-month .btn-default span,
 #hrjob-contract .uib-year .btn-default span {
   padding: 0 !important;
 }
-/* line 85, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 #hrjob-contract .uib-day .btn-default.active,
 #hrjob-contract .uib-month .btn-default.active,
 #hrjob-contract .uib-year .btn-default.active {
@@ -12148,28 +9885,26 @@ fieldset[disabled]
   box-shadow: none;
   color: #FFFFFF;
 }
-/* line 91, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 #hrjob-contract .uib-day .btn-default.active .text-info,
 #hrjob-contract .uib-month .btn-default.active .text-info,
 #hrjob-contract .uib-year .btn-default.active .text-info {
   color: inherit;
 }
-/* line 98, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 #hrjob-contract .uib-datepicker-popup {
   border: 0;
   padding: 10px !important;
 }
-/* line 105, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
+
 .mobile [type='date'][uib-datepicker-popup] {
   line-height: normal;
+  /* stylelint-disable selector-max-compound-selectors */
+  /* stylelint-enable */
 }
-/* line 108, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 .mobile [type='date'][uib-datepicker-popup]::-webkit-inner-spin-button, .mobile [type='date'][uib-datepicker-popup]::-webkit-clear-button {
   -webkit-appearance: none;
   appearance: none;
   display: none;
 }
-/* line 114, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 .mobile [type='date'][uib-datepicker-popup]::-webkit-calendar-picker-indicator {
   background: transparent;
   bottom: 0;
@@ -12181,7 +9916,6 @@ fieldset[disabled]
   top: 0;
   width: auto;
 }
-/* line 126, ../../../org.civicrm.shoreditch/scss/angular/overrides/_uib-datepicker.scss */
 .mobile [type='date'][uib-datepicker-popup] + .input-group-addon {
   border-left: 1px solid #C2CFD8 !important;
   height: 32px !important;

--- a/hrjobcontract/scss/civihr/partials/_shoreditch-imports.scss
+++ b/hrjobcontract/scss/civihr/partials/_shoreditch-imports.scss
@@ -1,0 +1,8 @@
+@import '../../../org.civicrm.shoreditch/scss/bootstrap/overrides/variables';
+@import '../../../org.civicrm.shoreditch/scss/bootstrap/mixins/prefix';
+
+##{$module} {
+  @import '../../../org.civicrm.shoreditch/scss/angular/overrides/uib-datepicker';
+}
+
+@import '../../../org.civicrm.shoreditch/scss/angular/overrides/outside-namespace/uib-datepicker-mobile';

--- a/hrjobcontract/scss/hrjc.scss
+++ b/hrjobcontract/scss/hrjc.scss
@@ -5,6 +5,10 @@
 @import 'compass/css3/animation';
 @import 'compass/css3/transform';
 
+@import 'bootstrap-compass';
+@import 'civihr/bootstrap-variables';
+@import 'bootstrap/variables';
+
 ##{$module} {
   //Unset reset.css
   @import 'civihr/modules/unset';
@@ -14,11 +18,6 @@
   // the narrowed scope of the styles for this CiviCRM module only.
   // ==========================================================================
   @import 'bootstrap-sprockets';
-
-  @import 'bootstrap-compass';
-  @import 'civihr/bootstrap-variables';
-
-  @import 'bootstrap/variables';
   @import 'bootstrap/mixins';
 
   // Reset and dependencies
@@ -121,8 +120,6 @@
   @import 'hrjc/partials/summary';
   @import 'hrjc/partials/tables';
   @import 'hrjc/partials/wizard';
-
-  @import '../../../org.civicrm.shoreditch/scss/bootstrap/overrides/variables';
-  @import '../../../org.civicrm.shoreditch/scss/bootstrap/mixins/prefix';
-  @import '../../../org.civicrm.shoreditch/scss/angular/overrides/uib-datepicker';
 }
+
+@import 'civihr/partials/shoreditch-imports';


### PR DESCRIPTION
## Overview

This PR syncs styles in the HRJobContract extension with Shoreditch. Please see https://github.com/compucorp/org.civicrm.shoreditch/pull/110 for more info.

## Technical Details

### Strip out comments in dist CSS file

```ruby
line_comments = false // that's why this PR introduces 2K+ deletions
```

### Move variables and mixins to make them accessible outside namespace

```css
/* Moved outside ##{$module} {...} */
@import 'civihr/bootstrap-variables';
@import 'bootstrap/variables';
```

### Create a partial for Shoreditch imports

```css
@import '../../../org.civicrm.shoreditch/scss/bootstrap/overrides/variables';
@import '../../../org.civicrm.shoreditch/scss/bootstrap/mixins/prefix';

##{$module} {
  // Still keep generic datepicker styles inside namespace
  @import '../../../org.civicrm.shoreditch/scss/angular/overrides/uib-datepicker';
}
// Import mobile datepicker styles outside namespace
@import '../../../org.civicrm.shoreditch/scss/angular/overrides/outside-namespace/uib-datepicker';
```

### Finally include the partial

```css
/* Also outside ##{$module} {...} */
@import 'civihr/partials/shoreditch-imports';
```

----
According to the dist CSS file diff, there are no style changes whatsoever.