### PR TITLE
PCHR-3799: change link title in SSP and in CiviHR admin to My Account from Edit Account

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/UserMenuMarkup.tpl
+++ b/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/UserMenuMarkup.tpl
@@ -14,7 +14,7 @@
       </li>
       <li>
         <a href="{$editLink}">
-          <i class="fa fa-edit"></i>{ts}Edit Account{/ts}
+          <i class="fa fa-edit"></i>{ts}My Account{/ts}
         </a>
       </li>
       <li>


### PR DESCRIPTION
## Overview
Change link title in SSP and in CiviHR admin to "My Account" from "Edit Account"

## Before
![image](https://user-images.githubusercontent.com/3916979/41114315-b29f0e2a-6a49-11e8-8152-6da5c02ca1fc.png)

## After
![image](https://user-images.githubusercontent.com/3916979/41114326-ba889700-6a49-11e8-90e9-fe554f1b6040.png)

