### PR TITLE
PCHR-3631: Hide Billing Location Type

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/PageRun/LocationTypeFilter.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/PageRun/LocationTypeFilter.php
@@ -1,9 +1,10 @@
 <?php
 
-
 class CRM_HRCore_Hook_PageRun_LocationTypeFilter {
 
   /**
+   * Removes certain location types from the admin edit page for them
+   *
    * @param CRM_Core_Page $page
    */
   public function handle($page) {
@@ -22,6 +23,8 @@ class CRM_HRCore_Hook_PageRun_LocationTypeFilter {
   }
 
   /**
+   * Checks if this is the right page
+   *
    * @param CRM_Core_Page $page
    *
    * @return bool

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/PageRun/LocationTypeFilter.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/PageRun/LocationTypeFilter.php
@@ -1,0 +1,33 @@
+<?php
+
+
+class CRM_HRCore_Hook_PageRun_LocationTypeFilter {
+
+  /**
+   * @param CRM_Core_Page $page
+   */
+  public function handle($page) {
+    if (!$this->shouldHandle($page)) {
+      return;
+    }
+
+    $rows = $page->get_template_vars('rows');
+    // remove the "Billing" location type
+    foreach ($rows as $index => $row) {
+      if (CRM_Utils_Array::value('name', $row) === 'Billing') {
+        unset($rows[$index]);
+      }
+    }
+    $page->assign('rows', $rows);
+  }
+
+  /**
+   * @param CRM_Core_Page $page
+   *
+   * @return bool
+   */
+  public function shouldHandle($page) {
+    return $page instanceof CRM_Admin_Page_LocationType;
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -276,6 +276,14 @@ function hrcore_civicrm_pre($op, $objectName, $objectId, &$params) {
  */
 function hrcore_civicrm_pageRun($page) {
   _hrcore_add_js_session_vars();
+
+  $hooks = [
+    new CRM_HRCore_Hook_PageRun_LocationTypeFilter(),
+  ];
+
+  foreach ($hooks as $hook) {
+    $hook->handle($page);
+  }
 }
 
 /**


### PR DESCRIPTION
## Overview

We want to keep the number of default location types to 2; "Personal" and "Work". "Billing" is created by core and is reserved. It is required in some parts of CiviCRM so we should not delete it. Instead it was made inactive and in this PR we will hide it from the location type edit page.

## Before

"Billing" appeared in the location type edit page

![image](https://user-images.githubusercontent.com/6374064/40966176-aa322068-68a7-11e8-9944-570a1da12670.png)

## After

"Billing" does not appear in the location type edit page

![image](https://user-images.githubusercontent.com/6374064/40966143-8fbc5104-68a7-11e8-854a-3a3824c05466.png)
