### PR TITLE
PCHR-3677: Allow The Value Field For TOIL  and Leave Days Amounts Option Values To Be Editable

### DIFF
--- a/hrui/hrui.php
+++ b/hrui/hrui.php
@@ -82,7 +82,15 @@ function hrui_civicrm_buildForm($formName, &$form) {
   }
 
   if ($formName === 'CRM_Admin_Form_Options' && $form->elementExists('value')) {
-    $form->removeElement('value');
+    $optionGroupName = $form->getVar('_gName');
+    $optionGroupsToCheck = [
+      'hrleaveandabsences_toil_amounts',
+      'hrleaveandabsences_leave_days_amounts'
+    ];
+
+    if (!in_array($optionGroupName, $optionGroupsToCheck)) {
+      $form->removeElement('value');
+    }
   }
 
   if ($form instanceof CRM_Admin_Form_Setting_Localization) {

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/ValidateForm/AdminFormOptionsValidation.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/ValidateForm/AdminFormOptionsValidation.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Class CRM_HRCore_Hook_ValidateForm_AdminFormOptionsValidation
+ */
+class CRM_HRCore_Hook_ValidateForm_AdminFormOptionsValidation {
+
+  /**
+   * Determines what happens if the hook is handled. Basically the hook
+   * is only handled for option values of the 'toil_amounts' and 'leave_days_amounts'
+   * option group. It basically ensures that the value of the value field of the
+   * option values for these option groups are validated before submission and
+   * if there are errors the form will not be submitted.
+   *
+   * @param string $formName
+   * @param array $fields
+   * @param mixed $files
+   * @param object $form
+   * @param array $errors
+   */
+  public function handle($formName, &$fields, &$files, &$form, &$errors) {
+    if (!$this->shouldHandle($formName, $form)) {
+      return;
+    }
+
+    $this->validateFormValues($fields, $errors);
+  }
+
+  /**
+   * Checks if the hook should be handled.
+   *
+   * @param string $formName
+   * @param object $form
+   *
+   * @return bool
+   */
+  private function shouldHandle($formName, $form) {
+    if ($formName === CRM_Admin_Form_Options::class && $form->elementExists('value')) {
+      $optionGroupName = $form->getVar( '_gName' );
+      $optionGroupsToCheck = ['hrleaveandabsences_toil_amounts', 'hrleaveandabsences_leave_days_amounts'];
+
+      if (in_array($optionGroupName, $optionGroupsToCheck)) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Validates the value field and ensures that the user is only
+   * allowed to enter a decimal or number and if it is a decimal, it
+   * must be correct to 2 decimal places.
+   *
+   * @param array $fields
+   * @param $errors
+   */
+  private function validateFormValues($fields, &$errors) {
+    $value = CRM_Utils_Array::value('value', $fields);
+
+    if (!filter_var($value, FILTER_VALIDATE_FLOAT)) {
+      $errors['value'] = ts( 'Value must be a whole number or decimal' );
+    }
+
+    if (strpos($value, '.') !== FALSE) {
+      $numbersAfterDecimal = substr($value, strpos($value, '.') + 1);
+      if (strlen($numbersAfterDecimal) != 2) {
+        $errors['value'] = ts( 'Please enter the value as a number correct to 2 decimal places' );
+      }
+    }
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -126,6 +126,25 @@ function hrcore_civicrm_buildForm($formName, &$form) {
 }
 
 /**
+ * Implements hook_civicrm_validateForm().
+ *
+ * @param string $formName
+ * @param array $fields
+ * @param mixed $files
+ * @param object $form
+ * @param array $errors
+ */
+function hrcore_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
+  $listeners = [
+    new CRM_HRCore_Hook_ValidateForm_AdminFormOptionsValidation(),
+  ];
+
+  foreach ($listeners as $currentListener) {
+    $currentListener->handle($formName, $fields, $files, $form, $errors);
+  }
+}
+
+/**
  * Implements hook_civicrm_xmlMenu().
  *
  * @param array $files


### PR DESCRIPTION
## Overview
in #1776 , The value field for Option value was made non editable and non visible. For the `hrleaveandabsences_toil_amounts` and `hrleaveandabsences_leave_days_amounts` option groups, we need to make an exception to this logic as it is necessary for users to be able to edit the value fields for these option groups.

## Before
- The value field for all option values of all option groups is hidden and not editable

![optionvaluebefore](https://user-images.githubusercontent.com/6951813/40925967-efa2437a-6812-11e8-952f-4a2f4ac4f05e.gif)


## After
- The value field for the `hrleaveandabsences_toil_amounts` and `hrleaveandabsences_leave_days_amounts` option groups option values are now editable while that of other option groups remain non editable.
- Validation was added for the value field to ensure that only numbers and decimal up to two d.p are allowed for the field.

![optionvalueafter](https://user-images.githubusercontent.com/6951813/40925930-d08cd3e2-6812-11e8-809e-1185ad37714e.gif)