### PR TITLE
PCHR-3519: If Absence Type Public Label is set to true, always include Absence Type field in Leave Requests

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissionsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissionsTest.php
@@ -241,7 +241,7 @@ class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extend
 
   public function testProcessWillHideAccessibleFieldsWhenRowIdentifierIsAbsentEvenIfUserHasAccess() {
     $absenceType = AbsenceTypeFabricator::fabricate([
-      'hide_label' => 1
+      'hide_label' => 0
     ]);
     //User is Staff with ID of 204 and has full access to only his data
     $this->setPermissions();
@@ -262,19 +262,18 @@ class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extend
 
     //Staff will not be able to access all restricted fields for his
     //records since the row identifier is absent
+    //The type_id field is not expected to be restricted to the user since the
+    //Absence type label is public which makes it accessible to user
     $expectedParams['values'][1]['from_date_amount'] = '';
     $expectedParams['values'][1]['to_date_amount'] = '';
     $expectedParams['values'][1]['balance_change'] = '';
-    $expectedParams['values'][1]['type_id'] = '';
     $expectedParams['values'][2]['from_date_amount'] = '';
     $expectedParams['values'][2]['to_date_amount'] = '';
     $expectedParams['values'][2]['balance_change'] = '';
-    $expectedParams['values'][2]['type_id'] = '';
     $expectedParams['values'][4]['sickness_reason'] = '';
     $expectedParams['values'][4]['from_date_amount'] = '';
     $expectedParams['values'][4]['to_date_amount'] = '';
     $expectedParams['values'][4]['balance_change'] = '';
-    $expectedParams['values'][4]['type_id'] = '';
 
     $genericFieldHandler->process($results);
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissionsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/API/Handler/GenericLeaveFieldPermissionsTest.php
@@ -2,6 +2,8 @@
 
 use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
 use CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissions as GenericLeaveFieldPermissions;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
+
 /**
  * Class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest
  *
@@ -187,6 +189,9 @@ class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extend
   ];
 
   public function testProcessWhenUserIsNotAnAdminUser() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'hide_label' => 1
+    ]);
     $this->setPermissions();
     //User has access to two leave contacts.
     $leaveRequestRights = $this->prophesize(LeaveRequestRightsService::class);
@@ -194,8 +199,11 @@ class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extend
     $apiRequest = [];
     $genericFieldHandler = new GenericLeaveFieldPermissions($apiRequest, $leaveRequestRights->reveal());
 
-    $results = $this->sampleData;
-    $expectedParams = $this->sampleData;
+    $sampleData = $this->sampleData;
+    $this->setAbsenceTypeID($sampleData, $absenceType->id);
+
+    $results = $sampleData;
+    $expectedParams = $sampleData;
     $expectedParams['values'][1]['from_date_amount'] = '';
     $expectedParams['values'][1]['to_date_amount'] = '';
     $expectedParams['values'][1]['balance_change'] = '';
@@ -232,6 +240,9 @@ class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extend
   }
 
   public function testProcessWillHideAccessibleFieldsWhenRowIdentifierIsAbsentEvenIfUserHasAccess() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'hide_label' => 1
+    ]);
     //User is Staff with ID of 204 and has full access to only his data
     $this->setPermissions();
     $leaveRequestRights = $this->prophesize(LeaveRequestRightsService::class);
@@ -240,6 +251,7 @@ class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extend
     $genericFieldHandler = new GenericLeaveFieldPermissions($apiRequest, $leaveRequestRights->reveal());
 
     $sampleData = $this->sampleData;
+    $this->setAbsenceTypeID($sampleData, $absenceType->id);
     unset($sampleData['values'][0], $sampleData['values'][3], $sampleData['values'][5]);
     unset($sampleData['values'][1]['contact_id']);
     unset($sampleData['values'][2]['contact_id']);
@@ -267,5 +279,45 @@ class CRM_HRLeaveAndAbsences_API_Handler_GenericLeaveFieldPermissionsTest extend
     $genericFieldHandler->process($results);
 
     $this->assertEquals($expectedParams, $results);
+  }
+
+  public function testTypeIDFieldIsNotHiddenWhenAbsenceTypeIsPublicAndUserDoesNotHaveAccessToTheLeaveContact() {
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'hide_label' => 0
+    ]);
+    $this->setPermissions();
+    //User has access to two leave contacts.
+    $leaveRequestRights = $this->prophesize(LeaveRequestRightsService::class);
+    $leaveRequestRights->getLeaveContactsCurrentUserHasAccessTo()->willReturn([209, 208]);
+    $apiRequest = [];
+    $genericFieldHandler = new GenericLeaveFieldPermissions($apiRequest, $leaveRequestRights->reveal());
+
+    $sampleData = $this->sampleData;
+    $this->setAbsenceTypeID($sampleData, $absenceType->id);
+
+    $results = $sampleData;
+    $expectedParams = $sampleData;
+
+    // All other restricted fields are hidden for the user except the type ID field
+    // because the Absence type allows the label to be public.
+    $expectedParams['values'][1]['from_date_amount'] = '';
+    $expectedParams['values'][1]['to_date_amount'] = '';
+    $expectedParams['values'][1]['balance_change'] = '';
+    $expectedParams['values'][2]['from_date_amount'] = '';
+    $expectedParams['values'][2]['to_date_amount'] = '';
+    $expectedParams['values'][2]['balance_change'] = '';
+    $expectedParams['values'][4]['sickness_reason'] = '';
+    $expectedParams['values'][4]['from_date_amount'] = '';
+    $expectedParams['values'][4]['to_date_amount'] = '';
+    $expectedParams['values'][4]['balance_change'] = '';
+    $genericFieldHandler->process($results);
+
+    $this->assertEquals($expectedParams, $results);
+  }
+
+  private function setAbsenceTypeID(&$sampleData, $absenceTypeID) {
+    foreach ($sampleData['values'] as &$data) {
+      $data['type_id'] = $absenceTypeID;
+    }
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -3717,6 +3717,76 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals('', $result['values'][1]['balance_change']);
   }
 
+  public function testGetAndGetFullShouldNotHideTypeIDFieldValueForContactsOtherThanLoggedInUserWhenUserIsStaffAndAbsenceTypeLabelIsPublic() {
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    $this->registerCurrentLoggedInContactInSession($contact1['id']);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API'];
+
+    HRJobContractFabricator::fabricate(
+      [ 'contact_id' => $contact1['id'] ],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => '2016-10-01'
+      ]
+    );
+
+    HRJobContractFabricator::fabricate(
+      [ 'contact_id' => $contact2['id'] ],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => '2016-10-01'
+      ]
+    );
+
+    //The type ID field will be visible since the Absence type label is set as public
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'hide_label' => 0
+    ]);
+
+    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contact1['id'],
+      'type_id' => $absenceType->id,
+      'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
+      'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
+      'status_id' => 1,
+    ], true);
+
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contact2['id'],
+      'type_id' => $absenceType->id,
+      'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
+      'to_date' =>  CRM_Utils_Date::processDate('2016-02-23'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
+      'status_id' => 1,
+    ], true);
+
+    //The logged in contact would be able to see results for the other contact too since the Leave ACL
+    //allows it and would not be able to view field values for restricted fields but would view the
+    //type_id field for other users since the Absence type label is public
+    $result = civicrm_api3('LeaveRequest', 'get', ['check_permissions' => true, 'sequential' => 1]);
+    $this->assertEquals(2, $result['count']);
+    $this->assertEquals($contact1['id'], $result['values'][0]['contact_id']);
+    $this->assertEquals($leaveRequest1->type_id, $result['values'][0]['type_id']);
+
+    $this->assertEquals($contact2['id'], $result['values'][1]['contact_id']);
+    $this->assertEquals($leaveRequest2->type_id, $result['values'][1]['type_id']);
+
+    $result = civicrm_api3('LeaveRequest', 'getfull', ['check_permissions' => true, 'sequential' => 1]);
+    $this->assertEquals(2, $result['count']);
+    $this->assertEquals($contact1['id'], $result['values'][0]['contact_id']);
+    $this->assertEquals($leaveRequest1->type_id, $result['values'][0]['type_id']);
+    $this->assertNotEmpty($result['values'][0]['balance_change']);
+
+    $this->assertEquals($contact2['id'], $result['values'][1]['contact_id']);
+    $this->assertEquals($leaveRequest2->type_id, $result['values'][1]['type_id']);
+    $this->assertEquals('', $result['values'][1]['balance_change']);
+  }
+
   public function testGetAndGetFullHidesRestrictedFieldValuesForNonManageesWhenLoggedInUserIsALeaveApprover() {
     $manager = ContactFabricator::fabricate();
     $contact1 = ContactFabricator::fabricate();
@@ -3785,6 +3855,82 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $this->assertEquals($contact1['id'], $result['values'][0]['contact_id']);
     $this->assertEquals('', $result['values'][0]['type_id']);
+    $this->assertEquals('', $result['values'][0]['balance_change']);
+
+    $this->assertEquals($contact2['id'], $result['values'][1]['contact_id']);
+    $this->assertEquals($leaveRequest2->type_id, $result['values'][1]['type_id']);
+    $this->assertNotEmpty($result['values'][1]['balance_change']);
+  }
+
+  public function testGetAndGetFullShouldNotHideTypeIDFieldValueForNonManageesWhenLoggedInUserIsALeaveApproverAndAbsenceTypeLabelIsPublic() {
+    $manager = ContactFabricator::fabricate();
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    $this->registerCurrentLoggedInContactInSession($manager['id']);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API'];
+
+    $this->setContactAsLeaveApproverOf($manager, $contact2);
+
+    HRJobContractFabricator::fabricate(
+      [ 'contact_id' => $contact2['id'] ],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => '2016-10-01'
+      ]
+    );
+
+    HRJobContractFabricator::fabricate(
+      [ 'contact_id' => $contact1['id'] ],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => '2016-10-01'
+      ]
+    );
+
+    //The type ID field will be visible if the Absence type label is not hidden.
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'hide_label' => 0
+    ]);
+
+    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contact1['id'],
+      'type_id' => $absenceType->id,
+      'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
+      'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
+      'status_id' => 1,
+    ], true);
+
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contact2['id'],
+      'type_id' => $absenceType->id,
+      'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
+      'to_date' =>  CRM_Utils_Date::processDate('2016-02-23'),
+      'from_date_type' => 1,
+      'to_date_type' => 1,
+      'status_id' => 1,
+    ], true);
+
+    //Results will be returned for both leave contacts even though contact1 is not being managed by
+    //the logged in manager but manager will not be able to view restricted field values for the contact
+    //which he's not a leave approver for but would view the type_id field for other non managees since the
+    // Absence type label is public
+    $result = civicrm_api3('LeaveRequest', 'get', ['check_permissions' => true, 'sequential' => 1]);
+    $this->assertEquals(2, $result['count']);
+
+    $this->assertEquals($contact1['id'], $result['values'][0]['contact_id']);
+    $this->assertEquals($leaveRequest1->type_id, $result['values'][0]['type_id']);
+
+    $this->assertEquals($contact2['id'], $result['values'][1]['contact_id']);
+    $this->assertEquals($leaveRequest2->type_id, $result['values'][1]['type_id']);
+
+    $result = civicrm_api3('LeaveRequest', 'getfull', ['check_permissions' => true, 'sequential' => 1]);
+    $this->assertEquals(2, $result['count']);
+
+    $this->assertEquals($contact1['id'], $result['values'][0]['contact_id']);
+    $this->assertEquals($leaveRequest1->type_id, $result['values'][0]['type_id']);
     $this->assertEquals('', $result['values'][0]['balance_change']);
 
     $this->assertEquals($contact2['id'], $result['values'][1]['contact_id']);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -1749,6 +1749,11 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       ['period_start_date' => '2015-10-01']
     );
 
+    //The type ID field will be visible if the Absence type label is not hidden.
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'hide_label' => 1
+    ]);
+
     // Set Leave Approvers for staffMembers 1 and 2.
     // staffMember2 does not have an active leave manager relationship
     $this->setContactAsLeaveApproverOf($manager1, $staffMember1, null, null, true, 'has Leaves Approved By');
@@ -1756,7 +1761,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember1['id'],
-      'type_id' => $this->absenceType->id,
+      'type_id' => $absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'from_date_type' => 1,
@@ -1765,7 +1770,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $staffMember2['id'],
-      'type_id' => $this->absenceType->id,
+      'type_id' => $absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-01-05'),
       'to_date' => CRM_Utils_Date::processDate('2016-01-05'),
       'from_date_type' => 1,
@@ -3666,9 +3671,14 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       ]
     );
 
+    //The type ID field will be visible if the Absence type label is not hidden.
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'hide_label' => 1
+    ]);
+
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact1['id'],
-      'type_id' => $this->absenceType->id,
+      'type_id' => $absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'from_date_type' => 1,
@@ -3678,7 +3688,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact2['id'],
-      'type_id' => $this->absenceType->id,
+      'type_id' => $absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-02-23'),
       'from_date_type' => 1,
@@ -3733,9 +3743,14 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       ]
     );
 
+    //The type ID field will be visible if the Absence type label is not hidden.
+    $absenceType = AbsenceTypeFabricator::fabricate([
+      'hide_label' => 1
+    ]);
+
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact1['id'],
-      'type_id' => $this->absenceType->id,
+      'type_id' => $absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'to_date' => CRM_Utils_Date::processDate('2016-03-02'),
       'from_date_type' => 1,
@@ -3745,7 +3760,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => $contact2['id'],
-      'type_id' => $this->absenceType->id,
+      'type_id' => $absenceType->id,
       'from_date' => CRM_Utils_Date::processDate('2016-02-20'),
       'to_date' =>  CRM_Utils_Date::processDate('2016-02-23'),
       'from_date_type' => 1,


### PR DESCRIPTION
## Overview
On #2618 , Changes were made to restrict access to Leave request API field values based on the User and Leave ACL rules. This PR introduces an exception to the condition in which the type_id restricted field values is displayed based on the hide_label property on the Absence Type introduced in #2625 . The rule is that even if a user does not have access to other contact's restricted fields, For the type_id field, if the Absence Type label is set to Public, the user is allowed to view the type_id field values.

## Before
- A user can not view the field value for the type_id field of a contact he does not have access to.

## After
- A user can view the field value for the type_id field of a contact he does not have access to if the Absence Type label is set to public.

## Technical Details
- A new method that sets visible absence types was added to the `GenericLeaveFieldPermissions` class

```php
  private function setVisibleAbsenceTypes() {
    $activeAbsenceTypes = AbsenceType::getEnabledAbsenceTypes();
    $visibleAbsenceTypes = [];
    foreach ($activeAbsenceTypes as $absenceType) {
      if (!$absenceType->hide_label) {
        $visibleAbsenceTypes[] = $absenceType->id;
      }
    }

    $this->visibleAbsenceTypes = $visibleAbsenceTypes;
  }
```

A new check was added in the `getNewFieldValue` function to check if user should access the field value 
```php
    if ($field === 'type_id' && in_array($oldValue, $this->visibleAbsenceTypes)) {
      return $oldValue;
    }
```
