### PR TITLE
PCHR-3787: Fix postInstall hooks

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Base.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Base.php
@@ -1,6 +1,7 @@
 <?php
 
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+use CRM_HRCore_ExtensionUtil as E;
 
 /**
  * Base class which provides helpers to execute upgrade logic
@@ -8,7 +9,7 @@
 class CRM_HRCore_Upgrader_Base {
 
   /**
-   * @var varies, subclass of ttis
+   * @var varies, subclass of this
    */
   static $instance;
 
@@ -97,7 +98,6 @@ class CRM_HRCore_Upgrader_Base {
    * @return bool
    */
   protected static function executeCustomDataFileByAbsPath($xml_file) {
-    require_once 'CRM/Utils/Migrate/Import.php';
     $import = new CRM_Utils_Migrate_Import();
     $import->run($xml_file);
     return TRUE;

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.civix.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.civix.php
@@ -3,6 +3,83 @@
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
 
 /**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_HRCore_ExtensionUtil {
+  const SHORT_NAME = "hrcore";
+  const LONG_NAME = "uk.co.compucorp.civicrm.hrcore";
+  const CLASS_PREFIX = "CRM_HRCore";
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = array()) {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = array(self::LONG_NAME, NULL);
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL) {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_HRCore_ExtensionUtil as E;
+
+/**
  * (Delegated) Implements hook_civicrm_config().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
@@ -19,14 +96,14 @@ function _hrcore_civix_civicrm_config(&$config = NULL) {
   $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
-  if ( is_array( $template->template_dir ) ) {
-      array_unshift( $template->template_dir, $extDir );
+  if (is_array($template->template_dir)) {
+    array_unshift($template->template_dir, $extDir);
   }
   else {
-      $template->template_dir = array( $extDir, $template->template_dir );
+    $template->template_dir = array($extDir, $template->template_dir);
   }
 
-  $include_path = $extRoot . PATH_SEPARATOR . get_include_path( );
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);
 }
 
@@ -131,7 +208,7 @@ function _hrcore_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
  * @return CRM_HRCore_Upgrader
  */
 function _hrcore_civix_upgrader() {
-  if (!file_exists(__DIR__.'/CRM/HRCore/Upgrader.php')) {
+  if (!file_exists(__DIR__ . '/CRM/HRCore/Upgrader.php')) {
     return NULL;
   }
   else {
@@ -167,7 +244,8 @@ function _hrcore_civix_find_files($dir, $pattern) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
         if ($entry{0} == '.') {
-        } elseif (is_dir($path)) {
+        }
+        elseif (is_dir($path)) {
           $todos[] = $path;
         }
       }
@@ -189,9 +267,12 @@ function _hrcore_civix_civicrm_managed(&$entities) {
     $es = include $file;
     foreach ($es as $e) {
       if (empty($e['module'])) {
-        $e['module'] = 'uk.co.compucorp.civicrm.hrcore';
+        $e['module'] = E::LONG_NAME;
       }
       $entities[] = $e;
+      if (empty($e['params']['version'])) {
+        $e['params']['version'] = '3';
+      }
     }
   }
 }
@@ -218,7 +299,7 @@ function _hrcore_civix_civicrm_caseTypes(&$caseTypes) {
       // throw new CRM_Core_Exception($errorMessage);
     }
     $caseTypes[$name] = array(
-      'module' => 'uk.co.compucorp.civicrm.hrcore',
+      'module' => E::LONG_NAME,
       'name' => $name,
       'file' => $file,
     );
@@ -244,7 +325,7 @@ function _hrcore_civix_civicrm_angularModules(&$angularModules) {
     $name = preg_replace(':\.ang\.php$:', '', basename($file));
     $module = include $file;
     if (empty($module['ext'])) {
-      $module['ext'] = 'uk.co.compucorp.civicrm.hrcore';
+      $module['ext'] = E::LONG_NAME;
     }
     $angularModules[$name] = $module;
   }
@@ -271,8 +352,10 @@ function _hrcore_civix_glob($pattern) {
  * Inserts a navigation menu item at a given place in the hierarchy.
  *
  * @param array $menu - menu hierarchy
- * @param string $path - path where insertion should happen (ie. Administer/System Settings)
- * @param array $item - menu you need to insert (parent/child attributes will be filled for you)
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
  */
 function _hrcore_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
@@ -287,7 +370,7 @@ function _hrcore_civix_insert_navigation_menu(&$menu, $path, $item) {
   }
   else {
     // Find an recurse into the next level down
-    $found = false;
+    $found = FALSE;
     $path = explode('/', $path);
     $first = array_shift($path);
     foreach ($menu as $key => &$entry) {
@@ -321,7 +404,7 @@ function _hrcore_civix_fixNavigationMenu(&$nodes) {
     if ($key === 'navID') {
       $maxNavID = max($maxNavID, $item);
     }
-    });
+  });
   _hrcore_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
 }
 
@@ -358,7 +441,20 @@ function _hrcore_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $configured = TRUE;
 
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if(is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
+  if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
     $metaDataFolders[] = $settingsDir;
   }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_entityTypes().
+ *
+ * Find any *.entityType.php files, merge their content, and return.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
+ */
+
+function _hrcore_civix_civicrm_entityTypes(&$entityTypes) {
+  $entityTypes = array_merge($entityTypes, array (
+  ));
 }

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -146,6 +146,15 @@ function hrcore_civicrm_install() {
 }
 
 /**
+ * Implements hook_civicrm_postInstall().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+ */
+function hrcore_civicrm_postInstall() {
+  _hrcore_civix_civicrm_postInstall();
+}
+
+/**
  * Implements hook_civicrm_uninstall().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.civix.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.civix.php
@@ -3,6 +3,83 @@
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
 
 /**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_HRLeaveAndAbsences_ExtensionUtil {
+  const SHORT_NAME = "hrleaveandabsences";
+  const LONG_NAME = "uk.co.compucorp.civicrm.hrleaveandabsences";
+  const CLASS_PREFIX = "CRM_HRLeaveAndAbsences";
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = array()) {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = array(self::LONG_NAME, NULL);
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL) {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_HRLeaveAndAbsences_ExtensionUtil as E;
+
+/**
  * (Delegated) Implements hook_civicrm_config().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
@@ -19,14 +96,14 @@ function _hrleaveandabsences_civix_civicrm_config(&$config = NULL) {
   $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
-  if ( is_array( $template->template_dir ) ) {
-      array_unshift( $template->template_dir, $extDir );
+  if (is_array($template->template_dir)) {
+    array_unshift($template->template_dir, $extDir);
   }
   else {
-      $template->template_dir = array( $extDir, $template->template_dir );
+    $template->template_dir = array($extDir, $template->template_dir);
   }
 
-  $include_path = $extRoot . PATH_SEPARATOR . get_include_path( );
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);
 }
 
@@ -52,6 +129,20 @@ function _hrleaveandabsences_civix_civicrm_install() {
   _hrleaveandabsences_civix_civicrm_config();
   if ($upgrader = _hrleaveandabsences_civix_upgrader()) {
     $upgrader->onInstall();
+  }
+}
+
+/**
+ * Implements hook_civicrm_postInstall().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+ */
+function _hrleaveandabsences_civix_civicrm_postInstall() {
+  _hrleaveandabsences_civix_civicrm_config();
+  if ($upgrader = _hrleaveandabsences_civix_upgrader()) {
+    if (is_callable(array($upgrader, 'onPostInstall'))) {
+      $upgrader->onPostInstall();
+    }
   }
 }
 
@@ -117,7 +208,7 @@ function _hrleaveandabsences_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue =
  * @return CRM_HRLeaveAndAbsences_Upgrader
  */
 function _hrleaveandabsences_civix_upgrader() {
-  if (!file_exists(__DIR__.'/CRM/HRLeaveAndAbsences/Upgrader.php')) {
+  if (!file_exists(__DIR__ . '/CRM/HRLeaveAndAbsences/Upgrader.php')) {
     return NULL;
   }
   else {
@@ -153,7 +244,8 @@ function _hrleaveandabsences_civix_find_files($dir, $pattern) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
         if ($entry{0} == '.') {
-        } elseif (is_dir($path)) {
+        }
+        elseif (is_dir($path)) {
           $todos[] = $path;
         }
       }
@@ -175,9 +267,12 @@ function _hrleaveandabsences_civix_civicrm_managed(&$entities) {
     $es = include $file;
     foreach ($es as $e) {
       if (empty($e['module'])) {
-        $e['module'] = 'uk.co.compucorp.civicrm.hrleaveandabsences';
+        $e['module'] = E::LONG_NAME;
       }
       $entities[] = $e;
+      if (empty($e['params']['version'])) {
+        $e['params']['version'] = '3';
+      }
     }
   }
 }
@@ -204,7 +299,7 @@ function _hrleaveandabsences_civix_civicrm_caseTypes(&$caseTypes) {
       // throw new CRM_Core_Exception($errorMessage);
     }
     $caseTypes[$name] = array(
-      'module' => 'uk.co.compucorp.civicrm.hrleaveandabsences',
+      'module' => E::LONG_NAME,
       'name' => $name,
       'file' => $file,
     );
@@ -230,7 +325,7 @@ function _hrleaveandabsences_civix_civicrm_angularModules(&$angularModules) {
     $name = preg_replace(':\.ang\.php$:', '', basename($file));
     $module = include $file;
     if (empty($module['ext'])) {
-      $module['ext'] = 'uk.co.compucorp.civicrm.hrleaveandabsences';
+      $module['ext'] = E::LONG_NAME;
     }
     $angularModules[$name] = $module;
   }
@@ -257,8 +352,10 @@ function _hrleaveandabsences_civix_glob($pattern) {
  * Inserts a navigation menu item at a given place in the hierarchy.
  *
  * @param array $menu - menu hierarchy
- * @param string $path - path where insertion should happen (ie. Administer/System Settings)
- * @param array $item - menu you need to insert (parent/child attributes will be filled for you)
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
  */
 function _hrleaveandabsences_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
@@ -273,12 +370,14 @@ function _hrleaveandabsences_civix_insert_navigation_menu(&$menu, $path, $item) 
   }
   else {
     // Find an recurse into the next level down
-    $found = false;
+    $found = FALSE;
     $path = explode('/', $path);
     $first = array_shift($path);
     foreach ($menu as $key => &$entry) {
       if ($entry['attributes']['name'] == $first) {
-        if (!$entry['child']) $entry['child'] = array();
+        if (!isset($entry['child'])) {
+          $entry['child'] = array();
+        }
         $found = _hrleaveandabsences_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
       }
     }
@@ -305,7 +404,7 @@ function _hrleaveandabsences_civix_fixNavigationMenu(&$nodes) {
     if ($key === 'navID') {
       $maxNavID = max($maxNavID, $item);
     }
-    });
+  });
   _hrleaveandabsences_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
 }
 
@@ -342,7 +441,104 @@ function _hrleaveandabsences_civix_civicrm_alterSettingsFolders(&$metaDataFolder
   $configured = TRUE;
 
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if(is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
+  if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
     $metaDataFolders[] = $settingsDir;
   }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_entityTypes().
+ *
+ * Find any *.entityType.php files, merge their content, and return.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
+ */
+
+function _hrleaveandabsences_civix_civicrm_entityTypes(&$entityTypes) {
+  $entityTypes = array_merge($entityTypes, array (
+    'CRM_HRLeaveAndAbsences_DAO_AbsencePeriod' => 
+    array (
+      'name' => 'AbsencePeriod',
+      'class' => 'CRM_HRLeaveAndAbsences_DAO_AbsencePeriod',
+      'table' => 'civicrm_absenceperiod',
+    ),
+    'CRM_HRLeaveAndAbsences_DAO_AbsenceType' => 
+    array (
+      'name' => 'AbsenceType',
+      'class' => 'CRM_HRLeaveAndAbsences_DAO_AbsenceType',
+      'table' => 'civicrm_hrleaveandabsences_absence_type',
+    ),
+    'CRM_HRLeaveAndAbsences_DAO_ContactWorkPattern' => 
+    array (
+      'name' => 'ContactWorkPattern',
+      'class' => 'CRM_HRLeaveAndAbsences_DAO_ContactWorkPattern',
+      'table' => 'civicrm_hrleaveandabsences_contact_work_pattern',
+    ),
+    'CRM_HRLeaveAndAbsences_DAO_LeaveBalanceChange' => 
+    array (
+      'name' => 'LeaveBalanceChange',
+      'class' => 'CRM_HRLeaveAndAbsences_DAO_LeaveBalanceChange',
+      'table' => 'civicrm_hrleaveandabsences_leave_balance_change',
+    ),
+    'CRM_HRLeaveAndAbsences_DAO_LeaveBalanceChangeExpiryLog' => 
+    array (
+      'name' => 'LeaveBalanceChangeExpiryLog',
+      'class' => 'CRM_HRLeaveAndAbsences_DAO_LeaveBalanceChangeExpiryLog',
+      'table' => 'civicrm_leave_balance_change_expiry_log',
+    ),
+    'CRM_HRLeaveAndAbsences_DAO_LeavePeriodEntitlement' => 
+    array (
+      'name' => 'LeavePeriodEntitlement',
+      'class' => 'CRM_HRLeaveAndAbsences_DAO_LeavePeriodEntitlement',
+      'table' => 'civicrm_hrleaveandabsences_leave_period_entitlement',
+    ),
+    'CRM_HRLeaveAndAbsences_DAO_LeavePeriodEntitlementLog' => 
+    array (
+      'name' => 'LeavePeriodEntitlementLog',
+      'class' => 'CRM_HRLeaveAndAbsences_DAO_LeavePeriodEntitlementLog',
+      'table' => 'civicrm_hrleaveandabsences_leave_period_entitlement_log',
+    ),
+    'CRM_HRLeaveAndAbsences_DAO_LeaveRequest' => 
+    array (
+      'name' => 'LeaveRequest',
+      'class' => 'CRM_HRLeaveAndAbsences_DAO_LeaveRequest',
+      'table' => 'civicrm_hrleaveandabsences_leave_request',
+    ),
+    'CRM_HRLeaveAndAbsences_DAO_LeaveRequestDate' => 
+    array (
+      'name' => 'LeaveRequestDate',
+      'class' => 'CRM_HRLeaveAndAbsences_DAO_LeaveRequestDate',
+      'table' => 'civicrm_hrleaveandabsences_leave_request_date',
+    ),
+    'CRM_HRLeaveAndAbsences_DAO_NotificationReceiver' => 
+    array (
+      'name' => 'NotificationReceiver',
+      'class' => 'CRM_HRLeaveAndAbsences_DAO_NotificationReceiver',
+      'table' => 'civicrm_hrleaveandabsences_notification_receiver',
+    ),
+    'CRM_HRLeaveAndAbsences_DAO_PublicHoliday' => 
+    array (
+      'name' => 'PublicHoliday',
+      'class' => 'CRM_HRLeaveAndAbsences_DAO_PublicHoliday',
+      'table' => 'civicrm_hrleaveandabsences_public_holiday',
+    ),
+    'CRM_HRLeaveAndAbsences_DAO_WorkDay' => 
+    array (
+      'name' => 'WorkDay',
+      'class' => 'CRM_HRLeaveAndAbsences_DAO_WorkDay',
+      'table' => 'civicrm_hrleaveandabsences_work_day',
+    ),
+    'CRM_HRLeaveAndAbsences_DAO_WorkPattern' => 
+    array (
+      'name' => 'WorkPattern',
+      'class' => 'CRM_HRLeaveAndAbsences_DAO_WorkPattern',
+      'table' => 'civicrm_hrleaveandabsences_work_pattern',
+    ),
+    'CRM_HRLeaveAndAbsences_DAO_WorkWeek' => 
+    array (
+      'name' => 'WorkWeek',
+      'class' => 'CRM_HRLeaveAndAbsences_DAO_WorkWeek',
+      'table' => 'civicrm_hrleaveandabsences_work_week',
+    ),
+  ));
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -360,6 +360,7 @@ function hrleaveandabsences_civicrm_container(\Symfony\Component\DependencyInjec
  */
 function hrleaveandabsences_civicrm_postInstall() {
   _hrleaveandabsences_set_has_leave_approved_by_as_default_relationship_type();
+  _hrleaveandabsences_civix_civicrm_postInstall();
 }
 
 /**

--- a/uk.co.compucorp.civicrm.hrsampledata/hrsampledata.php
+++ b/uk.co.compucorp.civicrm.hrsampledata/hrsampledata.php
@@ -25,6 +25,13 @@ function hrsampledata_civicrm_install() {
   return _hrsampledata_civix_civicrm_install();
 }
 
+/**
+ * Implementation of hook_civicrm_postInstall
+ */
+function hrsampledata_civicrm_postInstall() {
+  return _hrsampledata_civix_civicrm_postInstall();
+}
+
   /**
  * Implementation of hook_civicrm_uninstall
  */


### PR DESCRIPTION
## Overview

Right after creating a new CiviHR site (with any of the build methods available), CiviCRM would tell us that there were some extension updates available. We run all of an extension upgraders during the installation, so it's not possible for any of them to have any pending updates.

After some investigation, it turns out that this was caused by the extension schema version not being saved to the database after the installation is complete. Without that, Civi doesn't know that the extension is already in the latest version and tells the user that they should update it.

## Before

Users would be informed about pending extension updates right after a CiviHR installation.

## After

Users will not informed about pending extension updates right after a CiviHR installation.

## Technical Details
When developing a CiviCRM extension, it's common to use the `civix` tool to automatically generated some skeleton code for us. Among this, is the default implementation of some hooks, which is kept in a file named `<extension>.civix.php` and the Base Upgrader class, which is kept in `CRM/<ExtensionNamespace>/Upgrader/Base.php`.

This tool is constantly updated and some of these updates change the contents and format of these files. Unfortunately, the files need to be updated manually once a new version of `civix` is out (by calling the generate command again) and for this reason, it is easy for files to get outdated.

Outdated files are what caused the issue this PR fixes. On https://github.com/totten/civix/pull/79, they changed the way the schema version is saved to the database after an extension is installed. This is how the installation cycle would work before that PR:

1. Civi calls `hook_civicrm_install()`
 1.1 The implementation of that hook in `<extenstion>.php` would call the implementation inside the `<extension>.civix.php` file
 1.2 The implementation in `<extension>.civix.php` would call the `onInstall()` method in the Base Upgrader class
 1.3 The `onInstall()` method would call the `install()` method
 1.4 After the `install()` finishes the installation, `onInstall()` would save the max revision number (the schema version) to the database
2. Civi calls `hook_civicrm_postInstall()`
 2.1 Nothing would happen, as the extension didn't implement the `postInstall()` hook

And this is how it works after that PR:

1. Civi calls `hook_civicrm_install()`
 1.1 The implementation of that hook in `<extenstion>.php` would call the implementation inside the `<extension>.civix.php` file
 1.2 The implementation in `<extension>.civix.php` would call the `onInstall()` method in the Base Upgrader class
 1.3 The `onInstall()` method would call the `install()` method
2. Civi calls `hook_civicrm_postInstall()`
 2.1 The implementation of that hook in `<extenstion>.php` would call the implementation inside the `<extension>.civix.php` file
 2.2 The implementation in `<extension>.civix.php` would call the `onPostInstall()` method in the Base Upgrader class
 2.3 The `onPostInstall()` saves the schema version to the database

Note that now the responsibility of saving the schema version to the database belongs to the `onPostInstall()` method. Also, note that in order for this to work, it is expected that extensions implement the `hook_civicrm_postInstall()` hook. Part of the changes introduced in https://github.com/totten/civix/pull/79 is exactly about making sure that new extensions created with it would implement that by default. Unfortunately, some CiviHR extension were created before that and the automatically generated files have not been updated ever since. This PR updates these files and make sure that they implement `hook_civicrm_postInstall()` and call the `onPostInstall()` method in the Base Upgrader.

### Comments

Because of this problem, running `drush cvapi Extension.upgrade` on a CiviHR site for the first time after an installation, would run all the upgraders again and result in some duplicated data. A separate PR will be created later to remove this duplicated data from existing sites.

Only these 3 extension have been updated because they were in a unique scenario where the Base Upgrader was created after https://github.com/totten/civix/pull/79, but the `<extension>.php` file was created before that. So the Base Upgrader already contained the change where the schema was saved in the `onPostInstall()` method, but there was no hook calling it. The other extensions still have the old Upgrader which saves the schema version in the `onInstall()` method. So, other than having some outdated files, everything is good there. In order to reduce the number of changes in this PR (and the risk of breaking something with these changes) I decided to keep them as is.