### PR TITLE
PCHR-3774: Do not show deduction for other staff in tooltips

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-calendar-day.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-calendar-day.html
@@ -55,7 +55,8 @@
             <div ng-if="day.contactData.leaveRequestsAttributes[leaveRequest.id].unit === 'hours'">
               <div>From: {{day.contactData.leaveRequestsAttributes[leaveRequest.id].from_date | date:'HH:mm'}}</div>
               <div>To: {{day.contactData.leaveRequestsAttributes[leaveRequest.id].to_date | date:'HH:mm'}}</div>
-              <div>For: {{ leaveRequest.from_date_amount | timeUnitApplier :day.contactData.leaveRequestsAttributes[leaveRequest.id].unit }}</div>
+              <div ng-if="leaveRequest.from_date_amount"
+                >For: {{leaveRequest.from_date_amount | timeUnitApplier: day.contactData.leaveRequestsAttributes[leaveRequest.id].unit}}</div>
             </div>
           </div>
           <div ng-if="!day.contactData.leaveRequestsAttributes[leaveRequest.id].isSingleDay">


### PR DESCRIPTION
## Overview

This PR simply hides the deduction info for **other staff** from tooltips in Leave Calendar since the deduction info is omitted for **other staff** from the Leave Request response API.

## Before

![image](https://user-images.githubusercontent.com/3973243/40909879-9f5cfd54-67e2-11e8-9925-14df4c3ab99b.png)


## After

![image](https://user-images.githubusercontent.com/3973243/40909735-32b96174-67e2-11e8-99a2-5185d3b69784.png)

Note: staff can still see their own Leave Requests deduction, which is expected.

![image](https://user-images.githubusercontent.com/3973243/40910038-02b40212-67e3-11e8-8670-b950bd843417.png)



## Technical Details

Simply add an `ng-if` condition to the HTML template:

```html
<div ng-if="leaveRequest.from_date_amount"
  >For: {{leaveRequest.from_date_amount...</div>
```
----

Since this is a very minor change, only manual tests were performed.
